### PR TITLE
Make Scaladoc comments consistent in style, including migrating wikidoc to markdown and making markdown the default

### DIFF
--- a/library-js/src/scala/App.scala
+++ b/library-js/src/scala/App.scala
@@ -19,22 +19,22 @@ import scala.collection.mutable.ListBuffer
 
 /** The `App` trait can be used to quickly turn objects
  *  into executable programs. Here is an example:
- *  {{{
+ *  ```
  *  object Main extends App {
  *    Console.println("Hello World: " + (args mkString ", "))
  *  }
- *  }}}
+ *  ```
  *
  *  No explicit `main` method is needed.  Instead,
  *  the whole class body becomes the “main method”.
  *
  *  `args` returns the current command line arguments as an array.
  *
- *  ==Caveats==
+ *  ## Caveats
  *
- *  '''''It should be noted that this trait is implemented using the [[DelayedInit]]
+ *  ***It should be noted that this trait is implemented using the [[DelayedInit]]
  *  functionality, which means that fields of the object will not have been initialized
- *  before the main method has been executed.'''''
+ *  before the main method has been executed.***
  *
  *  Future versions of this trait will no longer extend `DelayedInit`.
  *

--- a/library-js/src/scala/Array.scala
+++ b/library-js/src/scala/Array.scala
@@ -27,11 +27,11 @@ import scala.runtime.ScalaRunTime.{array_apply, array_update}
 
 /** Utility methods for operating on arrays.
  *  For example:
- *  {{{
+ *  ```
  *  val a = Array(1, 2)
  *  val b = Array.ofDim[Int](2)
  *  val c = Array.concat(a, b)
- *  }}}
+ *  ```
  *  where the array objects `a`, `b` and `c` have respectively the values
  *  `Array(1, 2)`, `Array(0, 0)` and `Array(1, 2, 0, 0)`.
  *
@@ -69,9 +69,7 @@ object Array {
     def newBuilder: mutable.Builder[A, Array[A]] = Array.newBuilder[A]
   }
 
-  /**
-   * Returns a new [[scala.collection.mutable.ArrayBuilder]].
-   */
+  /** Returns a new [[scala.collection.mutable.ArrayBuilder]]. */
   def newBuilder[T](implicit t: ClassTag[T]): ArrayBuilder[T] = ArrayBuilder.make[T](using t)
 
   def from[A: ClassTag](it: IterableOnce[A]^): Array[A] = {
@@ -133,14 +131,14 @@ object Array {
   }
 
   /** Copies one array to another, truncating or padding with default values (if
-    * necessary) so the copy has the specified length.
-    *
-    * Equivalent to Java's
-    *   `java.util.Arrays.copyOf(original, newLength)`,
-    * except that this works for primitive and object arrays in a single method.
-    *
-    * @see `java.util.Arrays#copyOf`
-    */
+   *  necessary) so the copy has the specified length.
+   *
+   *  Equivalent to Java's
+   *   `java.util.Arrays.copyOf(original, newLength)`,
+   *  except that this works for primitive and object arrays in a single method.
+   *
+   *  @see `java.util.Arrays#copyOf`
+   */
   def copyOf[A](original: Array[A], newLength: Int): Array[A] = (original match {
     case x: Array[BoxedUnit]  => newUnitArray(newLength).asInstanceOf[Array[A]]
     case x: Array[AnyRef]     => java.util.Arrays.copyOf(x, newLength)
@@ -155,18 +153,18 @@ object Array {
   }).asInstanceOf[Array[A]]
 
   /** Copies one array to another, truncating or padding with default values (if
-    * necessary) so the copy has the specified length. The new array can have
-    * a different type than the original one as long as the values are
-    * assignment-compatible. When copying between primitive and object arrays,
-    * boxing and unboxing are supported.
-    *
-    * Equivalent to Java's
-    *   `java.util.Arrays.copyOf(original, newLength, newType)`,
-    * except that this works for all combinations of primitive and object arrays
-    * in a single method.
-    *
-    * @see `java.util.Arrays#copyOf`
-    */
+   *  necessary) so the copy has the specified length. The new array can have
+   *  a different type than the original one as long as the values are
+   *  assignment-compatible. When copying between primitive and object arrays,
+   *  boxing and unboxing are supported.
+   *
+   *  Equivalent to Java's
+   *   `java.util.Arrays.copyOf(original, newLength, newType)`,
+   *  except that this works for all combinations of primitive and object arrays
+   *  in a single method.
+   *
+   *  @see `java.util.Arrays#copyOf`
+   */
   def copyAs[A](original: Array[_], newLength: Int)(implicit ct: ClassTag[A]): Array[A] = {
     val runtimeClass = ct.runtimeClass
     if (runtimeClass == Void.TYPE) newUnitArray(newLength).asInstanceOf[Array[A]]
@@ -364,10 +362,10 @@ object Array {
    *  of times.
    *
    *  Note that this means that `elem` is computed a total of n times:
-   *  {{{
-   * scala> Array.fill(3){ math.random }
-   * res3: Array[Double] = Array(0.365461167592537, 1.550395944913685E-4, 0.7907242137333306)
-   *  }}}
+   *  ```
+   *  scala> Array.fill(3){ math.random }
+   *  res3: Array[Double] = Array(0.365461167592537, 1.550395944913685E-4, 0.7907242137333306)
+   *  ```
    *
    *  @param   n  the number of elements desired
    *  @param   elem the element computation
@@ -504,7 +502,7 @@ object Array {
   /** Returns an array containing a sequence of increasing integers in a range.
    *
    *  @param start  the start value of the array
-   *  @param end    the end value of the array, exclusive (in other words, this is the first value '''not''' returned)
+   *  @param end    the end value of the array, exclusive (in other words, this is the first value **not** returned)
    *  @return  the array with values in range `start, start + 1, ..., end - 1`
    *  up to, but excluding, `end`.
    */
@@ -513,7 +511,7 @@ object Array {
   /** Returns an array containing equally spaced values in some integer interval.
    *
    *  @param start the start value of the array
-   *  @param end   the end value of the array, exclusive (in other words, this is the first value '''not''' returned)
+   *  @param end   the end value of the array, exclusive (in other words, this is the first value **not** returned)
    *  @param step  the increment value of the array (may not be zero)
    *  @return      the array with values in `start, start + step, ...` up to, but excluding `end`
    */
@@ -592,12 +590,12 @@ object Array {
 /** Arrays are mutable, indexed collections of values. `Array[T]` is Scala's representation
  *  for Java's `T[]`.
  *
- *  {{{
+ *  ```
  *  val numbers = Array(1, 2, 3, 4)
  *  val first = numbers(0) // read the first element
  *  numbers(3) = 100 // replace the 4th array element with 100
  *  val biggerNumbers = numbers.map(_ * 2) // multiply all numbers by two
- *  }}}
+ *  ```
  *
  *  Arrays make use of two common pieces of Scala syntactic sugar, shown on lines 2 and 3 of the above
  *  example code.
@@ -614,11 +612,11 @@ object Array {
  *  The conversion to `ArrayOps` takes priority over the conversion to `ArraySeq`. For instance,
  *  consider the following code:
  *
- *  {{{
+ *  ```
  *  val arr = Array(1, 2, 3)
  *  val arrReversed = arr.reverse
  *  val seqReversed : collection.Seq[Int] = arr.reverse
- *  }}}
+ *  ```
  *
  *  Value `arrReversed` will be of type `Array[Int]`, with an implicit conversion to `ArrayOps` occurring
  *  to perform the `reverse` operation. The value of `seqReversed`, on the other hand, will be computed
@@ -627,9 +625,9 @@ object Array {
  *
  *  @author Martin Odersky
  *  @since  1.0
- *  @see [[http://www.scala-lang.org/files/archive/spec/2.13/ Scala Language Specification]], for in-depth information on the transformations the Scala compiler makes on Arrays (Sections 6.6 and 6.15 respectively.)
- *  @see [[http://docs.scala-lang.org/sips/completed/scala-2-8-arrays.html "Scala 2.8 Arrays"]] the Scala Improvement Document detailing arrays since Scala 2.8.
- *  @see [[http://docs.scala-lang.org/overviews/collections/arrays.html "The Scala 2.8 Collections' API"]] section on `Array` by Martin Odersky for more information.
+ *  @see [Scala Language Specification](http://www.scala-lang.org/files/archive/spec/2.13/), for in-depth information on the transformations the Scala compiler makes on Arrays (Sections 6.6 and 6.15 respectively.)
+ *  @see ["Scala 2.8 Arrays"](http://docs.scala-lang.org/sips/completed/scala-2-8-arrays.html) the Scala Improvement Document detailing arrays since Scala 2.8.
+ *  @see ["The Scala 2.8 Collections' API"](http://docs.scala-lang.org/overviews/collections/arrays.html) section on `Array` by Martin Odersky for more information.
  *  @hideImplicitConversion scala.Predef.booleanArrayOps
  *  @hideImplicitConversion scala.Predef.byteArrayOps
  *  @hideImplicitConversion scala.Predef.charArrayOps

--- a/library-js/src/scala/Console.scala
+++ b/library-js/src/scala/Console.scala
@@ -22,20 +22,20 @@ import scala.util.DynamicVariable
  *  use [[scala.io.StdIn$ StdIn]].
  *  Also defines constants for marking up text on ANSI terminals.
  *
- *  == Console Output ==
+ *  ## Console Output
  *
  *  Use the print methods to output text.
- *  {{{
+ *  ```
  *   scala> Console.printf(
  *     "Today the outside temperature is a balmy %.1f°C. %<.1f°C beats the previous record of %.1f°C.\n",
  *     -137.0,
  *     -135.05)
  *   Today the outside temperature is a balmy -137.0°C. -137.0°C beats the previous record of -135.1°C.
- *  }}}
+ *  ```
  *
- *  == ANSI escape codes ==
+ *  ## ANSI escape codes
  *  Use the ANSI escape codes for colorizing console output either to STDOUT or STDERR.
- *  {{{
+ *  ```
  *    import Console.{GREEN, RED, RESET, YELLOW_B, UNDERLINED}
  *
  *    object PrimeTest {
@@ -55,7 +55,7 @@ import scala.util.DynamicVariable
  *      def main(args: Array[String]): Unit = isPrime()
  *
  *    }
- *  }}}
+ *  ```
  *
  *  <table style="border: 10px solid #000;width:100%">
  *    <tr><td style="background-color:#000;color:#fff">$ scala PrimeTest</td></tr>
@@ -66,12 +66,12 @@ import scala.util.DynamicVariable
  *    <tr><td style="background-color:#000;color:#fff"><span style="background-color:#ff0;color:#f00;text-decoration:underline">NO!</span></td></tr>
  *  </table>
  *
- *  == IO redefinition ==
+ *  ## IO redefinition
  *
  *  Use IO redefinition to temporarily swap in a different set of input and/or output streams. In this example the stream based
  *  method above is wrapped into a function.
  *
- *  {{{
+ *  ```
  *    import java.io.{ByteArrayOutputStream, StringReader}
  *
  *    object FunctionalPrimeTest {
@@ -103,7 +103,7 @@ import scala.util.DynamicVariable
  *      }
  *
  *    }
- *  }}}
+ *  ```
  *
  *
  *  <table style="border: 10px solid #000;width:100%">
@@ -126,7 +126,6 @@ import scala.util.DynamicVariable
  *  @groupprio io-redefinition 60
  *  @groupdesc io-redefinition These methods allow substituting alternative streams for the duration of
  *             a body of code. Threadsafe by virtue of [[scala.util.DynamicVariable]].
- *
  */
 object Console extends AnsiColor {
   private[this] val outVar = new DynamicVariable[PrintStream](java.lang.System.out)
@@ -154,9 +153,9 @@ object Console extends AnsiColor {
   /** Sets the default output stream for the duration
    *  of execution of one thunk.
    *
-   *  @example {{{
+   *  @example ```
    *  withOut(Console.err) { println("This goes to default _error_") }
-   *  }}}
+   *  ```
    *
    *  @param out the new output stream.
    *  @param thunk the code to execute with
@@ -183,9 +182,9 @@ object Console extends AnsiColor {
 
   /** Sets the default error stream for the duration
    *  of execution of one thunk.
-   *  @example {{{
+   *  @example ```
    *  withErr(Console.out) { err.println("This goes to default _out_") }
-   *  }}}
+   *  ```
    *
    *  @param err the new error stream.
    *  @param thunk the code to execute with
@@ -213,13 +212,13 @@ object Console extends AnsiColor {
   /** Sets the default input stream for the duration
    *  of execution of one thunk.
    *
-   *  @example {{{
+   *  @example ```
    *  val someFile:Reader = openFile("file.txt")
    *  withIn(someFile) {
    *    // Reads a line from file.txt instead of default input
    *    println(readLine)
    *  }
-   *  }}}
+   *  ```
    *
    *  @param thunk the code to execute with
    *               the new input stream active
@@ -256,12 +255,12 @@ object Console extends AnsiColor {
   /** Flushes the output stream. This function is required when partial
    *  output (i.e. output not terminated by a newline character) has
    *  to be made visible on the terminal.
-    * @group console-output
+   *  @group console-output
    */
   def flush(): Unit = { out.flush() }
 
   /** Prints a newline character on the default output.
-    * @group console-output
+   *  @group console-output
    */
   def println(): Unit = { out.println() }
 

--- a/library-js/src/scala/Enumeration.scala
+++ b/library-js/src/scala/Enumeration.scala
@@ -38,28 +38,28 @@ import scala.util.matching.Regex
  *  enumeration from multiple threads (in a non-synchronized fashion) after
  *  construction, the behavior of the enumeration is undefined.
  *
- * @example {{{
- * // Define a new enumeration with a type alias and work with the full set of enumerated values
- * object WeekDay extends Enumeration {
+ *  @example ```
+ *  // Define a new enumeration with a type alias and work with the full set of enumerated values
+ *  object WeekDay extends Enumeration {
  *   type WeekDay = Value
  *   val Mon, Tue, Wed, Thu, Fri, Sat, Sun = Value
- * }
- * import WeekDay._
+ *  }
+ *  import WeekDay._
  *
- * def isWorkingDay(d: WeekDay) = ! (d == Sat || d == Sun)
+ *  def isWorkingDay(d: WeekDay) = ! (d == Sat || d == Sun)
  *
- * WeekDay.values filter isWorkingDay foreach println
- * // output:
- * // Mon
- * // Tue
- * // Wed
- * // Thu
- * // Fri
- * }}}
+ *  WeekDay.values filter isWorkingDay foreach println
+ *  // output:
+ *  // Mon
+ *  // Tue
+ *  // Wed
+ *  // Thu
+ *  // Fri
+ *  ```
  *
- * @example {{{
- * // Example of adding attributes to an enumeration by extending the Enumeration.Val class
- * object Planet extends Enumeration {
+ *  @example ```
+ *  // Example of adding attributes to an enumeration by extending the Enumeration.Val class
+ *  object Planet extends Enumeration {
  *   protected case class Val(mass: Double, radius: Double) extends super.Val {
  *     def surfaceGravity: Double = Planet.G * mass / (radius * radius)
  *     def surfaceWeight(otherMass: Double): Double = otherMass * surfaceGravity
@@ -76,12 +76,12 @@ import scala.util.matching.Regex
  *   val Saturn  = Val(5.688e+26, 6.0268e7)
  *   val Uranus  = Val(8.686e+25, 2.5559e7)
  *   val Neptune = Val(1.024e+26, 2.4746e7)
- * }
+ *  }
  *
- * println(Planet.values.filter(_.radius > 7.0e6))
- * // output:
- * // Planet.ValueSet(Jupiter, Saturn, Uranus, Neptune)
- * }}}
+ *  println(Planet.values.filter(_.radius > 7.0e6))
+ *  // output:
+ *  // Planet.ValueSet(Jupiter, Saturn, Uranus, Neptune)
+ *  ```
  *
  *  @param initial The initial value from which to count the integers that
  *                 identifies values at run-time.
@@ -97,13 +97,13 @@ abstract class Enumeration (initial: Int) extends Serializable {
      the JVM does not invoke it when deserializing subclasses. */
   protected def readResolve(): AnyRef = ???
 
-  /** The name of this enumeration.
-   */
+  /** The name of this enumeration. */
   override def toString =
     (getClass.getName.stripSuffix("$").split('.')).last.split('$').last
 
   /** The mapping from the integer used to identify values to the actual
-    * values. */
+   *  values. 
+   */
   private val vmap: mutable.Map[Int, Value] = new mutable.HashMap
 
   /** The cache listing all values of this enumeration. */
@@ -111,11 +111,11 @@ abstract class Enumeration (initial: Int) extends Serializable {
   @transient @volatile private var vsetDefined = false
 
   /** The mapping from the integer used to identify values to their
-    * names. */
+   *  names. 
+   */
   private[this] val nmap: mutable.Map[Int, String] = new mutable.HashMap
 
-  /** The values of this enumeration as a set.
-   */
+  /** The values of this enumeration as a set. */
   def values: ValueSet = {
     if (!vsetDefined) {
       vset = (ValueSet.newBuilder ++= vmap.values).result()
@@ -134,27 +134,29 @@ abstract class Enumeration (initial: Int) extends Serializable {
     if (nextName != null && nextName.hasNext) nextName.next() else null
 
   /** The highest integer amongst those used to identify values in this
-    * enumeration. */
+   *  enumeration. 
+   */
   private[this] var topId = initial
 
   /** The lowest integer amongst those used to identify values in this
-    * enumeration, but no higher than 0. */
+   *  enumeration, but no higher than 0. 
+   */
   private[this] var bottomId = if(initial < 0) initial else 0
 
   /** The one higher than the highest integer amongst those used to identify
-    *  values in this enumeration. */
+   *  values in this enumeration. 
+   */
   final def maxId = topId
 
-  /** The value of this enumeration with given id `x`
-   */
+  /** The value of this enumeration with given id `x` */
   final def apply(x: Int): Value = vmap(x)
 
   /** Returns a `Value` from this `Enumeration` whose name matches
    *  the argument `s`.  The names are determined automatically via reflection.
    *
-   * @param  s an `Enumeration` name
-   * @return   the `Value` of this `Enumeration` if its name matches `s`
-   * @throws   NoSuchElementException if no `Value` with a matching
+   *  @param  s an `Enumeration` name
+   *  @return   the `Value` of this `Enumeration` if its name matches `s`
+   *  @throws   NoSuchElementException if no `Value` with a matching
    *           name is in this `Enumeration`
    */
   final def withName(s: String): Value = {
@@ -197,10 +199,10 @@ abstract class Enumeration (initial: Int) extends Serializable {
   /** Creates a fresh value, part of this enumeration, called `name`
    *  and identified by the integer `i`.
    *
-   * @param i    An integer that identifies this value at run-time. It must be
+   *  @param i    An integer that identifies this value at run-time. It must be
    *             unique amongst all values of the enumeration.
-   * @param name A human-readable name for that value.
-   * @return     Fresh value with the provided identifier `i` and name `name`.
+   *  @param name A human-readable name for that value.
+   *  @return     Fresh value with the provided identifier `i` and name `name`.
    */
   protected final def Value(i: Int, name: String | Null): Value = new Val(i, name)
 
@@ -288,7 +290,8 @@ abstract class Enumeration (initial: Int) extends Serializable {
     override def iteratorFrom(start: Value) = nnIds iteratorFrom start.id  map (id => thisenum.apply(bottomId + id))
     override def className = s"$thisenum.ValueSet"
     /** Creates a bit mask for the zero-adjusted ids in this set as a
-     *  new array of longs */
+     *  new array of longs 
+     */
     def toBitMask: Array[Long] = nnIds.toBitMask
 
     override protected def fromSpecific(coll: IterableOnce[Value]) = ValueSet.fromSpecific(coll)
@@ -317,7 +320,8 @@ abstract class Enumeration (initial: Int) extends Serializable {
     /** The empty value set. */
     val empty = new ValueSet(immutable.BitSet.empty)
     /** A value set containing all the values for the zero-adjusted ids
-     *  corresponding to the bits in an array. */
+     *  corresponding to the bits in an array. 
+     */
     def fromBitMask(elems: Array[Long]): ValueSet = new ValueSet(immutable.BitSet.fromBitMask(elems))
     /** A builder object for value sets. */
     def newBuilder: mutable.Builder[Value, ValueSet] = new mutable.Builder[Value, ValueSet] {

--- a/library-js/src/scala/collection/immutable/NumericRange.scala
+++ b/library-js/src/scala/collection/immutable/NumericRange.scala
@@ -18,26 +18,26 @@ import scala.collection.Stepper.EfficientSplit
 import scala.collection.{AbstractIterator, AnyStepper, IterableFactoryDefaults, Iterator, Stepper, StepperShape}
 
 /** `NumericRange` is a more generic version of the
-  *  `Range` class which works with arbitrary types.
-  *  It must be supplied with an `Integral` implementation of the
-  *  range type.
-  *
-  *  Factories for likely types include `Range.BigInt`, `Range.Long`,
-  *  and `Range.BigDecimal`.  `Range.Int` exists for completeness, but
-  *  the `Int`-based `scala.Range` should be more performant.
-  *
-  *  {{{
-  *     val r1 = Range(0, 100, 1)
-  *     val veryBig = Int.MaxValue.toLong + 1
-  *     val r2 = Range.Long(veryBig, veryBig + 100, 1)
-  *     assert(r1 sameElements r2.map(_ - veryBig))
-  *  }}}
-  *
-  *  @define Coll `NumericRange`
-  *  @define coll numeric range
-  *  @define mayNotTerminateInf
-  *  @define willNotTerminateInf
-  */
+ *  `Range` class which works with arbitrary types.
+ *  It must be supplied with an `Integral` implementation of the
+ *  range type.
+ *
+ *  Factories for likely types include `Range.BigInt`, `Range.Long`,
+ *  and `Range.BigDecimal`.  `Range.Int` exists for completeness, but
+ *  the `Int`-based `scala.Range` should be more performant.
+ *
+ *  ```
+ *     val r1 = Range(0, 100, 1)
+ *     val veryBig = Int.MaxValue.toLong + 1
+ *     val r2 = Range.Long(veryBig, veryBig + 100, 1)
+ *     assert(r1 sameElements r2.map(_ - veryBig))
+ *  ```
+ *
+ *  @define Coll `NumericRange`
+ *  @define coll numeric range
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
 @SerialVersionUID(3L)
 sealed class NumericRange[T](
   val start: T,
@@ -69,8 +69,8 @@ sealed class NumericRange[T](
 
 
   /** Note that NumericRange must be invariant so that constructs
-    *  such as "1L to 10 by 5" do not infer the range type as AnyVal.
-    */
+   *  such as "1L to 10 by 5" do not infer the range type as AnyVal.
+   */
   import num._
 
   // See comment in Range for why this must be lazy.
@@ -94,13 +94,12 @@ sealed class NumericRange[T](
     else new NumericRange.Exclusive(start + step, end, step)
 
   /** Creates a new range with the start and end values of this range and
-    *  a new `step`.
-    */
+   *  a new `step`.
+   */
   def by(newStep: T): NumericRange[T] = copy(start, end, newStep)
 
 
-  /** Creates a copy of this range.
-    */
+  /** Creates a copy of this range. */
   def copy(start: T, end: T, step: T): NumericRange[T] =
     new NumericRange(start, end, step, isInclusive)
 
@@ -330,9 +329,9 @@ sealed class NumericRange[T](
 }
 
 /** A companion object for numeric ranges.
-  *  @define Coll `NumericRange`
-  *  @define coll numeric range
-  */
+ *  @define Coll `NumericRange`
+ *  @define coll numeric range
+ */
 object NumericRange {
   private def bigDecimalCheckUnderflow[T](start: T, end: T, step: T)(implicit num: Integral[T]): Unit = {
     def FAIL(boundary: T, step: T): Unit = {
@@ -349,9 +348,9 @@ object NumericRange {
   }
 
   /** Calculates the number of elements in a range given start, end, step, and
-    *  whether or not it is inclusive.  Throws an exception if step == 0 or
-    *  the number of elements exceeds the maximum Int.
-    */
+   *  whether or not it is inclusive.  Throws an exception if step == 0 or
+   *  the number of elements exceeds the maximum Int.
+   */
   def count[T](start: T, end: T, step: T, isInclusive: Boolean)(implicit num: Integral[T]): Int = {
     val zero    = num.zero
     val upward  = num.lt(start, end)

--- a/library-js/src/scala/collection/immutable/Range.scala
+++ b/library-js/src/scala/collection/immutable/Range.scala
@@ -21,42 +21,42 @@ import scala.collection.{AbstractIterator, AnyStepper, IterableFactoryDefaults, 
 import scala.util.hashing.MurmurHash3
 
 /** The `Range` class represents integer values in range
-  *  ''[start;end)'' with non-zero step value `step`.
-  *  It's a special case of an indexed sequence.
-  *  For example:
-  *
-  *  {{{
-  *     val r1 = 0 until 10
-  *     val r2 = r1.start until r1.end by r1.step + 1
-  *     println(r2.length) // = 5
-  *  }}}
-  *
-  *  Ranges that contain more than `Int.MaxValue` elements can be created, but
-  *  these overfull ranges have only limited capabilities. Any method that
-  *  could require a collection of over `Int.MaxValue` length to be created, or
-  *  could be asked to index beyond `Int.MaxValue` elements will throw an
-  *  exception. Overfull ranges can safely be reduced in size by changing
-  *  the step size (e.g. `by 3`) or taking/dropping elements. `contains`,
-  *  `equals`, and access to the ends of the range (`head`, `last`, `tail`,
-  *  `init`) are also permitted on overfull ranges.
-  *
-  *  @param start       the start of this range.
-  *  @param end         the end of the range.  For exclusive ranges, e.g.
-  *                     `Range(0,3)` or `(0 until 3)`, this is one
-  *                     step past the last one in the range.  For inclusive
-  *                     ranges, e.g. `Range.inclusive(0,3)` or `(0 to 3)`,
-  *                     it may be in the range if it is not skipped by the step size.
-  *                     To find the last element inside a non-empty range,
-  *                     use `last` instead.
-  *  @param step        the step for the range.
-  *
-  *  @define coll range
-  *  @define mayNotTerminateInf
-  *  @define willNotTerminateInf
-  *  @define doesNotUseBuilders
-  *    '''Note:''' this method does not use builders to construct a new range,
-  *         and its complexity is O(1).
-  */
+ *  *[start;end)* with non-zero step value `step`.
+ *  It's a special case of an indexed sequence.
+ *  For example:
+ *
+ *  ```
+ *     val r1 = 0 until 10
+ *     val r2 = r1.start until r1.end by r1.step + 1
+ *     println(r2.length) // = 5
+ *  ```
+ *
+ *  Ranges that contain more than `Int.MaxValue` elements can be created, but
+ *  these overfull ranges have only limited capabilities. Any method that
+ *  could require a collection of over `Int.MaxValue` length to be created, or
+ *  could be asked to index beyond `Int.MaxValue` elements will throw an
+ *  exception. Overfull ranges can safely be reduced in size by changing
+ *  the step size (e.g. `by 3`) or taking/dropping elements. `contains`,
+ *  `equals`, and access to the ends of the range (`head`, `last`, `tail`,
+ *  `init`) are also permitted on overfull ranges.
+ *
+ *  @param start       the start of this range.
+ *  @param end         the end of the range.  For exclusive ranges, e.g.
+ *                     `Range(0,3)` or `(0 until 3)`, this is one
+ *                     step past the last one in the range.  For inclusive
+ *                     ranges, e.g. `Range.inclusive(0,3)` or `(0 to 3)`,
+ *                     it may be in the range if it is not skipped by the step size.
+ *                     To find the last element inside a non-empty range,
+ *                     use `last` instead.
+ *  @param step        the step for the range.
+ *
+ *  @define coll range
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ *  @define doesNotUseBuilders
+ *    **Note:** this method does not use builders to construct a new range,
+ *         and its complexity is O(1).
+ */
 @SerialVersionUID(3L)
 sealed abstract class Range(
   val start: Int,
@@ -120,28 +120,28 @@ sealed abstract class Range(
   }
 
   /** The last element of this range.  This method will return the correct value
-    *  even if there are too many elements to iterate over.
-    */
+   *  even if there are too many elements to iterate over.
+   */
   final override def last: Int =
     if (isEmpty) throw Range.emptyRangeError("last") else lastElement
   final override def head: Int =
     if (isEmpty) throw Range.emptyRangeError("head") else start
 
   /** Creates a new range containing all the elements of this range except the last one.
-    *
-    *  $doesNotUseBuilders
-    *
-    *  @return  a new range consisting of all the elements of this range except the last one.
-    */
+   *
+   *  $doesNotUseBuilders
+   *
+   *  @return  a new range consisting of all the elements of this range except the last one.
+   */
   final override def init: Range =
     if (isEmpty) throw Range.emptyRangeError("init") else dropRight(1)
 
   /** Creates a new range containing all the elements of this range except the first one.
-    *
-    *  $doesNotUseBuilders
-    *
-    *  @return  a new range consisting of all the elements of this range except the first one.
-    */
+   *
+   *  $doesNotUseBuilders
+   *
+   *  @return  a new range consisting of all the elements of this range except the first one.
+   */
   final override def tail: Range = {
     if (isEmpty) throw Range.emptyRangeError("tail")
     if (numRangeElements == 1) newEmptyRange(end)
@@ -158,10 +158,10 @@ sealed abstract class Range(
     if(isInclusive) new Range.Inclusive(start, end, step) else new Range.Exclusive(start, end, step)
 
   /** Creates a new range with the `start` and `end` values of this range and
-    *  a new `step`.
-    *
-    *  @return a new range with a different step
-    */
+   *  a new `step`.
+   *
+   *  @return a new range with a different step
+   */
   final def by(step: Int): Range = copy(start, end, step)
 
   // Check cannot be evaluated eagerly because we have a pattern where
@@ -228,10 +228,10 @@ sealed abstract class Range(
   }
 
   /** Creates a new range containing the first `n` elements of this range.
-    *
-    *  @param n  the number of elements to take.
-    *  @return   a new range consisting of `n` first elements.
-    */
+   *
+   *  @param n  the number of elements to take.
+   *  @return   a new range consisting of `n` first elements.
+   */
   final override def take(n: Int): Range =
     if (n <= 0 || isEmpty) newEmptyRange(start)
     else if (n >= numRangeElements && numRangeElements >= 0) this
@@ -242,10 +242,10 @@ sealed abstract class Range(
     }
 
   /** Creates a new range containing all the elements of this range except the first `n` elements.
-    *
-    *  @param n  the number of elements to drop.
-    *  @return   a new range consisting of all the elements of this range except `n` first elements.
-    */
+   *
+   *  @param n  the number of elements to drop.
+   *  @return   a new range consisting of all the elements of this range except `n` first elements.
+   */
   final override def drop(n: Int): Range =
     if (n <= 0 || isEmpty) this
     else if (n >= numRangeElements && numRangeElements >= 0) newEmptyRange(end)
@@ -256,9 +256,9 @@ sealed abstract class Range(
     }
 
   /** Creates a new range consisting of the last `n` elements of the range.
-    *
-    *  $doesNotUseBuilders
-    */
+   *
+   *  $doesNotUseBuilders
+   */
   final override def takeRight(n: Int): Range = {
     if (n <= 0) newEmptyRange(start)
     else if (numRangeElements >= 0) drop(numRangeElements - n)
@@ -272,9 +272,9 @@ sealed abstract class Range(
   }
 
   /** Creates a new range consisting of the initial `length - n` elements of the range.
-    *
-    *  $doesNotUseBuilders
-    */
+   *
+   *  $doesNotUseBuilders
+   */
   final override def dropRight(n: Int): Range = {
     if (n <= 0) this
     else if (numRangeElements >= 0) take(numRangeElements - n)
@@ -329,13 +329,13 @@ sealed abstract class Range(
   }
 
   /** Creates a new range containing the elements starting at `from` up to but not including `until`.
-    *
-    *  $doesNotUseBuilders
-    *
-    *  @param from  the element at which to start
-    *  @param until  the element at which to end (not included in the range)
-    *  @return   a new range consisting of a contiguous interval of values in the old range
-    */
+   *
+   *  $doesNotUseBuilders
+   *
+   *  @param from  the element at which to start
+   *  @param until  the element at which to end (not included in the range)
+   *  @return   a new range consisting of a contiguous interval of values in the old range
+   */
   final override def slice(from: Int, until: Int): Range =
     if (from <= 0) take(until)
     else if (until >= numRangeElements && numRangeElements >= 0) drop(from)
@@ -358,14 +358,12 @@ sealed abstract class Range(
   // based on the given value.
   private[this] def newEmptyRange(value: Int) = new Range.Exclusive(value, value, step)
 
-  /** Returns the reverse of this range.
-    */
+  /** Returns the reverse of this range. */
   final override def reverse: Range =
     if (isEmpty) this
     else new Range.Inclusive(last, start, -step)
 
-  /** Makes range inclusive.
-    */
+  /** Makes range inclusive. */
   final def inclusive: Range =
     if (isInclusive) this
     else new Range.Inclusive(start, end, step)
@@ -521,11 +519,10 @@ sealed abstract class Range(
     }
 }
 
-/**
-  * Companion object for ranges.
-  *  @define Coll `Range`
-  *  @define coll range
-  */
+/** Companion object for ranges.
+ *  @define Coll `Range`
+ *  @define coll range
+ */
 object Range {
 
   private def description(start: Int, end: Int, step: Int, isInclusive: Boolean) =
@@ -536,10 +533,10 @@ object Range {
         ": seqs cannot contain more than Int.MaxValue elements.")
 
   /** Counts the number of range elements.
-    *  precondition:  step != 0
-    *  If the size of the range exceeds Int.MaxValue, the
-    *  result will be negative.
-    */
+   *  precondition:  step != 0
+   *  If the size of the range exceeds Int.MaxValue, the
+   *  result will be negative.
+   */
   def count(start: Int, end: Int, step: Int, isInclusive: Boolean): Int = {
     if (step == 0)
       throw new IllegalArgumentException("step cannot be 0.")
@@ -567,21 +564,19 @@ object Range {
     count(start, end, step, isInclusive = false)
 
   /** Makes a range from `start` until `end` (exclusive) with given step value.
-    * @note step != 0
-    */
+   *  @note step != 0
+   */
   def apply(start: Int, end: Int, step: Int): Range.Exclusive = new Range.Exclusive(start, end, step)
 
-  /** Makes a range from `start` until `end` (exclusive) with step value 1.
-    */
+  /** Makes a range from `start` until `end` (exclusive) with step value 1. */
   def apply(start: Int, end: Int): Range.Exclusive = new Range.Exclusive(start, end, 1)
 
   /** Makes an inclusive range from `start` to `end` with given step value.
-    * @note step != 0
-    */
+   *  @note step != 0
+   */
   def inclusive(start: Int, end: Int, step: Int): Range.Inclusive = new Range.Inclusive(start, end, step)
 
-  /** Makes an inclusive range from `start` to `end` with step value 1.
-    */
+  /** Makes an inclusive range from `start` to `end` with step value 1. */
   def inclusive(start: Int, end: Int): Range.Inclusive = new Range.Inclusive(start, end, 1)
 
   @SerialVersionUID(3L)
@@ -642,9 +637,9 @@ object Range {
 }
 
 /**
-  * @param lastElement The last element included in the Range
-  * @param initiallyEmpty Whether the Range was initially empty or not
-  */
+ *  @param lastElement The last element included in the Range
+ *  @param initiallyEmpty Whether the Range was initially empty or not
+ */
 @SerialVersionUID(3L)
 private class RangeIterator(
   start: Int,

--- a/library-js/src/scala/collection/mutable/Buffer.scala
+++ b/library-js/src/scala/collection/mutable/Buffer.scala
@@ -31,24 +31,24 @@ trait Buffer[A]
 
   //TODO Prepend is a logical choice for a readable name of `+=:` but it conflicts with the renaming of `append` to `add`
   /** Prepends a single element at the front of this $coll.
-    *
-    *  @param elem  the element to $add.
-    *  @return the $coll itself
-    */
+   *
+   *  @param elem  the element to $add.
+   *  @return the $coll itself
+   */
   def prepend(elem: A): this.type
 
   /** Appends the given elements to this buffer.
-    *
-    *  @param elem  the element to append.
-    */
+   *
+   *  @param elem  the element to append.
+   */
   @`inline` final def append(elem: A): this.type = addOne(elem)
 
   @deprecated("Use appendAll instead", "2.13.0")
   @`inline` final def append(elems: A*): this.type = addAll(elems)
 
   /** Appends the elements contained in a iterable object to this buffer.
-    *  @param xs  the iterable object containing the elements to append.
-    */
+   *  @param xs  the iterable object containing the elements to append.
+   */
   @`inline` final def appendAll(xs: IterableOnce[A]): this.type = addAll(xs)
 
 
@@ -64,71 +64,71 @@ trait Buffer[A]
   @inline final def ++=:(elems: IterableOnce[A]): this.type = prependAll(elems)
 
   /** Inserts a new element at a given index into this buffer.
-    *
-    *  @param idx    the index where the new elements is inserted.
-    *  @param elem   the element to insert.
-    *  @throws   IndexOutOfBoundsException if the index `idx` is not in the valid range
-    *            `0 <= idx <= length`.
-    */
+   *
+   *  @param idx    the index where the new elements is inserted.
+   *  @param elem   the element to insert.
+   *  @throws   IndexOutOfBoundsException if the index `idx` is not in the valid range
+   *            `0 <= idx <= length`.
+   */
   @throws[IndexOutOfBoundsException]
   def insert(idx: Int, elem: A): Unit
 
   /** Inserts new elements at the index `idx`. Opposed to method
-    *  `update`, this method will not replace an element with a new
-    *  one. Instead, it will insert a new element at index `idx`.
-    *
-    *  @param idx     the index where a new element will be inserted.
-    *  @param elems   the iterable object providing all elements to insert.
-    *  @throws IndexOutOfBoundsException if `idx` is out of bounds.
-    */
+   *  `update`, this method will not replace an element with a new
+   *  one. Instead, it will insert a new element at index `idx`.
+   *
+   *  @param idx     the index where a new element will be inserted.
+   *  @param elems   the iterable object providing all elements to insert.
+   *  @throws IndexOutOfBoundsException if `idx` is out of bounds.
+   */
   @throws[IndexOutOfBoundsException]
   def insertAll(idx: Int, elems: IterableOnce[A]): Unit
 
   /** Removes the element at a given index position.
-    *
-    *  @param idx  the index which refers to the element to delete.
-    *  @return   the element that was formerly at index `idx`.
-    */
+   *
+   *  @param idx  the index which refers to the element to delete.
+   *  @return   the element that was formerly at index `idx`.
+   */
   @throws[IndexOutOfBoundsException]
   def remove(idx: Int): A
 
   /** Removes the element on a given index position. It takes time linear in
-    *  the buffer size.
-    *
-    *  @param idx       the index which refers to the first element to remove.
-    *  @param count   the number of elements to remove.
-    *  @throws   IndexOutOfBoundsException if the index `idx` is not in the valid range
-    *            `0 <= idx <= length - count` (with `count > 0`).
-    *  @throws   IllegalArgumentException if `count < 0`.
-    */
+   *  the buffer size.
+   *
+   *  @param idx       the index which refers to the first element to remove.
+   *  @param count   the number of elements to remove.
+   *  @throws   IndexOutOfBoundsException if the index `idx` is not in the valid range
+   *            `0 <= idx <= length - count` (with `count > 0`).
+   *  @throws   IllegalArgumentException if `count < 0`.
+   */
   @throws[IndexOutOfBoundsException]
   @throws[IllegalArgumentException]
   def remove(idx: Int, count: Int): Unit
 
   /** Removes a single element from this buffer, at its first occurrence.
-    *  If the buffer does not contain that element, it is unchanged.
-    *
-    *  @param x  the element to remove.
-    *  @return   the buffer itself
-    */
+   *  If the buffer does not contain that element, it is unchanged.
+   *
+   *  @param x  the element to remove.
+   *  @return   the buffer itself
+   */
   def subtractOne (x: A): this.type = {
     val i = indexOf(x)
     if (i != -1) remove(i)
     this
   }
 
-  /** Removes the first ''n'' elements of this buffer.
-    *
-    *  @param n  the number of elements to remove from the beginning
-    *            of this buffer.
-    */
+  /** Removes the first *n* elements of this buffer.
+   *
+   *  @param n  the number of elements to remove from the beginning
+   *            of this buffer.
+   */
   def trimStart(n: Int): Unit = remove(0, normalized(n))
 
-  /** Removes the last ''n'' elements of this buffer.
-    *
-    *  @param n  the number of elements to remove from the end
-    *            of this buffer.
-    */
+  /** Removes the last *n* elements of this buffer.
+   *
+   *  @param n  the number of elements to remove from the end
+   *            of this buffer.
+   */
   def trimEnd(n: Int): Unit = {
     val norm = normalized(n)
     remove(length - norm, norm)

--- a/library-js/src/scala/concurrent/ExecutionContext.scala
+++ b/library-js/src/scala/concurrent/ExecutionContext.scala
@@ -17,46 +17,45 @@ import scala.language.`2.13`
 import java.util.concurrent.{ ExecutorService, Executor }
 import scala.annotation.implicitNotFound
 
-/**
- * An `ExecutionContext` can execute program logic asynchronously,
- * typically but not necessarily on a thread pool.
+/** An `ExecutionContext` can execute program logic asynchronously,
+ *  typically but not necessarily on a thread pool.
  *
- * A general purpose `ExecutionContext` must be asynchronous in executing
- * any `Runnable` that is passed into its `execute`-method. A special purpose
- * `ExecutionContext` may be synchronous but must only be passed to code that
- * is explicitly safe to be run using a synchronously executing `ExecutionContext`.
+ *  A general purpose `ExecutionContext` must be asynchronous in executing
+ *  any `Runnable` that is passed into its `execute`-method. A special purpose
+ *  `ExecutionContext` may be synchronous but must only be passed to code that
+ *  is explicitly safe to be run using a synchronously executing `ExecutionContext`.
  *
- * APIs such as `Future.onComplete` require you to provide a callback
- * and an implicit `ExecutionContext`. The implicit `ExecutionContext`
- * will be used to execute the callback.
+ *  APIs such as `Future.onComplete` require you to provide a callback
+ *  and an implicit `ExecutionContext`. The implicit `ExecutionContext`
+ *  will be used to execute the callback.
  *
- * While it is possible to simply import
- * `scala.concurrent.ExecutionContext.Implicits.global` to obtain an
- * implicit `ExecutionContext`, application developers should carefully
- * consider where they want to set execution policy;
- * ideally, one place per application—or per logically related section of code—
- * will make a decision about which `ExecutionContext` to use.
- * That is, you will mostly want to avoid hardcoding, especially via an import,
- * `scala.concurrent.ExecutionContext.Implicits.global`.
- * The recommended approach is to add `(implicit ec: ExecutionContext)` to methods,
- * or class constructor parameters, which need an `ExecutionContext`.
+ *  While it is possible to simply import
+ *  `scala.concurrent.ExecutionContext.Implicits.global` to obtain an
+ *  implicit `ExecutionContext`, application developers should carefully
+ *  consider where they want to set execution policy;
+ *  ideally, one place per application—or per logically related section of code—
+ *  will make a decision about which `ExecutionContext` to use.
+ *  That is, you will mostly want to avoid hardcoding, especially via an import,
+ *  `scala.concurrent.ExecutionContext.Implicits.global`.
+ *  The recommended approach is to add `(implicit ec: ExecutionContext)` to methods,
+ *  or class constructor parameters, which need an `ExecutionContext`.
  *
- * Then locally import a specific `ExecutionContext` in one place for the entire
- * application or module, passing it implicitly to individual methods.
- * Alternatively define a local implicit val with the required `ExecutionContext`.
+ *  Then locally import a specific `ExecutionContext` in one place for the entire
+ *  application or module, passing it implicitly to individual methods.
+ *  Alternatively define a local implicit val with the required `ExecutionContext`.
  *
- * A custom `ExecutionContext` may be appropriate to execute code
- * which blocks on IO or performs long-running computations.
- * `ExecutionContext.fromExecutorService` and `ExecutionContext.fromExecutor`
- * are good ways to create a custom `ExecutionContext`.
+ *  A custom `ExecutionContext` may be appropriate to execute code
+ *  which blocks on IO or performs long-running computations.
+ *  `ExecutionContext.fromExecutorService` and `ExecutionContext.fromExecutor`
+ *  are good ways to create a custom `ExecutionContext`.
  *
- * The intent of `ExecutionContext` is to lexically scope code execution.
- * That is, each method, class, file, package, or application determines
- * how to run its own code. This avoids issues such as running
- * application callbacks on a thread pool belonging to a networking library.
- * The size of a networking library's thread pool can be safely configured,
- * knowing that only that library's network operations will be affected.
- * Application callback execution can be configured separately.
+ *  The intent of `ExecutionContext` is to lexically scope code execution.
+ *  That is, each method, class, file, package, or application determines
+ *  how to run its own code. This avoids issues such as running
+ *  application callbacks on a thread pool belonging to a networking library.
+ *  The size of a networking library's thread pool can be safely configured,
+ *  knowing that only that library's network operations will be affected.
+ *  Application callback execution can be configured separately.
  */
 @implicitNotFound("""Cannot find an implicit ExecutionContext. You might pass
 an (implicit ec: ExecutionContext) parameter to your method.
@@ -85,82 +84,77 @@ trait ExecutionContext {
   def reportFailure(@deprecatedName("t") cause: Throwable): Unit
 
   /** Prepares for the execution of a task. Returns the prepared
-     *  execution context. The recommended implementation of
-     *  `prepare` is to return `this`.
-     *
-     *  This method should no longer be overridden or called. It was
-     *  originally expected that `prepare` would be called by
-     *  all libraries that consume ExecutionContexts, in order to
-     *  capture thread local context. However, this usage has proven
-     *  difficult to implement in practice and instead it is
-     *  now better to avoid using `prepare` entirely.
-     *
-     *  Instead, if an `ExecutionContext` needs to capture thread
-     *  local context, it should capture that context when it is
-     *  constructed, so that it doesn't need any additional
-     *  preparation later.
-     */
+   *  execution context. The recommended implementation of
+   *  `prepare` is to return `this`.
+   *
+   *  This method should no longer be overridden or called. It was
+   *  originally expected that `prepare` would be called by
+   *  all libraries that consume ExecutionContexts, in order to
+   *  capture thread local context. However, this usage has proven
+   *  difficult to implement in practice and instead it is
+   *  now better to avoid using `prepare` entirely.
+   *
+   *  Instead, if an `ExecutionContext` needs to capture thread
+   *  local context, it should capture that context when it is
+   *  constructed, so that it doesn't need any additional
+   *  preparation later.
+   */
   @deprecated("preparation of ExecutionContexts will be removed", "2.12.0")
   // This cannot be removed until there is a suitable replacement
   def prepare(): ExecutionContext = this
 }
 
-/**
- * An [[ExecutionContext]] that is also a
- * Java [[http://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/Executor.html Executor]].
+/** An [[ExecutionContext]] that is also a
+ *  Java [Executor](http://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/Executor.html).
  */
 trait ExecutionContextExecutor extends ExecutionContext with Executor
 
-/**
- * An [[ExecutionContext]] that is also a
- * Java [[http://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/ExecutorService.html ExecutorService]].
+/** An [[ExecutionContext]] that is also a
+ *  Java [ExecutorService](http://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/ExecutorService.html).
  */
 trait ExecutionContextExecutorService extends ExecutionContextExecutor with ExecutorService
 
 
-/** Contains factory methods for creating execution contexts.
- */
+/** Contains factory methods for creating execution contexts. */
 object ExecutionContext {
-  /**
-   * The explicit global `ExecutionContext`. Invoke `global` when you want to provide the global
-   * `ExecutionContext` explicitly.
+  /** The explicit global `ExecutionContext`. Invoke `global` when you want to provide the global
+   *  `ExecutionContext` explicitly.
    *
-   * The default `ExecutionContext` implementation is backed by a work-stealing thread pool.
-   * It can be configured via the following [[scala.sys.SystemProperties]]:
+   *  The default `ExecutionContext` implementation is backed by a work-stealing thread pool.
+   *  It can be configured via the following [[scala.sys.SystemProperties]]:
    *
-   * `scala.concurrent.context.minThreads` = defaults to "1"
-   * `scala.concurrent.context.numThreads` = defaults to "x1" (i.e. the current number of available processors * 1)
-   * `scala.concurrent.context.maxThreads` = defaults to "x1" (i.e. the current number of available processors * 1)
-   * `scala.concurrent.context.maxExtraThreads` = defaults to "256"
+   *  `scala.concurrent.context.minThreads` = defaults to "1"
+   *  `scala.concurrent.context.numThreads` = defaults to "x1" (i.e. the current number of available processors * 1)
+   *  `scala.concurrent.context.maxThreads` = defaults to "x1" (i.e. the current number of available processors * 1)
+   *  `scala.concurrent.context.maxExtraThreads` = defaults to "256"
    *
-   * The pool size of threads is then `numThreads` bounded by `minThreads` on the lower end and `maxThreads` on the high end.
+   *  The pool size of threads is then `numThreads` bounded by `minThreads` on the lower end and `maxThreads` on the high end.
    *
-   * The `maxExtraThreads` is the maximum number of extra threads to have at any given time to evade deadlock,
-   * see [[scala.concurrent.BlockContext]].
+   *  The `maxExtraThreads` is the maximum number of extra threads to have at any given time to evade deadlock,
+   *  see [[scala.concurrent.BlockContext]].
    *
-   * @return the global `ExecutionContext`
+   *  @return the global `ExecutionContext`
    */
   final lazy val global: ExecutionContextExecutor =
     scala.scalajs.concurrent.JSExecutionContext.queue
 
-  /**
-   * WARNING: Only ever execute logic which will quickly return control to the caller.
+  /** WARNING: Only ever execute logic which will quickly return control to the caller.
    *
-   * This `ExecutionContext` steals execution time from other threads by having its
-   * `Runnable`s run on the `Thread` which calls `execute` and then yielding back control
-   * to the caller after *all* its `Runnable`s have been executed.
-   * Nested invocations of `execute` will be trampolined to prevent uncontrolled stack space growth.
+   *  This `ExecutionContext` steals execution time from other threads by having its
+   *  `Runnable`s run on the `Thread` which calls `execute` and then yielding back control
+   *  to the caller after *all* its `Runnable`s have been executed.
+   *  Nested invocations of `execute` will be trampolined to prevent uncontrolled stack space growth.
    *
-   * When using `parasitic` with abstractions such as `Future` it will in many cases be non-deterministic
-   * as to which `Thread` will be executing the logic, as it depends on when/if that `Future` is completed.
+   *  When using `parasitic` with abstractions such as `Future` it will in many cases be non-deterministic
+   *  as to which `Thread` will be executing the logic, as it depends on when/if that `Future` is completed.
    *
-   * Do *not* call any blocking code in the `Runnable`s submitted to this `ExecutionContext`
-   * as it will prevent progress by other enqueued `Runnable`s and the calling `Thread`.
+   *  Do *not* call any blocking code in the `Runnable`s submitted to this `ExecutionContext`
+   *  as it will prevent progress by other enqueued `Runnable`s and the calling `Thread`.
    *
-   * Symptoms of misuse of this `ExecutionContext` include, but are not limited to, deadlocks
-   * and severe performance problems.
+   *  Symptoms of misuse of this `ExecutionContext` include, but are not limited to, deadlocks
+   *  and severe performance problems.
    *
-   * Any `NonFatal` or `InterruptedException`s will be reported to the `defaultReporter`.
+   *  Any `NonFatal` or `InterruptedException`s will be reported to the `defaultReporter`.
    */
   object parasitic extends ExecutionContextExecutor with BatchingExecutor {
     override final def submitForExecution(runnable: Runnable): Unit = runnable.run()
@@ -169,13 +163,12 @@ object ExecutionContext {
   }
 
   object Implicits {
-    /**
-     * The implicit global `ExecutionContext`. Import `global` when you want to provide the global
-     * `ExecutionContext` implicitly.
+    /** The implicit global `ExecutionContext`. Import `global` when you want to provide the global
+     *  `ExecutionContext` implicitly.
      *
-     * The default `ExecutionContext` implementation is backed by a work-stealing thread pool. By default,
-     * the thread pool uses a target number of worker threads equal to the number of
-     * [[https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Runtime.html#availableProcessors() available processors]].
+     *  The default `ExecutionContext` implementation is backed by a work-stealing thread pool. By default,
+     *  the thread pool uses a target number of worker threads equal to the number of
+     *  [available processors](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Runtime.html#availableProcessors()).
      */
     implicit final def global: ExecutionContext = ExecutionContext.global
   }
@@ -194,10 +187,10 @@ object ExecutionContext {
    *  If it is guaranteed that none of the executed tasks are blocking, a single-threaded `ExecutorService`
    *  can be used to create an `ExecutionContext` as follows:
    *
-   *  {{{
+   *  ```
    *  import java.util.concurrent.Executors
    *  val ec = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
-   *  }}}
+   *  ```
    *
    *  @param e the `ExecutorService` to use. If `null`, a new `ExecutorService` is created with [[scala.concurrent.ExecutionContext$.global default configuration]].
    *  @return  the `ExecutionContext` using the given `ExecutorService`
@@ -220,7 +213,7 @@ object ExecutionContext {
    */
   def fromExecutor(e: Executor): ExecutionContextExecutor = fromExecutor(e, defaultReporter)
 
-  /** The default reporter simply prints the stack trace of the `Throwable` to [[http://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/System.html#err System.err]].
+  /** The default reporter simply prints the stack trace of the `Throwable` to [System.err](http://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/System.html#err).
    *
    *  @return the function for error reporting
    */

--- a/library-js/src/scala/reflect/ClassTag.scala
+++ b/library-js/src/scala/reflect/ClassTag.scala
@@ -22,20 +22,18 @@ import java.lang.{ Class => jClass }
 import scala.collection.mutable
 import scala.runtime.BoxedUnit
 
-/**
+/** A `ClassTag[T]` stores the erased class of a given type `T`, accessible via the `runtimeClass`
+ *  field. This is particularly useful for instantiating `Array`s whose element types are unknown
+ *  at compile time.
  *
- * A `ClassTag[T]` stores the erased class of a given type `T`, accessible via the `runtimeClass`
- * field. This is particularly useful for instantiating `Array`s whose element types are unknown
- * at compile time.
+ *  `ClassTag`s are a weaker special case of [[scala.reflect.api.TypeTags#TypeTag]]s, in that they
+ *  wrap only the runtime class of a given type, whereas a `TypeTag` contains all static type
+ *  information. That is, `ClassTag`s are constructed from knowing only the top-level class of a
+ *  type, without necessarily knowing all of its argument types. This runtime information is enough
+ *  for runtime `Array` creation.
  *
- * `ClassTag`s are a weaker special case of [[scala.reflect.api.TypeTags#TypeTag]]s, in that they
- * wrap only the runtime class of a given type, whereas a `TypeTag` contains all static type
- * information. That is, `ClassTag`s are constructed from knowing only the top-level class of a
- * type, without necessarily knowing all of its argument types. This runtime information is enough
- * for runtime `Array` creation.
- *
- * For example:
- * {{{
+ *  For example:
+ *  ```
  *   scala> def mkArray[T : ClassTag](elems: T*) = Array[T](elems: _*)
  *   mkArray: [T](elems: T*)(implicit evidence$1: scala.reflect.ClassTag[T])Array[T]
  *
@@ -44,12 +42,11 @@ import scala.runtime.BoxedUnit
  *
  *   scala> mkArray("Japan","Brazil","Germany")
  *   res1: Array[String] = Array(Japan, Brazil, Germany)
- * }}}
+ *  ```
  *
- * See [[scala.reflect.api.TypeTags]] for more examples, or the
- * [[http://docs.scala-lang.org/overviews/reflection/typetags-manifests.html Reflection Guide: TypeTags]]
- * for more details.
- *
+ *  See [[scala.reflect.api.TypeTags]] for more examples, or the
+ *  [Reflection Guide: TypeTags](http://docs.scala-lang.org/overviews/reflection/typetags-manifests.html)
+ *  for more details.
  */
 @scala.annotation.implicitNotFound(msg = "No ClassTag available for ${T}")
 trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serializable {
@@ -70,11 +67,11 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
 
   /** A ClassTag[T] can serve as an extractor that matches only objects of type T.
    *
-   * The compiler tries to turn unchecked type tests in pattern matches into checked ones
-   * by wrapping a `(_: T)` type pattern as `ct(_: T)`, where `ct` is the `ClassTag[T]` instance.
-   * Type tests necessary before calling other extractors are treated similarly.
-   * `SomeExtractor(...)` is turned into `ct(SomeExtractor(...))` if `T` in `SomeExtractor.unapply(x: T)`
-   * is uncheckable, but we have an instance of `ClassTag[T]`.
+   *  The compiler tries to turn unchecked type tests in pattern matches into checked ones
+   *  by wrapping a `(_: T)` type pattern as `ct(_: T)`, where `ct` is the `ClassTag[T]` instance.
+   *  Type tests necessary before calling other extractors are treated similarly.
+   *  `SomeExtractor(...)` is turned into `ct(SomeExtractor(...))` if `T` in `SomeExtractor.unapply(x: T)`
+   *  is uncheckable, but we have an instance of `ClassTag[T]`.
    */
   def unapply(x: Any): Option[T] =
     if (runtimeClass.isInstance(x)) Some(x.asInstanceOf[T])
@@ -92,9 +89,7 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
   }
 }
 
-/**
- * Class tags corresponding to primitive types and constructor/extractor for ClassTags.
- */
+/** Class tags corresponding to primitive types and constructor/extractor for ClassTags. */
 object ClassTag {
   import ManifestFactory._
 

--- a/library-js/src/scala/reflect/Manifest.scala
+++ b/library-js/src/scala/reflect/Manifest.scala
@@ -27,7 +27,7 @@ import scala.collection.mutable.{ArrayBuilder, ArraySeq}
  *  which are not yet adequately represented in manifests.
  *
  *  Example usages:
- *  {{{
+ *  ```
  *    def arr[T] = new Array[T](0)                          // does not compile
  *    def arr[T](implicit m: Manifest[T]) = new Array[T](0) // compiles
  *    def arr[T: Manifest] = new Array[T](0)                // shorthand for the preceding
@@ -42,7 +42,7 @@ import scala.collection.mutable.{ArrayBuilder, ArraySeq}
  *      methods[T] find (_.getName == name) map (_.getGenericReturnType)
  *
  *    retType[Map[_, _]]("values")  // Some(scala.collection.Iterable<B>)
- *  }}}
+ *  ```
  */
 @scala.annotation.implicitNotFound(msg = "No Manifest available for ${T}.")
 // TODO undeprecated until Scala reflection becomes non-experimental
@@ -104,23 +104,24 @@ object Manifest {
     ManifestFactory.singleType[T](value)
 
   /** Manifest for the class type `clazz[args]`, where `clazz` is
-    * a top-level or static class.
-    * @note This no-prefix, no-arguments case is separate because we
-    *       it's called from ScalaRunTime.boxArray itself. If we
-    *       pass varargs as arrays into this, we get an infinitely recursive call
-    *       to boxArray. (Besides, having a separate case is more efficient)
-    */
+   *  a top-level or static class.
+   *  @note This no-prefix, no-arguments case is separate because we
+   *       it's called from ScalaRunTime.boxArray itself. If we
+   *       pass varargs as arrays into this, we get an infinitely recursive call
+   *       to boxArray. (Besides, having a separate case is more efficient)
+   */
   def classType[T](clazz: Predef.Class[_]): Manifest[T] =
     ManifestFactory.classType[T](clazz)
 
   /** Manifest for the class type `clazz`, where `clazz` is
-    * a top-level or static class and args are its type arguments. */
+   *  a top-level or static class and args are its type arguments. 
+   */
   def classType[T](clazz: Predef.Class[T], arg1: Manifest[_], args: Manifest[_]*): Manifest[T] =
     ManifestFactory.classType[T](clazz, arg1, args: _*)
 
   /** Manifest for the class type `clazz[args]`, where `clazz` is
-    * a class with non-package prefix type `prefix` and type arguments `args`.
-    */
+   *  a class with non-package prefix type `prefix` and type arguments `args`.
+   */
   def classType[T](prefix: Manifest[_], clazz: Predef.Class[_], args: Manifest[_]*): Manifest[T] =
     ManifestFactory.classType[T](prefix, clazz, args: _*)
 
@@ -128,8 +129,9 @@ object Manifest {
     ManifestFactory.arrayType[T](arg)
 
   /** Manifest for the abstract type `prefix # name`. `upperBound` is not
-    * strictly necessary as it could be obtained by reflection. It was
-    * added so that erasure can be calculated without reflection. */
+   *  strictly necessary as it could be obtained by reflection. It was
+   *  added so that erasure can be calculated without reflection. 
+   */
   def abstractType[T](prefix: Manifest[_], name: String, upperBound: Predef.Class[_], args: Manifest[_]*): Manifest[T] =
     ManifestFactory.abstractType[T](prefix, name, upperBound, args: _*)
 
@@ -379,23 +381,24 @@ object ManifestFactory {
     new SingletonTypeManifest[T](value)
 
   /** Manifest for the class type `clazz[args]`, where `clazz` is
-    * a top-level or static class.
-    * @note This no-prefix, no-arguments case is separate because we
-    *       it's called from ScalaRunTime.boxArray itself. If we
-    *       pass varargs as arrays into this, we get an infinitely recursive call
-    *       to boxArray. (Besides, having a separate case is more efficient)
-    */
+   *  a top-level or static class.
+   *  @note This no-prefix, no-arguments case is separate because we
+   *       it's called from ScalaRunTime.boxArray itself. If we
+   *       pass varargs as arrays into this, we get an infinitely recursive call
+   *       to boxArray. (Besides, having a separate case is more efficient)
+   */
   def classType[T](clazz: Predef.Class[_]): Manifest[T] =
     new ClassTypeManifest[T](None, clazz, Nil)
 
   /** Manifest for the class type `clazz`, where `clazz` is
-    * a top-level or static class and args are its type arguments. */
+   *  a top-level or static class and args are its type arguments. 
+   */
   def classType[T](clazz: Predef.Class[T], arg1: Manifest[_], args: Manifest[_]*): Manifest[T] =
     new ClassTypeManifest[T](None, clazz, arg1 :: args.toList)
 
   /** Manifest for the class type `clazz[args]`, where `clazz` is
-    * a class with non-package prefix type `prefix` and type arguments `args`.
-    */
+   *  a class with non-package prefix type `prefix` and type arguments `args`.
+   */
   def classType[T](prefix: Manifest[_], clazz: Predef.Class[_], args: Manifest[_]*): Manifest[T] =
     new ClassTypeManifest[T](Some(prefix), clazz, args.toList)
 
@@ -407,7 +410,8 @@ object ManifestFactory {
   }
 
   /** Manifest for the class type `clazz[args]`, where `clazz` is
-    * a top-level or static class. */
+   *  a top-level or static class. 
+   */
   @SerialVersionUID(1L)
   private class ClassTypeManifest[T](prefix: Option[Manifest[_]],
                                      runtimeClass1: Predef.Class[_],
@@ -430,8 +434,9 @@ object ManifestFactory {
   }
 
   /** Manifest for the abstract type `prefix # name`. `upperBound` is not
-    * strictly necessary as it could be obtained by reflection. It was
-    * added so that erasure can be calculated without reflection. */
+   *  strictly necessary as it could be obtained by reflection. It was
+   *  added so that erasure can be calculated without reflection. 
+   */
   def abstractType[T](prefix: Manifest[_], name: String, upperBound: Predef.Class[_], args: Manifest[_]*): Manifest[T] =
     new AbstractTypeManifest[T](prefix, name, upperBound, args)
 
@@ -444,8 +449,7 @@ object ManifestFactory {
         (if (upperBound eq Nothing) "" else " <: "+upperBound)
   }
 
-  /** Manifest for the unknown type `_ >: L <: U` in an existential.
-    */
+  /** Manifest for the unknown type `_ >: L <: U` in an existential. */
   def wildcardType[T](lowerBound: Manifest[_], upperBound: Manifest[_]): Manifest[T] =
     new WildcardManifest[T](lowerBound, upperBound)
 

--- a/library-js/src/scala/runtime/ScalaRunTime.scala
+++ b/library-js/src/scala/runtime/ScalaRunTime.scala
@@ -39,8 +39,7 @@ object ScalaRunTime {
   def drop[Repr](coll: Repr, num: Int)(implicit iterable: IsIterable[Repr] { type C <: Repr }): Repr =
     iterable(coll) drop num
 
-  /** Returns the class object representing an array with element class `clazz`.
-   */
+  /** Returns the class object representing an array with element class `clazz`. */
   def arrayClass(clazz: jClass[_]): jClass[_] = {
     // newInstance throws an exception if the erasure is Void.TYPE. see scala/bug#5680
     if (clazz == java.lang.Void.TYPE) classOf[Array[Unit]]
@@ -153,15 +152,15 @@ object ScalaRunTime {
 
   /** Given any Scala value, convert it to a String.
    *
-   * The primary motivation for this method is to provide a means for
-   * correctly obtaining a String representation of a value, while
-   * avoiding the pitfalls of naively calling toString on said value.
-   * In particular, it addresses the fact that (a) toString cannot be
-   * called on null and (b) depending on the apparent type of an
-   * array, toString may or may not print it in a human-readable form.
+   *  The primary motivation for this method is to provide a means for
+   *  correctly obtaining a String representation of a value, while
+   *  avoiding the pitfalls of naively calling toString on said value.
+   *  In particular, it addresses the fact that (a) toString cannot be
+   *  called on null and (b) depending on the apparent type of an
+   *  array, toString may or may not print it in a human-readable form.
    *
-   * @param   arg   the value to stringify
-   * @return        a string representation of arg.
+   *  @param   arg   the value to stringify
+   *  @return        a string representation of arg.
    */
   def stringOf(arg: Any): String = stringOf(arg, scala.Int.MaxValue)
   def stringOf(arg: Any, maxElements: Int): String = {

--- a/library-js/src/scala/util/DynamicVariable.scala
+++ b/library-js/src/scala/util/DynamicVariable.scala
@@ -27,12 +27,12 @@ import java.lang.InheritableThreadLocal
  *  parameterless closure, executes. When the second argument finishes,
  *  the variable reverts to the previous value.
  *
- *  {{{
+ *  ```
  *  someDynamicVariable.withValue(newValue) {
  *    // ... code called in here that calls value ...
  *    // ... will be given back the newValue ...
  *  }
- *  }}}
+ *  ```
  *
  *  Each thread gets its own stack of bindings.  When a
  *  new thread is created, the `DynamicVariable` gets a copy
@@ -54,11 +54,11 @@ class DynamicVariable[T](init: T) {
   def value: T = v
 
   /** Sets the value of the variable while executing the specified
-    * thunk.
-    *
-    * @param newval The value to which to set the variable
-    * @param thunk The code to evaluate under the new setting
-    */
+   *  thunk.
+   *
+   *  @param newval The value to which to set the variable
+   *  @param thunk The code to evaluate under the new setting
+   */
   def withValue[S](newval: T)(thunk: => S): S = {
     val oldval = v
     v = newval
@@ -68,8 +68,8 @@ class DynamicVariable[T](init: T) {
   }
 
   /** Changes the currently bound value, discarding the old value.
-    * Usually withValue() gives better semantics.
-    */
+   *  Usually withValue() gives better semantics.
+   */
   def value_=(newval: T) = v = newval
 
   override def toString: String = "DynamicVariable(" + value + ")"

--- a/library/src/scala/AnyVal.scala
+++ b/library/src/scala/AnyVal.scala
@@ -14,24 +14,24 @@ package scala
 
 import scala.language.`2.13`
 
-/** `AnyVal` is the root class of all ''value types'', which describe values
+/** `AnyVal` is the root class of all *value types*, which describe values
  *  not implemented as objects in the underlying host system. Value classes
  *  are specified in Scala Language Specification, section 12.2.
  *
  *  The standard implementation includes nine `AnyVal` subtypes:
  *
  *  [[scala.Double]], [[scala.Float]], [[scala.Long]], [[scala.Int]], [[scala.Char]],
- *  [[scala.Short]], and [[scala.Byte]] are the ''numeric value types''.
+ *  [[scala.Short]], and [[scala.Byte]] are the *numeric value types*.
  *
- *  [[scala.Unit]] and [[scala.Boolean]] are the ''non-numeric value types''.
+ *  [[scala.Unit]] and [[scala.Boolean]] are the *non-numeric value types*.
  *
  *  Other groupings:
  *
- *   - The ''subrange types'' are [[scala.Byte]], [[scala.Short]], and [[scala.Char]].
- *   - The ''integer types'' include the subrange types as well as [[scala.Int]] and [[scala.Long]].
- *   - The ''floating point types'' are [[scala.Float]] and [[scala.Double]].
+ *   - The *subrange types* are [[scala.Byte]], [[scala.Short]], and [[scala.Char]].
+ *   - The *integer types* include the subrange types as well as [[scala.Int]] and [[scala.Long]].
+ *   - The *floating point types* are [[scala.Float]] and [[scala.Double]].
  *
- * A subclass of `AnyVal` is called a ''user-defined value class''
+ * A subclass of `AnyVal` is called a *user-defined value class*
  * and is treated specially by the compiler. Properly-defined user value classes provide a way
  * to improve performance on user-defined types by avoiding object allocation at runtime, and by
  * replacing virtual method invocations with static method invocations.
@@ -45,15 +45,15 @@ import scala.language.`2.13`
  *   - may not override `equals` or `hashCode` methods.
  *
  * A minimal example:
- * {{{
+ * ```
  *     class Wrapper(val underlying: Int) extends AnyVal {
  *       def foo: Wrapper = new Wrapper(underlying * 19)
  *     }
- * }}}
+ * ```
  *
  * It's important to note that user-defined value classes are limited, and in some circumstances,
  * still must allocate a value class instance at runtime. These limitations and circumstances are
- * explained in greater detail in the [[https://docs.scala-lang.org/overviews/core/value-classes.html Value Classes and Universal Traits]].
+ * explained in greater detail in the [Value Classes and Universal Traits](https://docs.scala-lang.org/overviews/core/value-classes.html).
  */
 transparent abstract class AnyVal extends Any, Matchable {
   def getClass(): Class[? <: AnyVal] = null.asInstanceOf[Class[? <: AnyVal]]

--- a/library/src/scala/AnyValCompanion.scala
+++ b/library/src/scala/AnyValCompanion.scala
@@ -19,9 +19,9 @@ import scala.language.`2.13`
  *  A common trait for /companion/ objects of primitive types comes handy
  *  when parameterizing code on types. For instance, the specialized
  *  annotation is passed a sequence of types on which to specialize:
- *  {{{
+ *  ```
  *     class Tuple1[@specialized(Unit, Int, Double) T]
- *  }}}
+ *  ```
  *
  */
 private[scala] trait AnyValCompanion extends Specializable { }

--- a/library/src/scala/App.scala
+++ b/library/src/scala/App.scala
@@ -21,46 +21,46 @@ import scala.collection.mutable.ListBuffer
 
 /** The `App` trait can be used to quickly turn objects
  *  into executable programs. Here is an example:
- *  {{{
+ *  ```
  *  object Main extends App {
  *    Console.println("Hello World: " + (args mkString ", "))
  *  }
- *  }}}
+ *  ```
  *
  *  No explicit `main` method is needed.  Instead,
  *  the whole class body becomes the “main method”.
  *
  *  `args` returns the current command line arguments as an array.
  *
- *  ==Caveats==
+ *  ## Caveats
  *
- *  '''''It should be noted that this trait is implemented using the [[DelayedInit]]
+ *  ***It should be noted that this trait is implemented using the [[DelayedInit]]
  *  functionality, which means that fields of the object will not have been initialized
- *  before the main method has been executed.'''''
+ *  before the main method has been executed.***
  *
  *  Future versions of this trait will no longer extend `DelayedInit`.
  *
  *  In Scala 3, the `DelayedInit` feature was dropped. `App` exists only in a limited form
  *  that also does not support command line arguments and will be deprecated in the future.
  *
- *  [[https://docs.scala-lang.org/scala3/book/methods-main-methods.html @main]] methods are the
+ *  [@main](https://docs.scala-lang.org/scala3/book/methods-main-methods.html) methods are the
  *  recommended scheme to generate programs that can be invoked from the command line in Scala 3.
  *
- *  {{{
+ *  ```
  *  @main def runMyProgram(args: String*): Unit = {
  *    // your program here
  *  }
- *  }}}
+ *  ```
  *
  *  If programs need to cross-build between Scala 2 and Scala 3, it is recommended to use an
  *  explicit `main` method:
- *  {{{
+ *  ```
  *  object Main {
  *    def main(args: Array[String]): Unit = {
  *      // your program here
  *    }
  *  }
- *  }}}
+ *  ```
  */
 @deprecated(message = "Support for trait App is deprecated in Scala 3. Please refer to https://docs.scala-lang.org/scala3/book/methods-main-methods.html.", since = "3.8.0")
 trait App extends DelayedInit {

--- a/library/src/scala/Array.scala
+++ b/library/src/scala/Array.scala
@@ -27,11 +27,11 @@ import scala.runtime.ScalaRunTime.{array_apply, array_update}
 
 /** Utility methods for operating on arrays.
  *  For example:
- *  {{{
+ *  ```
  *  val a = Array(1, 2)
  *  val b = Array.ofDim[Int](2)
  *  val c = Array.concat(a, b)
- *  }}}
+ *  ```
  *  where the array objects `a`, `b` and `c` have respectively the values
  *  `Array(1, 2)`, `Array(0, 0)` and `Array(1, 2, 0, 0)`.
  */
@@ -54,20 +54,18 @@ object Array {
     def newBuilder: mutable.Builder[A, Array[A]] = Array.newBuilder[A]
   }
 
-  /**
-   * Returns a new [[scala.collection.mutable.ArrayBuilder]].
-   */
+  /** Returns a new [[scala.collection.mutable.ArrayBuilder]]. */
   def newBuilder[T](implicit t: ClassTag[T]): ArrayBuilder[T] = ArrayBuilder.make[T](using t)
 
   /** Builds an array from the iterable collection.
    *
-   *  {{{
+   *  ```
    *  scala> val a = Array.from(Seq(1, 5))
    *  val a: Array[Int] = Array(1, 5)
    *
    *  scala> val b = Array.from(Range(1, 5))
    *  val b: Array[Int] = Array(1, 2, 3, 4)
-   *  }}}
+   *  ```
    *
    *  @param  it the iterable collection
    *  @return    an array consisting of elements of the iterable collection
@@ -118,14 +116,14 @@ object Array {
   }
 
   /** Copies one array to another, truncating or padding with default values (if
-    * necessary) so the copy has the specified length.
-    *
-    * Equivalent to Java's
-    *   `java.util.Arrays.copyOf(original, newLength)`,
-    * except that this works for primitive and object arrays in a single method.
-    *
-    * @see `java.util.Arrays#copyOf`
-    */
+   *  necessary) so the copy has the specified length.
+   *
+   *  Equivalent to Java's
+   *   `java.util.Arrays.copyOf(original, newLength)`,
+   *  except that this works for primitive and object arrays in a single method.
+   *
+   *  @see `java.util.Arrays#copyOf`
+   */
   def copyOf[A](original: Array[A], newLength: Int): Array[A] = ((original: @unchecked) match {
     case original: Array[BoxedUnit]  => newUnitArray(newLength).asInstanceOf[Array[A]]
     case original: Array[AnyRef]     => java.util.Arrays.copyOf(original, newLength)
@@ -140,18 +138,18 @@ object Array {
   }).asInstanceOf[Array[A]]
 
   /** Copies one array to another, truncating or padding with default values (if
-    * necessary) so the copy has the specified length. The new array can have
-    * a different type than the original one as long as the values are
-    * assignment-compatible. When copying between primitive and object arrays,
-    * boxing and unboxing are supported.
-    *
-    * Equivalent to Java's
-    *   `java.util.Arrays.copyOf(original, newLength, newType)`,
-    * except that this works for all combinations of primitive and object arrays
-    * in a single method.
-    *
-    * @see `java.util.Arrays#copyOf`
-    */
+   *  necessary) so the copy has the specified length. The new array can have
+   *  a different type than the original one as long as the values are
+   *  assignment-compatible. When copying between primitive and object arrays,
+   *  boxing and unboxing are supported.
+   *
+   *  Equivalent to Java's
+   *   `java.util.Arrays.copyOf(original, newLength, newType)`,
+   *  except that this works for all combinations of primitive and object arrays
+   *  in a single method.
+   *
+   *  @see `java.util.Arrays#copyOf`
+   */
   def copyAs[A](original: Array[?], newLength: Int)(implicit ct: ClassTag[A]): Array[A] = {
     val runtimeClass = ct.runtimeClass
     if (runtimeClass == Void.TYPE) newUnitArray(newLength).asInstanceOf[Array[A]]
@@ -359,10 +357,10 @@ object Array {
    *  of times.
    *
    *  Note that this means that `elem` is computed a total of n times:
-   *  {{{
-   * scala> Array.fill(3){ math.random }
-   * res3: Array[Double] = Array(0.365461167592537, 1.550395944913685E-4, 0.7907242137333306)
-   *  }}}
+   *  ```
+   *  scala> Array.fill(3){ math.random }
+   *  res3: Array[Double] = Array(0.365461167592537, 1.550395944913685E-4, 0.7907242137333306)
+   *  ```
    *
    *  @param   n  the number of elements desired
    *  @param   elem the element computation
@@ -499,7 +497,7 @@ object Array {
   /** Returns an array containing a sequence of increasing integers in a range.
    *
    *  @param start  the start value of the array
-   *  @param end    the end value of the array, exclusive (in other words, this is the first value '''not''' returned)
+   *  @param end    the end value of the array, exclusive (in other words, this is the first value **not** returned)
    *  @return  the array with values in range `start, start + 1, ..., end - 1`
    *  up to, but excluding, `end`.
    */
@@ -508,7 +506,7 @@ object Array {
   /** Returns an array containing equally spaced values in some integer interval.
    *
    *  @param start the start value of the array
-   *  @param end   the end value of the array, exclusive (in other words, this is the first value '''not''' returned)
+   *  @param end   the end value of the array, exclusive (in other words, this is the first value **not** returned)
    *  @param step  the increment value of the array (may not be zero)
    *  @return      the array with values in `start, start + step, ...` up to, but excluding `end`
    */
@@ -594,12 +592,12 @@ object Array {
 /** Arrays are mutable, indexed collections of values. `Array[T]` is Scala's representation
  *  for Java's `T[]`.
  *
- *  {{{
+ *  ```
  *  val numbers = Array(1, 2, 3, 4)
  *  val first = numbers(0) // read the first element
  *  numbers(3) = 100 // replace the 4th array element with 100
  *  val biggerNumbers = numbers.map(_ * 2) // multiply all numbers by two
- *  }}}
+ *  ```
  *
  *  Arrays make use of two common pieces of Scala syntactic sugar, shown on lines 2 and 3 of the above
  *  example code.
@@ -616,20 +614,20 @@ object Array {
  *  The conversion to `ArrayOps` takes priority over the conversion to `ArraySeq`. For instance,
  *  consider the following code:
  *
- *  {{{
+ *  ```
  *  val arr = Array(1, 2, 3)
  *  val arrReversed = arr.reverse
  *  val seqReversed : collection.Seq[Int] = arr.reverse
- *  }}}
+ *  ```
  *
  *  Value `arrReversed` will be of type `Array[Int]`, with an implicit conversion to `ArrayOps` occurring
  *  to perform the `reverse` operation. The value of `seqReversed`, on the other hand, will be computed
  *  by converting to `ArraySeq` first and invoking the variant of `reverse` that returns another
  *  `ArraySeq`.
  *
- *  @see [[https://www.scala-lang.org/files/archive/spec/2.13/ Scala Language Specification]], for in-depth information on the transformations the Scala compiler makes on Arrays (Sections 6.6 and 6.15 respectively.)
- *  @see [[https://docs.scala-lang.org/sips/scala-2-8-arrays.html "Scala 2.8 Arrays"]] the Scala Improvement Document detailing arrays since Scala 2.8.
- *  @see [[https://docs.scala-lang.org/overviews/collections-2.13/arrays.html "The Scala 2.8 Collections' API"]] section on `Array` by Martin Odersky for more information.
+ *  @see [Scala Language Specification](https://www.scala-lang.org/files/archive/spec/2.13/), for in-depth information on the transformations the Scala compiler makes on Arrays (Sections 6.6 and 6.15 respectively.)
+ *  @see ["Scala 2.8 Arrays"](https://docs.scala-lang.org/sips/scala-2-8-arrays.html) the Scala Improvement Document detailing arrays since Scala 2.8.
+ *  @see ["The Scala 2.8 Collections' API"](https://docs.scala-lang.org/overviews/collections-2.13/arrays.html) section on `Array` by Martin Odersky for more information.
  *  @hideImplicitConversion scala.Predef.booleanArrayOps
  *  @hideImplicitConversion scala.Predef.byteArrayOps
  *  @hideImplicitConversion scala.Predef.charArrayOps

--- a/library/src/scala/Boolean.scala
+++ b/library/src/scala/Boolean.scala
@@ -27,53 +27,52 @@ import scala.language.`2.13`
  */
 final abstract class Boolean private extends AnyVal {
   /** Negates a Boolean expression.
-    *
-    * - `!a` results in `false` if and only if `a` evaluates to `true` and
-    * - `!a` results in `true` if and only if `a` evaluates to `false`.
-    *
-    * @return the negated expression
-    */
+   *
+   *  - `!a` results in `false` if and only if `a` evaluates to `true` and
+   *  - `!a` results in `true` if and only if `a` evaluates to `false`.
+   *
+   *  @return the negated expression
+   */
   def unary_! : Boolean
 
   /** Compares two Boolean expressions and returns `true` if they evaluate to the same value.
-    *
-    * `a == b` returns `true` if and only if
-    *  - `a` and `b` are `true` or
-    *  - `a` and `b` are `false`.
-    */
+   *
+   *  `a == b` returns `true` if and only if
+   *  - `a` and `b` are `true` or
+   *  - `a` and `b` are `false`.
+   */
   def ==(x: Boolean): Boolean
 
-  /**
-    * Compares two Boolean expressions and returns `true` if they evaluate to a different value.
-    *
-    * `a != b` returns `true` if and only if
-    *  - `a` is `true` and `b` is `false` or
-    *  - `a` is `false` and `b` is `true`.
-    */
+  /** Compares two Boolean expressions and returns `true` if they evaluate to a different value.
+   *
+   *  `a != b` returns `true` if and only if
+   *  - `a` is `true` and `b` is `false` or
+   *  - `a` is `false` and `b` is `true`.
+   */
   def !=(x: Boolean): Boolean
 
   /** Compares two Boolean expressions and returns `true` if one or both of them evaluate to true.
-    *
-    * `a || b` returns `true` if and only if
-    *  - `a` is `true` or
-    *  - `b` is `true` or
-    *  - `a` and `b` are `true`.
-    *
-    * @note This method uses 'short-circuit' evaluation and
-    *       behaves as if it was declared as `def ||(x: => Boolean): Boolean`.
-    *       If `a` evaluates to `true`, `true` is returned without evaluating `b`.
-    */
+   *
+   *  `a || b` returns `true` if and only if
+   *  - `a` is `true` or
+   *  - `b` is `true` or
+   *  - `a` and `b` are `true`.
+   *
+   *  @note This method uses 'short-circuit' evaluation and
+   *       behaves as if it was declared as `def ||(x: => Boolean): Boolean`.
+   *       If `a` evaluates to `true`, `true` is returned without evaluating `b`.
+   */
   def ||(x: Boolean): Boolean
 
   /** Compares two Boolean expressions and returns `true` if both of them evaluate to true.
-    *
-    * `a && b` returns `true` if and only if
-    *  - `a` and `b` are `true`.
-    *
-    * @note This method uses 'short-circuit' evaluation and
-    *       behaves as if it was declared as `def &&(x: => Boolean): Boolean`.
-    *       If `a` evaluates to `false`, `false` is returned without evaluating `b`.
-    */
+   *
+   *  `a && b` returns `true` if and only if
+   *  - `a` and `b` are `true`.
+   *
+   *  @note This method uses 'short-circuit' evaluation and
+   *       behaves as if it was declared as `def &&(x: => Boolean): Boolean`.
+   *       If `a` evaluates to `false`, `false` is returned without evaluating `b`.
+   */
   def &&(x: Boolean): Boolean
 
   // Compiler won't build with these seemingly more accurate signatures
@@ -81,31 +80,31 @@ final abstract class Boolean private extends AnyVal {
   // def &&(x: => Boolean): Boolean
 
   /** Compares two Boolean expressions and returns `true` if one or both of them evaluate to true.
-    *
-    * `a | b` returns `true` if and only if
-    *  - `a` is `true` or
-    *  - `b` is `true` or
-    *  - `a` and `b` are `true`.
-    *
-    * @note This method evaluates both `a` and `b`, even if the result is already determined after evaluating `a`.
-    */
+   *
+   *  `a | b` returns `true` if and only if
+   *  - `a` is `true` or
+   *  - `b` is `true` or
+   *  - `a` and `b` are `true`.
+   *
+   *  @note This method evaluates both `a` and `b`, even if the result is already determined after evaluating `a`.
+   */
   def |(x: Boolean): Boolean
 
   /** Compares two Boolean expressions and returns `true` if both of them evaluate to true.
-    *
-    * `a & b` returns `true` if and only if
-    *  - `a` and `b` are `true`.
-    *
-    * @note This method evaluates both `a` and `b`, even if the result is already determined after evaluating `a`.
-    */
+   *
+   *  `a & b` returns `true` if and only if
+   *  - `a` and `b` are `true`.
+   *
+   *  @note This method evaluates both `a` and `b`, even if the result is already determined after evaluating `a`.
+   */
   def &(x: Boolean): Boolean
 
   /** Compares two Boolean expressions and returns `true` if they evaluate to a different value.
-    *
-    * `a ^ b` returns `true` if and only if
-    *  - `a` is `true` and `b` is `false` or
-    *  - `a` is `false` and `b` is `true`.
-    */
+   *
+   *  `a ^ b` returns `true` if and only if
+   *  - `a` is `true` and `b` is `false` or
+   *  - `a` is `false` and `b` is `true`.
+   */
   def ^(x: Boolean): Boolean
 
   // Provide a more specific return type for Scaladoc
@@ -116,7 +115,7 @@ object Boolean extends AnyValCompanion {
 
   /** Transforms a value type into a boxed reference type.
    *
-   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.boxToBoolean`. See [[https://github.com/scala/scala src/library/scala/runtime/BoxesRunTime.java]].
+   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.boxToBoolean`. See [src/library/scala/runtime/BoxesRunTime.java](https://github.com/scala/scala).
    *
    *  @param  x   the Boolean to be boxed
    *  @return     a java.lang.Boolean offering `x` as its underlying value.
@@ -127,11 +126,11 @@ object Boolean extends AnyValCompanion {
    *  method is not typesafe: it accepts any Object, but will throw
    *  an exception if the argument is not a java.lang.Boolean.
    *
-   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.unboxToBoolean`. See [[https://github.com/scala/scala src/library/scala/runtime/BoxesRunTime.java]].
+   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.unboxToBoolean`. See [src/library/scala/runtime/BoxesRunTime.java](https://github.com/scala/scala).
    *
    *  @param  x   the java.lang.Boolean to be unboxed.
-   *  @throws     ClassCastException  if the argument is not a java.lang.Boolean
    *  @return     the Boolean resulting from calling booleanValue() on `x`
+   *  @throws     ClassCastException  if the argument is not a java.lang.Boolean
    */
   def unbox(x: java.lang.Object): Boolean = ???
 

--- a/library/src/scala/Byte.scala
+++ b/library/src/scala/Byte.scala
@@ -34,14 +34,13 @@ final abstract class Byte private extends AnyVal {
   def toFloat: Float
   def toDouble: Double
 
-  /**
- * Returns the bitwise negation of this value.
- * @example {{{
- * ~5 == -6
- * // in binary: ~00000101 ==
- * //             11111010
- * }}}
- */
+  /** Returns the bitwise negation of this value.
+   *  @example ```
+   *  ~5 == -6
+   *  // in binary: ~00000101 ==
+   *  //             11111010
+   *  ```
+   */
   def unary_~ : Int
   /** Returns this value, unmodified. */
   def unary_+ : Int
@@ -51,63 +50,63 @@ final abstract class Byte private extends AnyVal {
   @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0")
   def +(x: String): String
 
-  /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the new right bits with zeroes.
-  * @example {{{ 6 << 3 == 48 // in binary: 0110 << 3 == 0110000 }}}
-  */
+  /** Returns this value bit-shifted left by the specified number of bits,
+   *         filling in the new right bits with zeroes.
+   *  @example
+   *  ```
+   *  6 << 3 == 48 // in binary: 0110 << 3 == 0110000
+   *  ```
+   */
   def <<(x: Int): Int
-  /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the new right bits with zeroes.
-  * @example {{{ 6 << 3 == 48 // in binary: 0110 << 3 == 0110000 }}}
-  */
+  /** Returns this value bit-shifted left by the specified number of bits,
+   *         filling in the new right bits with zeroes.
+   *  @example
+   *  ```
+   *  6 << 3 == 48 // in binary: 0110 << 3 == 0110000
+   *  ```
+   */
   @deprecated("shifting a value by a `Long` argument is deprecated (except when the value is a `Long`).\nCall `toInt` on the argument to maintain the current behavior and avoid the deprecation warning.", "2.12.7")
   def <<(x: Long): Int
-  /**
-  * Returns this value bit-shifted right by the specified number of bits,
-  *         filling the new left bits with zeroes.
-  * @example {{{ 21 >>> 3 == 2 // in binary: 010101 >>> 3 == 010 }}}
-  * @example {{{
-  * -21 >>> 3 == 536870909
-  * // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
-  * //            00011111 11111111 11111111 11111101
-  * }}}
-  */
+  /** Returns this value bit-shifted right by the specified number of bits,
+   *         filling the new left bits with zeroes.
+   *  @example ``` 21 >>> 3 == 2 // in binary: 010101 >>> 3 == 010 ```
+   *  @example ```
+   *  -21 >>> 3 == 536870909
+   *  // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
+   *  //            00011111 11111111 11111111 11111101
+   *  ```
+   */
   def >>>(x: Int): Int
-  /**
-  * Returns this value bit-shifted right by the specified number of bits,
-  *         filling the new left bits with zeroes.
-  * @example {{{ 21 >>> 3 == 2 // in binary: 010101 >>> 3 == 010 }}}
-  * @example {{{
-  * -21 >>> 3 == 536870909
-  * // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
-  * //            00011111 11111111 11111111 11111101
-  * }}}
-  */
+  /** Returns this value bit-shifted right by the specified number of bits,
+   *         filling the new left bits with zeroes.
+   *  @example ``` 21 >>> 3 == 2 // in binary: 010101 >>> 3 == 010 ```
+   *  @example ```
+   *  -21 >>> 3 == 536870909
+   *  // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
+   *  //            00011111 11111111 11111111 11111101
+   *  ```
+   */
   @deprecated("shifting a value by a `Long` argument is deprecated (except when the value is a `Long`).\nCall `toInt` on the argument to maintain the current behavior and avoid the deprecation warning.", "2.12.7")
   def >>>(x: Long): Int
-  /**
-  * Returns this value bit-shifted right by the specified number of bits,
-  *         filling in the left bits with the same value as the left-most bit of this.
-  *         The effect of this is to retain the sign of the value.
-  * @example {{{
-  * -21 >> 3 == -3
-  * // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
-  * //            11111111 11111111 11111111 11111101
-  * }}}
-  */
+  /** Returns this value bit-shifted right by the specified number of bits,
+   *         filling in the left bits with the same value as the left-most bit of this.
+   *         The effect of this is to retain the sign of the value.
+   *  @example ```
+   *  -21 >> 3 == -3
+   *  // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
+   *  //            11111111 11111111 11111111 11111101
+   *  ```
+   */
   def >>(x: Int): Int
-  /**
-  * Returns this value bit-shifted right by the specified number of bits,
-  *         filling in the left bits with the same value as the left-most bit of this.
-  *         The effect of this is to retain the sign of the value.
-  * @example {{{
-  * -21 >> 3 == -3
-  * // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
-  * //            11111111 11111111 11111111 11111101
-  * }}}
-  */
+  /** Returns this value bit-shifted right by the specified number of bits,
+   *         filling in the left bits with the same value as the left-most bit of this.
+   *         The effect of this is to retain the sign of the value.
+   *  @example ```
+   *  -21 >> 3 == -3
+   *  // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
+   *  //            11111111 11111111 11111111 11111101
+   *  ```
+   */
   @deprecated("shifting a value by a `Long` argument is deprecated (except when the value is a `Long`).\nCall `toInt` on the argument to maintain the current behavior and avoid the deprecation warning.", "2.12.7")
   def >>(x: Long): Int
 
@@ -201,172 +200,157 @@ final abstract class Byte private extends AnyVal {
   /** Returns `true` if this value is greater than or equal to x, `false` otherwise. */
   def >=(x: Double): Boolean
 
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Byte): Int
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Short): Int
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Char): Int
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Int): Int
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Long): Long
 
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Byte): Int
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Short): Int
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Char): Int
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Int): Int
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Long): Long
 
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Byte): Int
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Short): Int
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Char): Int
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Int): Int
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Long): Long
 
   /** Returns the sum of this value and `x`. */
@@ -457,7 +441,7 @@ object Byte extends AnyValCompanion {
 
   /** Transforms a value type into a boxed reference type.
    *
-   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.boxToByte`. See [[https://github.com/scala/scala src/library/scala/runtime/BoxesRunTime.java]].
+   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.boxToByte`. See [src/library/scala/runtime/BoxesRunTime.java](https://github.com/scala/scala).
    *
    *  @param  x   the Byte to be boxed
    *  @return     a java.lang.Byte offering `x` as its underlying value.
@@ -468,11 +452,11 @@ object Byte extends AnyValCompanion {
    *  method is not typesafe: it accepts any Object, but will throw
    *  an exception if the argument is not a java.lang.Byte.
    *
-   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.unboxToByte`. See [[https://github.com/scala/scala src/library/scala/runtime/BoxesRunTime.java]].
+   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.unboxToByte`. See [src/library/scala/runtime/BoxesRunTime.java](https://github.com/scala/scala).
    *
    *  @param  x   the java.lang.Byte to be unboxed.
-   *  @throws     ClassCastException  if the argument is not a java.lang.Byte
    *  @return     the Byte resulting from calling byteValue() on `x`
+   *  @throws     ClassCastException  if the argument is not a java.lang.Byte
    */
   def unbox(x: java.lang.Object): Byte = ???
 

--- a/library/src/scala/Char.scala
+++ b/library/src/scala/Char.scala
@@ -34,14 +34,13 @@ final abstract class Char private extends AnyVal {
   def toFloat: Float
   def toDouble: Double
 
-  /**
- * Returns the bitwise negation of this value.
- * @example {{{
- * ~5 == -6
- * // in binary: ~00000101 ==
- * //             11111010
- * }}}
- */
+  /** Returns the bitwise negation of this value.
+   *  @example ```
+   *  ~5 == -6
+   *  // in binary: ~00000101 ==
+   *  //             11111010
+   *  ```
+   */
   def unary_~ : Int
   /** Returns this value, unmodified. */
   def unary_+ : Int
@@ -51,63 +50,63 @@ final abstract class Char private extends AnyVal {
   @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0")
   def +(x: String): String
 
-  /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the new right bits with zeroes.
-  * @example {{{ 6 << 3 == 48 // in binary: 0110 << 3 == 0110000 }}}
-  */
+  /** Returns this value bit-shifted left by the specified number of bits,
+   *         filling in the new right bits with zeroes.
+   *  @example
+   *  ```
+   *  6 << 3 == 48 // in binary: 0110 << 3 == 0110000
+   *  ```
+   */
   def <<(x: Int): Int
-  /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the new right bits with zeroes.
-  * @example {{{ 6 << 3 == 48 // in binary: 0110 << 3 == 0110000 }}}
-  */
+  /** Returns this value bit-shifted left by the specified number of bits,
+   *         filling in the new right bits with zeroes.
+   *  @example
+   *  ```
+   *  6 << 3 == 48 // in binary: 0110 << 3 == 0110000
+   *  ```
+   */
   @deprecated("shifting a value by a `Long` argument is deprecated (except when the value is a `Long`).\nCall `toInt` on the argument to maintain the current behavior and avoid the deprecation warning.", "2.12.7")
   def <<(x: Long): Int
-  /**
-  * Returns this value bit-shifted right by the specified number of bits,
-  *         filling the new left bits with zeroes.
-  * @example {{{ 21 >>> 3 == 2 // in binary: 010101 >>> 3 == 010 }}}
-  * @example {{{
-  * -21 >>> 3 == 536870909
-  * // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
-  * //            00011111 11111111 11111111 11111101
-  * }}}
-  */
+  /** Returns this value bit-shifted right by the specified number of bits,
+   *         filling the new left bits with zeroes.
+   *  @example ``` 21 >>> 3 == 2 // in binary: 010101 >>> 3 == 010 ```
+   *  @example ```
+   *  -21 >>> 3 == 536870909
+   *  // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
+   *  //            00011111 11111111 11111111 11111101
+   *  ```
+   */
   def >>>(x: Int): Int
-  /**
-  * Returns this value bit-shifted right by the specified number of bits,
-  *         filling the new left bits with zeroes.
-  * @example {{{ 21 >>> 3 == 2 // in binary: 010101 >>> 3 == 010 }}}
-  * @example {{{
-  * -21 >>> 3 == 536870909
-  * // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
-  * //            00011111 11111111 11111111 11111101
-  * }}}
-  */
+  /** Returns this value bit-shifted right by the specified number of bits,
+   *         filling the new left bits with zeroes.
+   *  @example ``` 21 >>> 3 == 2 // in binary: 010101 >>> 3 == 010 ```
+   *  @example ```
+   *  -21 >>> 3 == 536870909
+   *  // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
+   *  //            00011111 11111111 11111111 11111101
+   *  ```
+   */
   @deprecated("shifting a value by a `Long` argument is deprecated (except when the value is a `Long`).\nCall `toInt` on the argument to maintain the current behavior and avoid the deprecation warning.", "2.12.7")
   def >>>(x: Long): Int
-  /**
-  * Returns this value bit-shifted right by the specified number of bits,
-  *         filling in the left bits with the same value as the left-most bit of this.
-  *         The effect of this is to retain the sign of the value.
-  * @example {{{
-  * -21 >> 3 == -3
-  * // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
-  * //            11111111 11111111 11111111 11111101
-  * }}}
-  */
+  /** Returns this value bit-shifted right by the specified number of bits,
+   *         filling in the left bits with the same value as the left-most bit of this.
+   *         The effect of this is to retain the sign of the value.
+   *  @example ```
+   *  -21 >> 3 == -3
+   *  // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
+   *  //            11111111 11111111 11111111 11111101
+   *  ```
+   */
   def >>(x: Int): Int
-  /**
-  * Returns this value bit-shifted right by the specified number of bits,
-  *         filling in the left bits with the same value as the left-most bit of this.
-  *         The effect of this is to retain the sign of the value.
-  * @example {{{
-  * -21 >> 3 == -3
-  * // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
-  * //            11111111 11111111 11111111 11111101
-  * }}}
-  */
+  /** Returns this value bit-shifted right by the specified number of bits,
+   *         filling in the left bits with the same value as the left-most bit of this.
+   *         The effect of this is to retain the sign of the value.
+   *  @example ```
+   *  -21 >> 3 == -3
+   *  // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
+   *  //            11111111 11111111 11111111 11111101
+   *  ```
+   */
   @deprecated("shifting a value by a `Long` argument is deprecated (except when the value is a `Long`).\nCall `toInt` on the argument to maintain the current behavior and avoid the deprecation warning.", "2.12.7")
   def >>(x: Long): Int
 
@@ -201,172 +200,157 @@ final abstract class Char private extends AnyVal {
   /** Returns `true` if this value is greater than or equal to x, `false` otherwise. */
   def >=(x: Double): Boolean
 
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Byte): Int
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Short): Int
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Char): Int
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Int): Int
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Long): Long
 
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Byte): Int
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Short): Int
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Char): Int
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Int): Int
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Long): Long
 
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Byte): Int
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Short): Int
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Char): Int
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Int): Int
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Long): Long
 
   /** Returns the sum of this value and `x`. */
@@ -457,7 +441,7 @@ object Char extends AnyValCompanion {
 
   /** Transforms a value type into a boxed reference type.
    *
-   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.boxToCharacter`. See [[https://github.com/scala/scala src/library/scala/runtime/BoxesRunTime.java]].
+   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.boxToCharacter`. See [src/library/scala/runtime/BoxesRunTime.java](https://github.com/scala/scala).
    *
    *  @param  x   the Char to be boxed
    *  @return     a java.lang.Character offering `x` as its underlying value.
@@ -468,11 +452,11 @@ object Char extends AnyValCompanion {
    *  method is not typesafe: it accepts any Object, but will throw
    *  an exception if the argument is not a java.lang.Character.
    *
-   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.unboxToChar`. See [[https://github.com/scala/scala src/library/scala/runtime/BoxesRunTime.java]].
+   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.unboxToChar`. See [src/library/scala/runtime/BoxesRunTime.java](https://github.com/scala/scala).
    *
    *  @param  x   the java.lang.Character to be unboxed.
-   *  @throws     ClassCastException  if the argument is not a java.lang.Character
    *  @return     the Char resulting from calling charValue() on `x`
+   *  @throws     ClassCastException  if the argument is not a java.lang.Character
    */
   def unbox(x: java.lang.Object): Char = ???
 

--- a/library/src/scala/Console.scala
+++ b/library/src/scala/Console.scala
@@ -22,20 +22,20 @@ import scala.util.DynamicVariable
  *  use [[scala.io.StdIn$ StdIn]].
  *  Also defines constants for marking up text on ANSI terminals.
  *
- *  == Console Output ==
+ *  ## Console Output
  *
  *  Use the print methods to output text.
- *  {{{
+ *  ```
  *   scala> Console.printf(
  *     "Today the outside temperature is a balmy %.1f°C. %<.1f°C beats the previous record of %.1f°C.\n",
  *     -137.0,
  *     -135.05)
  *   Today the outside temperature is a balmy -137.0°C. -137.0°C beats the previous record of -135.1°C.
- *  }}}
+ *  ```
  *
- *  == ANSI escape codes ==
+ *  ## ANSI escape codes
  *  Use the ANSI escape codes for colorizing console output either to STDOUT or STDERR.
- *  {{{
+ *  ```
  *    import Console.{GREEN, RED, RESET, YELLOW_B, UNDERLINED}
  *
  *    object PrimeTest {
@@ -55,7 +55,7 @@ import scala.util.DynamicVariable
  *      def main(args: Array[String]): Unit = isPrime()
  *
  *    }
- *  }}}
+ *  ```
  *
  *  <table style="border: 10px solid #000;width:100%">
  *    <tr><td style="background-color:#000;color:#fff">\$ scala PrimeTest</td></tr>
@@ -66,12 +66,12 @@ import scala.util.DynamicVariable
  *    <tr><td style="background-color:#000;color:#fff"><span style="background-color:#ff0;color:#f00;text-decoration:underline">NO!</span></td></tr>
  *  </table>
  *
- *  == IO redefinition ==
+ *  ## IO redefinition
  *
  *  Use IO redefinition to temporarily swap in a different set of input and/or output streams. In this example the stream based
  *  method above is wrapped into a function.
  *
- *  {{{
+ *  ```
  *    import java.io.{ByteArrayOutputStream, StringReader}
  *
  *    object FunctionalPrimeTest {
@@ -103,7 +103,7 @@ import scala.util.DynamicVariable
  *      }
  *
  *    }
- *  }}}
+ *  ```
  *
  *
  *  <table style="border: 10px solid #000;width:100%">
@@ -123,7 +123,6 @@ import scala.util.DynamicVariable
  *  @groupprio io-redefinition 60
  *  @groupdesc io-redefinition These methods allow substituting alternative streams for the duration of
  *             a body of code. Threadsafe by virtue of [[scala.util.DynamicVariable]].
- *
  */
 object Console extends AnsiColor {
   private val outVar = new DynamicVariable[PrintStream](java.lang.System.out)
@@ -151,9 +150,9 @@ object Console extends AnsiColor {
   /** Sets the default output stream for the duration
    *  of execution of one thunk.
    *
-   *  @example {{{
+   *  @example ```
    *  withOut(Console.err) { println("This goes to default _error_") }
-   *  }}}
+   *  ```
    *
    *  @param out the new output stream.
    *  @param thunk the code to execute with
@@ -180,9 +179,9 @@ object Console extends AnsiColor {
 
   /** Sets the default error stream for the duration
    *  of execution of one thunk.
-   *  @example {{{
+   *  @example ```
    *  withErr(Console.out) { err.println("This goes to default _out_") }
-   *  }}}
+   *  ```
    *
    *  @param err the new error stream.
    *  @param thunk the code to execute with
@@ -210,13 +209,13 @@ object Console extends AnsiColor {
   /** Sets the default input stream for the duration
    *  of execution of one thunk.
    *
-   *  @example {{{
+   *  @example ```
    *  val someFile:Reader = openFile("file.txt")
    *  withIn(someFile) {
    *    // Reads a line from file.txt instead of default input
    *    println(readLine)
    *  }
-   *  }}}
+   *  ```
    *
    *  @param thunk the code to execute with
    *               the new input stream active
@@ -253,12 +252,12 @@ object Console extends AnsiColor {
   /** Flushes the output stream. This function is required when partial
    *  output (i.e. output not terminated by a newline character) has
    *  to be made visible on the terminal.
-    * @group console-output
+   *  @group console-output
    */
   def flush(): Unit = { out.flush() }
 
   /** Prints a newline character on the default output.
-    * @group console-output
+   *  @group console-output
    */
   def println(): Unit = { out.println() }
 

--- a/library/src/scala/Conversion.scala
+++ b/library/src/scala/Conversion.scala
@@ -4,26 +4,26 @@ import language.experimental.captureChecking
 import annotation.internal.preview
 
 /** A class for implicit values that can serve as implicit conversions.
-*  The implicit resolution algorithm will act as if there existed
-*  the additional implicit definition:
-*
-*    def $implicitConversion[T, U](x: T)(c: Conversion[T, U]): U = c(x)
-*
-*  However, the presence of this definition would slow down implicit search since
-*  its outermost type matches any pair of types. Therefore, implicit search
-*  contains a special case in `Implicits#discardForView` which emulates the
-*  conversion in a more efficient way.
-*
-*  Note that this is a SAM class - function literals are automatically converted
-*  to the `Conversion` values.
-*
-*  Also note that in bootstrapped dotty, `Predef.<:<` should inherit from
-*  `Conversion`. This would cut the number of special cases in `discardForView`
-*  from two to one.
-*
-*  The `Conversion` class can also be used to convert explicitly, using
-*  the `convert` extension method.
-*/
+ *  The implicit resolution algorithm will act as if there existed
+ *  the additional implicit definition:
+ *
+ *    def $implicitConversion[T, U](x: T)(c: Conversion[T, U]): U = c(x)
+ *
+ *  However, the presence of this definition would slow down implicit search since
+ *  its outermost type matches any pair of types. Therefore, implicit search
+ *  contains a special case in `Implicits#discardForView` which emulates the
+ *  conversion in a more efficient way.
+ *
+ *  Note that this is a SAM class - function literals are automatically converted
+ *  to the `Conversion` values.
+ *
+ *  Also note that in bootstrapped dotty, `Predef.<:<` should inherit from
+ *  `Conversion`. This would cut the number of special cases in `discardForView`
+ *  from two to one.
+ *
+ *  The `Conversion` class can also be used to convert explicitly, using
+ *  the `convert` extension method.
+ */
 @java.lang.FunctionalInterface
 abstract class Conversion[-T, +U] extends Function1[T, U]:
   self =>

--- a/library/src/scala/DelayedInit.scala
+++ b/library/src/scala/DelayedInit.scala
@@ -22,7 +22,7 @@ import scala.language.`2.13`
  *  that are executed during initialization.
  *
  *  Example:
- *  {{{
+ *  ```
  *    trait Helper extends DelayedInit {
  *      def delayedInit(body: => Unit) = {
  *        println("dummy text, printed before initialization of C")
@@ -37,13 +37,13 @@ import scala.language.`2.13`
  *    object Test extends App {
  *      val c = new C
  *    }
- *  }}}
+ *  ```
  *
  *  Should result in the following being printed:
- *  {{{
+ *  ```
  *    dummy text, printed before initialization of C
  *    this is the initialization code of C
- *  }}}
+ *  ```
  *
  *  @see "Delayed Initialization" subsection of the Scala Language Specification (section 5.1)
  *

--- a/library/src/scala/Double.scala
+++ b/library/src/scala/Double.scala
@@ -232,7 +232,7 @@ object Double extends AnyValCompanion {
 
   /** Transforms a value type into a boxed reference type.
    *
-   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.boxToDouble`. See [[https://github.com/scala/scala src/library/scala/runtime/BoxesRunTime.java]].
+   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.boxToDouble`. See [src/library/scala/runtime/BoxesRunTime.java](https://github.com/scala/scala).
    *
    *  @param  x   the Double to be boxed
    *  @return     a java.lang.Double offering `x` as its underlying value.
@@ -243,11 +243,11 @@ object Double extends AnyValCompanion {
    *  method is not typesafe: it accepts any Object, but will throw
    *  an exception if the argument is not a java.lang.Double.
    *
-   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.unboxToDouble`. See [[https://github.com/scala/scala src/library/scala/runtime/BoxesRunTime.java]].
+   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.unboxToDouble`. See [src/library/scala/runtime/BoxesRunTime.java](https://github.com/scala/scala).
    *
    *  @param  x   the java.lang.Double to be unboxed.
-   *  @throws     ClassCastException  if the argument is not a java.lang.Double
    *  @return     the Double resulting from calling doubleValue() on `x`
+   *  @throws     ClassCastException  if the argument is not a java.lang.Double
    */
   def unbox(x: java.lang.Object): Double = ???
 

--- a/library/src/scala/Dynamic.scala
+++ b/library/src/scala/Dynamic.scala
@@ -22,7 +22,7 @@ import scala.language.`2.13`
  *  If a call is not natively supported by `x` (i.e. if type checking
  *  fails), it is rewritten according to the following rules:
  *
- *  {{{
+ *  ```
  *  foo.method("blah")      ~~> foo.applyDynamic("method")("blah")
  *  foo.method(x = "blah")  ~~> foo.applyDynamicNamed("method")(("x", "blah"))
  *  foo.method(x = 1, 2)    ~~> foo.applyDynamicNamed("method")(("x", 1), ("", 2))
@@ -30,7 +30,7 @@ import scala.language.`2.13`
  *  foo.varia = 10      ~~> foo.updateDynamic("varia")(10)
  *  foo.arr(10) = 13    ~~> foo.selectDynamic("arr").update(10, 13)
  *  foo.arr(10)         ~~> foo.applyDynamic("arr")(10)
- *  }}}
+ *  ```
  *
  *  Defining direct or indirect subclasses of this trait
  *  is only possible if the language feature `dynamics` is enabled.

--- a/library/src/scala/Enumeration.scala
+++ b/library/src/scala/Enumeration.scala
@@ -38,28 +38,28 @@ import scala.util.matching.Regex
  *  enumeration from multiple threads (in a non-synchronized fashion) after
  *  construction, the behavior of the enumeration is undefined.
  *
- * @example {{{
- * // Define a new enumeration with a type alias and work with the full set of enumerated values
- * object WeekDay extends Enumeration {
+ *  @example ```
+ *  // Define a new enumeration with a type alias and work with the full set of enumerated values
+ *  object WeekDay extends Enumeration {
  *   type WeekDay = Value
  *   val Mon, Tue, Wed, Thu, Fri, Sat, Sun = Value
- * }
- * import WeekDay._
+ *  }
+ *  import WeekDay._
  *
- * def isWorkingDay(d: WeekDay) = ! (d == Sat || d == Sun)
+ *  def isWorkingDay(d: WeekDay) = ! (d == Sat || d == Sun)
  *
- * WeekDay.values filter isWorkingDay foreach println
- * // output:
- * // Mon
- * // Tue
- * // Wed
- * // Thu
- * // Fri
- * }}}
+ *  WeekDay.values filter isWorkingDay foreach println
+ *  // output:
+ *  // Mon
+ *  // Tue
+ *  // Wed
+ *  // Thu
+ *  // Fri
+ *  ```
  *
- * @example {{{
- * // Example of adding attributes to an enumeration by extending the Enumeration.Val class
- * object Planet extends Enumeration {
+ *  @example ```
+ *  // Example of adding attributes to an enumeration by extending the Enumeration.Val class
+ *  object Planet extends Enumeration {
  *   protected case class PlanetVal(mass: Double, radius: Double) extends super.Val {
  *     def surfaceGravity: Double = Planet.G * mass / (radius * radius)
  *     def surfaceWeight(otherMass: Double): Double = otherMass * surfaceGravity
@@ -76,12 +76,12 @@ import scala.util.matching.Regex
  *   val Saturn  = PlanetVal(5.688e+26, 6.0268e7)
  *   val Uranus  = PlanetVal(8.686e+25, 2.5559e7)
  *   val Neptune = PlanetVal(1.024e+26, 2.4746e7)
- * }
+ *  }
  *
- * println(Planet.values.filter(_.radius > 7.0e6))
- * // output:
- * // Planet.ValueSet(Jupiter, Saturn, Uranus, Neptune)
- * }}}
+ *  println(Planet.values.filter(_.radius > 7.0e6))
+ *  // output:
+ *  // Planet.ValueSet(Jupiter, Saturn, Uranus, Neptune)
+ *  ```
  *
  *  @param initial The initial value from which to count the integers that
  *                 identifies values at run-time.
@@ -96,8 +96,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
      the JVM does not invoke it when deserializing subclasses. */
   protected def readResolve(): AnyRef = thisenum.getClass.getField(MODULE_INSTANCE_NAME).get(null)
 
-  /** The name of this enumeration.
-   */
+  /** The name of this enumeration. */
   override def toString(): String =
     getClass.getName
       .stripSuffix(MODULE_SUFFIX_STRING)
@@ -107,7 +106,8 @@ abstract class Enumeration (initial: Int) extends Serializable {
       .last
 
   /** The mapping from the integer used to identify values to the actual
-    * values. */
+   *  values. 
+   */
   private val vmap: mutable.Map[Int, Value] = new mutable.HashMap
 
   /** The cache listing all values of this enumeration. */
@@ -115,11 +115,11 @@ abstract class Enumeration (initial: Int) extends Serializable {
   @transient @volatile private var vsetDefined = false
 
   /** The mapping from the integer used to identify values to their
-    * names. */
+   *  names. 
+   */
   private val nmap: mutable.Map[Int, String] = new mutable.HashMap
 
-  /** The values of this enumeration as a set.
-   */
+  /** The values of this enumeration as a set. */
   def values: ValueSet = {
     if (!vsetDefined) {
       vset = (ValueSet.newBuilder ++= vmap.values).result()
@@ -138,27 +138,29 @@ abstract class Enumeration (initial: Int) extends Serializable {
     if (nextName != null && nextName.hasNext) nextName.next() else null
 
   /** The highest integer amongst those used to identify values in this
-    * enumeration. */
+   *  enumeration. 
+   */
   private var topId = initial
 
   /** The lowest integer amongst those used to identify values in this
-    * enumeration, but no higher than 0. */
+   *  enumeration, but no higher than 0. 
+   */
   private var bottomId = if(initial < 0) initial else 0
 
   /** The one higher than the highest integer amongst those used to identify
-    *  values in this enumeration. */
+   *  values in this enumeration. 
+   */
   final def maxId = topId
 
-  /** The value of this enumeration with given id `x`.
-   */
+  /** The value of this enumeration with given id `x`. */
   final def apply(x: Int): Value = vmap(x)
 
   /** Returns a `Value` from this `Enumeration` whose name matches
    *  the argument `s`.  The names are determined automatically via reflection.
    *
-   * @param  s an `Enumeration` name
-   * @return   the `Value` of this `Enumeration` if its name matches `s`
-   * @throws   NoSuchElementException if no `Value` with a matching
+   *  @param  s an `Enumeration` name
+   *  @return   the `Value` of this `Enumeration` if its name matches `s`
+   *  @throws   NoSuchElementException if no `Value` with a matching
    *           name is in this `Enumeration`
    */
   final def withName(s: String): Value = values.byName.getOrElse(s,
@@ -186,10 +188,10 @@ abstract class Enumeration (initial: Int) extends Serializable {
   /** Creates a fresh value, part of this enumeration, called `name`
    *  and identified by the integer `i`.
    *
-   * @param i    An integer that identifies this value at run-time. It must be
+   *  @param i    An integer that identifies this value at run-time. It must be
    *             unique amongst all values of the enumeration.
-   * @param name A human-readable name for that value.
-   * @return     Fresh value with the provided identifier `i` and name `name`.
+   *  @param name A human-readable name for that value.
+   *  @return     Fresh value with the provided identifier `i` and name `name`.
    */
   protected final def Value(i: Int, name: String | Null): Value = new Val(i, name)
 
@@ -310,7 +312,8 @@ abstract class Enumeration (initial: Int) extends Serializable {
     override def iteratorFrom(start: Value): Iterator[Value] = nnIds iteratorFrom start.id  map (id => thisenum.apply(bottomId + id))
     override def className: String = s"$thisenum.ValueSet"
     /** Creates a bit mask for the zero-adjusted ids in this set as a
-     *  new array of longs */
+     *  new array of longs 
+     */
     def toBitMask: Array[Long] = nnIds.toBitMask
 
     override protected def fromSpecific(coll: IterableOnce[Value]): ValueSet = ValueSet.fromSpecific(coll)
@@ -341,7 +344,8 @@ abstract class Enumeration (initial: Int) extends Serializable {
     /** The empty value set. */
     val empty: ValueSet = new ValueSet(immutable.BitSet.empty)
     /** A value set containing all the values for the zero-adjusted ids
-     *  corresponding to the bits in an array */
+     *  corresponding to the bits in an array 
+     */
     def fromBitMask(elems: Array[Long]): ValueSet = new ValueSet(immutable.BitSet.fromBitMask(elems))
     /** A builder object for value sets. */
     def newBuilder: mutable.Builder[Value, ValueSet] = new mutable.Builder[Value, ValueSet] {

--- a/library/src/scala/Float.scala
+++ b/library/src/scala/Float.scala
@@ -232,7 +232,7 @@ object Float extends AnyValCompanion {
 
   /** Transforms a value type into a boxed reference type.
    *
-   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.boxToFloat`. See [[https://github.com/scala/scala src/library/scala/runtime/BoxesRunTime.java]].
+   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.boxToFloat`. See [src/library/scala/runtime/BoxesRunTime.java](https://github.com/scala/scala).
    *
    *  @param  x   the Float to be boxed
    *  @return     a java.lang.Float offering `x` as its underlying value.
@@ -243,11 +243,11 @@ object Float extends AnyValCompanion {
    *  method is not typesafe: it accepts any Object, but will throw
    *  an exception if the argument is not a java.lang.Float.
    *
-   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.unboxToFloat`. See [[https://github.com/scala/scala src/library/scala/runtime/BoxesRunTime.java]].
+   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.unboxToFloat`. See [src/library/scala/runtime/BoxesRunTime.java](https://github.com/scala/scala).
    *
    *  @param  x   the java.lang.Float to be unboxed.
-   *  @throws     ClassCastException  if the argument is not a java.lang.Float
    *  @return     the Float resulting from calling floatValue() on `x`
+   *  @throws     ClassCastException  if the argument is not a java.lang.Float
    */
   def unbox(x: java.lang.Object): Float = ???
 

--- a/library/src/scala/Function.scala
+++ b/library/src/scala/Function.scala
@@ -14,8 +14,7 @@ package scala
 
 import scala.language.`2.13`
 
-/** A module defining utility methods for higher-order functional programming.
- */
+/** A module defining utility methods for higher-order functional programming. */
 object Function {
   /** Given a sequence of functions `f,,1,,`, ..., `f,,n,,`, return the
    *  function `f,,1,, andThen ... andThen f,,n,,`.
@@ -29,7 +28,7 @@ object Function {
 
   /** Turns a function `A => Option[B]` into a `PartialFunction[A, B]`.
    *
-   *  '''Important note''': this transformation implies the original function
+   *  **Important note**: this transformation implies the original function
    *  may be called 2 or more times on each logical invocation, because the
    *  only way to supply an implementation of `isDefinedAt` is to call the
    *  function and examine the return value.
@@ -49,20 +48,17 @@ object Function {
     (x1, x2) => f(x1)(x2)
   }
 
-  /** Uncurrying for functions of arity 3.
-   */
+  /** Uncurrying for functions of arity 3. */
   def uncurried[T1, T2, T3, R](f: T1 => T2 => T3 => R): (T1, T2, T3) => R = {
     (x1, x2, x3) => f(x1)(x2)(x3)
   }
 
-  /** Uncurrying for functions of arity 4.
-   */
+  /** Uncurrying for functions of arity 4. */
   def uncurried[T1, T2, T3, T4, R](f: T1 => T2 => T3 => T4 => R): (T1, T2, T3, T4) => R = {
     (x1, x2, x3, x4) => f(x1)(x2)(x3)(x4)
   }
 
-  /** Uncurrying for functions of arity 5.
-   */
+  /** Uncurrying for functions of arity 5. */
   def uncurried[T1, T2, T3, T4, T5, R](f: T1 => T2 => T3 => T4 => T5 => R): (T1, T2, T3, T4, T5) => R  =  {
     (x1, x2, x3, x4, x5) => f(x1)(x2)(x3)(x4)(x5)
   }

--- a/library/src/scala/Function0.scala
+++ b/library/src/scala/Function0.scala
@@ -18,13 +18,13 @@ package scala
 import scala.language.`2.13`
 
 /** A function of 0 parameters.
- *  
+ *
  *  In the following example, the definition of `greeting` is
  *  shorthand, conceptually, for the anonymous class definition
  *  `anonfun0`, although the implementation details of how the
  *  function value is constructed may differ:
  *
- *  {{{
+ *  ```
  *  val name = "world"
  *  val greeting = () => s"hello, $name"
  *
@@ -32,7 +32,7 @@ import scala.language.`2.13`
  *    def apply(): String = s"hello, $name"
  *  }
  *  assert(greeting() == anonfun0())
- *  }}}
+ *  ```
  */
 trait Function0[@specialized(Specializable.Primitives) +R] extends AnyRef {
   /** Applies the body of this function to the arguments.

--- a/library/src/scala/Function1.scala
+++ b/library/src/scala/Function1.scala
@@ -20,44 +20,44 @@ object Function1 {
 
   implicit final class UnliftOps[A, B] private[Function1](private val f: A => Option[B]) extends AnyVal {
     /** Converts an optional function to a partial function.
-      *
-      * @example Unlike [[Function.unlift]], this [[UnliftOps.unlift]] method can be used in extractors.
-      *          {{{
-      *          val of: Int => Option[String] = { i =>
-      *            if (i == 2) {
-      *              Some("matched by an optional function")
-      *            } else {
-      *              None
-      *            }
-      *          }
-      *
-      *          util.Random.nextInt(4) match {
-      *            case of.unlift(m) => // Convert an optional function to a pattern
-      *              println(m)
-      *            case _ =>
-      *              println("Not matched")
-      *          }
-      *          }}}
-      */
+     *
+     *  @example Unlike [[Function.unlift]], this [[UnliftOps.unlift]] method can be used in extractors.
+     *          ```
+     *          val of: Int => Option[String] = { i =>
+     *            if (i == 2) {
+     *              Some("matched by an optional function")
+     *            } else {
+     *              None
+     *            }
+     *          }
+     *
+     *          util.Random.nextInt(4) match {
+     *            case of.unlift(m) => // Convert an optional function to a pattern
+     *              println(m)
+     *            case _ =>
+     *              println("Not matched")
+     *          }
+     *          ```
+     */
     def unlift: PartialFunction[A, B] = Function.unlift(f)
   }
 
 }
 
 /** A function of 1 parameter.
- *  
+ *
  *  In the following example, the definition of `succ` is
  *  shorthand, conceptually, for the anonymous class definition
  *  `anonfun1`, although the implementation details of how the
  *  function value is constructed may differ:
  *
- *  {{{
+ *  ```
  *  val succ = (x: Int) => x + 1
  *  val anonfun1 = new Function1[Int, Int] {
  *    def apply(x: Int): Int = x + 1
  *  }
  *  assert(succ(0) == anonfun1(0))
- *  }}}
+ *  ```
  *
  *  Note that the difference between `Function1` and [[scala.PartialFunction]]
  *  is that the latter can specify inputs which it will not handle.

--- a/library/src/scala/Function10.scala
+++ b/library/src/scala/Function10.scala
@@ -16,9 +16,7 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 10 parameters.
- *
- */
+/** A function of 10 parameters. */
 trait Function10[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
    *  @return   the result of function application.

--- a/library/src/scala/Function11.scala
+++ b/library/src/scala/Function11.scala
@@ -16,9 +16,7 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 11 parameters.
- *
- */
+/** A function of 11 parameters. */
 trait Function11[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
    *  @return   the result of function application.

--- a/library/src/scala/Function12.scala
+++ b/library/src/scala/Function12.scala
@@ -16,9 +16,7 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 12 parameters.
- *
- */
+/** A function of 12 parameters. */
 trait Function12[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
    *  @return   the result of function application.

--- a/library/src/scala/Function13.scala
+++ b/library/src/scala/Function13.scala
@@ -16,9 +16,7 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 13 parameters.
- *
- */
+/** A function of 13 parameters. */
 trait Function13[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
    *  @return   the result of function application.

--- a/library/src/scala/Function14.scala
+++ b/library/src/scala/Function14.scala
@@ -16,9 +16,7 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 14 parameters.
- *
- */
+/** A function of 14 parameters. */
 trait Function14[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
    *  @return   the result of function application.

--- a/library/src/scala/Function15.scala
+++ b/library/src/scala/Function15.scala
@@ -16,9 +16,7 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 15 parameters.
- *
- */
+/** A function of 15 parameters. */
 trait Function15[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
    *  @return   the result of function application.

--- a/library/src/scala/Function16.scala
+++ b/library/src/scala/Function16.scala
@@ -16,9 +16,7 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 16 parameters.
- *
- */
+/** A function of 16 parameters. */
 trait Function16[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
    *  @return   the result of function application.

--- a/library/src/scala/Function17.scala
+++ b/library/src/scala/Function17.scala
@@ -16,9 +16,7 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 17 parameters.
- *
- */
+/** A function of 17 parameters. */
 trait Function17[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
    *  @return   the result of function application.

--- a/library/src/scala/Function18.scala
+++ b/library/src/scala/Function18.scala
@@ -16,9 +16,7 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 18 parameters.
- *
- */
+/** A function of 18 parameters. */
 trait Function18[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
    *  @return   the result of function application.

--- a/library/src/scala/Function19.scala
+++ b/library/src/scala/Function19.scala
@@ -16,9 +16,7 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 19 parameters.
- *
- */
+/** A function of 19 parameters. */
 trait Function19[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
    *  @return   the result of function application.

--- a/library/src/scala/Function2.scala
+++ b/library/src/scala/Function2.scala
@@ -17,20 +17,20 @@ package scala
 import scala.language.`2.13`
 
 /** A function of 2 parameters.
- *  
+ *
  *  In the following example, the definition of `max` is
  *  shorthand, conceptually, for the anonymous class definition
  *  `anonfun2`, although the implementation details of how the
  *  function value is constructed may differ:
  *
- *  {{{
+ *  ```
  *  val max = (x: Int, y: Int) => if (x < y) y else x
  *
  *  val anonfun2 = new Function2[Int, Int, Int] {
  *    def apply(x: Int, y: Int): Int = if (x < y) y else x
  *  }
  *  assert(max(0, 1) == anonfun2(0, 1))
- *  }}}
+ *  ```
  */
 trait Function2[@specialized(Specializable.Args) -T1, @specialized(Specializable.Args) -T2, @specialized(Specializable.Return) +R] extends AnyRef {
   /** Applies the body of this function to the arguments.

--- a/library/src/scala/Function20.scala
+++ b/library/src/scala/Function20.scala
@@ -16,9 +16,7 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 20 parameters.
- *
- */
+/** A function of 20 parameters. */
 trait Function20[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
    *  @return   the result of function application.

--- a/library/src/scala/Function21.scala
+++ b/library/src/scala/Function21.scala
@@ -16,9 +16,7 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 21 parameters.
- *
- */
+/** A function of 21 parameters. */
 trait Function21[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, -T21, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
    *  @return   the result of function application.

--- a/library/src/scala/Function22.scala
+++ b/library/src/scala/Function22.scala
@@ -16,9 +16,7 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 22 parameters.
- *
- */
+/** A function of 22 parameters. */
 trait Function22[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, -T21, -T22, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
    *  @return   the result of function application.

--- a/library/src/scala/Function3.scala
+++ b/library/src/scala/Function3.scala
@@ -16,9 +16,7 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 3 parameters.
- *
- */
+/** A function of 3 parameters. */
 trait Function3[-T1, -T2, -T3, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
    *  @return   the result of function application.

--- a/library/src/scala/Function4.scala
+++ b/library/src/scala/Function4.scala
@@ -16,9 +16,7 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 4 parameters.
- *
- */
+/** A function of 4 parameters. */
 trait Function4[-T1, -T2, -T3, -T4, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
    *  @return   the result of function application.

--- a/library/src/scala/Function5.scala
+++ b/library/src/scala/Function5.scala
@@ -16,9 +16,7 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 5 parameters.
- *
- */
+/** A function of 5 parameters. */
 trait Function5[-T1, -T2, -T3, -T4, -T5, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
    *  @return   the result of function application.

--- a/library/src/scala/Function6.scala
+++ b/library/src/scala/Function6.scala
@@ -16,9 +16,7 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 6 parameters.
- *
- */
+/** A function of 6 parameters. */
 trait Function6[-T1, -T2, -T3, -T4, -T5, -T6, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
    *  @return   the result of function application.

--- a/library/src/scala/Function7.scala
+++ b/library/src/scala/Function7.scala
@@ -16,9 +16,7 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 7 parameters.
- *
- */
+/** A function of 7 parameters. */
 trait Function7[-T1, -T2, -T3, -T4, -T5, -T6, -T7, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
    *  @return   the result of function application.

--- a/library/src/scala/Function8.scala
+++ b/library/src/scala/Function8.scala
@@ -16,9 +16,7 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 8 parameters.
- *
- */
+/** A function of 8 parameters. */
 trait Function8[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
    *  @return   the result of function application.

--- a/library/src/scala/Function9.scala
+++ b/library/src/scala/Function9.scala
@@ -16,9 +16,7 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 9 parameters.
- *
- */
+/** A function of 9 parameters. */
 trait Function9[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
    *  @return   the result of function application.

--- a/library/src/scala/IArray.scala
+++ b/library/src/scala/IArray.scala
@@ -15,11 +15,11 @@ opaque type IArray[+T] = Array[? <: T]
 object IArray:
 
   /** The selection operation on an immutable array.
-    *
-    *  @param arr the immutable array
-    *  @param n   the index of the element to select
-    *  @return    the element of the array at the given index
-    */
+   *
+   *  @param arr the immutable array
+   *  @param n   the index of the element to select
+   *  @return    the element of the array at the given index
+   */
   extension (arr: IArray[Byte]) def apply(n: Int): Byte = arr.asInstanceOf[Array[Byte]].apply(n)
   extension (arr: IArray[Short]) def apply(n: Int): Short = arr.asInstanceOf[Array[Short]].apply(n)
   extension (arr: IArray[Char]) def apply(n: Int): Char = arr.asInstanceOf[Array[Char]].apply(n)
@@ -31,8 +31,8 @@ object IArray:
   extension [T](arr: IArray[T]) def apply (n: Int): T = arr.asInstanceOf[Array[T]].apply(n)
 
   /** The number of elements in an immutable array.
-    *  @param arr  the immutable array
-    */
+   *  @param arr  the immutable array
+   */
   extension (arr: IArray[Byte]) def length: Int = arr.asInstanceOf[Array[Byte]].length
   extension (arr: IArray[Short]) def length: Int = arr.asInstanceOf[Array[Short]].length
   extension (arr: IArray[Char]) def length: Int = arr.asInstanceOf[Array[Char]].length
@@ -93,12 +93,14 @@ object IArray:
     genericArrayOps(arr).find(p)
 
   /** Builds a new array by applying a function to all elements of this array
-    * and using the elements of the resulting collections. */
+   *  and using the elements of the resulting collections. 
+   */
   extension [T](arr: IArray[T]) def flatMap[U: ClassTag](f: T => IterableOnce[U]^): IArray[U] =
     genericArrayOps(arr).flatMap(f)
 
   /** Flattens a two-dimensional array by concatenating all its rows
-    * into a single array. */
+   *  into a single array. 
+   */
   extension [T](arr: IArray[T]) def flatten[U](using asIterable: T => Iterable[U]^, ct: ClassTag[U]): IArray[U] =
     genericArrayOps(arr).flatten
 
@@ -107,12 +109,14 @@ object IArray:
     genericArrayOps(arr).fold(z)(op)
 
   /** Applies a binary operator to a start value and all elements of this array,
-    * going left to right. */
+   *  going left to right. 
+   */
   extension [T](arr: IArray[T]) def foldLeft[U](z: U)(op: (U, T) => U): U =
     genericArrayOps(arr).foldLeft(z)(op)
 
   /** Applies a binary operator to all elements of this array and a start value,
-    * going right to left. */
+   *  going right to left. 
+   */
   extension [T](arr: IArray[T]) def foldRight[U](z: U)(op: (T, U) => U): U =
     genericArrayOps(arr).foldRight(z)(op)
 
@@ -197,12 +201,14 @@ object IArray:
     genericArrayOps(arr).scan(z)(op)
 
   /** Produces an array containing cumulative results of applying the binary
-    * operator going left to right. */
+   *  operator going left to right. 
+   */
   extension [T](arr: IArray[T]) def scanLeft[U: ClassTag](z: U)(op: (U, T) => U): IArray[U] =
     genericArrayOps(arr).scanLeft(z)(op)
 
   /** Produces an array containing cumulative results of applying the binary
-    * operator going right to left. */
+   *  operator going right to left. 
+   */
   extension [T](arr: IArray[T]) def scanRight[U: ClassTag](z: U)(op: (T, U) => U): IArray[U] =
     genericArrayOps(arr).scanRight(z)(op)
 
@@ -215,7 +221,8 @@ object IArray:
     genericArrayOps(arr).slice(from, until)
 
   /** Sorts this array according to the Ordering which results from transforming
-    * an implicitly given Ordering with a transformation function. */
+   *  an implicitly given Ordering with a transformation function. 
+   */
   extension [T](arr: IArray[T]) def sortBy[U](f: T => U)(using math.Ordering[U]): IArray[T] =
     genericArrayOps(arr).sortBy(f)
 
@@ -442,13 +449,13 @@ object IArray:
 
   /** Builds an array from the iterable collection.
    *
-   *  {{{
+   *  ```
    *  scala> val a = IArray.from(Seq(1, 5))
    *  val a: IArray[Int] = IArray(1, 5)
    *
    *  scala> val b = IArray.from(Range(1, 5))
    *  val b: IArray[Int] = IArray(1, 2, 3, 4)
-   *  }}}
+   *  ```
    *
    *  @param  it the iterable collection
    *  @return    an array consisting of elements of the iterable collection
@@ -583,7 +590,7 @@ object IArray:
   /** Returns an immutable array containing a sequence of increasing integers in a range.
    *
    *  @param start  the start value of the array
-   *  @param end    the end value of the array, exclusive (in other words, this is the first value '''not''' returned)
+   *  @param end    the end value of the array, exclusive (in other words, this is the first value **not** returned)
    *  @return  the immutable array with values in range `start, start + 1, ..., end - 1`
    *  up to, but excluding, `end`.
    */
@@ -592,7 +599,7 @@ object IArray:
   /** Returns an immutable array containing equally spaced values in some integer interval.
    *
    *  @param start the start value of the array
-   *  @param end   the end value of the array, exclusive (in other words, this is the first value '''not''' returned)
+   *  @param end   the end value of the array, exclusive (in other words, this is the first value **not** returned)
    *  @param step  the increment value of the array (may not be zero)
    *  @return      the immutable array with values in `start, start + step, ...` up to, but excluding `end`
    */
@@ -631,8 +638,8 @@ object IArray:
   class WithFilter[T](p: T => Boolean, xs: IArray[T]):
 
     /** Applies `f` to each element for its side effects.
-      * Note: [U] parameter needed to help scalac's type inference.
-      */
+     *  Note: [U] parameter needed to help scalac's type inference.
+     */
     def foreach[U](f: T => U): Unit = {
       val len = xs.length
       var i = 0
@@ -644,12 +651,12 @@ object IArray:
     }
 
     /** Builds a new array by applying a function to all elements of this array.
-      *
-      *  @param f      the function to apply to each element.
-      *  @tparam U     the element type of the returned array.
-      *  @return       a new array resulting from applying the given function
-      *                `f` to each element of this array and collecting the results.
-      */
+     *
+     *  @tparam U     the element type of the returned array.
+     *  @param f      the function to apply to each element.
+     *  @return       a new array resulting from applying the given function
+     *                `f` to each element of this array and collecting the results.
+     */
     def map[U: ClassTag](f: T => U): IArray[U] = {
       val b = IArray.newBuilder[U]
       var i = 0
@@ -662,13 +669,13 @@ object IArray:
     }
 
     /** Builds a new array by applying a function to all elements of this array
-      * and using the elements of the resulting collections.
-      *
-      *  @param f      the function to apply to each element.
-      *  @tparam U     the element type of the returned array.
-      *  @return       a new array resulting from applying the given collection-valued function
-      *                `f` to each element of this array and concatenating the results.
-      */
+     *  and using the elements of the resulting collections.
+     *
+     *  @tparam U     the element type of the returned array.
+     *  @param f      the function to apply to each element.
+     *  @return       a new array resulting from applying the given collection-valued function
+     *                `f` to each element of this array and concatenating the results.
+     */
     def flatMap[U: ClassTag](f: T => IterableOnce[U]^): IArray[U] = {
       val b = IArray.newBuilder[U]
       var i = 0

--- a/library/src/scala/Int.scala
+++ b/library/src/scala/Int.scala
@@ -34,14 +34,13 @@ final abstract class Int private extends AnyVal {
   def toFloat: Float
   def toDouble: Double
 
-  /**
- * Returns the bitwise negation of this value.
- * @example {{{
- * ~5 == -6
- * // in binary: ~00000101 ==
- * //             11111010
- * }}}
- */
+  /** Returns the bitwise negation of this value.
+   *  @example ```
+   *  ~5 == -6
+   *  // in binary: ~00000101 ==
+   *  //             11111010
+   *  ```
+   */
   def unary_~ : Int
   /** Returns this value, unmodified. */
   def unary_+ : Int
@@ -51,63 +50,63 @@ final abstract class Int private extends AnyVal {
   @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0")
   def +(x: String): String
 
-  /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the new right bits with zeroes.
-  * @example {{{ 6 << 3 == 48 // in binary: 0110 << 3 == 0110000 }}}
-  */
+  /** Returns this value bit-shifted left by the specified number of bits,
+   *         filling in the new right bits with zeroes.
+   *  @example
+   *  ```
+   *  6 << 3 == 48 // in binary: 0110 << 3 == 0110000
+   *  ```
+   */
   def <<(x: Int): Int
-  /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the new right bits with zeroes.
-  * @example {{{ 6 << 3 == 48 // in binary: 0110 << 3 == 0110000 }}}
-  */
+  /** Returns this value bit-shifted left by the specified number of bits,
+   *         filling in the new right bits with zeroes.
+   *  @example
+   *  ```
+   *  6 << 3 == 48 // in binary: 0110 << 3 == 0110000
+   *  ```
+   */
   @deprecated("shifting a value by a `Long` argument is deprecated (except when the value is a `Long`).\nCall `toInt` on the argument to maintain the current behavior and avoid the deprecation warning.", "2.12.7")
   def <<(x: Long): Int
-  /**
-  * Returns this value bit-shifted right by the specified number of bits,
-  *         filling the new left bits with zeroes.
-  * @example {{{ 21 >>> 3 == 2 // in binary: 010101 >>> 3 == 010 }}}
-  * @example {{{
-  * -21 >>> 3 == 536870909
-  * // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
-  * //            00011111 11111111 11111111 11111101
-  * }}}
-  */
+  /** Returns this value bit-shifted right by the specified number of bits,
+   *         filling the new left bits with zeroes.
+   *  @example ``` 21 >>> 3 == 2 // in binary: 010101 >>> 3 == 010 ```
+   *  @example ```
+   *  -21 >>> 3 == 536870909
+   *  // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
+   *  //            00011111 11111111 11111111 11111101
+   *  ```
+   */
   def >>>(x: Int): Int
-  /**
-  * Returns this value bit-shifted right by the specified number of bits,
-  *         filling the new left bits with zeroes.
-  * @example {{{ 21 >>> 3 == 2 // in binary: 010101 >>> 3 == 010 }}}
-  * @example {{{
-  * -21 >>> 3 == 536870909
-  * // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
-  * //            00011111 11111111 11111111 11111101
-  * }}}
-  */
+  /** Returns this value bit-shifted right by the specified number of bits,
+   *         filling the new left bits with zeroes.
+   *  @example ``` 21 >>> 3 == 2 // in binary: 010101 >>> 3 == 010 ```
+   *  @example ```
+   *  -21 >>> 3 == 536870909
+   *  // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
+   *  //            00011111 11111111 11111111 11111101
+   *  ```
+   */
   @deprecated("shifting a value by a `Long` argument is deprecated (except when the value is a `Long`).\nCall `toInt` on the argument to maintain the current behavior and avoid the deprecation warning.", "2.12.7")
   def >>>(x: Long): Int
-  /**
-  * Returns this value bit-shifted right by the specified number of bits,
-  *         filling in the left bits with the same value as the left-most bit of this.
-  *         The effect of this is to retain the sign of the value.
-  * @example {{{
-  * -21 >> 3 == -3
-  * // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
-  * //            11111111 11111111 11111111 11111101
-  * }}}
-  */
+  /** Returns this value bit-shifted right by the specified number of bits,
+   *         filling in the left bits with the same value as the left-most bit of this.
+   *         The effect of this is to retain the sign of the value.
+   *  @example ```
+   *  -21 >> 3 == -3
+   *  // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
+   *  //            11111111 11111111 11111111 11111101
+   *  ```
+   */
   def >>(x: Int): Int
-  /**
-  * Returns this value bit-shifted right by the specified number of bits,
-  *         filling in the left bits with the same value as the left-most bit of this.
-  *         The effect of this is to retain the sign of the value.
-  * @example {{{
-  * -21 >> 3 == -3
-  * // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
-  * //            11111111 11111111 11111111 11111101
-  * }}}
-  */
+  /** Returns this value bit-shifted right by the specified number of bits,
+   *         filling in the left bits with the same value as the left-most bit of this.
+   *         The effect of this is to retain the sign of the value.
+   *  @example ```
+   *  -21 >> 3 == -3
+   *  // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
+   *  //            11111111 11111111 11111111 11111101
+   *  ```
+   */
   @deprecated("shifting a value by a `Long` argument is deprecated (except when the value is a `Long`).\nCall `toInt` on the argument to maintain the current behavior and avoid the deprecation warning.", "2.12.7")
   def >>(x: Long): Int
 
@@ -201,172 +200,157 @@ final abstract class Int private extends AnyVal {
   /** Returns `true` if this value is greater than or equal to x, `false` otherwise. */
   def >=(x: Double): Boolean
 
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Byte): Int
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Short): Int
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Char): Int
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Int): Int
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Long): Long
 
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Byte): Int
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Short): Int
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Char): Int
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Int): Int
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Long): Long
 
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Byte): Int
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Short): Int
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Char): Int
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Int): Int
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Long): Long
 
   /** Returns the sum of this value and `x`. */
@@ -457,7 +441,7 @@ object Int extends AnyValCompanion {
 
   /** Transforms a value type into a boxed reference type.
    *
-   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.boxToInteger`. See [[https://github.com/scala/scala src/library/scala/runtime/BoxesRunTime.java]].
+   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.boxToInteger`. See [src/library/scala/runtime/BoxesRunTime.java](https://github.com/scala/scala).
    *
    *  @param  x   the Int to be boxed
    *  @return     a java.lang.Integer offering `x` as its underlying value.
@@ -468,11 +452,11 @@ object Int extends AnyValCompanion {
    *  method is not typesafe: it accepts any Object, but will throw
    *  an exception if the argument is not a java.lang.Integer.
    *
-   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.unboxToInt`. See [[https://github.com/scala/scala src/library/scala/runtime/BoxesRunTime.java]].
+   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.unboxToInt`. See [src/library/scala/runtime/BoxesRunTime.java](https://github.com/scala/scala).
    *
    *  @param  x   the java.lang.Integer to be unboxed.
-   *  @throws     ClassCastException  if the argument is not a java.lang.Integer
    *  @return     the Int resulting from calling intValue() on `x`
+   *  @throws     ClassCastException  if the argument is not a java.lang.Integer
    */
   def unbox(x: java.lang.Object): Int = ???
 

--- a/library/src/scala/Long.scala
+++ b/library/src/scala/Long.scala
@@ -34,14 +34,13 @@ final abstract class Long private extends AnyVal {
   def toFloat: Float
   def toDouble: Double
 
-  /**
- * Returns the bitwise negation of this value.
- * @example {{{
- * ~5 == -6
- * // in binary: ~00000101 ==
- * //             11111010
- * }}}
- */
+  /** Returns the bitwise negation of this value.
+   *  @example ```
+   *  ~5 == -6
+   *  // in binary: ~00000101 ==
+   *  //             11111010
+   *  ```
+   */
   def unary_~ : Long
   /** Returns this value, unmodified. */
   def unary_+ : Long
@@ -51,61 +50,61 @@ final abstract class Long private extends AnyVal {
   @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0")
   def +(x: String): String
 
-  /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the new right bits with zeroes.
-  * @example {{{ 6 << 3 == 48 // in binary: 0110 << 3 == 0110000 }}}
-  */
+  /** Returns this value bit-shifted left by the specified number of bits,
+   *         filling in the new right bits with zeroes.
+   *  @example
+   *  ```
+   *  6 << 3 == 48 // in binary: 0110 << 3 == 0110000
+   *  ```
+   */
   def <<(x: Int): Long
-  /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the new right bits with zeroes.
-  * @example {{{ 6 << 3 == 48 // in binary: 0110 << 3 == 0110000 }}}
-  */
+  /** Returns this value bit-shifted left by the specified number of bits,
+   *         filling in the new right bits with zeroes.
+   *  @example
+   *  ```
+   *  6 << 3 == 48 // in binary: 0110 << 3 == 0110000
+   *  ```
+   */
   def <<(x: Long): Long
-  /**
-  * Returns this value bit-shifted right by the specified number of bits,
-  *         filling the new left bits with zeroes.
-  * @example {{{ 21 >>> 3 == 2 // in binary: 010101 >>> 3 == 010 }}}
-  * @example {{{
-  * -21 >>> 3 == 536870909
-  * // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
-  * //            00011111 11111111 11111111 11111101
-  * }}}
-  */
+  /** Returns this value bit-shifted right by the specified number of bits,
+   *         filling the new left bits with zeroes.
+   *  @example ``` 21 >>> 3 == 2 // in binary: 010101 >>> 3 == 010 ```
+   *  @example ```
+   *  -21 >>> 3 == 536870909
+   *  // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
+   *  //            00011111 11111111 11111111 11111101
+   *  ```
+   */
   def >>>(x: Int): Long
-  /**
-  * Returns this value bit-shifted right by the specified number of bits,
-  *         filling the new left bits with zeroes.
-  * @example {{{ 21 >>> 3 == 2 // in binary: 010101 >>> 3 == 010 }}}
-  * @example {{{
-  * -21 >>> 3 == 536870909
-  * // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
-  * //            00011111 11111111 11111111 11111101
-  * }}}
-  */
+  /** Returns this value bit-shifted right by the specified number of bits,
+   *         filling the new left bits with zeroes.
+   *  @example ``` 21 >>> 3 == 2 // in binary: 010101 >>> 3 == 010 ```
+   *  @example ```
+   *  -21 >>> 3 == 536870909
+   *  // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
+   *  //            00011111 11111111 11111111 11111101
+   *  ```
+   */
   def >>>(x: Long): Long
-  /**
-  * Returns this value bit-shifted right by the specified number of bits,
-  *         filling in the left bits with the same value as the left-most bit of this.
-  *         The effect of this is to retain the sign of the value.
-  * @example {{{
-  * -21 >> 3 == -3
-  * // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
-  * //            11111111 11111111 11111111 11111101
-  * }}}
-  */
+  /** Returns this value bit-shifted right by the specified number of bits,
+   *         filling in the left bits with the same value as the left-most bit of this.
+   *         The effect of this is to retain the sign of the value.
+   *  @example ```
+   *  -21 >> 3 == -3
+   *  // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
+   *  //            11111111 11111111 11111111 11111101
+   *  ```
+   */
   def >>(x: Int): Long
-  /**
-  * Returns this value bit-shifted right by the specified number of bits,
-  *         filling in the left bits with the same value as the left-most bit of this.
-  *         The effect of this is to retain the sign of the value.
-  * @example {{{
-  * -21 >> 3 == -3
-  * // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
-  * //            11111111 11111111 11111111 11111101
-  * }}}
-  */
+  /** Returns this value bit-shifted right by the specified number of bits,
+   *         filling in the left bits with the same value as the left-most bit of this.
+   *         The effect of this is to retain the sign of the value.
+   *  @example ```
+   *  -21 >> 3 == -3
+   *  // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
+   *  //            11111111 11111111 11111111 11111101
+   *  ```
+   */
   def >>(x: Long): Long
 
   /** Returns `true` if this value is equal to x, `false` otherwise. */
@@ -198,172 +197,157 @@ final abstract class Long private extends AnyVal {
   /** Returns `true` if this value is greater than or equal to x, `false` otherwise. */
   def >=(x: Double): Boolean
 
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Byte): Long
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Short): Long
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Char): Long
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Int): Long
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Long): Long
 
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Byte): Long
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Short): Long
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Char): Long
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Int): Long
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Long): Long
 
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Byte): Long
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Short): Long
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Char): Long
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Int): Long
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Long): Long
 
   /** Returns the sum of this value and `x`. */
@@ -454,7 +438,7 @@ object Long extends AnyValCompanion {
 
   /** Transforms a value type into a boxed reference type.
    *
-   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.boxToLong`. See [[https://github.com/scala/scala src/library/scala/runtime/BoxesRunTime.java]].
+   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.boxToLong`. See [src/library/scala/runtime/BoxesRunTime.java](https://github.com/scala/scala).
    *
    *  @param  x   the Long to be boxed
    *  @return     a java.lang.Long offering `x` as its underlying value.
@@ -465,11 +449,11 @@ object Long extends AnyValCompanion {
    *  method is not typesafe: it accepts any Object, but will throw
    *  an exception if the argument is not a java.lang.Long.
    *
-   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.unboxToLong`. See [[https://github.com/scala/scala src/library/scala/runtime/BoxesRunTime.java]].
+   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.unboxToLong`. See [src/library/scala/runtime/BoxesRunTime.java](https://github.com/scala/scala).
    *
    *  @param  x   the java.lang.Long to be unboxed.
-   *  @throws     ClassCastException  if the argument is not a java.lang.Long
    *  @return     the Long resulting from calling longValue() on `x`
+   *  @throws     ClassCastException  if the argument is not a java.lang.Long
    */
   def unbox(x: java.lang.Object): Long = ???
 

--- a/library/src/scala/NamedTuple.scala
+++ b/library/src/scala/NamedTuple.scala
@@ -21,7 +21,7 @@ object NamedTuple:
   def unapply[N <: Tuple, V <: Tuple](x: NamedTuple[N, V]): Some[V] = Some(x)
 
   /** A named tuple expression will desugar to a call to `build`. For instance,
-   * `(name = "Lyra", age = 23)` will desugar to `build[("name", "age")]()(("Lyra", 23))`.
+   *  `(name = "Lyra", age = 23)` will desugar to `build[("name", "age")]()(("Lyra", 23))`.
    */
   inline def build[N <: Tuple]()[V <: Tuple](x: V): NamedTuple[N, V] = x
 

--- a/library/src/scala/Option.scala
+++ b/library/src/scala/Option.scala
@@ -56,20 +56,20 @@ object Option {
  *  as a collection or monad and use `map`,`flatMap`, `filter`, or
  *  `foreach`:
  *
- *  {{{
+ *  ```
  *  val name: Option[String] = request.getParameter("name")
  *  val upper = name.map(_.trim).filter(_.length != 0).map(_.toUpperCase)
  *  println(upper.getOrElse(""))
- *  }}}
+ *  ```
  *
- *  Note that this is equivalent to {{{
+ *  Note that this is equivalent to ```
  *  val upper = for {
  *    name <- request.getParameter("name")
  *    trimmed <- Some(name.trim)
  *    upper <- Some(trimmed.toUpperCase) if trimmed.length != 0
  *  } yield upper
  *  println(upper.getOrElse(""))
- *  }}}
+ *  ```
  *
  *  Because of how for comprehension works, if $none is returned
  *  from `request.getParameter`, the entire expression results in
@@ -78,7 +78,7 @@ object Option {
  *  This allows for sophisticated chaining of $option values without
  *  having to check for the existence of a value.
  *
- * These are useful methods that exist for both $some and $none.
+ *  These are useful methods that exist for both $some and $none.
  *  - [[isDefined]] — True if not empty
  *  - [[isEmpty]] — True if empty
  *  - [[nonEmpty]] — True if not empty
@@ -100,7 +100,7 @@ object Option {
  *  - [[unzip3]] — Split an optional triple to three optional values
  *  - [[toList]] — Unary list of optional value, otherwise the empty list
  *
- *  A less-idiomatic way to use $option values is via pattern matching: {{{
+ *  A less-idiomatic way to use $option values is via pattern matching: ```
  *  val nameMaybe = request.getParameter("name")
  *  nameMaybe match {
  *    case Some(name) =>
@@ -108,20 +108,20 @@ object Option {
  *    case None =>
  *      println("No name value")
  *  }
- *  }}}
+ *  ```
  *
- * Interacting with code that can occasionally return null can be
- * safely wrapped in $option to become $none and $some otherwise. {{{
- * val abc = new java.util.HashMap[Int, String]
- * abc.put(1, "A")
- * bMaybe = Option(abc.get(2))
- * bMaybe match {
+ *  Interacting with code that can occasionally return null can be
+ *  safely wrapped in $option to become $none and $some otherwise. ```
+ *  val abc = new java.util.HashMap[Int, String]
+ *  abc.put(1, "A")
+ *  bMaybe = Option(abc.get(2))
+ *  bMaybe match {
  *   case Some(b) =>
  *     println(s"Found \$b")
  *   case None =>
  *     println("Not found")
- * }
- * }}}
+ *  }
+ *  ```
  *
  *  @note Many of the methods in here are duplicative with those
  *  in the Iterable hierarchy, but they are duplicated for a reason:
@@ -148,25 +148,25 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
 
   /** Returns true if the option is $none, false otherwise.
    *
-   * This is equivalent to:
-   * {{{
-   * option match {
+   *  This is equivalent to:
+   *  ```
+   *  option match {
    *   case Some(_) => false
    *   case None    => true
-   * }
-   * }}}
+   *  }
+   *  ```
    */
   final def isEmpty: Boolean = this eq None
 
   /** Returns true if the option is an instance of $some, false otherwise.
    *
-   * This is equivalent to:
-   * {{{
-   * option match {
+   *  This is equivalent to:
+   *  ```
+   *  option match {
    *   case Some(_) => true
    *   case None    => false
-   * }
-   * }}}
+   *  }
+   *  ```
    */
   final def isDefined: Boolean = !isEmpty
 
@@ -174,28 +174,28 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
 
   /** Returns the option's value.
    *
-   * This is equivalent to:
-   * {{{
-   * option match {
+   *  This is equivalent to:
+   *  ```
+   *  option match {
    *   case Some(x) => x
    *   case None    => throw new Exception
-   * }
-   * }}}
+   *  }
+   *  ```
    *  @note The option must be nonempty.
    *  @throws NoSuchElementException if the option is empty.
    */
   def get: A
 
   /** Returns the option's value if the option is nonempty, otherwise
-   * return the result of evaluating `default`.
+   *  return the result of evaluating `default`.
    *
-   * This is equivalent to:
-   * {{{
-   * option match {
+   *  This is equivalent to:
+   *  ```
+   *  option match {
    *   case Some(x) => x
    *   case None    => default
-   * }
-   * }}}
+   *  }
+   *  ```
    *
    *  @param default  the default expression.
    */
@@ -203,36 +203,36 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
     if (isEmpty) default else this.get
 
   /** Returns the option's value if it is nonempty,
-   * or `null` if it is empty.
+   *  or `null` if it is empty.
    *
-   * Although the use of null is discouraged, code written to use
-   * $option must often interface with code that expects and returns nulls.
+   *  Although the use of null is discouraged, code written to use
+   *  $option must often interface with code that expects and returns nulls.
    *
-   * This is equivalent to:
-   * {{{
-   * option match {
+   *  This is equivalent to:
+   *  ```
+   *  option match {
    *   case Some(x) => x
    *   case None    => null
-   * }
-   * }}}
-   * @example {{{
-   * val initialText: Option[String] = getInitialText
-   * val textField = new JComponent(initialText.orNull,20)
-   * }}}
+   *  }
+   *  ```
+   *  @example ```
+   *  val initialText: Option[String] = getInitialText
+   *  val textField = new JComponent(initialText.orNull,20)
+   *  ```
    */
   @inline final def orNull[A1 >: A](implicit ev: Null <:< A1): A1 = this getOrElse ev(null)
 
   /** Returns a $some containing the result of applying $f to this $option's
-   * value if this $option is nonempty.
-   * Otherwise return $none.
+   *  value if this $option is nonempty.
+   *  Otherwise return $none.
    *
-   * This is equivalent to:
-   * {{{
-   * option match {
+   *  This is equivalent to:
+   *  ```
+   *  option match {
    *   case Some(x) => Some(f(x))
    *   case None    => None
-   * }
-   * }}}
+   *  }
+   *  ```
    *  @note This is similar to `flatMap` except here,
    *  $f does not need to wrap its result in an $option.
    *
@@ -247,17 +247,17 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
    *  value if the $option is nonempty.  Otherwise, evaluates
    *  expression `ifEmpty`.
    *
-   * This is equivalent to:
-   * {{{
-   * option match {
+   *  This is equivalent to:
+   *  ```
+   *  option match {
    *   case Some(x) => f(x)
    *   case None    => ifEmpty
-   * }
-   * }}}
-   * This is also equivalent to:
-   * {{{
-   * option.map(f).getOrElse(ifEmpty)
-   * }}}
+   *  }
+   *  ```
+   *  This is also equivalent to:
+   *  ```
+   *  option.map(f).getOrElse(ifEmpty)
+   *  ```
    *  @param  ifEmpty the expression to evaluate if empty.
    *  @param  f       the function to apply if nonempty.
    */
@@ -265,18 +265,18 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
     if (isEmpty) ifEmpty else f(this.get)
 
   /** Returns the result of applying $f to this $option's value if
-   * this $option is nonempty.
-   * Returns $none if this $option is empty.
-   * Slightly different from `map` in that $f is expected to
-   * return an $option (which could be $none).
+   *  this $option is nonempty.
+   *  Returns $none if this $option is empty.
+   *  Slightly different from `map` in that $f is expected to
+   *  return an $option (which could be $none).
    *
-   * This is equivalent to:
-   * {{{
-   * option match {
+   *  This is equivalent to:
+   *  ```
+   *  option match {
    *   case Some(x) => f(x)
    *   case None    => None
-   * }
-   * }}}
+   *  }
+   *  ```
    *  @param  f   the function to apply
    *  @see map
    *  @see foreach
@@ -285,51 +285,51 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
     if (isEmpty) None else f(this.get)
 
   /** Returns the nested $option value if it is nonempty.  Otherwise,
-   * return $none.
+   *  return $none.
    *
-   * This is equivalent to:
-   * {{{
-   * option match {
+   *  This is equivalent to:
+   *  ```
+   *  option match {
    *   case Some(Some(b)) => Some(b)
    *   case _             => None
-   * }
-   * }}}
-   * @example {{{
-   * Some(Some("something")).flatten
-   * }}}
+   *  }
+   *  ```
+   *  @example ```
+   *  Some(Some("something")).flatten
+   *  ```
    *
-   * @param ev an implicit conversion that asserts that the value is
+   *  @param ev an implicit conversion that asserts that the value is
    *           also an $option.
-   * @see flatMap
+   *  @see flatMap
    */
   def flatten[B](implicit ev: A <:< Option[B]): Option[B] =
     if (isEmpty) None else ev(this.get)
 
-  /** Returns this $option if it is nonempty '''and''' applying the predicate $p to
-   * this $option's value returns true. Otherwise, return $none.
+  /** Returns this $option if it is nonempty **and** applying the predicate $p to
+   *  this $option's value returns true. Otherwise, return $none.
    *
-   * This is equivalent to:
-   * {{{
-   * option match {
+   *  This is equivalent to:
+   *  ```
+   *  option match {
    *   case Some(x) if p(x) => Some(x)
    *   case _               => None
-   * }
-   * }}}
+   *  }
+   *  ```
    *  @param  p   the predicate used for testing.
    */
   @inline final def filter(p: A => Boolean): Option[A] =
     if (isEmpty || p(this.get)) this else None
 
-  /** Returns this $option if it is nonempty '''and''' applying the predicate $p to
-   * this $option's value returns false. Otherwise, return $none.
+  /** Returns this $option if it is nonempty **and** applying the predicate $p to
+   *  this $option's value returns false. Otherwise, return $none.
    *
-   * This is equivalent to:
-   * {{{
-   * option match {
+   *  This is equivalent to:
+   *  ```
+   *  option match {
    *   case Some(x) if !p(x) => Some(x)
    *   case _                => None
-   * }
-   * }}}
+   *  }
+   *  ```
    *  @param  p   the predicate used for testing.
    */
   @inline final def filterNot(p: A => Boolean): Option[A] =
@@ -337,13 +337,13 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
 
   /** Returns false if the option is $none, true otherwise.
    *
-   * This is equivalent to:
-   * {{{
-   * option match {
+   *  This is equivalent to:
+   *  ```
+   *  option match {
    *   case Some(_) => true
    *   case None    => false
-   * }
-   * }}}
+   *  }
+   *  ```
    *  @note   Implemented here to avoid the implicit conversion to Iterable.
    */
   final def nonEmpty: Boolean = isDefined
@@ -366,14 +366,14 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
 
   /** Tests whether the option contains a given value as an element.
    *
-   * This is equivalent to:
-   * {{{
-   * option match {
+   *  This is equivalent to:
+   *  ```
+   *  option match {
    *   case Some(x) => x == elem
    *   case None    => false
-   * }
-   * }}}
-   *  @example {{{
+   *  }
+   *  ```
+   *  @example ```
    *  // Returns true because Some instance contains string "something" which equals "something".
    *  Some("something") contains "something"
    *
@@ -382,7 +382,7 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
    *
    *  // Returns false when method called on None.
    *  None contains "anything"
-   *  }}}
+   *  ```
    *
    *  @param elem the element to test.
    *  @return `true` if the option has an element that is equal (as
@@ -391,32 +391,32 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
   final def contains[A1 >: A](elem: A1): Boolean =
     !isEmpty && this.get == elem
 
-  /** Returns true if this option is nonempty '''and''' the predicate
-   * $p returns true when applied to this $option's value.
-   * Otherwise, returns false.
+  /** Returns true if this option is nonempty **and** the predicate
+   *  $p returns true when applied to this $option's value.
+   *  Otherwise, returns false.
    *
-   * This is equivalent to:
-   * {{{
-   * option match {
+   *  This is equivalent to:
+   *  ```
+   *  option match {
    *   case Some(x) => p(x)
    *   case None    => false
-   * }
-   * }}}
+   *  }
+   *  ```
    *  @param  p   the predicate to test
    */
   @inline final def exists(p: A => Boolean): Boolean =
     !isEmpty && p(this.get)
 
-  /** Returns true if this option is empty '''or''' the predicate
-   * $p returns true when applied to this $option's value.
+  /** Returns true if this option is empty **or** the predicate
+   *  $p returns true when applied to this $option's value.
    *
-   * This is equivalent to:
-   * {{{
-   * option match {
+   *  This is equivalent to:
+   *  ```
+   *  option match {
    *   case Some(x) => p(x)
    *   case None    => true
-   * }
-   * }}}
+   *  }
+   *  ```
    *  @param  p   the predicate to test
    */
   @inline final def forall(p: A => Boolean): Boolean = isEmpty || p(this.get)
@@ -424,13 +424,13 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
   /** Applies the given procedure $f to the option's value,
    *  if it is nonempty. Otherwise, do nothing.
    *
-   * This is equivalent to:
-   * {{{
-   * option match {
+   *  This is equivalent to:
+   *  ```
+   *  option match {
    *   case Some(x) => f(x)
    *   case None    => ()
-   * }
-   * }}}
+   *  }
+   *  ```
    *  @param  f   the procedure to apply.
    *  @see map
    *  @see flatMap
@@ -440,12 +440,12 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
   }
 
   /** Returns a $some containing the result of
-   * applying `pf` to this $option's contained
-   * value, '''if''' this option is
-   * nonempty '''and''' `pf` is defined for that value.
-   * Returns $none otherwise.
+   *  applying `pf` to this $option's contained
+   *  value, **if** this option is
+   *  nonempty **and** `pf` is defined for that value.
+   *  Returns $none otherwise.
    *
-   *  @example {{{
+   *  @example ```
    *  // Returns Some(HTTP) because the partial function covers the case.
    *  Some("http") collect {case "http" => "HTTP"}
    *
@@ -454,7 +454,7 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
    *
    *  // Returns None because the option is empty. There is no value to pass to the partial function.
    *  None collect {case value => value}
-   *  }}}
+   *  ```
    *
    *  @param  pf   the partial function.
    *  @return the result of applying `pf` to this $option's
@@ -466,13 +466,13 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
   /** Returns this $option if it is nonempty,
    *  otherwise return the result of evaluating `alternative`.
    *
-   * This is equivalent to:
-   * {{{
-   * option match {
+   *  This is equivalent to:
+   *  ```
+   *  option match {
    *   case Some(x) => Some(x)
    *   case None    => alternative
-   * }
-   * }}}
+   *  }
+   *  ```
    *  @param alternative the alternative expression.
    */
   @inline final def orElse[B >: A](alternative: => Option[B]): Option[B] =
@@ -483,13 +483,13 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
    *  If either of the two options is empty, $none is returned.
    *
    *  This is equivalent to:
-   *  {{{
+   *  ```
    *  (option1, option2) match {
    *    case (Some(x), Some(y)) => Some((x, y))
    *    case _                  => None
    *  }
-   *  }}}
-   *  @example {{{
+   *  ```
+   *  @example ```
    *  // Returns Some(("foo", "bar")) because both options are nonempty.
    *  Some("foo") zip Some("bar")
    *
@@ -498,7 +498,7 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
    *
    *  // Returns None because `this` option is empty.
    *  None zip Some("bar")
-   *  }}}
+   *  ```
    *
    *  @param  that   the options which is going to be zipped
    */
@@ -506,21 +506,21 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
     if (isEmpty || that.isEmpty) None else Some((this.get, that.get))
 
   /** Converts an Option of a pair into an Option of the first element and an Option of the second element.
-    *
-    *  This is equivalent to:
-    *  {{{
-    *  option match {
-    *    case Some((x, y)) => (Some(x), Some(y))
-    *    case _            => (None,    None)
-    *  }
-    *  }}}
-    *  @tparam A1    the type of the first half of the element pair
-    *  @tparam A2    the type of the second half of the element pair
-    *  @param asPair an implicit conversion which asserts that the element type
-    *                of this Option is a pair.
-    *  @return       a pair of Options, containing, respectively, the first and second half
-    *                of the element pair of this Option.
-    */
+   *
+   *  This is equivalent to:
+   *  ```
+   *  option match {
+   *    case Some((x, y)) => (Some(x), Some(y))
+   *    case _            => (None,    None)
+   *  }
+   *  ```
+   *  @tparam A1    the type of the first half of the element pair
+   *  @tparam A2    the type of the second half of the element pair
+   *  @param asPair an implicit conversion which asserts that the element type
+   *                of this Option is a pair.
+   *  @return       a pair of Options, containing, respectively, the first and second half
+   *                of the element pair of this Option.
+   */
   final def unzip[A1, A2](implicit asPair: A <:< (A1, A2)): (Option[A1], Option[A2]) = {
     if (isEmpty)
       (None, None)
@@ -531,22 +531,22 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
   }
 
   /** Converts an Option of a triple into three Options, one containing the element from each position of the triple.
-    *
-    *  This is equivalent to:
-    *  {{{
-    *  option match {
-    *    case Some((x, y, z)) => (Some(x), Some(y), Some(z))
-    *    case _               => (None,    None,    None)
-    *  }
-    *  }}}
-    *  @tparam A1      the type of the first of three elements in the triple
-    *  @tparam A2      the type of the second of three elements in the triple
-    *  @tparam A3      the type of the third of three elements in the triple
-    *  @param asTriple an implicit conversion which asserts that the element type
-    *                  of this Option is a triple.
-    *  @return         a triple of Options, containing, respectively, the first, second, and third
-    *                  elements from the element triple of this Option.
-    */
+   *
+   *  This is equivalent to:
+   *  ```
+   *  option match {
+   *    case Some((x, y, z)) => (Some(x), Some(y), Some(z))
+   *    case _               => (None,    None,    None)
+   *  }
+   *  ```
+   *  @tparam A1      the type of the first of three elements in the triple
+   *  @tparam A2      the type of the second of three elements in the triple
+   *  @tparam A3      the type of the third of three elements in the triple
+   *  @param asTriple an implicit conversion which asserts that the element type
+   *                  of this Option is a triple.
+   *  @return         a triple of Options, containing, respectively, the first, second, and third
+   *                  elements from the element triple of this Option.
+   */
   final def unzip3[A1, A2, A3](implicit asTriple: A <:< (A1, A2, A3)): (Option[A1], Option[A2], Option[A3]) = {
     if (isEmpty)
       (None, None, None)
@@ -557,57 +557,57 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
   }
 
   /** Returns a singleton iterator returning the $option's value
-   * if it is nonempty, or an empty iterator if the option is empty.
+   *  if it is nonempty, or an empty iterator if the option is empty.
    */
   def iterator: Iterator[A] =
     if (isEmpty) collection.Iterator.empty else collection.Iterator.single(this.get)
 
   /** Returns a singleton list containing the $option's value
-   * if it is nonempty, or the empty list if the $option is empty.
+   *  if it is nonempty, or the empty list if the $option is empty.
    *
-   * This is equivalent to:
-   * {{{
-   * option match {
+   *  This is equivalent to:
+   *  ```
+   *  option match {
    *   case Some(x) => List(x)
    *   case None    => Nil
-   * }
-   * }}}
+   *  }
+   *  ```
    */
   def toList: List[A] =
     if (isEmpty) List() else new ::(this.get, Nil)
 
   /** Returns a [[scala.util.Left]] containing the given
-   * argument `left` if this $option is empty, or
-   * a [[scala.util.Right]] containing this $option's value if
-   * this is nonempty.
+   *  argument `left` if this $option is empty, or
+   *  a [[scala.util.Right]] containing this $option's value if
+   *  this is nonempty.
    *
-   * This is equivalent to:
-   * {{{
-   * option match {
+   *  This is equivalent to:
+   *  ```
+   *  option match {
    *   case Some(x) => Right(x)
    *   case None    => Left(left)
-   * }
-   * }}}
-   * @param left the expression to evaluate and return if this is empty
-   * @see toLeft
+   *  }
+   *  ```
+   *  @param left the expression to evaluate and return if this is empty
+   *  @see toLeft
    */
   @inline final def toRight[X](left: => X): Either[X, A] =
     if (isEmpty) Left(left) else Right(this.get)
 
   /** Returns a [[scala.util.Right]] containing the given
-   * argument `right` if this is empty, or
-   * a [[scala.util.Left]] containing this $option's value
-   * if this $option is nonempty.
+   *  argument `right` if this is empty, or
+   *  a [[scala.util.Left]] containing this $option's value
+   *  if this $option is nonempty.
    *
-   * This is equivalent to:
-   * {{{
-   * option match {
+   *  This is equivalent to:
+   *  ```
+   *  option match {
    *   case Some(x) => Left(x)
    *   case None    => Right(right)
-   * }
-   * }}}
-   * @param right the expression to evaluate and return if this is empty
-   * @see toRight
+   *  }
+   *  ```
+   *  @param right the expression to evaluate and return if this is empty
+   *  @see toRight
    */
   @inline final def toLeft[X](right: => X): Either[A, X] =
     if (isEmpty) Right(right) else Left(this.get)
@@ -622,8 +622,7 @@ final case class Some[+A](value: A) extends Option[A] {
 }
 
 
-/** This case object represents non-existent values.
- */
+/** This case object represents non-existent values. */
 @SerialVersionUID(5066590221178148012L) // value computed by serialver for 2.11.2, annotation added in 2.11.4
 case object None extends Option[Nothing] {
   def get: Nothing = throw new NoSuchElementException("None.get")

--- a/library/src/scala/PartialFunction.scala
+++ b/library/src/scala/PartialFunction.scala
@@ -27,9 +27,9 @@ import scala.util.boundary.break
  *  Even if `isDefinedAt` returns true for an `a: A`, calling `apply(a)` may
  *  still throw an exception, so the following code is legal:
  *
- *  {{{
+ *  ```
  *  val f: PartialFunction[Int, Any] = { case x => x / 0 }   // ArithmeticException: / by zero
- *  }}}
+ *  ```
  *
  *  It is the responsibility of the caller to call `isDefinedAt` before
  *  calling `apply`, because if `isDefinedAt` is false, it is not guaranteed
@@ -43,7 +43,7 @@ import scala.util.boundary.break
  *  Note that `isDefinedAt` may itself throw an exception while evaluating pattern guards
  *  or other parts of the `PartialFunction`. The same caveat holds for `applyOrElse`.
  *
- *  {{{
+ *  ```
  *  val sample = 1 to 10
  *  def isEven(n: Int) = n % 2 == 0
  *
@@ -64,7 +64,7 @@ import scala.util.boundary.break
  *  // A method that takes a Function will get one, using the same syntax.
  *  // Note that all cases are supplied since Function has no `isDefinedAt`.
  *  def evened = sample.map { case odd if !isEven(odd) => odd + 1 case even => even }
- *  }}}
+ *  ```
  *
  *  The main distinction between `PartialFunction` and [[scala.Function1]] is
  *  that the client of a `PartialFunction` can perform an alternative computation
@@ -72,7 +72,7 @@ import scala.util.boundary.break
  *
  *  For example:
  *
- *  {{{
+ *  ```
  *  val oddlyEnough: PartialFunction[Int, String] = {
  *    case x if !isEven(x) => s"\$x is odd"
  *  }
@@ -84,28 +84,28 @@ import scala.util.boundary.break
  *  // The same computation but with a function literal that calls applyOrElse
  *  // with oddlyEnough as fallback, which it can do because a PartialFunction is a Function.
  *  val numbers = sample.map(n => eveningNews.applyOrElse(n, oddlyEnough))
- *  }}}
+ *  ```
  *
  *  As a convenience, function literals can also be adapted into partial functions
  *  when needed. If the body of the function is a match expression, then the cases
  *  are used to synthesize the PartialFunction as already shown.
  *
- *  {{{
+ *  ```
  *  // The partial function isDefinedAt inputs resulting in the Success case.
  *  val inputs = List("1", "two", "3").collect(x => Try(x.toInt) match { case Success(i) => i })
- *  }}}
+ *  ```
  *
  *  @note Optional [[Function]]s, [[PartialFunction]]s and extractor objects
  *        can be converted to each other as shown in the following table.
  *  &nbsp;
- * | How to convert ... | to a [[PartialFunction]] | to an optional [[Function]] | to an extractor |
- * | :---:  | ---  | --- | --- |
- * | from a [[PartialFunction]] | [[Predef.identity]] | [[lift]] | [[Predef.identity]] |
- * | from optional [[Function]] | [[Function1.UnliftOps#unlift]] or [[Function.unlift]] | [[Predef.identity]] | [[Function1.UnliftOps#unlift]] |
- * | from an extractor | `{ case extractor(x) => x }` | `extractor.unapply(_)` | [[Predef.identity]] |
+ *  | How to convert ... | to a [[PartialFunction]] | to an optional [[Function]] | to an extractor |
+ *  | :---:  | ---  | --- | --- |
+ *  | from a [[PartialFunction]] | [[Predef.identity]] | [[lift]] | [[Predef.identity]] |
+ *  | from optional [[Function]] | [[Function1.UnliftOps#unlift]] or [[Function.unlift]] | [[Predef.identity]] | [[Function1.UnliftOps#unlift]] |
+ *  | from an extractor | `{ case extractor(x) => x }` | `extractor.unapply(_)` | [[Predef.identity]] |
  *  &nbsp;
  *
- * @define applyOrElseOrElse Note that calling [[isDefinedAt]] on the resulting partial function
+ *  @define applyOrElseOrElse Note that calling [[isDefinedAt]] on the resulting partial function
  *                           may apply the first partial function and execute its side effect.
  *                           For efficiency, it is recommended to call [[applyOrElse]] instead of [[isDefinedAt]] or [[apply]].
  */
@@ -117,30 +117,30 @@ trait PartialFunction[-A, +B] extends Function1[A, B] { self: PartialFunction[A,
 
   /** Returns an extractor object with a `unapplySeq` method, which extracts each element of a sequence data.
    *
-   *  @example {{{
+   *  @example ```
    *           val firstChar: String => Option[Char] = _.headOption
    *
    *           Seq("foo", "bar", "baz") match {
    *             case firstChar.unlift.elementWise(c0, c1, c2) =>
    *               println(s"\$c0, \$c1, \$c2") // Output: f, b, b
    *           }
-   *           }}}
+   *           ```
    */
   def elementWise: ElementWiseExtractor[A, B]^{this} = new ElementWiseExtractor[A, B](this)
 
   /** Checks if a value is contained in the function's domain.
    *
    *  @param  x   the value to test
-   *  @return `'''true'''`, iff `x` is in the domain of this function, `'''false'''` otherwise.
+   *  @return `**true**`, iff `x` is in the domain of this function, `**false**` otherwise.
    */
   def isDefinedAt(x: A): Boolean
 
   /** Composes this partial function with a fallback partial function which
    *  gets applied where this partial function is not defined.
    *
-   *  @param   that    the fallback function
    *  @tparam  A1      the argument type of the fallback function
    *  @tparam  B1      the result type of the fallback function
+   *  @param   that    the fallback function
    *  @return  a partial function which has as domain the union of the domains
    *           of this partial function and `that`. The resulting partial function
    *           takes `x` to `this(x)` where `this` is defined, and to `that(x)` where it is not.
@@ -149,15 +149,15 @@ trait PartialFunction[-A, +B] extends Function1[A, B] { self: PartialFunction[A,
     new OrElse[A1, B1] (this, that)
   //TODO: why not overload it with orElse(that: F1): F1?
 
-  /**  Composes this partial function with a transformation function that
+  /** Composes this partial function with a transformation function that
    *   gets applied to results of this partial function.
    *
    *   If the runtime type of the function is a `PartialFunction` then the
    *   other `andThen` method is used (note its cautions).
    *
-   *   @param  k  the transformation function
-   *   @tparam C  the result type of the transformation function.
-   *   @return a partial function with the domain of this partial function,
+   *  @tparam C  the result type of the transformation function.
+   *  @param  k  the transformation function
+   *  @return a partial function with the domain of this partial function,
    *           possibly narrowed by the specified function, which maps
    *           arguments `x` to `k(this(x))`.
    */
@@ -166,29 +166,27 @@ trait PartialFunction[-A, +B] extends Function1[A, B] { self: PartialFunction[A,
     case _                         => new AndThen[A, B, C](this, k)
   }
 
-  /**
-   * Composes this partial function with another partial function that
-   * gets applied to results of this partial function.
+  /** Composes this partial function with another partial function that
+   *  gets applied to results of this partial function.
    *
-   * $applyOrElseOrElse
+   *  $applyOrElseOrElse
    *
-   * @param  k  the transformation function
-   * @tparam C  the result type of the transformation function.
-   * @return a partial function with the domain of this partial function narrowed by
+   *  @tparam C  the result type of the transformation function.
+   *  @param  k  the transformation function
+   *  @return a partial function with the domain of this partial function narrowed by
    *         other partial function, which maps arguments `x` to `k(this(x))`.
    */
   def andThen[C](k: PartialFunction[B, C]^): PartialFunction[A, C]^{this, k} =
     new Combined[A, B, C](this, k)
 
-  /**
-   * Composes another partial function `k` with this partial function so that this
-   * partial function gets applied to results of `k`.
+  /** Composes another partial function `k` with this partial function so that this
+   *  partial function gets applied to results of `k`.
    *
-   * $applyOrElseOrElse
+   *  $applyOrElseOrElse
    *
-   * @param  k  the transformation function
-   * @tparam R  the parameter type of the transformation function.
-   * @return a partial function with the domain of other partial function narrowed by
+   *  @tparam R  the parameter type of the transformation function.
+   *  @param  k  the transformation function
+   *  @return a partial function with the domain of other partial function narrowed by
    *         this partial function, which maps arguments `x` to `this(k(x))`.
    */
   def compose[R](k: PartialFunction[R, A]^): PartialFunction[R, B]^{this, k} =
@@ -205,7 +203,7 @@ trait PartialFunction[-A, +B] extends Function1[A, B] { self: PartialFunction[A,
    *  Applies fallback function where this partial function is not defined.
    *
    *  Note that expression `pf.applyOrElse(x, default)` is equivalent to
-   *  {{{ if(pf isDefinedAt x) pf(x) else default(x) }}}
+   *  ``` if(pf isDefinedAt x) pf(x) else default(x) ```
    *  except that `applyOrElse` method can be implemented more efficiently.
    *  For all partial function literals the compiler generates an `applyOrElse` implementation which
    *  avoids double evaluation of pattern matchers and guards.
@@ -234,7 +232,7 @@ trait PartialFunction[-A, +B] extends Function1[A, B] { self: PartialFunction[A,
    *  The action function is invoked only for its side effects; its result is ignored.
    *
    *  Note that expression `pf.runWith(action)(x)` is equivalent to
-   *  {{{ if(pf isDefinedAt x) { action(pf(x)); true } else false }}}
+   *  ``` if(pf isDefinedAt x) { action(pf(x)); true } else false ```
    *  except that `runWith` is implemented via `applyOrElse` and thus potentially more efficient.
    *  Using `runWith` avoids double evaluation of pattern matchers and guards for partial function literals.
    *  @see `applyOrElse`.
@@ -251,7 +249,7 @@ trait PartialFunction[-A, +B] extends Function1[A, B] { self: PartialFunction[A,
 
 /** A few handy operations which leverage the extra bit of information
  *  available in partial functions.  Examples:
- *  {{{
+ *  ```
  *  import PartialFunction._
  *
  *  def strangeConditional(other: Any): Boolean = cond(other) {
@@ -259,7 +257,7 @@ trait PartialFunction[-A, +B] extends Function1[A, B] { self: PartialFunction[A,
  *    case x: Int => true
  *  }
  *  def onlyInt(v: Any): Option[Int] = condOpt(v) { case x: Int => x }
- *  }}}
+ *  ```
  */
 object PartialFunction {
 
@@ -273,8 +271,7 @@ object PartialFunction {
     }
   }
 
-  /** Composite function produced by `PartialFunction#orElse` method
-   */
+  /** Composite function produced by `PartialFunction#orElse` method */
   private class OrElse[-A, +B] (f1: PartialFunction[A, B]^, f2: PartialFunction[A, B]^)
     extends scala.runtime.AbstractPartialFunction[A, B] with Serializable {
     def isDefinedAt(x: A) = f1.isDefinedAt(x) || f2.isDefinedAt(x)
@@ -293,8 +290,7 @@ object PartialFunction {
       new OrElse[A, C] (f1 andThen k, f2 andThen k)
   }
 
-  /** Composite function produced by `PartialFunction#andThen` method
-   */
+  /** Composite function produced by `PartialFunction#andThen` method */
   private class AndThen[-A, B, +C] (pf: PartialFunction[A, B]^, k: B => C) extends PartialFunction[A, C] with Serializable {
     def isDefinedAt(x: A) = pf.isDefinedAt(x)
 
@@ -306,8 +302,7 @@ object PartialFunction {
     }
   }
 
-  /** Composite function produced by `PartialFunction#andThen` method
-    */
+  /** Composite function produced by `PartialFunction#andThen` method */
   private class Combined[-A, B, +C] (pf: PartialFunction[A, B]^, k: PartialFunction[B, C]^) extends PartialFunction[A, C] with Serializable {
     def isDefinedAt(x: A): Boolean = {
       val b: B = pf.applyOrElse(x, checkFallback[B])
@@ -322,12 +317,14 @@ object PartialFunction {
     }
   }
 
-  /** To implement patterns like {{{ if(pf isDefinedAt x) f1(pf(x)) else f2(x) }}} efficiently
+  /** To implement patterns like
+   *  ```
+   *  if(pf isDefinedAt x) f1(pf(x)) else f2(x)
+   *  ```
+   *  efficiently
    *  the following trick is used:
-   *
    *  To avoid double evaluation of pattern matchers & guards `applyOrElse` method is used here
    *  instead of `isDefinedAt`/`apply` pair.
-   *
    *  After call to `applyOrElse` we need both the function result it returned and
    *  the fact if the function's argument was contained in its domain. The only degree of freedom we have here
    *  to achieve this goal is tweaking with the continuation argument (`default`) of `applyOrElse` method.
@@ -337,10 +334,8 @@ object PartialFunction {
    *  I know only one way how you can do this task efficiently: `default` function should return unique marker object
    *  which never may be returned by any other (regular/partial) function. This way after calling `applyOrElse` you need
    *  just one reference comparison to distinguish if `pf isDefined x` or not.
-   *
    *  This correctly interacts with specialization as return type of `applyOrElse`
    *  (which is parameterized upper bound) can never be specialized.
-   *
    *  Here `fallback_fn` is used as both unique marker object and special fallback function that returns it.
    */
   private val fallback_fn: Any -> Any = _ => fallback_fn
@@ -371,10 +366,10 @@ object PartialFunction {
     case _ => new Unlifted(f)
   }
 
-  /**  Converts an ordinary function to a partial function. Note that calling `isDefinedAt(x)` on
+  /** Converts an ordinary function to a partial function. Note that calling `isDefinedAt(x)` on
    *   this partial function will return `true` for every `x`.
-   *   @param  f  an ordinary function
-   *   @return    a partial function which delegates to the ordinary function `f`
+   *  @param  f  an ordinary function
+   *  @return    a partial function which delegates to the ordinary function `f`
    */
   def fromFunction[A, B](f: A => B): PartialFunction[A, B]^{f} = { case x => f(x) }
 

--- a/library/src/scala/Predef.scala
+++ b/library/src/scala/Predef.scala
@@ -25,16 +25,16 @@ import scala.runtime.ScalaRunTime.mapNull
 /** The `Predef` object provides definitions that are accessible in all Scala
  *  compilation units without explicit qualification.
  *
- *  === Commonly Used Types ===
+ *  ### Commonly Used Types
  *  Predef provides type aliases for types which are commonly used, such as
  *  the immutable collection types [[scala.collection.immutable.Map]] and
  *  [[scala.collection.immutable.Set]].
  *
- *  === Console Output ===
+ *  ### Console Output
  *  For basic console output, `Predef` provides convenience methods [[print(x:Any* print]] and [[println(x:Any* println]],
  *  which are aliases of the methods in the object [[scala.Console]].
  *
- *  === Assertions ===
+ *  ### Assertions
  *  A set of `assert` functions are provided for use as a way to document
  *  and dynamically check invariants in code.
  *
@@ -44,12 +44,12 @@ import scala.runtime.ScalaRunTime.mapNull
  *  of pre- and post-conditions on functions, with the intention that these
  *  specifications could be consumed by a static analysis tool. For instance,
  *
- *  {{{
+ *  ```
  *  def addNaturals(nats: List[Int]): Int = {
  *    require(nats forall (_ >= 0), "List contains negative numbers")
  *    nats.foldLeft(0)(_ + _)
  *  } ensuring(_ >= 0)
- *  }}}
+ *  ```
  *
  *  The declaration of `addNaturals` states that the list of integers passed should
  *  only contain natural numbers (i.e. non-negative), and that the result returned
@@ -59,97 +59,94 @@ import scala.runtime.ScalaRunTime.mapNull
  *  form of `assert` that declares the guarantee the function is providing with
  *  regards to its return value.
  *
- *  === Implicit Conversions ===
+ *  ### Implicit Conversions
  *  A number of commonly applied implicit conversions are also defined here, and
  *  in the parent type [[scala.LowPriorityImplicits]]. Implicit conversions
  *  are provided for the "widening" of numeric values, for instance, converting a
  *  Short value to a Long value as required, and to add additional higher-order
  *  functions to Array values. These are described in more detail in the documentation of [[scala.Array]].
  *
- * @groupname utilities Utility Methods
- * @groupprio utilities 10
+ *  @groupname utilities Utility Methods
+ *  @groupprio utilities 10
  *
- * @groupname assertions Assertions
- * @groupprio assertions 20
- * @groupdesc assertions These methods support program verification and runtime correctness.
+ *  @groupname assertions Assertions
+ *  @groupprio assertions 20
+ *  @groupdesc assertions These methods support program verification and runtime correctness.
  *
- * @groupname console-output Console Output
- * @groupprio console-output 30
- * @groupdesc console-output These methods provide output via the console.
+ *  @groupname console-output Console Output
+ *  @groupprio console-output 30
+ *  @groupdesc console-output These methods provide output via the console.
  *
- * @groupname aliases Aliases
- * @groupprio aliases 50
- * @groupdesc aliases These aliases bring selected immutable types into scope without any imports.
+ *  @groupname aliases Aliases
+ *  @groupprio aliases 50
+ *  @groupdesc aliases These aliases bring selected immutable types into scope without any imports.
  *
- * @groupname conversions-string String Conversions
- * @groupprio conversions-string 60
- * @groupdesc conversions-string Conversions from String to StringOps or WrappedString.
+ *  @groupname conversions-string String Conversions
+ *  @groupprio conversions-string 60
+ *  @groupdesc conversions-string Conversions from String to StringOps or WrappedString.
  *
- * @groupname implicit-classes-any Implicit Classes
- * @groupprio implicit-classes-any 70
- * @groupdesc implicit-classes-any These implicit classes add useful extension methods to every type.
+ *  @groupname implicit-classes-any Implicit Classes
+ *  @groupprio implicit-classes-any 70
+ *  @groupdesc implicit-classes-any These implicit classes add useful extension methods to every type.
  *
- * @groupname char-sequence-wrappers CharSequence Wrappers
- * @groupprio char-sequence-wrappers 80
- * @groupdesc char-sequence-wrappers Wrappers that implements CharSequence and were implicit classes.
+ *  @groupname char-sequence-wrappers CharSequence Wrappers
+ *  @groupprio char-sequence-wrappers 80
+ *  @groupdesc char-sequence-wrappers Wrappers that implements CharSequence and were implicit classes.
  *
- * @groupname conversions-java-to-anyval Java to Scala
- * @groupprio conversions-java-to-anyval 90
- * @groupdesc conversions-java-to-anyval Implicit conversion from Java primitive wrapper types to Scala equivalents.
+ *  @groupname conversions-java-to-anyval Java to Scala
+ *  @groupprio conversions-java-to-anyval 90
+ *  @groupdesc conversions-java-to-anyval Implicit conversion from Java primitive wrapper types to Scala equivalents.
  *
- * @groupname conversions-anyval-to-java Scala to Java
- * @groupprio conversions-anyval-to-java 100
- * @groupdesc conversions-anyval-to-java Implicit conversion from Scala AnyVals to Java primitive wrapper types equivalents.
+ *  @groupname conversions-anyval-to-java Scala to Java
+ *  @groupprio conversions-anyval-to-java 100
+ *  @groupdesc conversions-anyval-to-java Implicit conversion from Scala AnyVals to Java primitive wrapper types equivalents.
  *
- * @groupname conversions-array-to-wrapped-array Array to ArraySeq
- * @groupprio conversions-array-to-wrapped-array 110
- * @groupdesc conversions-array-to-wrapped-array Conversions from Arrays to ArraySeqs.
+ *  @groupname conversions-array-to-wrapped-array Array to ArraySeq
+ *  @groupprio conversions-array-to-wrapped-array 110
+ *  @groupdesc conversions-array-to-wrapped-array Conversions from Arrays to ArraySeqs.
  */
 object Predef extends LowPriorityImplicits {
-  /**
-   * Retrieves the runtime representation of a class type. `classOf[T]` is equivalent to
-   * the class literal `T.class` in Java.
+  /** Retrieves the runtime representation of a class type. `classOf[T]` is equivalent to
+   *  the class literal `T.class` in Java.
    *
-   * @example {{{
-   * val listClass = classOf[List[?]]
-   * // listClass is java.lang.Class[List[?]] = class scala.collection.immutable.List
+   *  @example ```
+   *  val listClass = classOf[List[?]]
+   *  // listClass is java.lang.Class[List[?]] = class scala.collection.immutable.List
    *
-   * val mapIntString = classOf[Map[Int,String]]
-   * // mapIntString is java.lang.Class[Map[Int,String]] = interface scala.collection.immutable.Map
-   * }}}
+   *  val mapIntString = classOf[Map[Int,String]]
+   *  // mapIntString is java.lang.Class[Map[Int,String]] = interface scala.collection.immutable.Map
+   *  ```
    *
-   * @return The runtime [[Class]] representation of type `T`.
-   * @group utilities
+   *  @return The runtime [[Class]] representation of type `T`.
+   *  @group utilities
    */
   def classOf[T]: Class[T] = null.asInstanceOf[Class[T]] // This is a stub method. The actual implementation is filled in by the compiler.
 
-  /**
-   * Retrieves the single value of a type with a unique inhabitant.
+  /** Retrieves the single value of a type with a unique inhabitant.
    *
-   * @example {{{
-   * object Foo
-   * val foo = valueOf[Foo.type]
-   * // foo is Foo.type = Foo
+   *  @example ```
+   *  object Foo
+   *  val foo = valueOf[Foo.type]
+   *  // foo is Foo.type = Foo
    *
-   * val bar = valueOf[23]
-   * // bar is 23.type = 23
-   * }}}
-   * @group utilities
+   *  val bar = valueOf[23]
+   *  // bar is 23.type = 23
+   *  ```
+   *  @group utilities
    */
   @inline def valueOf[T](implicit vt: ValueOf[T]): T = vt.value
 
-  /**
-   * Retrieves the single value of a type with a unique inhabitant.
+  /** Retrieves the single value of a type with a unique inhabitant.
    *
-   * @example {{{
-   * object Foo
-   * val foo = valueOf[Foo.type]
-   * // foo is Foo.type = Foo
+   *  @example ```
+   *  object Foo
+   *  val foo = valueOf[Foo.type]
+   *  // foo is Foo.type = Foo
    *
-   * val bar = valueOf[23]
-   * // bar is 23.type = 23
-   * }}}
-   * @group utilities
+   *  val bar = valueOf[23]
+   *  // bar is 23.type = 23
+   *  ```
+   *  @group utilities
    */
   inline def valueOf[T]: T = summonFrom {
     case ev: ValueOf[T] => ev.value
@@ -182,17 +179,16 @@ object Predef extends LowPriorityImplicits {
   /**  @group aliases */
   val Set         = immutable.Set
 
-  /**
-   * Allows destructuring tuples with the same syntax as constructing them.
+  /** Allows destructuring tuples with the same syntax as constructing them.
    *
-   * @example {{{
-   * val tup = "foobar" -> 3
+   *  @example ```
+   *  val tup = "foobar" -> 3
    *
-   * val c = tup match {
+   *  val c = tup match {
    *   case str -> i => str.charAt(i)
-   * }
-   * }}}
-   * @group aliases
+   *  }
+   *  ```
+   *  @group aliases
    */
   val ->        = Tuple2
 
@@ -220,12 +216,12 @@ object Predef extends LowPriorityImplicits {
 
   // Minor variations on identity functions
 
-  /**
-   * A method that returns its input value.
-   * @tparam A type of the input value x.
-   * @param x the value of type `A` to be returned.
-   * @return the value `x`.
-   * @group utilities */
+  /** A method that returns its input value.
+   *  @tparam A type of the input value x.
+   *  @param x the value of type `A` to be returned.
+   *  @return the value `x`.
+   *  @group utilities
+   */
   @inline def identity[A](x: A): A = x // see `$conforms` for the implicit version
 
   /** Summon an implicit value of type `T`. Usually, the argument is not passed explicitly.
@@ -247,7 +243,7 @@ object Predef extends LowPriorityImplicits {
    *  This is just a different name for [[identity]].
    *
    *  @example Separating code blocks from `new`:
-   *           {{{
+   *           ```
    *             val x = new AnyRef
    *             {
    *               val y = ...
@@ -269,7 +265,7 @@ object Predef extends LowPriorityImplicits {
    *               println(y)
    *             }
    *             // locally guards the block and helps communicate intent
-   *           }}}
+   *           ```
    *  @group utilities
    */
   @inline def locally[T](@deprecatedName("x") x: T): T = x
@@ -414,7 +410,7 @@ object Predef extends LowPriorityImplicits {
   }
 
   /** Injects String concatenation operator `+` to any classes.
-   * @group implicit-classes-any
+   *  @group implicit-classes-any
    */
   @(deprecated @companionMethod)("Implicit injection of + is deprecated. Convert to String to call +", "2.13.0")
   @(deprecated @companionClass)("Implicit injection of + is deprecated. Convert to String to call +", "2.13.0") // for Scaladoc
@@ -558,13 +554,13 @@ object Predef extends LowPriorityImplicits {
 
   /** Strips away the nullability from a value. Note that `.nn` performs a checked cast,
    *  so if invoked on a `null` value it will throw an `NullPointerException`.
-   *  @example {{{
+   *  @example ```
    *  val s1: String | Null = "hello"
    *  val s2: String = s1.nn
    *
    *  val s3: String | Null = null
    *  val s4: String = s3.nn // throw NullPointerException
-   *  }}}
+   *  ```
    */
   extension [T](x: T | Null) inline def nn: x.type & T =
     if x.asInstanceOf[Any] == null then scala.runtime.Scala3RunTime.nnFail()
@@ -573,12 +569,14 @@ object Predef extends LowPriorityImplicits {
   extension (inline x: AnyRef | Null)
     /** Enables an expression of type `T|Null`, where `T` is a subtype of `AnyRef`, to be checked for `null`
      *  using `eq` rather than only `==`. This is needed because `Null` no longer has
-     *  `eq` or `ne` methods, only `==` and `!=` inherited from `Any`. */
+     *  `eq` or `ne` methods, only `==` and `!=` inherited from `Any`. 
+     */
     inline infix def eq(inline y: AnyRef | Null): Boolean =
       x.asInstanceOf[AnyRef] eq y.asInstanceOf[AnyRef]
     /** Enables an expression of type `T|Null`, where `T` is a subtype of `AnyRef`, to be checked for `null`
      *  using `ne` rather than only `!=`. This is needed because `Null` no longer has
-     *  `eq` or `ne` methods, only `==` and `!=` inherited from `Any`. */
+     *  `eq` or `ne` methods, only `==` and `!=` inherited from `Any`. 
+     */
     inline infix def ne(inline y: AnyRef | Null): Boolean =
       !(x eq y)
 
@@ -596,26 +594,26 @@ object Predef extends LowPriorityImplicits {
   infix type is[A <: AnyKind, B <: Any{type Self <: AnyKind}] = B { type Self = A }
 
   extension [T](x: T)
-    /**Asserts that a term should be exempt from static checks that can be reliably checked at runtime.
-     * @example {{{
-     * val xs: Option[Int] = Option(1)
-     * xs.runtimeChecked match
+    /** Asserts that a term should be exempt from static checks that can be reliably checked at runtime.
+     *  @example ```
+     *  val xs: Option[Int] = Option(1)
+     *  xs.runtimeChecked match
      *    case Some(x) => x // `Some(_)` can be checked at runtime, so no warning
-     * }}}
-     * @example {{{
-     * val xs: List[Int] = List(1,2,3)
-     * val y :: ys = xs.runtimeChecked // `_ :: _` can be checked at runtime, so no warning
-     * }}}
+     *  ```
+     *  @example ```
+     *  val xs: List[Int] = List(1,2,3)
+     *  val y :: ys = xs.runtimeChecked // `_ :: _` can be checked at runtime, so no warning
+     *  ```
      */
     inline def runtimeChecked: x.type @RuntimeChecked = x: @RuntimeChecked
 
 }
 
 /** The `LowPriorityImplicits` class provides implicit values that
-*  are valid in all Scala compilation units without explicit qualification,
-*  but that are partially overridden by higher-priority conversions in object
-*  `Predef`.
-*/
+ *  are valid in all Scala compilation units without explicit qualification,
+ *  but that are partially overridden by higher-priority conversions in object
+ *  `Predef`.
+ */
 // scala/bug#7335 Parents of Predef are defined in the same compilation unit to avoid
 // cyclic reference errors compiling the standard library *without* a previously
 // compiled copy on the classpath.

--- a/library/src/scala/Product10.scala
+++ b/library/src/scala/Product10.scala
@@ -21,8 +21,7 @@ object Product10 {
     Some(x)
 }
 
-/** Product10 is a Cartesian product of 10 components.
- */
+/** Product10 is a Cartesian product of 10 components. */
 trait Product10[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10] extends Any with Product {
   /** The arity of this product.
    *  @return 10

--- a/library/src/scala/Product11.scala
+++ b/library/src/scala/Product11.scala
@@ -21,8 +21,7 @@ object Product11 {
     Some(x)
 }
 
-/** Product11 is a Cartesian product of 11 components.
- */
+/** Product11 is a Cartesian product of 11 components. */
 trait Product11[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11] extends Any with Product {
   /** The arity of this product.
    *  @return 11

--- a/library/src/scala/Product12.scala
+++ b/library/src/scala/Product12.scala
@@ -21,8 +21,7 @@ object Product12 {
     Some(x)
 }
 
-/** Product12 is a Cartesian product of 12 components.
- */
+/** Product12 is a Cartesian product of 12 components. */
 trait Product12[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12] extends Any with Product {
   /** The arity of this product.
    *  @return 12

--- a/library/src/scala/Product13.scala
+++ b/library/src/scala/Product13.scala
@@ -21,8 +21,7 @@ object Product13 {
     Some(x)
 }
 
-/** Product13 is a Cartesian product of 13 components.
- */
+/** Product13 is a Cartesian product of 13 components. */
 trait Product13[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13] extends Any with Product {
   /** The arity of this product.
    *  @return 13

--- a/library/src/scala/Product14.scala
+++ b/library/src/scala/Product14.scala
@@ -21,8 +21,7 @@ object Product14 {
     Some(x)
 }
 
-/** Product14 is a Cartesian product of 14 components.
- */
+/** Product14 is a Cartesian product of 14 components. */
 trait Product14[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14] extends Any with Product {
   /** The arity of this product.
    *  @return 14

--- a/library/src/scala/Product15.scala
+++ b/library/src/scala/Product15.scala
@@ -21,8 +21,7 @@ object Product15 {
     Some(x)
 }
 
-/** Product15 is a Cartesian product of 15 components.
- */
+/** Product15 is a Cartesian product of 15 components. */
 trait Product15[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15] extends Any with Product {
   /** The arity of this product.
    *  @return 15

--- a/library/src/scala/Product16.scala
+++ b/library/src/scala/Product16.scala
@@ -21,8 +21,7 @@ object Product16 {
     Some(x)
 }
 
-/** Product16 is a Cartesian product of 16 components.
- */
+/** Product16 is a Cartesian product of 16 components. */
 trait Product16[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16] extends Any with Product {
   /** The arity of this product.
    *  @return 16

--- a/library/src/scala/Product17.scala
+++ b/library/src/scala/Product17.scala
@@ -21,8 +21,7 @@ object Product17 {
     Some(x)
 }
 
-/** Product17 is a Cartesian product of 17 components.
- */
+/** Product17 is a Cartesian product of 17 components. */
 trait Product17[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17] extends Any with Product {
   /** The arity of this product.
    *  @return 17

--- a/library/src/scala/Product18.scala
+++ b/library/src/scala/Product18.scala
@@ -21,8 +21,7 @@ object Product18 {
     Some(x)
 }
 
-/** Product18 is a Cartesian product of 18 components.
- */
+/** Product18 is a Cartesian product of 18 components. */
 trait Product18[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18] extends Any with Product {
   /** The arity of this product.
    *  @return 18

--- a/library/src/scala/Product19.scala
+++ b/library/src/scala/Product19.scala
@@ -21,8 +21,7 @@ object Product19 {
     Some(x)
 }
 
-/** Product19 is a Cartesian product of 19 components.
- */
+/** Product19 is a Cartesian product of 19 components. */
 trait Product19[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18, +T19] extends Any with Product {
   /** The arity of this product.
    *  @return 19

--- a/library/src/scala/Product20.scala
+++ b/library/src/scala/Product20.scala
@@ -21,8 +21,7 @@ object Product20 {
     Some(x)
 }
 
-/** Product20 is a Cartesian product of 20 components.
- */
+/** Product20 is a Cartesian product of 20 components. */
 trait Product20[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18, +T19, +T20] extends Any with Product {
   /** The arity of this product.
    *  @return 20

--- a/library/src/scala/Product21.scala
+++ b/library/src/scala/Product21.scala
@@ -21,8 +21,7 @@ object Product21 {
     Some(x)
 }
 
-/** Product21 is a Cartesian product of 21 components.
- */
+/** Product21 is a Cartesian product of 21 components. */
 trait Product21[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18, +T19, +T20, +T21] extends Any with Product {
   /** The arity of this product.
    *  @return 21

--- a/library/src/scala/Product22.scala
+++ b/library/src/scala/Product22.scala
@@ -21,8 +21,7 @@ object Product22 {
     Some(x)
 }
 
-/** Product22 is a Cartesian product of 22 components.
- */
+/** Product22 is a Cartesian product of 22 components. */
 trait Product22[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18, +T19, +T20, +T21, +T22] extends Any with Product {
   /** The arity of this product.
    *  @return 22

--- a/library/src/scala/Product3.scala
+++ b/library/src/scala/Product3.scala
@@ -21,8 +21,7 @@ object Product3 {
     Some(x)
 }
 
-/** Product3 is a Cartesian product of 3 components.
- */
+/** Product3 is a Cartesian product of 3 components. */
 trait Product3[+T1, +T2, +T3] extends Any with Product {
   /** The arity of this product.
    *  @return 3

--- a/library/src/scala/Product4.scala
+++ b/library/src/scala/Product4.scala
@@ -21,8 +21,7 @@ object Product4 {
     Some(x)
 }
 
-/** Product4 is a Cartesian product of 4 components.
- */
+/** Product4 is a Cartesian product of 4 components. */
 trait Product4[+T1, +T2, +T3, +T4] extends Any with Product {
   /** The arity of this product.
    *  @return 4

--- a/library/src/scala/Product5.scala
+++ b/library/src/scala/Product5.scala
@@ -21,8 +21,7 @@ object Product5 {
     Some(x)
 }
 
-/** Product5 is a Cartesian product of 5 components.
- */
+/** Product5 is a Cartesian product of 5 components. */
 trait Product5[+T1, +T2, +T3, +T4, +T5] extends Any with Product {
   /** The arity of this product.
    *  @return 5

--- a/library/src/scala/Product6.scala
+++ b/library/src/scala/Product6.scala
@@ -21,8 +21,7 @@ object Product6 {
     Some(x)
 }
 
-/** Product6 is a Cartesian product of 6 components.
- */
+/** Product6 is a Cartesian product of 6 components. */
 trait Product6[+T1, +T2, +T3, +T4, +T5, +T6] extends Any with Product {
   /** The arity of this product.
    *  @return 6

--- a/library/src/scala/Product7.scala
+++ b/library/src/scala/Product7.scala
@@ -21,8 +21,7 @@ object Product7 {
     Some(x)
 }
 
-/** Product7 is a Cartesian product of 7 components.
- */
+/** Product7 is a Cartesian product of 7 components. */
 trait Product7[+T1, +T2, +T3, +T4, +T5, +T6, +T7] extends Any with Product {
   /** The arity of this product.
    *  @return 7

--- a/library/src/scala/Product8.scala
+++ b/library/src/scala/Product8.scala
@@ -21,8 +21,7 @@ object Product8 {
     Some(x)
 }
 
-/** Product8 is a Cartesian product of 8 components.
- */
+/** Product8 is a Cartesian product of 8 components. */
 trait Product8[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8] extends Any with Product {
   /** The arity of this product.
    *  @return 8

--- a/library/src/scala/Product9.scala
+++ b/library/src/scala/Product9.scala
@@ -21,8 +21,7 @@ object Product9 {
     Some(x)
 }
 
-/** Product9 is a Cartesian product of 9 components.
- */
+/** Product9 is a Cartesian product of 9 components. */
 trait Product9[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9] extends Any with Product {
   /** The arity of this product.
    *  @return 9

--- a/library/src/scala/Proxy.scala
+++ b/library/src/scala/Proxy.scala
@@ -17,12 +17,12 @@ import scala.language.`2.13`
 /** This class implements a simple proxy that forwards all calls to
  *  the public, non-final methods defined in class `Any` to another
  *  object self.  Those methods are:
- *  {{{
+ *  ```
  *    def hashCode(): Int
  *    def equals(other: Any): Boolean
  *    def toString(): String
- *  }}}
- *  '''Note:''' forwarding methods in this way will most likely create
+ *  ```
+ *  **Note:** forwarding methods in this way will most likely create
  *  an asymmetric equals method, which is not generally recommended.
  */
 @deprecated("Explicitly override hashCode, equals and toString instead.", "2.13.0")

--- a/library/src/scala/Selectable.scala
+++ b/library/src/scala/Selectable.scala
@@ -7,19 +7,19 @@ import language.experimental.captureChecking
  *
  *  Implementation classes should define, or make available as extension
  *  methods, the following two method signatures:
- *  {{{
+ *  ```
  *    def selectDynamic(name: String): Any
  *    def applyDynamic(name: String)(args: Any*): Any =
- *  }}}
+ *  ```
  *  `selectDynamic` is invoked for simple selections `v.m`, whereas
  *  `applyDynamic` is invoked for selections with arguments `v.m(...)`.
  *  If there's only one kind of selection, the method supporting the
  *  other may be omitted. The `applyDynamic` can also have a second parameter
  *  list of `java.lang.Class` arguments, i.e. it may alternatively have the
  *  signature
- *  {{{
+ *  ```
  *    def applyDynamic(name: String, paramClasses: Class[?]*)(args: Any*): Any
- *  }}}
+ *  ```
  *  In this case the call will synthesize `Class` arguments for the erasure of
  *  all formal parameter types of the method in the structural type.
  */
@@ -40,9 +40,9 @@ object Selectable:
   /** A marker trait for subclasses of `Selectable` indicating
    *  that precise parameter types are not needed for method dispatch. That is,
    *  a class inheriting from this trait and implementing
-   *  {{{
+   *  ```
    *     def applyDynamic(name: String, paramTypes: Class[?]*)(args: Any*)
-   *  }}}
+   *  ```
    *  should dispatch to a method with the given `name` without having to rely
    *  on the precise `paramTypes`. Subtypes of `WithoutPreciseParameterTypes`
    *  can have more relaxed subtyping rules for refinements. They do not need

--- a/library/src/scala/Short.scala
+++ b/library/src/scala/Short.scala
@@ -34,14 +34,13 @@ final abstract class Short private extends AnyVal {
   def toFloat: Float
   def toDouble: Double
 
-  /**
- * Returns the bitwise negation of this value.
- * @example {{{
- * ~5 == -6
- * // in binary: ~00000101 ==
- * //             11111010
- * }}}
- */
+  /** Returns the bitwise negation of this value.
+   *  @example ```
+   *  ~5 == -6
+   *  // in binary: ~00000101 ==
+   *  //             11111010
+   *  ```
+   */
   def unary_~ : Int
   /** Returns this value, unmodified. */
   def unary_+ : Int
@@ -51,63 +50,63 @@ final abstract class Short private extends AnyVal {
   @deprecated("Adding a number and a String is deprecated. Use the string interpolation `s\"$num$str\"`", "2.13.0")
   def +(x: String): String
 
-  /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the new right bits with zeroes.
-  * @example {{{ 6 << 3 == 48 // in binary: 0110 << 3 == 0110000 }}}
-  */
+  /** Returns this value bit-shifted left by the specified number of bits,
+   *         filling in the new right bits with zeroes.
+   *  @example
+   *  ```
+   *  6 << 3 == 48 // in binary: 0110 << 3 == 0110000
+   *  ```
+   */
   def <<(x: Int): Int
-  /**
-  * Returns this value bit-shifted left by the specified number of bits,
-  *         filling in the new right bits with zeroes.
-  * @example {{{ 6 << 3 == 48 // in binary: 0110 << 3 == 0110000 }}}
-  */
+  /** Returns this value bit-shifted left by the specified number of bits,
+   *         filling in the new right bits with zeroes.
+   *  @example
+   *  ```
+   *  6 << 3 == 48 // in binary: 0110 << 3 == 0110000
+   *  ```
+   */
   @deprecated("shifting a value by a `Long` argument is deprecated (except when the value is a `Long`).\nCall `toInt` on the argument to maintain the current behavior and avoid the deprecation warning.", "2.12.7")
   def <<(x: Long): Int
-  /**
-  * Returns this value bit-shifted right by the specified number of bits,
-  *         filling the new left bits with zeroes.
-  * @example {{{ 21 >>> 3 == 2 // in binary: 010101 >>> 3 == 010 }}}
-  * @example {{{
-  * -21 >>> 3 == 536870909
-  * // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
-  * //            00011111 11111111 11111111 11111101
-  * }}}
-  */
+  /** Returns this value bit-shifted right by the specified number of bits,
+   *         filling the new left bits with zeroes.
+   *  @example ``` 21 >>> 3 == 2 // in binary: 010101 >>> 3 == 010 ```
+   *  @example ```
+   *  -21 >>> 3 == 536870909
+   *  // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
+   *  //            00011111 11111111 11111111 11111101
+   *  ```
+   */
   def >>>(x: Int): Int
-  /**
-  * Returns this value bit-shifted right by the specified number of bits,
-  *         filling the new left bits with zeroes.
-  * @example {{{ 21 >>> 3 == 2 // in binary: 010101 >>> 3 == 010 }}}
-  * @example {{{
-  * -21 >>> 3 == 536870909
-  * // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
-  * //            00011111 11111111 11111111 11111101
-  * }}}
-  */
+  /** Returns this value bit-shifted right by the specified number of bits,
+   *         filling the new left bits with zeroes.
+   *  @example ``` 21 >>> 3 == 2 // in binary: 010101 >>> 3 == 010 ```
+   *  @example ```
+   *  -21 >>> 3 == 536870909
+   *  // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
+   *  //            00011111 11111111 11111111 11111101
+   *  ```
+   */
   @deprecated("shifting a value by a `Long` argument is deprecated (except when the value is a `Long`).\nCall `toInt` on the argument to maintain the current behavior and avoid the deprecation warning.", "2.12.7")
   def >>>(x: Long): Int
-  /**
-  * Returns this value bit-shifted right by the specified number of bits,
-  *         filling in the left bits with the same value as the left-most bit of this.
-  *         The effect of this is to retain the sign of the value.
-  * @example {{{
-  * -21 >> 3 == -3
-  * // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
-  * //            11111111 11111111 11111111 11111101
-  * }}}
-  */
+  /** Returns this value bit-shifted right by the specified number of bits,
+   *         filling in the left bits with the same value as the left-most bit of this.
+   *         The effect of this is to retain the sign of the value.
+   *  @example ```
+   *  -21 >> 3 == -3
+   *  // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
+   *  //            11111111 11111111 11111111 11111101
+   *  ```
+   */
   def >>(x: Int): Int
-  /**
-  * Returns this value bit-shifted right by the specified number of bits,
-  *         filling in the left bits with the same value as the left-most bit of this.
-  *         The effect of this is to retain the sign of the value.
-  * @example {{{
-  * -21 >> 3 == -3
-  * // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
-  * //            11111111 11111111 11111111 11111101
-  * }}}
-  */
+  /** Returns this value bit-shifted right by the specified number of bits,
+   *         filling in the left bits with the same value as the left-most bit of this.
+   *         The effect of this is to retain the sign of the value.
+   *  @example ```
+   *  -21 >> 3 == -3
+   *  // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
+   *  //            11111111 11111111 11111111 11111101
+   *  ```
+   */
   @deprecated("shifting a value by a `Long` argument is deprecated (except when the value is a `Long`).\nCall `toInt` on the argument to maintain the current behavior and avoid the deprecation warning.", "2.12.7")
   def >>(x: Long): Int
 
@@ -201,172 +200,157 @@ final abstract class Short private extends AnyVal {
   /** Returns `true` if this value is greater than or equal to x, `false` otherwise. */
   def >=(x: Double): Boolean
 
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Byte): Int
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Short): Int
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Char): Int
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Int): Int
-  /**
-  * Returns the bitwise OR of this value and `x`.
-  * @example {{{
-  * (0xf0 | 0xaa) == 0xfa
-  * // in binary:   11110000
-  * //            | 10101010
-  * //              --------
-  * //              11111010
-  * }}}
-  */
+  /** Returns the bitwise OR of this value and `x`.
+   *  @example ```
+   *  (0xf0 | 0xaa) == 0xfa
+   *  // in binary:   11110000
+   *  //            | 10101010
+   *  //              --------
+   *  //              11111010
+   *  ```
+   */
   def |(x: Long): Long
 
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Byte): Int
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Short): Int
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Char): Int
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Int): Int
-  /**
-  * Returns the bitwise AND of this value and `x`.
-  * @example {{{
-  * (0xf0 & 0xaa) == 0xa0
-  * // in binary:   11110000
-  * //            & 10101010
-  * //              --------
-  * //              10100000
-  * }}}
-  */
+  /** Returns the bitwise AND of this value and `x`.
+   *  @example ```
+   *  (0xf0 & 0xaa) == 0xa0
+   *  // in binary:   11110000
+   *  //            & 10101010
+   *  //              --------
+   *  //              10100000
+   *  ```
+   */
   def &(x: Long): Long
 
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Byte): Int
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Short): Int
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Char): Int
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Int): Int
-  /**
-  * Returns the bitwise XOR of this value and `x`.
-  * @example {{{
-  * (0xf0 ^ 0xaa) == 0x5a
-  * // in binary:   11110000
-  * //            ^ 10101010
-  * //              --------
-  * //              01011010
-  * }}}
-  */
+  /** Returns the bitwise XOR of this value and `x`.
+   *  @example ```
+   *  (0xf0 ^ 0xaa) == 0x5a
+   *  // in binary:   11110000
+   *  //            ^ 10101010
+   *  //              --------
+   *  //              01011010
+   *  ```
+   */
   def ^(x: Long): Long
 
   /** Returns the sum of this value and `x`. */
@@ -457,7 +441,7 @@ object Short extends AnyValCompanion {
 
   /** Transforms a value type into a boxed reference type.
    *
-   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.boxToShort`. See [[https://github.com/scala/scala src/library/scala/runtime/BoxesRunTime.java]].
+   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.boxToShort`. See [src/library/scala/runtime/BoxesRunTime.java](https://github.com/scala/scala).
    *
    *  @param  x   the Short to be boxed
    *  @return     a java.lang.Short offering `x` as its underlying value.
@@ -468,11 +452,11 @@ object Short extends AnyValCompanion {
    *  method is not typesafe: it accepts any Object, but will throw
    *  an exception if the argument is not a java.lang.Short.
    *
-   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.unboxToShort`. See [[https://github.com/scala/scala src/library/scala/runtime/BoxesRunTime.java]].
+   *  Runtime implementation determined by `scala.runtime.BoxesRunTime.unboxToShort`. See [src/library/scala/runtime/BoxesRunTime.java](https://github.com/scala/scala).
    *
    *  @param  x   the java.lang.Short to be unboxed.
-   *  @throws     ClassCastException  if the argument is not a java.lang.Short
    *  @return     the Short resulting from calling shortValue() on `x`
+   *  @throws     ClassCastException  if the argument is not a java.lang.Short
    */
   def unbox(x: java.lang.Object): Short = ???
 

--- a/library/src/scala/StringContext.scala
+++ b/library/src/scala/StringContext.scala
@@ -18,37 +18,37 @@ import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuilder
 
 /** This class provides the basic mechanism to do String Interpolation.
- * String Interpolation allows users
- * to embed variable references directly in *processed* string literals.
- * Here's an example:
- * {{{
+ *  String Interpolation allows users
+ *  to embed variable references directly in *processed* string literals.
+ *  Here's an example:
+ *  ```
  *   val name = "James"
  *   println(s"Hello, \$name")  // Hello, James
- * }}}
+ *  ```
  *
- * Any processed string literal is rewritten as an instantiation and
- * method call against this class.   For example:
- * {{{
+ *  Any processed string literal is rewritten as an instantiation and
+ *  method call against this class.   For example:
+ *  ```
  *   s"Hello, \$name"
- * }}}
+ *  ```
  *
- * is rewritten to be:
+ *  is rewritten to be:
  *
- * {{{
+ *  ```
  *   StringContext("Hello, ", "").s(name)
- * }}}
+ *  ```
  *
- * By default, this class provides the `raw`, `s` and `f` methods as
- * available interpolators.
+ *  By default, this class provides the `raw`, `s` and `f` methods as
+ *  available interpolators.
  *
- * To provide your own string interpolator, create an implicit class
- * which adds a method to `StringContext`.  Here's an example:
- * {{{
+ *  To provide your own string interpolator, create an implicit class
+ *  which adds a method to `StringContext`.  Here's an example:
+ *  ```
  *    implicit class JsonHelper(private val sc: StringContext) extends AnyVal {
  *      def json(args: Any*): JSONObject = ...
  *    }
  *    val x: JSONObject = json"{ a: \$a }"
- * }}}
+ *  ```
  *
  *  Here the `JsonHelper` extension class implicitly adds the `json` method to
  *  `StringContext` which can be used for `json` string literals.
@@ -68,17 +68,17 @@ case class StringContext(parts: String*) {
    *  It inserts its arguments between corresponding parts of the string context.
    *  It also treats standard escape sequences as defined in the Scala specification.
    *  Here's an example of usage:
-   *  {{{
+   *  ```
    *    val name = "James"
    *    println(s"Hello, \$name")  // Hello, James
-   *  }}}
+   *  ```
    *  In this example, the expression \$name is replaced with the `toString` of the
    *  variable `name`.
    *  The `s` interpolator can take the `toString` of any arbitrary expression within
    *  a `\${}` block, for example:
-   *  {{{
+   *  ```
    *    println(s"1 + 1 = \${1 + 1}")
-   *  }}}
+   *  ```
    *  will print the string `1 + 1 = 2`.
    *
    *  @param `args` The arguments to be inserted into the resulting string.
@@ -100,30 +100,30 @@ case class StringContext(parts: String*) {
      *
      *  Here is an example usage:
      *
-     *  {{{
+     *  ```
      *    val s"Hello, \$name" = "Hello, James"
      *    println(name)  // "James"
-     *  }}}
+     *  ```
      *
      *  In this example, the string "James" ends up matching the location where the pattern
      *  `\$name` is positioned, and thus ends up bound to that variable.
      *
      *  Multiple matches are supported:
      *
-     *  {{{
+     *  ```
      *    val s"\$greeting, \$name" = "Hello, James"
      *    println(greeting)  // "Hello"
      *    println(name)  // "James"
-     *  }}}
+     *  ```
      *
      *  And the `s` matcher can match an arbitrary pattern within the `\${}` block, for example:
      *
-     *  {{{
+     *  ```
      *    val TimeSplitter = "([0-9]+)[.:]([0-9]+)".r
      *    val s"The time is \${TimeSplitter(hours, mins)}" = "The time is 10.50"
      *    println(hours) // 10
      *    println(mins) // 50
-     *  }}}
+     *  ```
      *
      *  Here, we use the `TimeSplitter` regex within the `s` matcher, further splitting the
      *  matched string "10.50" into its constituent parts
@@ -138,14 +138,14 @@ case class StringContext(parts: String*) {
    *
    *  For example, the raw processed string `raw"a\nb"` is equal to the scala string `"a\\nb"`.
    *
-   *  ''Note:'' Even when using the raw interpolator, Scala will process Unicode escapes.
+   *  *Note:* Even when using the raw interpolator, Scala will process Unicode escapes.
    *  Unicode processing in the raw interpolator is deprecated as of scala 2.13.2 and
    *  will be removed in the future
    *  For example:
-   *  {{{
+   *  ```
    *    scala> raw"\u005cu0023"
    *    res0: String = #
-   *  }}}
+   *  ```
    *
    *  @param `args` The arguments to be inserted into the resulting string.
    *  @throws IllegalArgumentException
@@ -169,11 +169,11 @@ case class StringContext(parts: String*) {
    *  way they are treated in Java.
    *
    *  For example:
-   *  {{{
+   *  ```
    *    val height = 1.9d
    *    val name = "James"
    *    println(f"\$name%s is \$height%2.2f meters tall")  // James is 1.90 meters tall
-   *  }}}
+   *  ```
    *
    *  @param `args` The arguments to be inserted into the resulting string.
    *  @throws IllegalArgumentException
@@ -198,16 +198,15 @@ case class StringContext(parts: String*) {
 }
 
 object StringContext {
-  /**
-    * Linear time glob-matching implementation.
-    * Adapted from https://research.swtch.com/glob
-    *
-    * @param patternChunks The non-wildcard portions of the input pattern,
-    *                      separated by wildcards
-    * @param input The input you wish to match against
-    * @return `None` if there is no match, `Some` containing the sequence of matched
-    *         wildcard strings if there is a match 
-    */
+  /** Linear time glob-matching implementation.
+   *  Adapted from https://research.swtch.com/glob
+   *
+   *  @param patternChunks The non-wildcard portions of the input pattern,
+   *                      separated by wildcards
+   *  @param input The input you wish to match against
+   *  @return `None` if there is no match, `Some` containing the sequence of matched
+   *         wildcard strings if there is a match 
+   */
   def glob(patternChunks: Seq[String], input: String): Option[Seq[String]] = {
     var patternIndex = 0
     var inputIndex = 0
@@ -413,15 +412,15 @@ object StringContext {
    *  index of the first index of a backslash character followed by a `u`
    *  character
    *
-   * If a backslash is followed by one or more `u` characters and there is
-   * an odd number of backslashes immediately preceding the `u`, processing
-   * the escape is attempted and an invalid escape is an error.
-   * The odd backslashes rule is, well, odd, but is grandfathered in from
-   * pre-2.13.2 times, when this same rule existed in the scanner, and was also
-   * odd. Since escape handling here is for backwards compatibility only, that
-   * backwards compatibility is also retained.
-   * Otherwise, the backslash is not taken to introduce an escape and the
-   * backslash is taken to be literal
+   *  If a backslash is followed by one or more `u` characters and there is
+   *  an odd number of backslashes immediately preceding the `u`, processing
+   *  the escape is attempted and an invalid escape is an error.
+   *  The odd backslashes rule is, well, odd, but is grandfathered in from
+   *  pre-2.13.2 times, when this same rule existed in the scanner, and was also
+   *  odd. Since escape handling here is for backwards compatibility only, that
+   *  backwards compatibility is also retained.
+   *  Otherwise, the backslash is not taken to introduce an escape and the
+   *  backslash is taken to be literal
    */
   private def replaceU(str: String, backslash: Int): String = {
     val len = str.length()

--- a/library/src/scala/Symbol.scala
+++ b/library/src/scala/Symbol.scala
@@ -18,8 +18,7 @@ import scala.language.`2.13`
  *  Since symbols are interned, they can be compared using reference equality.
  */
 final class Symbol private (val name: String) extends Serializable {
-  /** A string representation of this symbol.
-   */
+  /** A string representation of this symbol. */
   override def toString(): String = s"Symbol($name)"
 
   @throws(classOf[java.io.ObjectStreamException])
@@ -35,7 +34,8 @@ object Symbol extends UniquenessCache[String, Symbol] {
 }
 
 /** This is private so it won't appear in the library API, but
-  * abstracted to offer some hope of reusability.  */
+ *  abstracted to offer some hope of reusability.  
+ */
 private[scala] abstract class UniquenessCache[K, V] {
   import java.lang.ref.WeakReference
   import java.util.WeakHashMap

--- a/library/src/scala/Tuple.scala
+++ b/library/src/scala/Tuple.scala
@@ -254,7 +254,7 @@ object Tuple {
   }
 
   /** Splits a tuple (T1, ..., Tn) into a pair of two tuples `(T1, ..., Ti)` and
-   * `(Ti+1, ..., Tn)`.
+   *  `(Ti+1, ..., Tn)`.
    */
   type Split[T <: Tuple, N <: Int] = (Take[T, N], Drop[T, N])
 

--- a/library/src/scala/Tuple2.scala
+++ b/library/src/scala/Tuple2.scala
@@ -28,8 +28,8 @@ final case class Tuple2[@specialized(Int, Long, Double, Char, Boolean/*, AnyRef*
   override def toString(): String = "(" + _1 + "," + _2 + ")"
   
   /** Swaps the elements of this `Tuple`.
-   * @return a new Tuple where the first element is the second element of this Tuple and the
-   * second element is the first element of this Tuple.
+   *  @return a new Tuple where the first element is the second element of this Tuple and the
+   *  second element is the first element of this Tuple.
    */
   def swap: Tuple2[T2,T1] = Tuple2(_2, _1)
 

--- a/library/src/scala/Unit.scala
+++ b/library/src/scala/Unit.scala
@@ -49,8 +49,8 @@ object Unit extends AnyValCompanion {
    *  The result of successfully unboxing a value is `()`.
    *
    *  @param  x   the scala.runtime.BoxedUnit to be unboxed.
-   *  @throws     ClassCastException  if the argument is not a scala.runtime.BoxedUnit
    *  @return     the Unit value ()
+   *  @throws     ClassCastException  if the argument is not a scala.runtime.BoxedUnit
    */
   def unbox(x: java.lang.Object): Unit = x.asInstanceOf[scala.runtime.BoxedUnit]
 

--- a/library/src/scala/ValueOf.scala
+++ b/library/src/scala/ValueOf.scala
@@ -24,13 +24,12 @@ import scala.language.`2.13`
  *
  * The compiler provides instances of `ValueOf[T]` for all eligible types. Typically
  * an instance would be required where a runtime value corresponding to a type level
- * computation is needed.
-
+* computation is needed.
  * For example, we might define a type `Residue[M <: Int]` corresponding to the group of
  * integers modulo `M`. We could then mandate that residues can be summed only when they
  * are parameterized by the same modulus,
  *
- * {{{
+ * ```
  * case class Residue[M <: Int](n: Int) extends AnyVal {
  *   def +(rhs: Residue[M])(implicit m: ValueOf[M]): Residue[M] =
  *     Residue((this.n + rhs.n) % valueOf[M])
@@ -46,12 +45,13 @@ import scala.language.`2.13`
  * fiveModTen + fourModEleven // compiler error: type mismatch;
  *                            //   found   : Residue[11]
  *                            //   required: Residue[10]
- * }}}
+ * ```
  *
  * Notice that here the modulus is encoded in the type of the values and so does not
  * incur any additional per-value storage cost. When a runtime value of the modulus
  * is required in the implementation of `+` it is provided at the call site via the
  * implicit argument `m` of type `ValueOf[M]`.
+ 
  */
 @scala.annotation.implicitNotFound(msg = "No singleton value available for ${T}; eligible singleton types for `ValueOf` synthesis include literals and stable paths.")
 final class ValueOf[T](val value: T) extends AnyVal

--- a/library/src/scala/annotation/ClassfileAnnotation.scala
+++ b/library/src/scala/annotation/ClassfileAnnotation.scala
@@ -15,7 +15,7 @@ package scala.annotation
 import scala.language.`2.13`
 
 /** A base class for classfile annotations. These are stored as
- *  [[https://docs.oracle.com/javase/8/docs/technotes/guides/language/annotations.html Java annotations]]
+ *  [Java annotations](https://docs.oracle.com/javase/8/docs/technotes/guides/language/annotations.html)
  *  in classfiles.
  */
 @deprecated("Annotation classes need to be written in Java in order to be stored in classfiles in a Java-compatible manner", "2.13.0")

--- a/library/src/scala/annotation/ConstantAnnotation.scala
+++ b/library/src/scala/annotation/ConstantAnnotation.scala
@@ -33,7 +33,7 @@ import scala.language.`2.13`
  *
  * Example:
  *
- * {{{
+ * ```
  *   class Ann(value: Int, x: Int = 0) extends scala.annotation.ConstantAnnotation
  *   class Test {
  *     def someInt = 0
@@ -41,6 +41,7 @@ import scala.language.`2.13`
  *     @Ann(0) def f = 0                 // Internal representation contains `@Ann(value = 0)`
  *     @Ann(someInt)                     // error: argument needs to be a compile-time constant
  *   }
- * }}}
+ * ```
+ 
  */
 trait ConstantAnnotation extends StaticAnnotation

--- a/library/src/scala/annotation/elidable.scala
+++ b/library/src/scala/annotation/elidable.scala
@@ -22,24 +22,24 @@ import scala.language.`2.13`
  *  be omitted from generated code if the priority given the annotation
  *  is lower than that given on the command line.
  *
- *  {{{
+ *  ```
  *     @elidable(123)           // annotation priority
  *     scalac -Xelide-below 456 // command line priority
- *  }}}
+ *  ```
  *
  *  The method call will be replaced with an expression which depends on
  *  the type of the elided expression.  In decreasing order of precedence:
  *
- *  {{{
+ *  ```
  *    Unit            ()
  *    Boolean         false
  *    T <: AnyVal     0
  *    T >: Null       null
  *    T >: Nothing    Predef.???
- *  }}}
+ *  ```
  *
  *  Complete example:
- *  {{{
+ *  ```
  *    import scala.annotation._, elidable._
  *    object Test extends App {
  *      def expensiveComputation(): Int = { Thread.sleep(1000) ; 172 }
@@ -61,14 +61,14 @@ import scala.language.`2.13`
  *    % scalac -Xelide-below INFO example.scala && scala Test
  *    Warning! Danger! Warning!
  *    I computed a value: 0
- *  }}}
+ *  ```
  *
  * Note that only concrete methods can be marked `@elidable`. A non-annotated method
  * is not elided, even if it overrides / implements a method that has the annotation.
  *
  * Also note that the static type determines which annotations are considered:
  *
- * {{{
+ * ```
  *   import scala.annotation._, elidable._
  *   class C { @elidable(0) def f(): Unit = ??? }
  *   object O extends C { override def f(): Unit = println("O.f") }
@@ -76,30 +76,30 @@ import scala.language.`2.13`
  *     O.f()      // not elided
  *     (O: C).f() // elided if compiled with `-Xelide-below 1`
  *   }
- * }}}
+ * ```
  *
  * Note for Scala 3 users:
  * If you're using Scala 3, the annotation exists since Scala 3 uses the Scala 2
  * standard library, but it's unsupported by the Scala 3 compiler. Instead, to
  * achieve the same result you'd want to utilize the `inline if` feature to
  * introduce behavior that makes a method de facto elided at compile-time.
- * {{{
+ * ```
  *    type LogLevel = Int
- *    
+ *
  *    object LogLevel:
  *      inline val Info = 0
  *      inline val Warn = 1
  *      inline val Debug = 2
- *    
+ *
  *    inline val appLogLevel = LogLevel.Warn
- *    
+ *
  *    inline def log(msg: String, inline level: LogLevel): Unit = 
  *      inline if (level <= appLogLevel) then println(msg)
- *    
+ *
  *    log("Warn log", LogLevel.Warn)
- *    
+ *
  *    log("Debug log", LogLevel. Debug)
- * }}}
+ * ```
  */
 @deprecated(message = "@elidable is not supported by Scala 3", since = "3.8.0")
 final class elidable(final val level: Int) extends scala.annotation.ConstantAnnotation
@@ -108,9 +108,9 @@ final class elidable(final val level: Int) extends scala.annotation.ConstantAnno
  *  named constants for the elidable annotation.  This is what it takes
  *  to convince the compiler to fold the constants: otherwise when it's
  *  time to check an elision level it's staring at a tree like
- *  {{{
+ *  ```
  *  (Select(Level, Select(FINEST, Apply(intValue, Nil))))
- *  }}}
+ *  ```
  *  instead of the number `300`.
  */
 object elidable {
@@ -118,8 +118,8 @@ object elidable {
    *  the sentiment being expressed when using the annotation is at cross
    *  purposes with the one being expressed via `-Xelide-below`.  This
    *  confusion reaches its zenith at level `OFF`, where the annotation means
-   *  ''never elide this method'' but `-Xelide-below OFF` is how you would
-   *  say ''elide everything possible''.
+   *  *never elide this method* but `-Xelide-below OFF` is how you would
+   *  say *elide everything possible*.
    *
    *  With no simple remedy at hand, the issue is now at least documented,
    *  and aliases `MAXIMUM` and `MINIMUM` are offered.

--- a/library/src/scala/annotation/implicitAmbiguous.scala
+++ b/library/src/scala/annotation/implicitAmbiguous.scala
@@ -14,31 +14,30 @@ package scala.annotation
 
 import scala.language.`2.13`
 
-/**
-  * To customize the error message that's emitted when an implicit search finds
-  * multiple ambiguous values, annotate at least one of the implicit values
-  * `@implicitAmbiguous`. Assuming the implicit value is a method with type
-  * parameters `X1,..., XN`, the error message will be the result of replacing
-  * all occurrences of `\${Xi}` in the string `msg` with the string representation
-  * of the corresponding type argument `Ti`.
-  *
-  * If more than one `@implicitAmbiguous` annotation is collected, the compiler is
-  * free to pick any of them to display.
-  *
-  * Nice errors can direct users to fix imports or even tell them why code
-  * intentionally doesn't compile.
-  *
-  * {{{
-  * trait =!=[C, D]
-  *
-  * implicit def neq[E, F] : E =!= F = null
-  *
-  * @annotation.implicitAmbiguous("Could not prove \${J} =!= \${J}")
-  * implicit def neqAmbig1[G, H, J] : J =!= J = null
-  * implicit def neqAmbig2[I] : I =!= I = null
-  *
-  * implicitly[Int =!= Int]
-  * }}}
-  */
+/** To customize the error message that's emitted when an implicit search finds
+ *  multiple ambiguous values, annotate at least one of the implicit values
+ *  `@implicitAmbiguous`. Assuming the implicit value is a method with type
+ *  parameters `X1,..., XN`, the error message will be the result of replacing
+ *  all occurrences of `\${Xi}` in the string `msg` with the string representation
+ *  of the corresponding type argument `Ti`.
+ *
+ *  If more than one `@implicitAmbiguous` annotation is collected, the compiler is
+ *  free to pick any of them to display.
+ *
+ *  Nice errors can direct users to fix imports or even tell them why code
+ *  intentionally doesn't compile.
+ *
+ *  ```
+ *  trait =!=[C, D]
+ *
+ *  implicit def neq[E, F] : E =!= F = null
+ *
+ *  @annotation.implicitAmbiguous("Could not prove \${J} =!= \${J}")
+ *  implicit def neqAmbig1[G, H, J] : J =!= J = null
+ *  implicit def neqAmbig2[I] : I =!= I = null
+ *
+ *  implicitly[Int =!= Int]
+ *  ```
+ */
 @meta.getter
 final class implicitAmbiguous(msg: String) extends scala.annotation.ConstantAnnotation

--- a/library/src/scala/annotation/implicitNotFound.scala
+++ b/library/src/scala/annotation/implicitNotFound.scala
@@ -14,19 +14,18 @@ package scala.annotation
 
 import scala.language.`2.13`
 
-/**
- * To customize the error message that's emitted when an implicit of type
- * `C[T1,..., TN]` cannot be found, annotate the class `C` with `@implicitNotFound`.
- * Assuming `C` has type parameters `X1, ..., XN`, the error message will be the
- * result of replacing all occurrences of `\${Xi}` in the string `msg` with the
- * string representation of the corresponding type argument `Ti`.
- * The annotation is effectively inherited by subtypes if they are not annotated.
+/** To customize the error message that's emitted when an implicit of type
+ *  `C[T1,..., TN]` cannot be found, annotate the class `C` with `@implicitNotFound`.
+ *  Assuming `C` has type parameters `X1, ..., XN`, the error message will be the
+ *  result of replacing all occurrences of `\${Xi}` in the string `msg` with the
+ *  string representation of the corresponding type argument `Ti`.
+ *  The annotation is effectively inherited by subtypes if they are not annotated.
  *
- * The annotation can also be attached to implicit parameters. In this case, `\${Xi}`
- * can refer to type parameters in the current scope. The `@implicitNotFound` message
- * on the parameter takes precedence over the one on the parameter's type.
+ *  The annotation can also be attached to implicit parameters. In this case, `\${Xi}`
+ *  can refer to type parameters in the current scope. The `@implicitNotFound` message
+ *  on the parameter takes precedence over the one on the parameter's type.
  *
- * {{{
+ *  ```
  *   import scala.annotation.implicitNotFound
  *
  *   @implicitNotFound("Could not find an implicit C[\${T}, \${U}]")
@@ -42,17 +41,17 @@ import scala.language.`2.13`
  *     k.m[String]
  *     k.n[String]
  *   }
- * }}}
+ *  ```
  *
- * The compiler issues the following error messages:
+ *  The compiler issues the following error messages:
  *
- * <pre>
- * Test.scala:13: error: Could not find an implicit C[List[Int], String]
+ *  <pre>
+ *  Test.scala:13: error: Could not find an implicit C[List[Int], String]
  *   k.m[String]
  *      ^
- * Test.scala:14: error: Specific message for C of list of Int and String
+ *  Test.scala:14: error: Specific message for C of list of Int and String
  *   k.n[String]
  *      ^
- * </pre>
+ *  </pre>
  */
 final class implicitNotFound(msg: String) extends scala.annotation.ConstantAnnotation

--- a/library/src/scala/annotation/internal/requiresCapability.scala
+++ b/library/src/scala/annotation/internal/requiresCapability.scala
@@ -3,7 +3,6 @@ import annotation.StaticAnnotation
 
 import language.experimental.captureChecking
 
-/** An annotation to record a required capaility in the type of a throws
- */
+/** An annotation to record a required capaility in the type of a throws */
 class requiresCapability(capability: Any) extends StaticAnnotation
 

--- a/library/src/scala/annotation/meta/defaultArg.scala
+++ b/library/src/scala/annotation/meta/defaultArg.scala
@@ -15,17 +15,16 @@ package meta
 
 import scala.language.`2.13`
 
-/**
- * This internal meta annotation is used by the compiler to support default annotation arguments.
+/** This internal meta annotation is used by the compiler to support default annotation arguments.
  *
- * For an annotation definition `class ann(x: Int = defaultExpr) extends Annotation`, the compiler adds
- * `@defaultArg(defaultExpr)` to the parameter `x`. This causes the syntax tree of `defaultExpr` to be
- * stored in the classfile.
+ *  For an annotation definition `class ann(x: Int = defaultExpr) extends Annotation`, the compiler adds
+ *  `@defaultArg(defaultExpr)` to the parameter `x`. This causes the syntax tree of `defaultExpr` to be
+ *  stored in the classfile.
  *
- * When using a default annotation argument, the compiler can recover the syntax tree and insert it in the
- * `AnnotationInfo`.
+ *  When using a default annotation argument, the compiler can recover the syntax tree and insert it in the
+ *  `AnnotationInfo`.
  *
- * For details, see `scala.reflect.internal.AnnotationInfos.AnnotationInfo`.
+ *  For details, see `scala.reflect.internal.AnnotationInfos.AnnotationInfo`.
  */
 @meta.param class defaultArg(arg: Any) extends StaticAnnotation {
   def this() = this(null)

--- a/library/src/scala/annotation/meta/languageFeature.scala
+++ b/library/src/scala/annotation/meta/languageFeature.scala
@@ -14,7 +14,5 @@ package scala.annotation.meta
 
 import scala.language.`2.13`
 
-/**
- * An annotation giving particulars for a language feature in object `scala.language`.
- */
+/** An annotation giving particulars for a language feature in object `scala.language`. */
 final class languageFeature(feature: String, enableRequired: Boolean) extends scala.annotation.StaticAnnotation

--- a/library/src/scala/annotation/meta/package.scala
+++ b/library/src/scala/annotation/meta/package.scala
@@ -21,9 +21,9 @@ import scala.language.`2.13`
  *
  * For instance in the following class definition
  *
- * {{{
+ * ```
  * class C(@myAnnot @BeanProperty var c: Int)
- * }}}
+ * ```
  *
  * there are six entities which can carry the annotation `@myAnnot`: the
  * constructor parameter, the generated field and the four accessors.
@@ -37,25 +37,25 @@ import scala.language.`2.13`
  * This is done by annotating either the annotation type or the annotation
  * class with one or several of the meta-annotations in this package.
  *
- * ==Annotating the annotation type==
+ * ## Annotating the annotation type
  *
  * The target meta-annotations can be put on the annotation type when
  * instantiating the annotation. In the following example, the annotation
  * `@Id` will be added only to the bean getter `getX`.
  *
- * {{{
+ * ```
  * import javax.persistence.Id
  * class A {
  *   @(Id @beanGetter) @BeanProperty val x = 0
  * }
- * }}}
+ * ```
  *
  * In order to annotate the field as well, the meta-annotation `@field`
  * would need to be added.
  *
  * The syntax can be improved using a type alias:
  *
- * {{{
+ * ```
  * object ScalaJPA {
  *   type Id = javax.persistence.Id @beanGetter
  * }
@@ -63,20 +63,21 @@ import scala.language.`2.13`
  * class A {
  *   @Id @BeanProperty val x = 0
  * }
- * }}}
+ * ```
  *
- * ==Annotating the annotation class==
+ * ## Annotating the annotation class
  *
  * For annotations defined in Scala, a default target can be specified
  * in the annotation class itself, for example
  *
- * {{{
+ * ```
  * @getter
  * class myAnnotation extends Annotation
- * }}}
+ * ```
  *
  * This only changes the default target for the annotation `myAnnotation`.
  * When instantiating the annotation, the target can still be specified
  * as described in the last section.
+ 
  */
 package object meta

--- a/library/src/scala/annotation/meta/superArg.scala
+++ b/library/src/scala/annotation/meta/superArg.scala
@@ -15,22 +15,20 @@ package meta
 
 import scala.language.`2.13`
 
-/**
- * This internal annotation encodes arguments passed to annotation superclasses. Example:
+/** This internal annotation encodes arguments passed to annotation superclasses. Example:
  *
- * {{{
+ *  ```
  *   class a(x: Int) extends Annotation
  *   class b extends a(42) // the compiler adds `@superArg("x", 42)` to class b
- * }}}
+ *  ```
  */
 class superArg(p: String, v: Any) extends StaticAnnotation
 
-/**
- * This internal annotation encodes arguments passed to annotation superclasses. Example:
+/** This internal annotation encodes arguments passed to annotation superclasses. Example:
  *
- * {{{
+ *  ```
  *   class a(x: Int) extends Annotation
  *   class b(y: Int) extends a(y) // the compiler adds `@superFwdArg("x", "y")` to class b
- * }}}
+ *  ```
  */
 class superFwdArg(p: String, n: String) extends StaticAnnotation

--- a/library/src/scala/annotation/nowarn.scala
+++ b/library/src/scala/annotation/nowarn.scala
@@ -15,30 +15,30 @@ package scala.annotation
 import scala.language.`2.13`
 
 /** An annotation for local warning suppression.
-  *
-  * The optional `value` parameter allows selectively silencing messages. See `-Wconf:help` for help
-  * writing a message filter expression, or use `@nowarn("verbose")` / `@nowarn("v")` to display message
-  * filters applicable to a specific warning.
-  *
-  * Examples:
-  *
-  * {{{
-  *   def f = {
-  *     1: @nowarn // don't warn "a pure expression does nothing in statement position"
-  *     2
-  *   }
-  *
-  *   // show the warning, plus the applicable @nowarn / Wconf filters ("cat=other-pure-statement", ...)
-  *   @nowarn("v") def f = { 1; 2 }
-  *
-  *   @nowarn def f = { 1; deprecated() } // don't warn
-  *
-  *   @nowarn("msg=pure expression does nothing")
-  *   def f = { 1; deprecated() } // show deprecation warning
-  * }}}
-  *
-  * To ensure that a `@nowarn` annotation actually suppresses a warning, enable `-Xlint:unused` or `-Wunused:nowarn`.
-  * The unused annotation warning is emitted in category `unused-nowarn` and can be selectively managed
-  * using `-Wconf:cat=unused-nowarn:s`.
-  */
+ *
+ *  The optional `value` parameter allows selectively silencing messages. See `-Wconf:help` for help
+ *  writing a message filter expression, or use `@nowarn("verbose")` / `@nowarn("v")` to display message
+ *  filters applicable to a specific warning.
+ *
+ *  Examples:
+ *
+ *  ```
+ *   def f = {
+ *     1: @nowarn // don't warn "a pure expression does nothing in statement position"
+ *     2
+ *   }
+ *
+ *   // show the warning, plus the applicable @nowarn / Wconf filters ("cat=other-pure-statement", ...)
+ *   @nowarn("v") def f = { 1; 2 }
+ *
+ *   @nowarn def f = { 1; deprecated() } // don't warn
+ *
+ *   @nowarn("msg=pure expression does nothing")
+ *   def f = { 1; deprecated() } // show deprecation warning
+ *  ```
+ *
+ *  To ensure that a `@nowarn` annotation actually suppresses a warning, enable `-Xlint:unused` or `-Wunused:nowarn`.
+ *  The unused annotation warning is emitted in category `unused-nowarn` and can be selectively managed
+ *  using `-Wconf:cat=unused-nowarn:s`.
+ */
 class nowarn(value: String = "") extends ConstantAnnotation

--- a/library/src/scala/annotation/retains.scala
+++ b/library/src/scala/annotation/retains.scala
@@ -16,8 +16,7 @@ import language.experimental.captureChecking
 @experimental
 class retains[Elems] extends annotation.StaticAnnotation
 
-/** Equivalent in meaning to `@retains[any.type]`, but consumes less bytecode.
- */
+/** Equivalent in meaning to `@retains[any.type]`, but consumes less bytecode. */
 @experimental
 class retainsCap extends annotation.StaticAnnotation
   // This special case is needed to be able to load standard library modules without

--- a/library/src/scala/annotation/retainsByName.scala
+++ b/library/src/scala/annotation/retainsByName.scala
@@ -2,7 +2,6 @@ package scala.annotation
 
 import language.experimental.captureChecking
 
-/** An annotation that indicates capture of an enclosing by-name type
- */
+/** An annotation that indicates capture of an enclosing by-name type */
 @experimental class retainsByName[Elems] extends annotation.StaticAnnotation
 

--- a/library/src/scala/annotation/showAsInfix.scala
+++ b/library/src/scala/annotation/showAsInfix.scala
@@ -15,27 +15,25 @@ package scala.annotation
 import scala.language.`2.13`
 
 /**
- * This annotation configures how Scala prints two-parameter generic types.
+  * This annotation configures how Scala prints two-parameter generic types.
   *
   * By default, types with symbolic names are printed infix; while types without
   * them are printed using the regular generic type syntax.
   *
   * Example of usage:
-  {{{
-    scala> class Map[T, U]
-    defined class Map
-
-    scala> def foo: Int Map Int = ???
-    foo: Map[Int,Int]
-
-    scala> @showAsInfix class Map[T, U]
-    defined class Map
-
-    scala> def foo: Int Map Int = ???
-    foo: Int Map Int
-  }}}
+  *  ```
+  *    scala> class Map[T, U]
+  *    defined class Map
+  *    scala> def foo: Int Map Int = ???
+  *    foo: Map[Int,Int]
+  *    scala> @showAsInfix class Map[T, U]
+  *    defined class Map
+  *    scala> def foo: Int Map Int = ???
+  *    foo: Int Map Int
+  *  ```
   *
   * @param enabled whether to show this type as an infix type operator.
+  
   */
 @deprecatedInheritance("Scheduled for being final in the future", "2.13.0")
 class showAsInfix(enabled: Boolean = true) extends annotation.StaticAnnotation

--- a/library/src/scala/annotation/switch.scala
+++ b/library/src/scala/annotation/switch.scala
@@ -16,18 +16,18 @@ import scala.language.`2.13`
 
 /** An annotation to be applied to a match expression.  If present,
  *  the compiler will verify that the match has been compiled to a
- *  [[https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-3.html#jvms-3.10 tableswitch or lookupswitch]]
+ *  [tableswitch or lookupswitch](https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-3.html#jvms-3.10)
  *  and issue a warning if it instead compiles into a series of conditional expressions.
  *  Example usage:
-{{{
-  val Constant = 'Q'
-  def tokenMe(ch: Char) = (ch: @switch) match {
-    case ' ' | '\t' | '\n'  => 1
-    case 'A' | 'Z' | '$'    => 2
-    case '5' | Constant     => 3  // a non-literal may prevent switch generation: this would not compile
-    case _                  => 4
-  }
-}}}
+ *  ```
+ *  val Constant = 'Q'
+ *  def tokenMe(ch: Char) = (ch: @switch) match {
+ *    case ' ' | '\t' | '\n'  => 1
+ *    case 'A' | 'Z' | '$'    => 2
+ *    case '5' | Constant     => 3  // a non-literal may prevent switch generation: this would not compile
+ *    case _                  => 4
+ *  }
+ *  ```
  *
  *  Note: for pattern matches with one or two cases, the compiler generates jump instructions.
  *  Annotating such a match with `@switch` does not issue any warning.

--- a/library/src/scala/beans/BeanProperty.scala
+++ b/library/src/scala/beans/BeanProperty.scala
@@ -18,15 +18,15 @@ import scala.annotation.meta.{beanGetter, beanSetter, field}
 
 /** When attached to a field, this annotation adds a setter and a getter
  *  method following the Java Bean convention. For example:
- *  {{{
+ *  ```
  *    @BeanProperty
  *    var status = ""
- *  }}}
+ *  ```
  *  adds the following methods to the class:
- *  {{{
+ *  ```
  *    def setStatus(s: String): Unit = { this.status = s }
  *    def getStatus(): String = this.status
- *  }}}
+ *  ```
  *  For fields of type `Boolean`, if you need a getter named `isStatus`,
  *  use the `scala.beans.BooleanBeanProperty` annotation instead.
  *

--- a/library/src/scala/caps/package.scala
+++ b/library/src/scala/caps/package.scala
@@ -6,26 +6,25 @@ import language.experimental.captureChecking
 import annotation.{experimental, compileTimeOnly, retainsCap}
 import annotation.meta.*
 
-/**
- * Base trait for classes that represent capabilities in the
- * [object-capability model](https://en.wikipedia.org/wiki/Object-capability_model).
+/** Base trait for classes that represent capabilities in the
+ *  [object-capability model](https://en.wikipedia.org/wiki/Object-capability_model).
  *
- * A capability is a value representing a permission, access right, resource or effect.
- * Capabilities are typically passed to code as parameters; they should not be global objects.
- * Often, they come with access restrictions such as scoped lifetimes or limited sharing.
+ *  A capability is a value representing a permission, access right, resource or effect.
+ *  Capabilities are typically passed to code as parameters; they should not be global objects.
+ *  Often, they come with access restrictions such as scoped lifetimes or limited sharing.
  *
- * An example is the [[scala.util.boundary.Label Label]] class in [[scala.util.boundary]].
- * It represents a capability in the sense that it gives permission to [[scala.util.boundary.break break]]
- * to the enclosing boundary represented by the `Label`. It has a scoped lifetime, since breaking to
- * a `Label` after the associated `boundary` was exited gives a runtime exception.
+ *  An example is the [[scala.util.boundary.Label Label]] class in [[scala.util.boundary]].
+ *  It represents a capability in the sense that it gives permission to [[scala.util.boundary.break break]]
+ *  to the enclosing boundary represented by the `Label`. It has a scoped lifetime, since breaking to
+ *  a `Label` after the associated `boundary` was exited gives a runtime exception.
  *
- * [[Capability]] has a formal meaning when
- * [[scala.language.experimental.captureChecking Capture Checking]]
- * is turned on.
- * But even without capture checking, extending this trait can be useful for documenting the intended purpose
- * of a class.
+ *  [[Capability]] has a formal meaning when
+ *  [[scala.language.experimental.captureChecking Capture Checking]]
+ *  is turned on.
+ *  But even without capture checking, extending this trait can be useful for documenting the intended purpose
+ *  of a class.
  *
- * Capability has exactly two subtraits: [[SharedCapability Shared]] and [[ExclusiveCapability Exclusive]].
+ *  Capability has exactly two subtraits: [[SharedCapability Shared]] and [[ExclusiveCapability Exclusive]].
  */
 sealed trait Capability extends Any
 
@@ -33,9 +32,9 @@ sealed trait Capability extends Any
  *  qualifiers. Capability classes directly extending `Classifier` are treated
  *  as classifier capbilities.
  *
- * [[Classifier]] has a formal meaning when
- * [[scala.language.experimental.captureChecking Capture Checking]]
- * is turned on. It should not be used outside of capture checking.
+ *  [[Classifier]] has a formal meaning when
+ *  [[scala.language.experimental.captureChecking Capture Checking]]
+ *  is turned on. It should not be used outside of capture checking.
  */
 trait Classifier
 
@@ -53,10 +52,10 @@ object cap extends Capability
 
 /** Marker trait for capabilities that can be safely shared in a concurrent context.
  *
- * [[SharedCapability]] has a formal meaning when
- * [[scala.language.experimental.captureChecking Capture Checking]]
- * is turned on.
- * During separation checking, shared capabilities are not taken into account.
+ *  [[SharedCapability]] has a formal meaning when
+ *  [[scala.language.experimental.captureChecking Capture Checking]]
+ *  is turned on.
+ *  During separation checking, shared capabilities are not taken into account.
  */
 trait SharedCapability extends Capability, Classifier
 
@@ -66,10 +65,10 @@ type Shared = SharedCapability
 /** Marker trait for capabilities that should only be used by one concurrent process
  *  at a given time. For example, write-access to a shared mutable buffer.
  *
- * [[ExclusiveCapability]] has a formal meaning when
- * [[scala.language.experimental.captureChecking Capture Checking]]
- * is turned on.
- * During separation checking, exclusive usage of marked capabilities will be enforced.
+ *  [[ExclusiveCapability]] has a formal meaning when
+ *  [[scala.language.experimental.captureChecking Capture Checking]]
+ *  is turned on.
+ *  During separation checking, exclusive usage of marked capabilities will be enforced.
  */
 @experimental
 trait ExclusiveCapability extends Capability
@@ -81,9 +80,9 @@ type Exclusive = ExclusiveCapability
  *  the stack. Examples are exceptions, [[scala.util.boundary.Label labels]], [[scala.CanThrow CanThrow]]
  *  or Async contexts.
  *
- * [[Control]] has a formal meaning when
- * [[scala.language.experimental.captureChecking Capture Checking]]
- * is turned on.
+ *  [[Control]] has a formal meaning when
+ *  [[scala.language.experimental.captureChecking Capture Checking]]
+ *  is turned on.
  */
 trait Control extends SharedCapability, Classifier
 
@@ -99,8 +98,7 @@ trait Stateful extends ExclusiveCapability
 @experimental
 trait Separate extends Stateful
 
-/** Marker trait for classes that are not subject to scoping restrictions of captured capabilities.
- */
+/** Marker trait for classes that are not subject to scoping restrictions of captured capabilities. */
 @experimental
 trait Unscoped extends Stateful, Classifier
 
@@ -154,8 +152,8 @@ final class reserve extends annotation.StaticAnnotation
 final class use extends annotation.StaticAnnotation
 
 /** A trait that used to allow expressing existential types. Replaced by
-*  root.Result instances.
-*/
+ *  root.Result instances.
+ */
 @experimental
 @deprecated
 sealed trait Exists extends Capability
@@ -201,8 +199,7 @@ object internal:
    */
   def erasedValue[T]: T = ???
 
-  /** A trait for capabilities representing usage of mutable vars in capture sets.
-   */
+  /** A trait for capabilities representing usage of mutable vars in capture sets. */
   trait Var[T] extends Mutable:
     def get: T
     update def set(x: T): Unit
@@ -240,7 +237,7 @@ object unsafe:
    *   3. Allows a field to be declarewd in a class that does not extend Stateful,
    *      and suppresses checks for updates to the field.
    *
-   * @note This should go into annotations. For now it is here, so that we
+   *  @note This should go into annotations. For now it is here, so that we
    *  can experiment with it quickly between minor releases
    */
   @getter @param
@@ -253,8 +250,7 @@ object unsafe:
      */
     def unsafeAssumePure: T = x
 
-  /** A wrapper around code for which separation checks are suppressed.
-   */
+  /** A wrapper around code for which separation checks are suppressed. */
   def unsafeAssumeSeparate(op: Any): op.type = op
 
   /** A wrapper around code for which uses go unrecorded. */

--- a/library/src/scala/collection/ArrayOps.scala
+++ b/library/src/scala/collection/ArrayOps.scala
@@ -67,8 +67,8 @@ object ArrayOps {
   class WithFilter[A](p: A => Boolean, xs: Array[A]) {
 
     /** Applies `f` to each element for its side effects.
-      * Note: [U] parameter needed to help scalac's type inference.
-      */
+     *  Note: [U] parameter needed to help scalac's type inference.
+     */
     def foreach[U](f: A => U): Unit = {
       val len = xs.length
       var i = 0
@@ -80,12 +80,12 @@ object ArrayOps {
     }
 
     /** Builds a new array by applying a function to all elements of this array.
-      *
-      *  @param f      the function to apply to each element.
-      *  @tparam B     the element type of the returned array.
-      *  @return       a new array resulting from applying the given function
-      *                `f` to each element of this array and collecting the results.
-      */
+     *
+     *  @tparam B     the element type of the returned array.
+     *  @param f      the function to apply to each element.
+     *  @return       a new array resulting from applying the given function
+     *                `f` to each element of this array and collecting the results.
+     */
     def map[B: ClassTag](f: A => B): Array[B] = {
       val b = ArrayBuilder.make[B]
       var i = 0
@@ -98,13 +98,13 @@ object ArrayOps {
     }
 
     /** Builds a new array by applying a function to all elements of this array
-      * and using the elements of the resulting collections.
-      *
-      *  @param f      the function to apply to each element.
-      *  @tparam B     the element type of the returned array.
-      *  @return       a new array resulting from applying the given collection-valued function
-      *                `f` to each element of this array and concatenating the results.
-      */
+     *  and using the elements of the resulting collections.
+     *
+     *  @tparam B     the element type of the returned array.
+     *  @param f      the function to apply to each element.
+     *  @return       a new array resulting from applying the given collection-valued function
+     *                `f` to each element of this array and concatenating the results.
+     */
     def flatMap[B: ClassTag](f: A => IterableOnce[B]^): Array[B] = {
       val b = ArrayBuilder.make[B]
       var i = 0
@@ -176,8 +176,8 @@ object ArrayOps {
   }
 
   /** The cut-off point for the array size after which we switch from `Sorting.stableSort` to
-    * an implementation that copies the data to a boxed representation for use with `Arrays.sort`.
-    */
+   *  an implementation that copies the data to a boxed representation for use with `Arrays.sort`.
+   */
   private final val MaxStableSortLength = 300
 
   /** Avoid an allocation in [[collect]]. */
@@ -185,147 +185,147 @@ object ArrayOps {
 }
 
 /** This class serves as a wrapper for `Array`s with many of the operations found in
-  *  indexed sequences. Where needed, instances of arrays are implicitly converted
-  *  into this class. There is generally no reason to create an instance explicitly or use
-  *  an `ArrayOps` type. It is better to work with plain `Array` types instead and rely on
-  *  the implicit conversion to `ArrayOps` when calling a method (which does not actually
-  *  allocate an instance of `ArrayOps` because it is a value class).
-  *
-  *  Neither `Array` nor `ArrayOps` are proper collection types
-  *  (i.e. they do not extend `Iterable` or even `IterableOnce`). `mutable.ArraySeq` and
-  *  `immutable.ArraySeq` serve this purpose.
-  *
-  *  The difference between this class and `ArraySeq`s is that calling transformer methods such as
-  *  `filter` and `map` will yield an array, whereas an `ArraySeq` will remain an `ArraySeq`.
-  *
-  *  @tparam A   type of the elements contained in this array.
-  */
+ *  indexed sequences. Where needed, instances of arrays are implicitly converted
+ *  into this class. There is generally no reason to create an instance explicitly or use
+ *  an `ArrayOps` type. It is better to work with plain `Array` types instead and rely on
+ *  the implicit conversion to `ArrayOps` when calling a method (which does not actually
+ *  allocate an instance of `ArrayOps` because it is a value class).
+ *
+ *  Neither `Array` nor `ArrayOps` are proper collection types
+ *  (i.e. they do not extend `Iterable` or even `IterableOnce`). `mutable.ArraySeq` and
+ *  `immutable.ArraySeq` serve this purpose.
+ *
+ *  The difference between this class and `ArraySeq`s is that calling transformer methods such as
+ *  `filter` and `map` will yield an array, whereas an `ArraySeq` will remain an `ArraySeq`.
+ *
+ *  @tparam A   type of the elements contained in this array.
+ */
 final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
 
   @`inline` private implicit def elemTag: ClassTag[A] = ClassTag(xs.getClass.getComponentType)
 
   /** The size of this array.
-    *
-    *  @return    the number of elements in this array.
-    */
+   *
+   *  @return    the number of elements in this array.
+   */
   @`inline` def size: Int = xs.length
 
   /** The size of this array.
-    *
-    *  @return    the number of elements in this array.
-    */
+   *
+   *  @return    the number of elements in this array.
+   */
   @`inline` def knownSize: Int = xs.length
 
   /** Tests whether the array is empty.
-    *
-    *  @return    `true` if the array contains no elements, `false` otherwise.
-    */
+   *
+   *  @return    `true` if the array contains no elements, `false` otherwise.
+   */
   @`inline` def isEmpty: Boolean = xs.length == 0
 
   /** Tests whether the array is not empty.
-    *
-    *  @return    `true` if the array contains at least one element, `false` otherwise.
-    */
+   *
+   *  @return    `true` if the array contains at least one element, `false` otherwise.
+   */
   @`inline` def nonEmpty: Boolean = xs.length != 0
 
   /** Selects the first element of this array.
-    *
-    *  @return  the first element of this array.
-    *  @throws NoSuchElementException if the array is empty.
-    */
+   *
+   *  @return  the first element of this array.
+   *  @throws NoSuchElementException if the array is empty.
+   */
   def head: A = if (nonEmpty) xs.apply(0) else throw new NoSuchElementException("head of empty array")
 
   /** Selects the last element.
-    *
-    * @return The last element of this array.
-    * @throws NoSuchElementException If the array is empty.
-    */
+   *
+   *  @return The last element of this array.
+   *  @throws NoSuchElementException If the array is empty.
+   */
   def last: A = if (nonEmpty) xs.apply(xs.length-1) else throw new NoSuchElementException("last of empty array")
 
   /** Optionally selects the first element.
-    *
-    *  @return  the first element of this array if it is nonempty,
-    *           `None` if it is empty.
-    */
+   *
+   *  @return  the first element of this array if it is nonempty,
+   *           `None` if it is empty.
+   */
   def headOption: Option[A] = if(isEmpty) None else Some(head)
 
   /** Optionally selects the last element.
-    *
-    *  @return  the last element of this array$ if it is nonempty,
-    *           `None` if it is empty.
-    */
+   *
+   *  @return  the last element of this array$ if it is nonempty,
+   *           `None` if it is empty.
+   */
   def lastOption: Option[A] = if(isEmpty) None else Some(last)
 
   /** Compares the size of this array to a test value.
-    *
-    *   @param   otherSize the test value that gets compared with the size.
-    *   @return  A value `x` where
-    *   {{{
-    *        x <  0       if this.size <  otherSize
-    *        x == 0       if this.size == otherSize
-    *        x >  0       if this.size >  otherSize
-    *   }}}
-    */
+   *
+   *  @param   otherSize the test value that gets compared with the size.
+   *  @return  A value `x` where
+   *   ```
+   *        x <  0       if this.size <  otherSize
+   *        x == 0       if this.size == otherSize
+   *        x >  0       if this.size >  otherSize
+   *   ```
+   */
   def sizeCompare(otherSize: Int): Int = Integer.compare(xs.length, otherSize)
 
   /** Compares the length of this array to a test value.
-    *
-    *   @param   len   the test value that gets compared with the length.
-    *   @return  A value `x` where
-    *   {{{
-    *        x <  0       if this.length <  len
-    *        x == 0       if this.length == len
-    *        x >  0       if this.length >  len
-    *   }}}
-    */
+   *
+   *  @param   len   the test value that gets compared with the length.
+   *  @return  A value `x` where
+   *   ```
+   *        x <  0       if this.length <  len
+   *        x == 0       if this.length == len
+   *        x >  0       if this.length >  len
+   *   ```
+   */
   def lengthCompare(len: Int): Int = Integer.compare(xs.length, len)
 
   /** Method mirroring [[SeqOps.sizeIs]] for consistency, except it returns an `Int`
-    * because `size` is known and comparison is constant-time.
-    *
-    * These operations are equivalent to [[sizeCompare(Int) `sizeCompare(Int)`]], and
-    * allow the following more readable usages:
-    *
-    * {{{
-    * this.sizeIs < size     // this.sizeCompare(size) < 0
-    * this.sizeIs <= size    // this.sizeCompare(size) <= 0
-    * this.sizeIs == size    // this.sizeCompare(size) == 0
-    * this.sizeIs != size    // this.sizeCompare(size) != 0
-    * this.sizeIs >= size    // this.sizeCompare(size) >= 0
-    * this.sizeIs > size     // this.sizeCompare(size) > 0
-    * }}}
-    */
+   *  because `size` is known and comparison is constant-time.
+   *
+   *  These operations are equivalent to [[sizeCompare(Int) `sizeCompare(Int)`]], and
+   *  allow the following more readable usages:
+   *
+   *  ```
+   *  this.sizeIs < size     // this.sizeCompare(size) < 0
+   *  this.sizeIs <= size    // this.sizeCompare(size) <= 0
+   *  this.sizeIs == size    // this.sizeCompare(size) == 0
+   *  this.sizeIs != size    // this.sizeCompare(size) != 0
+   *  this.sizeIs >= size    // this.sizeCompare(size) >= 0
+   *  this.sizeIs > size     // this.sizeCompare(size) > 0
+   *  ```
+   */
   def sizeIs: Int = xs.length
 
   /** Method mirroring [[SeqOps.lengthIs]] for consistency, except it returns an `Int`
-    * because `length` is known and comparison is constant-time.
-    *
-    * These operations are equivalent to [[lengthCompare(Int) `lengthCompare(Int)`]], and
-    * allow the following more readable usages:
-    *
-    * {{{
-    * this.lengthIs < len     // this.lengthCompare(len) < 0
-    * this.lengthIs <= len    // this.lengthCompare(len) <= 0
-    * this.lengthIs == len    // this.lengthCompare(len) == 0
-    * this.lengthIs != len    // this.lengthCompare(len) != 0
-    * this.lengthIs >= len    // this.lengthCompare(len) >= 0
-    * this.lengthIs > len     // this.lengthCompare(len) > 0
-    * }}}
-    */
+   *  because `length` is known and comparison is constant-time.
+   *
+   *  These operations are equivalent to [[lengthCompare(Int) `lengthCompare(Int)`]], and
+   *  allow the following more readable usages:
+   *
+   *  ```
+   *  this.lengthIs < len     // this.lengthCompare(len) < 0
+   *  this.lengthIs <= len    // this.lengthCompare(len) <= 0
+   *  this.lengthIs == len    // this.lengthCompare(len) == 0
+   *  this.lengthIs != len    // this.lengthCompare(len) != 0
+   *  this.lengthIs >= len    // this.lengthCompare(len) >= 0
+   *  this.lengthIs > len     // this.lengthCompare(len) > 0
+   *  ```
+   */
   def lengthIs: Int = xs.length
 
   /** Selects an interval of elements. The returned array is made up
-    * of all elements `x` which satisfy the invariant:
-    * {{{
-    *   from <= indexOf(x) < until
-    * }}}
-    *
-    *  @param from   the lowest index to include from this array.
-    *  @param until  the lowest index to EXCLUDE from this array.
-    *  @return  an array containing the elements greater than or equal to
-    *           index `from` extending up to (but not including) index `until`
-    *           of this array.
-    */
+   *  of all elements `x` which satisfy the invariant:
+   *  ```
+   *   from <= indexOf(x) < until
+   *  ```
+   *
+   *  @param from   the lowest index to include from this array.
+   *  @param until  the lowest index to EXCLUDE from this array.
+   *  @return  an array containing the elements greater than or equal to
+   *           index `from` extending up to (but not including) index `until`
+   *           of this array.
+   */
   def slice(from: Int, until: Int): Array[A] = {
     import java.util.Arrays.copyOfRange
     val lo = max(from, 0)
@@ -354,19 +354,19 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     if(xs.length == 0) throw new UnsupportedOperationException("init of empty array") else slice(0, xs.length-1)
 
   /** Iterates over the tails of this array. The first value will be this
-    * array and the final one will be an empty array, with the intervening
-    * values the results of successive applications of `tail`.
-    *
-    *  @return   an iterator over all the tails of this array
-    */
+   *  array and the final one will be an empty array, with the intervening
+   *  values the results of successive applications of `tail`.
+   *
+   *  @return   an iterator over all the tails of this array
+   */
   def tails: Iterator[Array[A]] = iterateUntilEmpty(xs => new ArrayOps(xs).tail)
 
   /** Iterates over the inits of this array. The first value will be this
-    * array and the final one will be an empty array, with the intervening
-    * values the results of successive applications of `init`.
-    *
-    *  @return  an iterator over all the inits of this array
-    */
+   *  array and the final one will be an empty array, with the intervening
+   *  values the results of successive applications of `init`.
+   *
+   *  @return  an iterator over all the inits of this array
+   */
   def inits: Iterator[Array[A]] = iterateUntilEmpty(xs => new ArrayOps(xs).init)
 
   // A helper for tails and inits.
@@ -386,11 +386,11 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   def dropRight(n: Int): Array[A] = take(xs.length - max(n, 0))
 
   /** Takes longest prefix of elements that satisfy a predicate.
-    *
-    *  @param   p  The predicate used to test elements.
-    *  @return  the longest prefix of this array whose elements all satisfy
-    *           the predicate `p`.
-    */
+   *
+   *  @param   p  The predicate used to test elements.
+   *  @return  the longest prefix of this array whose elements all satisfy
+   *           the predicate `p`.
+   */
   def takeWhile(p: A => Boolean): Array[A] = {
     val i = indexWhere(x => !p(x))
     val hi = if(i < 0) xs.length else i
@@ -398,11 +398,11 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** Drops longest prefix of elements that satisfy a predicate.
-    *
-    *  @param   p  The predicate used to test elements.
-    *  @return  the longest suffix of this array whose first element
-    *           does not satisfy the predicate `p`.
-    */
+   *
+   *  @param   p  The predicate used to test elements.
+   *  @return  the longest suffix of this array whose first element
+   *           does not satisfy the predicate `p`.
+   */
   def dropWhile(p: A => Boolean): Array[A] = {
     val i = indexWhere(x => !p(x))
     val lo = if(i < 0) xs.length else i
@@ -443,24 +443,24 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** Partitions elements in fixed size arrays.
-    *  @see [[scala.collection.Iterator]], method `grouped`
-    *
-    *  @param size the number of elements per group
-    *  @return An iterator producing arrays of size `size`, except the
-    *          last will be less than size `size` if the elements don't divide evenly.
-    */
+   *  @see [[scala.collection.Iterator]], method `grouped`
+   *
+   *  @param size the number of elements per group
+   *  @return An iterator producing arrays of size `size`, except the
+   *          last will be less than size `size` if the elements don't divide evenly.
+   */
   def grouped(size: Int): Iterator[Array[A]] = new ArrayOps.GroupedIterator[A](xs, size)
 
   /** Splits this array into a prefix/suffix pair according to a predicate.
-    *
-    *  Note: `c span p`  is equivalent to (but more efficient than)
-    *  `(c takeWhile p, c dropWhile p)`, provided the evaluation of the
-    *  predicate `p` does not cause any side-effects.
-    *
-    *  @param p the test predicate
-    *  @return  a pair consisting of the longest prefix of this array whose
-    *           elements all satisfy `p`, and the rest of this array.
-    */
+   *
+   *  Note: `c span p`  is equivalent to (but more efficient than)
+   *  `(c takeWhile p, c dropWhile p)`, provided the evaluation of the
+   *  predicate `p` does not cause any side-effects.
+   *
+   *  @param p the test predicate
+   *  @return  a pair consisting of the longest prefix of this array whose
+   *           elements all satisfy `p`, and the rest of this array.
+   */
   def span(p: A => Boolean): (Array[A], Array[A]) = {
     val i = indexWhere(x => !p(x))
     val idx = if(i < 0) xs.length else i
@@ -468,12 +468,12 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** Splits this array into two at a given position.
-    * Note: `c splitAt n` is equivalent to `(c take n, c drop n)`.
-    *
-    *  @param n the position at which to split.
-    *  @return  a pair of arrays consisting of the first `n`
-    *           elements of this array, and the other elements.
-    */
+   *  Note: `c splitAt n` is equivalent to `(c take n, c drop n)`.
+   *
+   *  @param n the position at which to split.
+   *  @return  a pair of arrays consisting of the first `n`
+   *           elements of this array, and the other elements.
+   */
   def splitAt(n: Int): (Array[A], Array[A]) = (take(n), drop(n))
 
   /** A pair of, first, all elements that satisfy predicate `p` and, second, all elements that do not. */
@@ -489,25 +489,26 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** Applies a function `f` to each element of the array and returns a pair of arrays: the first one
-    *  made of those values returned by `f` that were wrapped in [[scala.util.Left]], and the second
-    *  one made of those wrapped in [[scala.util.Right]].
-    *
-    *  Example:
-    *  {{{
-    *    val xs = Array(1, "one", 2, "two", 3, "three") partitionMap {
-    *     case i: Int => Left(i)
-    *     case s: String => Right(s)
-    *    }
-    *    // xs == (Array(1, 2, 3),
-    *    //        Array(one, two, three))
-    *  }}}
-    *
-    *  @tparam A1  the element type of the first resulting collection
-    *  @tparam A2  the element type of the second resulting collection
-    *  @param f    the 'split function' mapping the elements of this array to an [[scala.util.Either]]
-    *
-    *  @return     a pair of arrays: the first one made of those values returned by `f` that were wrapped in [[scala.util.Left]],
-    *              and the second one made of those wrapped in [[scala.util.Right]]. */
+   *  made of those values returned by `f` that were wrapped in [[scala.util.Left]], and the second
+   *  one made of those wrapped in [[scala.util.Right]].
+   *
+   *  Example:
+   *  ```
+   *    val xs = Array(1, "one", 2, "two", 3, "three") partitionMap {
+   *     case i: Int => Left(i)
+   *     case s: String => Right(s)
+   *    }
+   *    // xs == (Array(1, 2, 3),
+   *    //        Array(one, two, three))
+   *  ```
+   *
+   *  @tparam A1  the element type of the first resulting collection
+   *  @tparam A2  the element type of the second resulting collection
+   *  @param f    the 'split function' mapping the elements of this array to an [[scala.util.Either]]
+   *
+   *  @return     a pair of arrays: the first one made of those values returned by `f` that were wrapped in [[scala.util.Left]],
+   *              and the second one made of those wrapped in [[scala.util.Right]]. 
+   */
   def partitionMap[A1: ClassTag, A2: ClassTag](f: A => Either[A1, A2]): (Array[A1], Array[A2]) = {
     val res1 = ArrayBuilder.make[A1]
     val res2 = ArrayBuilder.make[A2]
@@ -535,11 +536,11 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** An iterator yielding elements in reversed order.
-    *
-    * Note: `xs.reverseIterator` is the same as `xs.reverse.iterator` but implemented more efficiently.
-    *
-    *  @return  an iterator yielding the elements of this array in reversed order
-    */
+   *
+   *  Note: `xs.reverseIterator` is the same as `xs.reverse.iterator` but implemented more efficiently.
+   *
+   *  @return  an iterator yielding the elements of this array in reversed order
+   */
   def reverseIterator: Iterator[A] =
     ((xs: Any @unchecked) match {
       case xs: Array[AnyRef]  => new ArrayOps.ReverseIterator(xs)
@@ -556,10 +557,10 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     }).asInstanceOf[Iterator[A]]
 
   /** Selects all elements of this array which satisfy a predicate.
-    *
-    *  @param p  the predicate used to test elements.
-    *  @return   a new array consisting of all elements of this array that satisfy the given predicate `p`.
-    */
+   *
+   *  @param p  the predicate used to test elements.
+   *  @return   a new array consisting of all elements of this array that satisfy the given predicate `p`.
+   */
   def filter(p: A => Boolean): Array[A] = {
     val res = ArrayBuilder.make[A]
     var i = 0
@@ -572,23 +573,23 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** Selects all elements of this array which do not satisfy a predicate.
-    *
-    *  @param p     the predicate used to test elements.
-    *  @return      a new array consisting of all elements of this array that do not satisfy the given predicate `p`.
-    */
+   *
+   *  @param p     the predicate used to test elements.
+   *  @return      a new array consisting of all elements of this array that do not satisfy the given predicate `p`.
+   */
   def filterNot(p: A => Boolean): Array[A] = filter(x => !p(x))
 
   /** Sorts this array according to an Ordering.
-    *
-    *  The sort is stable. That is, elements that are equal (as determined by
-    *  `lt`) appear in the same order in the sorted sequence as in the original.
-    *
-    *  @see [[scala.math.Ordering]]
-    *
-    *  @param  ord the ordering to be used to compare elements.
-    *  @return     an array consisting of the elements of this array
-    *              sorted according to the ordering `ord`.
-    */
+   *
+   *  The sort is stable. That is, elements that are equal (as determined by
+   *  `lt`) appear in the same order in the sorted sequence as in the original.
+   *
+   *  @see [[scala.math.Ordering]]
+   *
+   *  @param  ord the ordering to be used to compare elements.
+   *  @return     an array consisting of the elements of this array
+   *              sorted according to the ordering `ord`.
+   */
   def sorted[B >: A](implicit ord: Ordering[B]^): Array[A] = {
     val len = xs.length
     def boxed = if(len < ArrayOps.MaxStableSortLength) {
@@ -627,55 +628,55 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** Sorts this array according to a comparison function.
-    *
-    *  The sort is stable. That is, elements that are equal (as determined by
-    *  `lt`) appear in the same order in the sorted sequence as in the original.
-    *
-    *  @param  lt  the comparison function which tests whether
-    *              its first argument precedes its second argument in
-    *              the desired ordering.
-    *  @return     an array consisting of the elements of this array
-    *              sorted according to the comparison function `lt`.
-    */
+   *
+   *  The sort is stable. That is, elements that are equal (as determined by
+   *  `lt`) appear in the same order in the sorted sequence as in the original.
+   *
+   *  @param  lt  the comparison function which tests whether
+   *              its first argument precedes its second argument in
+   *              the desired ordering.
+   *  @return     an array consisting of the elements of this array
+   *              sorted according to the comparison function `lt`.
+   */
   def sortWith(lt: (A, A) => Boolean): Array[A] = sorted(using Ordering.fromLessThan(lt))
 
   /** Sorts this array according to the Ordering which results from transforming
-    *  an implicitly given Ordering with a transformation function.
-    *
-    *  @see [[scala.math.Ordering]]
-    *  @param   f the transformation function mapping elements
-    *           to some other domain `B`.
-    *  @param   ord the ordering assumed on domain `B`.
-    *  @tparam  B the target type of the transformation `f`, and the type where
-    *           the ordering `ord` is defined.
-    *  @return  an array consisting of the elements of this array
-    *           sorted according to the ordering where `x < y` if
-    *           `ord.lt(f(x), f(y))`.
-    */
+   *  an implicitly given Ordering with a transformation function.
+   *
+   *  @see [[scala.math.Ordering]]
+   *  @tparam  B the target type of the transformation `f`, and the type where
+   *           the ordering `ord` is defined.
+   *  @param   f the transformation function mapping elements
+   *           to some other domain `B`.
+   *  @param   ord the ordering assumed on domain `B`.
+   *  @return  an array consisting of the elements of this array
+   *           sorted according to the ordering where `x < y` if
+   *           `ord.lt(f(x), f(y))`.
+   */
   def sortBy[B](f: A => B)(implicit ord: Ordering[B]): Array[A] = sorted(using ord.on(f))
 
   /** Creates a non-strict filter of this array.
-    *
-    *  Note: the difference between `c filter p` and `c withFilter p` is that
-    *        the former creates a new array, whereas the latter only
-    *        restricts the domain of subsequent `map`, `flatMap`, `foreach`,
-    *        and `withFilter` operations.
-    *
-    *  @param p   the predicate used to test elements.
-    *  @return    an object of class `ArrayOps.WithFilter`, which supports
-    *             `map`, `flatMap`, `foreach`, and `withFilter` operations.
-    *             All these operations apply to those elements of this array
-    *             which satisfy the predicate `p`.
-    */
+   *
+   *  Note: the difference between `c filter p` and `c withFilter p` is that
+   *        the former creates a new array, whereas the latter only
+   *        restricts the domain of subsequent `map`, `flatMap`, `foreach`,
+   *        and `withFilter` operations.
+   *
+   *  @param p   the predicate used to test elements.
+   *  @return    an object of class `ArrayOps.WithFilter`, which supports
+   *             `map`, `flatMap`, `foreach`, and `withFilter` operations.
+   *             All these operations apply to those elements of this array
+   *             which satisfy the predicate `p`.
+   */
   def withFilter(p: A => Boolean): ArrayOps.WithFilter[A]^{p} = new ArrayOps.WithFilter[A](p, xs)
 
   /** Finds index of first occurrence of some value in this array after or at some start index.
-    *
-    *  @param   elem   the element value to search for.
-    *  @param   from   the start index
-    *  @return  the index `>= from` of the first element of this array that is equal (as determined by `==`)
-    *           to `elem`, or `-1`, if none exists.
-    */
+   *
+   *  @param   elem   the element value to search for.
+   *  @param   from   the start index
+   *  @return  the index `>= from` of the first element of this array that is equal (as determined by `==`)
+   *           to `elem`, or `-1`, if none exists.
+   */
   def indexOf(elem: A, from: Int = 0): Int = {
     var i = from
     while(i < xs.length) {
@@ -686,12 +687,12 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** Finds index of the first element satisfying some predicate after or at some start index.
-    *
-    *  @param   p     the predicate used to test elements.
-    *  @param   from  the start index
-    *  @return  the index `>= from` of the first element of this array that satisfies the predicate `p`,
-    *           or `-1`, if none exists.
-    */
+   *
+   *  @param   p     the predicate used to test elements.
+   *  @param   from  the start index
+   *  @return  the index `>= from` of the first element of this array that satisfies the predicate `p`,
+   *           or `-1`, if none exists.
+   */
   def indexWhere(@deprecatedName("f", "2.13.3") p: A => Boolean, from: Int = 0): Int = {
     var i = from
     while(i < xs.length) {
@@ -702,12 +703,12 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** Finds index of last occurrence of some value in this array before or at a given end index.
-    *
-    *  @param   elem   the element value to search for.
-    *  @param   end    the end index.
-    *  @return  the index `<= end` of the last element of this array that is equal (as determined by `==`)
-    *           to `elem`, or `-1`, if none exists.
-    */
+   *
+   *  @param   elem   the element value to search for.
+   *  @param   end    the end index.
+   *  @return  the index `<= end` of the last element of this array that is equal (as determined by `==`)
+   *           to `elem`, or `-1`, if none exists.
+   */
   def lastIndexOf(elem: A, end: Int = xs.length - 1): Int = {
     var i = min(end, xs.length-1)
     while(i >= 0) {
@@ -718,11 +719,11 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** Finds index of last element satisfying some predicate before or at given end index.
-    *
-    *  @param   p     the predicate used to test elements.
-    *  @return  the index `<= end` of the last element of this array that satisfies the predicate `p`,
-    *           or `-1`, if none exists.
-    */
+   *
+   *  @param   p     the predicate used to test elements.
+   *  @return  the index `<= end` of the last element of this array that satisfies the predicate `p`,
+   *           or `-1`, if none exists.
+   */
   def lastIndexWhere(p: A => Boolean, end: Int = xs.length - 1): Int = {
     var i = min(end, xs.length-1)
     while(i >= 0) {
@@ -733,29 +734,29 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** Finds the first element of the array satisfying a predicate, if any.
-    *
-    *  @param p       the predicate used to test elements.
-    *  @return        an option value containing the first element in the array
-    *                 that satisfies `p`, or `None` if none exists.
-    */
+   *
+   *  @param p       the predicate used to test elements.
+   *  @return        an option value containing the first element in the array
+   *                 that satisfies `p`, or `None` if none exists.
+   */
   def find(@deprecatedName("f", "2.13.3") p: A => Boolean): Option[A] = {
     val idx = indexWhere(p)
     if(idx == -1) None else Some(xs(idx))
   }
 
   /** Tests whether a predicate holds for at least one element of this array.
-    *
-    *  @param   p     the predicate used to test elements.
-    *  @return        `true` if the given predicate `p` is satisfied by at least one element of this array, otherwise `false`
-    */
+   *
+   *  @param   p     the predicate used to test elements.
+   *  @return        `true` if the given predicate `p` is satisfied by at least one element of this array, otherwise `false`
+   */
   def exists(@deprecatedName("f", "2.13.3") p: A => Boolean): Boolean = indexWhere(p) >= 0
 
   /** Tests whether a predicate holds for all elements of this array.
-    *
-    *  @param   p     the predicate used to test elements.
-    *  @return        `true` if this array is empty or the given predicate `p`
-    *                 holds for all elements of this array, otherwise `false`.
-    */
+   *
+   *  @param   p     the predicate used to test elements.
+   *  @return        `true` if this array is empty or the given predicate `p`
+   *                 holds for all elements of this array, otherwise `false`.
+   */
   def forall(@deprecatedName("f", "2.13.3") p: A => Boolean): Boolean = {
     var i = 0
     while(i < xs.length) {
@@ -772,10 +773,10 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    *  If `x,,1,,`, `x,,2,,`, ..., `x,,n,,` are the elements of this array, the
    *  result is `op( op( ... op( op(z, x,,1,,), x,,2,,) ... ), x,,n,,)`.
    *
-   *   @param    z       An initial value.
-   *   @param    op      A binary operator.
-   *   @tparam   B       The result type of the binary operator.
-   *   @return           The result of applying `op` to `z` and all elements of this array,
+   *  @tparam   B       The result type of the binary operator.
+   *  @param    z       An initial value.
+   *  @param    op      A binary operator.
+   *  @return           The result of applying `op` to `z` and all elements of this array,
    *                     going left to right. Returns `z` if this array is empty.
    */
   def foldLeft[B](z: B)(op: (B, A) => B): B = {
@@ -804,20 +805,19 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     }).asInstanceOf[B]
   }
 
-   /** Produces an array containing cumulative results of applying the binary
-    *  operator going left to right.
-    *
-    *  @param   z    the start value.
-    *  @param   op   the binary operator.
-    *  @tparam  B    the result type of the binary operator.
-    *  @return  array with intermediate values.
-    *
-    *  Example:
-    *  {{{
-    *    Array(1, 2, 3, 4).scanLeft(0)(_ + _) == Array(0, 1, 3, 6, 10)
-    *  }}}
-    *
-    */
+  /** Produces an array containing cumulative results of applying the binary
+   *  operator going left to right.
+   *
+   *  @tparam  B    the result type of the binary operator.
+   *  @param   z    the start value.
+   *  @param   op   the binary operator.
+   *  @return  array with intermediate values.
+   *
+   *  Example:
+   *  ```
+   *    Array(1, 2, 3, 4).scanLeft(0)(_ + _) == Array(0, 1, 3, 6, 10)
+   *  ```
+   */
   def scanLeft[ B : ClassTag ](z: B)(op: (B, A) => B): Array[B] = {
     var v = z
     var i = 0
@@ -832,31 +832,30 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** Computes a prefix scan of the elements of the array.
-    *
-    *  Note: The neutral element `z` may be applied more than once.
-    *
-    *  @tparam B         element type of the resulting array
-    *  @param z          neutral element for the operator `op`
-    *  @param op         the associative operator for the scan
-    *
-    *  @return           a new array containing the prefix scan of the elements in this array
-    */
+   *
+   *  Note: The neutral element `z` may be applied more than once.
+   *
+   *  @tparam B         element type of the resulting array
+   *  @param z          neutral element for the operator `op`
+   *  @param op         the associative operator for the scan
+   *
+   *  @return           a new array containing the prefix scan of the elements in this array
+   */
   def scan[B >: A : ClassTag](z: B)(op: (B, B) => B): Array[B] = scanLeft(z)(op)
 
-   /** Produces an array containing cumulative results of applying the binary
-    *  operator going right to left.
-    *
-    *  @param   z    the start value.
-    *  @param   op   the binary operator.
-    *  @tparam  B    the result type of the binary operator.
-    *  @return  array with intermediate values.
-    *
-    *  Example:
-    *  {{{
-    *    Array(4, 3, 2, 1).scanRight(0)(_ + _) == Array(10, 6, 3, 1, 0)
-    *  }}}
-    *
-    */
+  /** Produces an array containing cumulative results of applying the binary
+   *  operator going right to left.
+   *
+   *  @tparam  B    the result type of the binary operator.
+   *  @param   z    the start value.
+   *  @param   op   the binary operator.
+   *  @return  array with intermediate values.
+   *
+   *  Example:
+   *  ```
+   *    Array(4, 3, 2, 1).scanRight(0)(_ + _) == Array(10, 6, 3, 1, 0)
+   *  ```
+   */
   def scanRight[ B : ClassTag ](z: B)(op: (A, B) => B): Array[B] = {
     var v = z
     var i = xs.length - 1
@@ -877,10 +876,10 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    *  If `x,,1,,`, `x,,2,,`, ..., `x,,n,,` are the elements of this array, the
    *  result is `op(x,,1,,, op(x,,2,,, op( ... op(x,,n,,, z) ... )))`.
    *
-   *   @param    z       An initial value.
-   *   @param    op      A binary operator.
-   *   @tparam   B       The result type of the binary operator.
-   *   @return           The result of applying `op` to all elements of this array
+   *  @tparam   B       The result type of the binary operator.
+   *  @param    z       An initial value.
+   *  @param    op      A binary operator.
+   *  @return           The result of applying `op` to all elements of this array
    *                     and `z`, going right to left. Returns `z` if this array
    *                     is empty.
    */
@@ -915,21 +914,21 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    *  The type parameter is more restrictive than for `foldLeft` to be
    *  consistent with [[IterableOnceOps.fold]].
    *
-   *   @tparam A1     The type parameter for the binary operator, a supertype of `A`.
-   *   @param z       An initial value.
-   *   @param op      A binary operator.
-   *   @return        The result of applying `op` to `z` and all elements of this array,
+   *  @tparam A1     The type parameter for the binary operator, a supertype of `A`.
+   *  @param z       An initial value.
+   *  @param op      A binary operator.
+   *  @return        The result of applying `op` to `z` and all elements of this array,
    *                  going left to right. Returns `z` if this string is empty.
    */
   def fold[A1 >: A](z: A1)(op: (A1, A1) => A1): A1 = foldLeft(z)(op)
 
   /** Builds a new array by applying a function to all elements of this array.
-    *
-    *  @param f      the function to apply to each element.
-    *  @tparam B     the element type of the returned array.
-    *  @return       a new array resulting from applying the given function
-    *                `f` to each element of this array and collecting the results.
-    */
+   *
+   *  @tparam B     the element type of the returned array.
+   *  @param f      the function to apply to each element.
+   *  @return       a new array resulting from applying the given function
+   *                `f` to each element of this array and collecting the results.
+   */
   def map[B](f: A => B)(implicit ct: ClassTag[B]): Array[B] = {
     val len = xs.length
     val ys = new Array[B](len)
@@ -960,13 +959,13 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** Builds a new array by applying a function to all elements of this array
-    * and using the elements of the resulting collections.
-    *
-    *  @param f      the function to apply to each element.
-    *  @tparam B     the element type of the returned array.
-    *  @return       a new array resulting from applying the given collection-valued function
-    *                `f` to each element of this array and concatenating the results.
-    */
+   *  and using the elements of the resulting collections.
+   *
+   *  @tparam B     the element type of the returned array.
+   *  @param f      the function to apply to each element.
+   *  @return       a new array resulting from applying the given collection-valued function
+   *                `f` to each element of this array and concatenating the results.
+   */
   def flatMap[B : ClassTag](f: A => IterableOnce[B]^): Array[B] = {
     val b = ArrayBuilder.make[B]
     var i = 0
@@ -981,12 +980,12 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     flatMap[B](x => asIterable(f(x)))
 
   /** Flattens a two-dimensional array by concatenating all its rows
-    *  into a single array.
-    *
-    *  @tparam B         Type of row elements.
-    *  @param asIterable A function that converts elements of this array to rows - Iterables of type `B`.
-    *  @return           An array obtained by concatenating rows of this array.
-    */
+   *  into a single array.
+   *
+   *  @tparam B         Type of row elements.
+   *  @param asIterable A function that converts elements of this array to rows - Iterables of type `B`.
+   *  @return           An array obtained by concatenating rows of this array.
+   */
   def flatten[B](implicit asIterable: A => IterableOnce[B]^, m: ClassTag[B]): Array[B] = {
     val b = ArrayBuilder.make[B]
     val len = xs.length
@@ -1012,14 +1011,14 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** Builds a new array by applying a partial function to all elements of this array
-    * on which the function is defined.
-    *
-    *  @param pf     the partial function which filters and maps the array.
-    *  @tparam B     the element type of the returned array.
-    *  @return       a new array resulting from applying the given partial function
-    *                `pf` to each element on which it is defined and collecting the results.
-    *                The order of the elements is preserved.
-    */
+   *  on which the function is defined.
+   *
+   *  @tparam B     the element type of the returned array.
+   *  @param pf     the partial function which filters and maps the array.
+   *  @return       a new array resulting from applying the given partial function
+   *                `pf` to each element on which it is defined and collecting the results.
+   *                The order of the elements is preserved.
+   */
   def collect[B: ClassTag](pf: PartialFunction[A, B]^): Array[B] = {
     val fallback: Any => Any = ArrayOps.fallback
     val b = ArrayBuilder.make[B]
@@ -1033,7 +1032,8 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** Finds the first element of the array for which the given partial function is defined, and applies the
-    * partial function to it. */
+   *  partial function to it. 
+   */
   def collectFirst[B](@deprecatedName("f","2.13.9") pf: PartialFunction[A, B]^): Option[B] = {
     val fallback: Any => Any = ArrayOps.fallback
     var i = 0
@@ -1046,14 +1046,14 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** Returns an array formed from this array and another iterable collection
-    * by combining corresponding elements in pairs.
-    * If one of the two collections is longer than the other, its remaining elements are ignored.
-    *
-    *  @param   that  The iterable providing the second half of each result pair
-    *  @tparam  B     the type of the second half of the returned pairs
-    *  @return        a new array containing pairs consisting of corresponding elements of this array and `that`.
-    *                 The length of the returned array is the minimum of the lengths of this array and `that`.
-    */
+   *  by combining corresponding elements in pairs.
+   *  If one of the two collections is longer than the other, its remaining elements are ignored.
+   *
+   *  @tparam  B     the type of the second half of the returned pairs
+   *  @param   that  The iterable providing the second half of each result pair
+   *  @return        a new array containing pairs consisting of corresponding elements of this array and `that`.
+   *                 The length of the returned array is the minimum of the lengths of this array and `that`.
+   */
   def zip[B](that: IterableOnce[B]^): Array[(A, B)] = {
     val b = new ArrayBuilder.ofRef[(A, B)]()
     val k = that.knownSize
@@ -1068,37 +1068,37 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** Analogous to `zip` except that the elements in each collection are not consumed until a strict operation is
-    * invoked on the returned `LazyZip2` decorator.
-    *
-    * Calls to `lazyZip` can be chained to support higher arities (up to 4) without incurring the expense of
-    * constructing and deconstructing intermediary tuples.
-    *
-    * {{{
-    *    val xs = List(1, 2, 3)
-    *    val res = (xs lazyZip xs lazyZip xs lazyZip xs).map((a, b, c, d) => a + b + c + d)
-    *    // res == List(4, 8, 12)
-    * }}}
-    *
-    * @param that the iterable providing the second element of each eventual pair
-    * @tparam B   the type of the second element in each eventual pair
-    * @return a decorator `LazyZip2` that allows strict operations to be performed on the lazily evaluated pairs
-    *         or chained calls to `lazyZip`. Implicit conversion to `Iterable[(A, B)]` is also supported.
-    */
+   *  invoked on the returned `LazyZip2` decorator.
+   *
+   *  Calls to `lazyZip` can be chained to support higher arities (up to 4) without incurring the expense of
+   *  constructing and deconstructing intermediary tuples.
+   *
+   *  ```
+   *    val xs = List(1, 2, 3)
+   *    val res = (xs lazyZip xs lazyZip xs lazyZip xs).map((a, b, c, d) => a + b + c + d)
+   *    // res == List(4, 8, 12)
+   *  ```
+   *
+   *  @tparam B   the type of the second element in each eventual pair
+   *  @param that the iterable providing the second element of each eventual pair
+   *  @return a decorator `LazyZip2` that allows strict operations to be performed on the lazily evaluated pairs
+   *         or chained calls to `lazyZip`. Implicit conversion to `Iterable[(A, B)]` is also supported.
+   */
   def lazyZip[B](that: Iterable[B]^): LazyZip2[A, B, Array[A]]^{that} = new LazyZip2(xs, immutable.ArraySeq.unsafeWrapArray(xs), that)
 
   /** Returns an array formed from this array and another iterable collection
-    *  by combining corresponding elements in pairs.
-    *  If one of the two collections is shorter than the other,
-    *  placeholder elements are used to extend the shorter collection to the length of the longer.
-    *
-    *  @param that     the iterable providing the second half of each result pair
-    *  @param thisElem the element to be used to fill up the result if this array is shorter than `that`.
-    *  @param thatElem the element to be used to fill up the result if `that` is shorter than this array.
-    *  @return        a new array containing pairs consisting of corresponding elements of this array and `that`.
-    *                 The length of the returned array is the maximum of the lengths of this array and `that`.
-    *                 If this array is shorter than `that`, `thisElem` values are used to pad the result.
-    *                 If `that` is shorter than this array, `thatElem` values are used to pad the result.
-    */
+   *  by combining corresponding elements in pairs.
+   *  If one of the two collections is shorter than the other,
+   *  placeholder elements are used to extend the shorter collection to the length of the longer.
+   *
+   *  @param that     the iterable providing the second half of each result pair
+   *  @param thisElem the element to be used to fill up the result if this array is shorter than `that`.
+   *  @param thatElem the element to be used to fill up the result if `that` is shorter than this array.
+   *  @return        a new array containing pairs consisting of corresponding elements of this array and `that`.
+   *                 The length of the returned array is the maximum of the lengths of this array and `that`.
+   *                 If this array is shorter than `that`, `thisElem` values are used to pad the result.
+   *                 If `that` is shorter than this array, `thatElem` values are used to pad the result.
+   */
   def zipAll[A1 >: A, B](that: Iterable[B]^, thisElem: A1, thatElem: B): Array[(A1, B)] = {
     val b = new ArrayBuilder.ofRef[(A1, B)]()
     val k = that.knownSize
@@ -1121,10 +1121,10 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** Zips this array with its indices.
-    *
-    *  @return   A new array containing pairs consisting of all elements of this array paired with their index.
-    *            Indices start at `0`.
-    */
+   *
+   *  @return   A new array containing pairs consisting of all elements of this array paired with their index.
+   *            Indices start at `0`.
+   */
   def zipWithIndex: Array[(A, Int)] = {
     val b = new Array[(A, Int)](xs.length)
     var i = 0
@@ -1205,22 +1205,22 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   @`inline` final def ++[B >: A : ClassTag](xs: Array[? <: B]): Array[B] = appendedAll(xs)
 
   /** Tests whether this array contains a given value as an element.
-    *
-    *  @param elem  the element to test.
-    *  @return     `true` if this array has an element that is equal (as
-    *              determined by `==`) to `elem`, `false` otherwise.
-    */
+   *
+   *  @param elem  the element to test.
+   *  @return     `true` if this array has an element that is equal (as
+   *              determined by `==`) to `elem`, `false` otherwise.
+   */
   def contains(elem: A): Boolean = exists (_ == elem)
 
   /** Returns a copy of this array with patched values.
-    * Patching at negative indices is the same as patching starting at 0.
-    * Patching at indices at or larger than the length of the original array appends the patch to the end.
-    * If more values are replaced than actually exist, the excess is ignored.
-    *
-    *  @param from       The start index from which to patch
-    *  @param other      The patch values
-    *  @param replaced   The number of values in the original array that are replaced by the patch.
-    */
+   *  Patching at negative indices is the same as patching starting at 0.
+   *  Patching at indices at or larger than the length of the original array appends the patch to the end.
+   *  If more values are replaced than actually exist, the excess is ignored.
+   *
+   *  @param from       The start index from which to patch
+   *  @param other      The patch values
+   *  @param replaced   The number of values in the original array that are replaced by the patch.
+   */
   def patch[B >: A : ClassTag](from: Int, other: IterableOnce[B]^, replaced: Int): Array[B] = {
     val b = ArrayBuilder.make[B]
     val k = other.knownSize
@@ -1235,18 +1235,18 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** Converts an array of pairs into an array of first elements and an array of second elements.
-    *
-    *  @tparam A1    the type of the first half of the element pairs
-    *  @tparam A2    the type of the second half of the element pairs
-    *  @param asPair an implicit conversion which asserts that the element type
-    *                of this Array is a pair.
-    *  @param ct1    a class tag for `A1` type parameter that is required to create an instance
-    *                of `Array[A1]`
-    *  @param ct2    a class tag for `A2` type parameter that is required to create an instance
-    *                of `Array[A2]`
-    *  @return       a pair of Arrays, containing, respectively, the first and second half
-    *                of each element pair of this Array.
-    */
+   *
+   *  @tparam A1    the type of the first half of the element pairs
+   *  @tparam A2    the type of the second half of the element pairs
+   *  @param asPair an implicit conversion which asserts that the element type
+   *                of this Array is a pair.
+   *  @param ct1    a class tag for `A1` type parameter that is required to create an instance
+   *                of `Array[A1]`
+   *  @param ct2    a class tag for `A2` type parameter that is required to create an instance
+   *                of `Array[A2]`
+   *  @return       a pair of Arrays, containing, respectively, the first and second half
+   *                of each element pair of this Array.
+   */
   def unzip[A1, A2](implicit asPair: A => (A1, A2), ct1: ClassTag[A1], ct2: ClassTag[A2]): (Array[A1], Array[A2]) = {
     val a1 = new Array[A1](xs.length)
     val a2 = new Array[A2](xs.length)
@@ -1261,21 +1261,21 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** Converts an array of triples into three arrays, one containing the elements from each position of the triple.
-    *
-    *  @tparam A1      the type of the first of three elements in the triple
-    *  @tparam A2      the type of the second of three elements in the triple
-    *  @tparam A3      the type of the third of three elements in the triple
-    *  @param asTriple an implicit conversion which asserts that the element type
-    *                  of this Array is a triple.
-    *  @param ct1      a class tag for T1 type parameter that is required to create an instance
-    *                  of Array[T1]
-    *  @param ct2      a class tag for T2 type parameter that is required to create an instance
-    *                  of Array[T2]
-    *  @param ct3      a class tag for T3 type parameter that is required to create an instance
-    *                  of Array[T3]
-    *  @return         a triple of Arrays, containing, respectively, the first, second, and third
-    *                  elements from each element triple of this Array.
-    */
+   *
+   *  @tparam A1      the type of the first of three elements in the triple
+   *  @tparam A2      the type of the second of three elements in the triple
+   *  @tparam A3      the type of the third of three elements in the triple
+   *  @param asTriple an implicit conversion which asserts that the element type
+   *                  of this Array is a triple.
+   *  @param ct1      a class tag for T1 type parameter that is required to create an instance
+   *                  of Array[T1]
+   *  @param ct2      a class tag for T2 type parameter that is required to create an instance
+   *                  of Array[T2]
+   *  @param ct3      a class tag for T3 type parameter that is required to create an instance
+   *                  of Array[T3]
+   *  @return         a triple of Arrays, containing, respectively, the first, second, and third
+   *                  elements from each element triple of this Array.
+   */
   def unzip3[A1, A2, A3](implicit asTriple: A => (A1, A2, A3), ct1: ClassTag[A1], ct2: ClassTag[A2],
                          ct3: ClassTag[A3]): (Array[A1], Array[A2], Array[A3]) = {
     val a1 = new Array[A1](xs.length)
@@ -1293,11 +1293,11 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** Transposes a two dimensional array.
-    *
-    *  @tparam B       Type of row elements.
-    *  @param asArray  A function that converts elements of this array to rows - arrays of type `B`.
-    *  @return         An array obtained by replacing elements of this arrays with rows the represent.
-    */
+   *
+   *  @tparam B       Type of row elements.
+   *  @param asArray  A function that converts elements of this array to rows - arrays of type `B`.
+   *  @return         An array obtained by replacing elements of this arrays with rows the represent.
+   */
   def transpose[B](implicit asArray: A => Array[B]): Array[Array[B]] = {
     val aClass = xs.getClass.getComponentType
     val bb = new ArrayBuilder.ofRef[Array[B]]()(using ClassTag[Array[B]](aClass))
@@ -1318,8 +1318,8 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** Applies `f` to each element for its side effects.
-    * Note: [U] parameter needed to help scalac's type inference.
-    */
+   *  Note: [U] parameter needed to help scalac's type inference.
+   */
   def foreach[U](f: A => U): Unit = {
     val len = xs.length
     var i = 0
@@ -1337,30 +1337,30 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** Selects all the elements of this array ignoring the duplicates.
-    *
-    * @return a new array consisting of all the elements of this array without duplicates.
-    */
+   *
+   *  @return a new array consisting of all the elements of this array without duplicates.
+   */
   def distinct: Array[A] = distinctBy(identity)
 
   /** Selects all the elements of this array ignoring the duplicates as determined by `==` after applying
-    * the transforming function `f`.
-    *
-    * @param f The transforming function whose result is used to determine the uniqueness of each element
-    * @tparam B the type of the elements after being transformed by `f`
-    * @return a new array consisting of all the elements of this array without duplicates.
-    */
+   *  the transforming function `f`.
+   *
+   *  @tparam B the type of the elements after being transformed by `f`
+   *  @param f The transforming function whose result is used to determine the uniqueness of each element
+   *  @return a new array consisting of all the elements of this array without duplicates.
+   */
   def distinctBy[B](f: A -> B): Array[A] =
     ArrayBuilder.make[A].addAll(iterator.distinctBy(f)).result()
 
   /** A copy of this array with an element value appended until a given target length is reached.
-    *
-    *  @param   len   the target length
-    *  @param   elem  the padding value
-    *  @tparam B      the element type of the returned array.
-    *  @return a new array consisting of
-    *          all elements of this array followed by the minimal number of occurrences of `elem` so
-    *          that the resulting collection has a length of at least `len`.
-    */
+   *
+   *  @tparam B      the element type of the returned array.
+   *  @param   len   the target length
+   *  @param   elem  the padding value
+   *  @return a new array consisting of
+   *          all elements of this array followed by the minimal number of occurrences of `elem` so
+   *          that the resulting collection has a length of at least `len`.
+   */
   def padTo[B >: A : ClassTag](len: Int, elem: B): Array[B] = {
     var i = xs.length
     val newlen = max(i, len)
@@ -1373,22 +1373,22 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** Produces the range of all indices of this sequence.
-    *
-    *  @return  a `Range` value from `0` to one less than the length of this array.
-    */
+   *
+   *  @return  a `Range` value from `0` to one less than the length of this array.
+   */
   def indices: Range = Range(0, xs.length)
 
   /** Partitions this array into a map of arrays according to some discriminator function.
-    *
-    *  @param f     the discriminator function.
-    *  @tparam K    the type of keys returned by the discriminator function.
-    *  @return      A map from keys to arrays such that the following invariant holds:
-    *               {{{
-    *                 (xs groupBy f)(k) = xs filter (x => f(x) == k)
-    *               }}}
-    *               That is, every key `k` is bound to an array of those elements `x`
-    *               for which `f(x)` equals `k`.
-    */
+   *
+   *  @tparam K    the type of keys returned by the discriminator function.
+   *  @param f     the discriminator function.
+   *  @return      A map from keys to arrays such that the following invariant holds:
+   *               ```
+   *                 (xs groupBy f)(k) = xs filter (x => f(x) == k)
+   *               ```
+   *               That is, every key `k` is bound to an array of those elements `x`
+   *               for which `f(x)` equals `k`.
+   */
   def groupBy[K](f: A => K): immutable.Map[K, Array[A]] = {
     val m = mutable.Map.empty[K, ArrayBuilder[A]]
     val len = xs.length
@@ -1403,24 +1403,23 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     m.view.mapValues(_.result()).toMap
   }
 
-  /**
-    * Partitions this array into a map of arrays according to a discriminator function `key`.
-    * Each element in a group is transformed into a value of type `B` using the `value` function.
-    *
-    * It is equivalent to `groupBy(key).mapValues(_.map(f))`, but more efficient.
-    *
-    * {{{
-    *   case class User(name: String, age: Int)
-    *
-    *   def namesByAge(users: Array[User]): Map[Int, Array[String]] =
-    *     users.groupMap(_.age)(_.name)
-    * }}}
-    *
-    * @param key the discriminator function
-    * @param f the element transformation function
-    * @tparam K the type of keys returned by the discriminator function
-    * @tparam B the type of values returned by the transformation function
-    */
+  /** Partitions this array into a map of arrays according to a discriminator function `key`.
+   *  Each element in a group is transformed into a value of type `B` using the `value` function.
+   *
+   *  It is equivalent to `groupBy(key).mapValues(_.map(f))`, but more efficient.
+   *
+   *  ```
+   *   case class User(name: String, age: Int)
+   *
+   *   def namesByAge(users: Array[User]): Map[Int, Array[String]] =
+   *     users.groupMap(_.age)(_.name)
+   *  ```
+   *
+   *  @tparam K the type of keys returned by the discriminator function
+   *  @tparam B the type of values returned by the transformation function
+   *  @param key the discriminator function
+   *  @param f the element transformation function
+   */
   def groupMap[K, B : ClassTag](key: A => K)(f: A => B): immutable.Map[K, Array[B]] = {
     val m = mutable.Map.empty[K, ArrayBuilder[B]]
     val len = xs.length
@@ -1441,36 +1440,36 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     immutable.ArraySeq.unsafeWrapArray(Array.copyOf(xs, xs.length))
 
   /** Copies elements of this array to another array.
-    *  Fills the given array `xs` starting at index 0.
-    *  Copying will stop once either all the elements of this array have been copied,
-    *  or the end of the array is reached.
-    *
-    *  @param  xs   the array to fill.
-    *  @tparam B      the type of the elements of the array.
-    */
+   *  Fills the given array `xs` starting at index 0.
+   *  Copying will stop once either all the elements of this array have been copied,
+   *  or the end of the array is reached.
+   *
+   *  @tparam B      the type of the elements of the array.
+   *  @param  xs   the array to fill.
+   */
   def copyToArray[B >: A](xs: Array[B]): Int = copyToArray(xs, 0)
 
   /** Copies elements of this array to another array.
-    *  Fills the given array `xs` starting at index `start`.
-    *  Copying will stop once either all the elements of this array have been copied,
-    *  or the end of the array is reached.
-    *
-    *  @param  xs   the array to fill.
-    *  @param  start  the starting index within the destination array.
-    *  @tparam B      the type of the elements of the array.
-    */
+   *  Fills the given array `xs` starting at index `start`.
+   *  Copying will stop once either all the elements of this array have been copied,
+   *  or the end of the array is reached.
+   *
+   *  @tparam B      the type of the elements of the array.
+   *  @param  xs   the array to fill.
+   *  @param  start  the starting index within the destination array.
+   */
   def copyToArray[B >: A](xs: Array[B], start: Int): Int = copyToArray(xs, start, Int.MaxValue)
 
   /** Copies elements of this array to another array.
-    *  Fills the given array `xs` starting at index `start` with at most `len` values.
-    *  Copying will stop once either all the elements of this array have been copied,
-    *  or the end of the array is reached, or `len` elements have been copied.
-    *
-    *  @param  xs   the array to fill.
-    *  @param  start  the starting index within the destination array.
-    *  @param  len    the maximal number of elements to copy.
-    *  @tparam B      the type of the elements of the array.
-    */
+   *  Fills the given array `xs` starting at index `start` with at most `len` values.
+   *  Copying will stop once either all the elements of this array have been copied,
+   *  or the end of the array is reached, or `len` elements have been copied.
+   *
+   *  @tparam B      the type of the elements of the array.
+   *  @param  xs   the array to fill.
+   *  @param  start  the starting index within the destination array.
+   *  @param  len    the maximal number of elements to copy.
+   */
   def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): Int = {
     val copied = IterableOnce.elemsToCopyToArray(this.xs.length, xs.length, start, len)
     if (copied > 0) {
@@ -1503,12 +1502,12 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   @`inline` def startsWith[B >: A](that: Array[B]): Boolean = startsWith(that, 0)
 
   /** Tests whether this array contains the given array at a given index.
-    *
-    * @param  that    the array to test
-    * @param  offset  the index where the array is searched.
-    * @return `true` if the array `that` is contained in this array at
-    *         index `offset`, otherwise `false`.
-    */
+   *
+   *  @param  that    the array to test
+   *  @param  offset  the index where the array is searched.
+   *  @return `true` if the array `that` is contained in this array at
+   *         index `offset`, otherwise `false`.
+   */
   def startsWith[B >: A](that: Array[B], offset: Int): Boolean = {
     val safeOffset = offset.max(0)
     val thatl = that.length
@@ -1524,10 +1523,10 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** Tests whether this array ends with the given array.
-    *
-    *  @param  that    the array to test
-    *  @return `true` if this array has `that` as a suffix, `false` otherwise.
-    */
+   *
+   *  @param  that    the array to test
+   *  @return `true` if this array has `that` as a suffix, `false` otherwise.
+   */
   def endsWith[B >: A](that: Array[B]): Boolean = {
     val thatl = that.length
     val off = xs.length - thatl
@@ -1543,11 +1542,11 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** A copy of this array with one single replaced element.
-    *  @param  index  the position of the replacement
-    *  @param  elem   the replacing element
-    *  @return a new array which is a copy of this array with the element at position `index` replaced by `elem`.
-    *  @throws IndexOutOfBoundsException if `index` does not satisfy `0 <= index < length`.
-    */
+   *  @param  index  the position of the replacement
+   *  @param  elem   the replacing element
+   *  @return a new array which is a copy of this array with the element at position `index` replaced by `elem`.
+   *  @throws IndexOutOfBoundsException if `index` does not satisfy `0 <= index < length`.
+   */
   def updated[B >: A : ClassTag](index: Int, elem: B): Array[B] = {
     if(index < 0 || index >= xs.length)
       throw CommonErrors.indexOutOfBounds(index = index, max = xs.length-1)
@@ -1567,42 +1566,42 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
 
 
   /** Computes the multiset difference between this array and another sequence.
-    *
-    *  @param that   the sequence of elements to remove
-    *  @return       a new array which contains all elements of this array
-    *                except some of occurrences of elements that also appear in `that`.
-    *                If an element value `x` appears
-    *                ''n'' times in `that`, then the first ''n'' occurrences of `x` will not form
-    *                part of the result, but any following occurrences will.
-    */
+   *
+   *  @param that   the sequence of elements to remove
+   *  @return       a new array which contains all elements of this array
+   *                except some of occurrences of elements that also appear in `that`.
+   *                If an element value `x` appears
+   *                *n* times in `that`, then the first *n* occurrences of `x` will not form
+   *                part of the result, but any following occurrences will.
+   */
   def diff[B >: A](that: Seq[B]): Array[A] = mutable.ArraySeq.make(xs).diff(that).toArray[A]
 
   /** Computes the multiset intersection between this array and another sequence.
    *
-   *   @param that   the sequence of elements to intersect with.
-   *   @return       a new array which contains all elements of this array
+   *  @param that   the sequence of elements to intersect with.
+   *  @return       a new array which contains all elements of this array
    *                 which also appear in `that`.
    *                 If an element value `x` appears
-   *                 ''n'' times in `that`, then the first ''n'' occurrences of `x` will be retained
+   *                 *n* times in `that`, then the first *n* occurrences of `x` will be retained
    *                 in the result, but any following occurrences will be omitted.
    */
   def intersect[B >: A](that: Seq[B]): Array[A] = mutable.ArraySeq.make(xs).intersect(that).toArray[A]
 
   /** Groups elements in fixed size blocks by passing a "sliding window"
-    *  over them (as opposed to partitioning them, as is done in grouped.)
-    *  @see [[scala.collection.Iterator]], method `sliding`
-    *
-    *  @param size the number of elements per group
-    *  @param step the distance between the first elements of successive groups
-    *  @return An iterator producing arrays of size `size`, except the
-    *          last element (which may be the only element) will be truncated
-    *          if there are fewer than `size` elements remaining to be grouped.
-    */
+   *  over them (as opposed to partitioning them, as is done in grouped.)
+   *  @see [[scala.collection.Iterator]], method `sliding`
+   *
+   *  @param size the number of elements per group
+   *  @param step the distance between the first elements of successive groups
+   *  @return An iterator producing arrays of size `size`, except the
+   *          last element (which may be the only element) will be truncated
+   *          if there are fewer than `size` elements remaining to be grouped.
+   */
   def sliding(size: Int, step: Int = 1): Iterator[Array[A]] = mutable.ArraySeq.make(xs).sliding(size, step).map(_.toArray[A])
 
   /** Iterates over combinations of elements.
    *
-   *  A '''combination''' of length `n` is a sequence of `n` elements selected in order of their first index in this sequence.
+   *  A **combination** of length `n` is a sequence of `n` elements selected in order of their first index in this sequence.
    *
    *  For example, `"xyx"` has two combinations of length 2. The `x` is selected first: `"xx"`, `"xy"`.
    *  The sequence `"yx"` is not returned as a combination because it is subsumed by `"xy"`.
@@ -1624,7 +1623,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    *  the order of each `x` element is also arbitrary.
    *
    *  @return   An Iterator which traverses the n-element combinations of this array
-   *  @example {{{
+   *  @example ```
    *    Array('a', 'b', 'b', 'b', 'c').combinations(2).map(runtime.ScalaRunTime.stringOf).foreach(println)
    *    // Array(a, b)
    *    // Array(a, c)
@@ -1633,37 +1632,37 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    *    Array('b', 'a', 'b').combinations(2).map(runtime.ScalaRunTime.stringOf).foreach(println)
    *    // Array(b, b)
    *    // Array(b, a)
-   *  }}}
+   *  ```
    */
   def combinations(n: Int): Iterator[Array[A]] = mutable.ArraySeq.make(xs).combinations(n).map(_.toArray[A])
 
   /** Iterates over distinct permutations of elements.
    *
    *  @return   An Iterator which traverses the distinct permutations of this array.
-   *  @example {{{
+   *  @example ```
    *    Array('a', 'b', 'b').permutations.map(runtime.ScalaRunTime.stringOf).foreach(println)
    *    // Array(a, b, b)
    *    // Array(b, a, b)
    *    // Array(b, b, a)
-   *  }}}
+   *  ```
    */
   def permutations: Iterator[Array[A]] = mutable.ArraySeq.make(xs).permutations.map(_.toArray[A])
 
   // we have another overload here, so we need to duplicate this method
   /** Tests whether this array contains the given sequence at a given index.
-    *
-    * @param  that    the sequence to test
-    * @param  offset  the index where the sequence is searched.
-    * @return `true` if the sequence `that` is contained in this array at
-    *         index `offset`, otherwise `false`.
-    */
+   *
+   *  @param  that    the sequence to test
+   *  @param  offset  the index where the sequence is searched.
+   *  @return `true` if the sequence `that` is contained in this array at
+   *         index `offset`, otherwise `false`.
+   */
   def startsWith[B >: A](that: IterableOnce[B]^, offset: Int = 0): Boolean = mutable.ArraySeq.make(xs).startsWith(that, offset)
 
   // we have another overload here, so we need to duplicate this method
   /** Tests whether this array ends with the given sequence.
-    *
-    *  @param  that    the sequence to test
-    *  @return `true` if this array has `that` as a suffix, `false` otherwise.
-    */
+   *
+   *  @param  that    the sequence to test
+   *  @return `true` if this array has `that` as a suffix, `false` otherwise.
+   */
   def endsWith[B >: A](that: Iterable[B]^): Boolean = mutable.ArraySeq.make(xs).endsWith(that)
 }

--- a/library/src/scala/collection/BitSet.scala
+++ b/library/src/scala/collection/BitSet.scala
@@ -24,17 +24,17 @@ import scala.collection.mutable.Builder
 
 
 /** Base type of bitsets.
-  *
-  * This trait provides most of the operations of a `BitSet` independently of its representation.
-  * It is inherited by all concrete implementations of bitsets.
-  *
-  * @define bitsetinfo
-  *  Bitsets are sets of non-negative integers which are represented as
-  *  variable-size arrays of bits packed into 64-bit words. The lower bound of memory footprint of a bitset is
-  *  determined by the largest number stored in it.
-  * @define coll bitset
-  * @define Coll `BitSet`
-  */
+ *
+ *  This trait provides most of the operations of a `BitSet` independently of its representation.
+ *  It is inherited by all concrete implementations of bitsets.
+ *
+ *  @define bitsetinfo
+ *  Bitsets are sets of non-negative integers which are represented as
+ *  variable-size arrays of bits packed into 64-bit words. The lower bound of memory footprint of a bitset is
+ *  determined by the largest number stored in it.
+ *  @define coll bitset
+ *  @define Coll `BitSet`
+ */
 trait BitSet extends SortedSet[Int] with BitSetOps[BitSet] { self: BitSet =>
   override protected def fromSpecific(coll: IterableOnce[Int]^): BitSet = bitSetFactory.fromSpecific(coll)
   override protected def newSpecificBuilder: Builder[Int, BitSet] = bitSetFactory.newBuilder
@@ -99,12 +99,11 @@ transparent trait BitSetOps[+C <: BitSet & BitSetOps[C]]
   protected[collection] def nwords: Int
 
   /** The words at index `idx`, or 0L if outside the range of the set
-    *  '''Note:''' requires `idx >= 0`
-    */
+   *  **Note:** requires `idx >= 0`
+   */
   protected[collection] def word(idx: Int): Long
 
-  /** Creates a new set of this kind from an array of longs
-    */
+  /** Creates a new set of this kind from an array of longs */
   protected[collection] def fromBitMaskNoCopy(elems: Array[Long]): C
 
   def contains(elem: Int): Boolean =
@@ -209,8 +208,7 @@ transparent trait BitSetOps[+C <: BitSet & BitSetOps[C]]
     }
   }
 
-  /** Creates a bit mask for this set as a new array of longs
-    */
+  /** Creates a bit mask for this set as a new array of longs */
   def toBitMask: Array[Long] = {
     val a = new Array[Long](nwords)
     var i = a.length
@@ -276,12 +274,12 @@ transparent trait BitSetOps[+C <: BitSet & BitSetOps[C]]
   }
 
   /** Computes the symmetric difference of this bitset and another bitset by performing
-    *  a bitwise "exclusive-or".
-    *
-    *  @param other the other bitset to take part in the symmetric difference.
-    *  @return     a bitset containing those bits of this
-    *              bitset or the other bitset that are not contained in both bitsets.
-    */
+   *  a bitwise "exclusive-or".
+   *
+   *  @param other the other bitset to take part in the symmetric difference.
+   *  @return     a bitset containing those bits of this
+   *              bitset or the other bitset that are not contained in both bitsets.
+   */
   def xor(other: BitSet): C = {
     val len = coll.nwords max other.nwords
     val words = new Array[Long](len)
@@ -292,12 +290,11 @@ transparent trait BitSetOps[+C <: BitSet & BitSetOps[C]]
 
   @`inline` final def ^ (other: BitSet): C = xor(other)
 
-  /**
-    * Builds a new bitset by applying a function to all elements of this bitset.
-    * @param f the function to apply to each element.
-    * @return a new bitset resulting from applying the given function ''f'' to
-    *         each element of this bitset and collecting the results
-    */
+  /** Builds a new bitset by applying a function to all elements of this bitset.
+   *  @param f the function to apply to each element.
+   *  @return a new bitset resulting from applying the given function *f* to
+   *         each element of this bitset and collecting the results
+   */
   def map(f: Int => Int): C = fromSpecific(new View.Map(this, f))
 
   def flatMap(f: Int => IterableOnce[Int]^): C = fromSpecific(new View.FlatMap(this, f))

--- a/library/src/scala/collection/BufferedIterator.scala
+++ b/library/src/scala/collection/BufferedIterator.scala
@@ -20,14 +20,13 @@ import language.experimental.captureChecking
  */
 trait BufferedIterator[+A] extends Iterator[A] {
 
-  /** Returns next element of iterator without advancing beyond it.
-   */
+  /** Returns next element of iterator without advancing beyond it. */
   def head: A
 
   /** Returns an option of the next element of an iterator without advancing beyond it.
-    * @return  the next element of this iterator if it has a next element
-    *           `None` if it does not
-    */
+   *  @return  the next element of this iterator if it has a next element
+   *           `None` if it does not
+   */
   def headOption : Option[A] = if (hasNext) Some(head) else None
 
   override def buffered: this.type = this

--- a/library/src/scala/collection/BuildFrom.scala
+++ b/library/src/scala/collection/BuildFrom.scala
@@ -21,18 +21,19 @@ import scala.collection.immutable.WrappedString
 import scala.reflect.ClassTag
 
 /** Builds a collection of type `C` from elements of type `A` when a source collection of type `From` is available.
-  * Implicit instances of `BuildFrom` are available for all collection types.
-  *
-  * @tparam From Type of source collection
-  * @tparam A Type of elements (e.g. `Int`, `Boolean`, etc.)
-  * @tparam C Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
-  */
+ *  Implicit instances of `BuildFrom` are available for all collection types.
+ *
+ *  @tparam From Type of source collection
+ *  @tparam A Type of elements (e.g. `Int`, `Boolean`, etc.)
+ *  @tparam C Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
+ */
 @implicitNotFound(msg = "Cannot construct a collection of type ${C} with elements of type ${A} based on a collection of type ${From}.")
 trait BuildFrom[-From, -A, +C] extends Any { self =>
   def fromSpecific(from: From)(it: IterableOnce[A]^): C^{it}
 
   /** Gets a Builder for the collection. For non-strict collection types this will use an intermediate buffer.
-    * Building collections with `fromSpecific` is preferred because it can be lazy for lazy collections. */
+   *  Building collections with `fromSpecific` is preferred because it can be lazy for lazy collections. 
+   */
   def newBuilder(from: From): Builder[A, C]
 
   @deprecated("Use newBuilder() instead of apply()", "2.13.0")

--- a/library/src/scala/collection/Factory.scala
+++ b/library/src/scala/collection/Factory.scala
@@ -22,27 +22,27 @@ import scala.collection.mutable.Builder
 import scala.annotation.unchecked.uncheckedVariance
 import scala.reflect.ClassTag
 
-/**
-  * A factory that builds a collection of type `C` with elements of type `A`.
-  *
-  * This is a general form of any factory ([[IterableFactory]],
-  * [[SortedIterableFactory]], [[MapFactory]] and [[SortedMapFactory]]) whose
-  * element type is fixed.
-  *
-  * @tparam A Type of elements (e.g. `Int`, `Boolean`, etc.)
-  * @tparam C Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
-  */
+/** A factory that builds a collection of type `C` with elements of type `A`.
+ *
+ *  This is a general form of any factory ([[IterableFactory]],
+ *  [[SortedIterableFactory]], [[MapFactory]] and [[SortedMapFactory]]) whose
+ *  element type is fixed.
+ *
+ *  @tparam A Type of elements (e.g. `Int`, `Boolean`, etc.)
+ *  @tparam C Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
+ */
 trait Factory[-A, +C] extends Any { self =>
 
   /**
-    * @return A collection of type `C` containing the same elements
-    *         as the source collection `it`.
-    * @param it Source collection
-    */
+   *  @param it Source collection
+   *  @return A collection of type `C` containing the same elements
+   *         as the source collection `it`.
+   */
   def fromSpecific(it: IterableOnce[A]^): C^{it}
 
   /** Gets a Builder for the collection. For non-strict collection types this will use an intermediate buffer.
-    * Building collections with `fromSpecific` is preferred because it can be lazy for lazy collections. */
+   *  Building collections with `fromSpecific` is preferred because it can be lazy for lazy collections. 
+   */
   def newBuilder: Builder[A, C]
 }
 
@@ -74,78 +74,78 @@ object Factory {
 }
 
 /** Base trait for companion objects of unconstrained collection types that may require
-  * multiple traversals of a source collection to build a target collection `CC`.
-  *
-  * @tparam CC Collection type constructor (e.g. `List`)
-  * @define factoryInfo
-  *   This object provides a set of operations to create $Coll values.
-  *
-  * @define coll collection
-  * @define Coll `Iterable`
-  */
+ *  multiple traversals of a source collection to build a target collection `CC`.
+ *
+ *  @tparam CC Collection type constructor (e.g. `List`)
+ *  @define factoryInfo
+ *   This object provides a set of operations to create $Coll values.
+ *
+ *  @define coll collection
+ *  @define Coll `Iterable`
+ */
 trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
 
   /** Creates a target $coll from an existing source collection
-    *
-    * @param source Source collection
-    * @tparam A the type of the collection’s elements
-    * @return a new $coll with the elements of `source`
-    */
+   *
+   *  @tparam A the type of the collection’s elements
+   *  @param source Source collection
+   *  @return a new $coll with the elements of `source`
+   */
   def from[A](source: IterableOnce[A]^): CC[A]^{source}
 
   /** An empty $coll.
-    * @tparam A      the type of the ${coll}'s elements
-    */
+   *  @tparam A      the type of the ${coll}'s elements
+   */
   def empty[A]: CC[A]
 
   /** Creates a $coll with the specified elements.
-    * @tparam A     the type of the ${coll}'s elements
-    * @param elems  the elements of the created $coll
-    * @return a new $coll with elements `elems`
-    */
+   *  @tparam A     the type of the ${coll}'s elements
+   *  @param elems  the elements of the created $coll
+   *  @return a new $coll with elements `elems`
+   */
   def apply[A](elems: A*): CC[A] = from(elems)
 
   /** Produces a $coll containing repeated applications of a function to a start value.
-    *
-    *  @param start the start value of the $coll
-    *  @param len   the number of elements contained in the $coll
-    *  @param f     the function that's repeatedly applied
-    *  @return      a $coll with `len` values in the sequence `start, f(start), f(f(start)), ...`
-    */
+   *
+   *  @param start the start value of the $coll
+   *  @param len   the number of elements contained in the $coll
+   *  @param f     the function that's repeatedly applied
+   *  @return      a $coll with `len` values in the sequence `start, f(start), f(f(start)), ...`
+   */
   def iterate[A](start: A, len: Int)(f: A => A): CC[A]^{f} = from(new View.Iterate(start, len)(f))
 
   /** Produces a $coll that uses a function `f` to produce elements of type `A`
-    * and update an internal state of type `S`.
-    *
-    * @param init State initial value
-    * @param f    Computes the next element (or returns `None` to signal
-    *             the end of the collection)
-    * @tparam A   Type of the elements
-    * @tparam S   Type of the internal state
-    * @return a $coll that produces elements using `f` until `f` returns `None`
-    */
+   *  and update an internal state of type `S`.
+   *
+   *  @tparam A   Type of the elements
+   *  @tparam S   Type of the internal state
+   *  @param init State initial value
+   *  @param f    Computes the next element (or returns `None` to signal
+   *             the end of the collection)
+   *  @return a $coll that produces elements using `f` until `f` returns `None`
+   */
   def unfold[A, S](init: S)(f: S => Option[(A, S)]): CC[A]^{f} = from(new View.Unfold(init)(f))
 
   /** Produces a $coll containing a sequence of increasing of integers.
-    *
-    *  @param start the first element of the $coll
-    *  @param end   the end value of the $coll (the first value NOT contained)
-    *  @return  a $coll with values `start, start + 1, ..., end - 1`
-    */
+   *
+   *  @param start the first element of the $coll
+   *  @param end   the end value of the $coll (the first value NOT contained)
+   *  @return  a $coll with values `start, start + 1, ..., end - 1`
+   */
   def range[A : Integral](start: A, end: A): CC[A] = from(NumericRange(start, end, implicitly[Integral[A]].one))
 
   /** Produces a $coll containing equally spaced values in some integer interval.
-    *  @param start the start value of the $coll
-    *  @param end   the end value of the $coll (the first value NOT contained)
-    *  @param step  the difference between successive elements of the $coll (must be positive or negative)
-    *  @return      a $coll with values `start, start + step, ...` up to, but excluding `end`
-    */
+   *  @param start the start value of the $coll
+   *  @param end   the end value of the $coll (the first value NOT contained)
+   *  @param step  the difference between successive elements of the $coll (must be positive or negative)
+   *  @return      a $coll with values `start, start + step, ...` up to, but excluding `end`
+   */
   def range[A : Integral](start: A, end: A, step: A): CC[A] = from(NumericRange(start, end, step))
 
   /**
-    * @return A builder for $Coll objects.
-    * @tparam A the type of the ${coll}’s elements
-    */
+   *  @tparam A the type of the ${coll}’s elements
+   *  @return A builder for $Coll objects.
+   */
   def newBuilder[A]: Builder[A, CC[A]]
 
   /** Produces a $coll containing the results of some element computation a number of times.
@@ -156,95 +156,95 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
   def fill[A](n: Int)(elem: => A): CC[A]^{elem} = from(new View.Fill(n)(elem))
 
   /** Produces a two-dimensional $coll containing the results of some element computation a number of times.
-    *  @param   n1  the number of elements in the 1st dimension
-    *  @param   n2  the number of elements in the 2nd dimension
-    *  @param   elem the element computation
-    *  @return  A $coll that contains the results of `n1 x n2` evaluations of `elem`.
-    */
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   elem the element computation
+   *  @return  A $coll that contains the results of `n1 x n2` evaluations of `elem`.
+   */
   def fill[A](n1: Int, n2: Int)(elem: => A): CC[(CC[A]^{elem}) @uncheckedVariance]^{elem} = fill(n1)(fill(n2)(elem))
 
   /** Produces a three-dimensional $coll containing the results of some element computation a number of times.
-    *  @param   n1  the number of elements in the 1st dimension
-    *  @param   n2  the number of elements in the 2nd dimension
-    *  @param   n3  the number of elements in the 3rd dimension
-    *  @param   elem the element computation
-    *  @return  A $coll that contains the results of `n1 x n2 x n3` evaluations of `elem`.
-    */
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   elem the element computation
+   *  @return  A $coll that contains the results of `n1 x n2 x n3` evaluations of `elem`.
+   */
   def fill[A](n1: Int, n2: Int, n3: Int)(elem: => A): CC[(CC[CC[A]^{elem}]^{elem}) @uncheckedVariance]^{elem} = fill(n1)(fill(n2, n3)(elem))
 
   /** Produces a four-dimensional $coll containing the results of some element computation a number of times.
-    *  @param   n1  the number of elements in the 1st dimension
-    *  @param   n2  the number of elements in the 2nd dimension
-    *  @param   n3  the number of elements in the 3rd dimension
-    *  @param   n4  the number of elements in the 4th dimension
-    *  @param   elem the element computation
-    *  @return  A $coll that contains the results of `n1 x n2 x n3 x n4` evaluations of `elem`.
-    */
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   elem the element computation
+   *  @return  A $coll that contains the results of `n1 x n2 x n3 x n4` evaluations of `elem`.
+   */
   def fill[A](n1: Int, n2: Int, n3: Int, n4: Int)(elem: => A): CC[(CC[CC[CC[A]^{elem}]^{elem}]^{elem}) @uncheckedVariance]^{elem} =
     fill(n1)(fill(n2, n3, n4)(elem))
 
   /** Produces a five-dimensional $coll containing the results of some element computation a number of times.
-    *  @param   n1  the number of elements in the 1st dimension
-    *  @param   n2  the number of elements in the 2nd dimension
-    *  @param   n3  the number of elements in the 3rd dimension
-    *  @param   n4  the number of elements in the 4th dimension
-    *  @param   n5  the number of elements in the 5th dimension
-    *  @param   elem the element computation
-    *  @return  A $coll that contains the results of `n1 x n2 x n3 x n4 x n5` evaluations of `elem`.
-    */
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   n5  the number of elements in the 5th dimension
+   *  @param   elem the element computation
+   *  @return  A $coll that contains the results of `n1 x n2 x n3 x n4 x n5` evaluations of `elem`.
+   */
   def fill[A](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(elem: => A): CC[(CC[CC[CC[CC[A]^{elem}]^{elem}]^{elem}]^{elem}) @uncheckedVariance]^{elem} =
     fill(n1)(fill(n2, n3, n4, n5)(elem))
 
   /** Produces a $coll containing values of a given function over a range of integer values starting from 0.
-    *  @param  n   The number of elements in the $coll
-    *  @param  f   The function computing element values
-    *  @return A $coll consisting of elements `f(0), ..., f(n -1)`
-    */
+   *  @param  n   The number of elements in the $coll
+   *  @param  f   The function computing element values
+   *  @return A $coll consisting of elements `f(0), ..., f(n -1)`
+   */
   def tabulate[A](n: Int)(f: Int => A): CC[A]^{f} = from(new View.Tabulate(n)(f))
 
   /** Produces a two-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
-    *  @param   n1  the number of elements in the 1st dimension
-    *  @param   n2  the number of elements in the 2nd dimension
-    *  @param   f   The function computing element values
-    *  @return A $coll consisting of elements `f(i1, i2)`
-    *          for `0 <= i1 < n1` and `0 <= i2 < n2`.
-    */
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   f   The function computing element values
+   *  @return A $coll consisting of elements `f(i1, i2)`
+   *          for `0 <= i1 < n1` and `0 <= i2 < n2`.
+   */
   def tabulate[A](n1: Int, n2: Int)(f: (Int, Int) => A): CC[(CC[A]^{f}) @uncheckedVariance]^{f} =
     tabulate(n1)(i1 => tabulate(n2)(f(i1, _)))
 
   /** Produces a three-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
-    *  @param   n1  the number of elements in the 1st dimension
-    *  @param   n2  the number of elements in the 2nd dimension
-    *  @param   n3  the number of elements in the 3rd dimension
-    *  @param   f   The function computing element values
-    *  @return A $coll consisting of elements `f(i1, i2, i3)`
-    *          for `0 <= i1 < n1`, `0 <= i2 < n2`, and `0 <= i3 < n3`.
-    */
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   f   The function computing element values
+   *  @return A $coll consisting of elements `f(i1, i2, i3)`
+   *          for `0 <= i1 < n1`, `0 <= i2 < n2`, and `0 <= i3 < n3`.
+   */
   def tabulate[A](n1: Int, n2: Int, n3: Int)(f: (Int, Int, Int) => A): CC[(CC[CC[A]^{f}]^{f}) @uncheckedVariance]^{f} =
     tabulate(n1)(i1 => tabulate(n2, n3)(f(i1, _, _)))
 
   /** Produces a four-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
-    *  @param   n1  the number of elements in the 1st dimension
-    *  @param   n2  the number of elements in the 2nd dimension
-    *  @param   n3  the number of elements in the 3rd dimension
-    *  @param   n4  the number of elements in the 4th dimension
-    *  @param   f   The function computing element values
-    *  @return A $coll consisting of elements `f(i1, i2, i3, i4)`
-    *          for `0 <= i1 < n1`, `0 <= i2 < n2`, `0 <= i3 < n3`, and `0 <= i4 < n4`.
-    */
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   f   The function computing element values
+   *  @return A $coll consisting of elements `f(i1, i2, i3, i4)`
+   *          for `0 <= i1 < n1`, `0 <= i2 < n2`, `0 <= i3 < n3`, and `0 <= i4 < n4`.
+   */
   def tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int)(f: (Int, Int, Int, Int) => A): CC[(CC[CC[CC[A]^{f}]^{f}]^{f}) @uncheckedVariance]^{f} =
     tabulate(n1)(i1 => tabulate(n2, n3, n4)(f(i1, _, _, _)))
 
   /** Produces a five-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
-    *  @param   n1  the number of elements in the 1st dimension
-    *  @param   n2  the number of elements in the 2nd dimension
-    *  @param   n3  the number of elements in the 3rd dimension
-    *  @param   n4  the number of elements in the 4th dimension
-    *  @param   n5  the number of elements in the 5th dimension
-    *  @param   f   The function computing element values
-    *  @return A $coll consisting of elements `f(i1, i2, i3, i4, i5)`
-    *          for `0 <= i1 < n1`, `0 <= i2 < n2`, `0 <= i3 < n3`, `0 <= i4 < n4`, and `0 <= i5 < n5`.
-    */
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   n5  the number of elements in the 5th dimension
+   *  @param   f   The function computing element values
+   *  @return A $coll consisting of elements `f(i1, i2, i3, i4, i5)`
+   *          for `0 <= i1 < n1`, `0 <= i2 < n2`, `0 <= i3 < n3`, `0 <= i4 < n4`, and `0 <= i5 < n5`.
+   */
   def tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(f: (Int, Int, Int, Int, Int) => A): CC[(CC[CC[CC[CC[A]^{f}]^{f}]^{f}]^{f}) @uncheckedVariance]^{f} =
     tabulate(n1)(i1 => tabulate(n2, n3, n4, n5)(f(i1, _, _, _, _)))
 
@@ -262,14 +262,13 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
 
 object IterableFactory {
 
-  /**
-    * Fixes the element type of `factory` to `A`.
-    * @param factory The factory to fix the element type
-    * @tparam A Type of elements
-    * @tparam CC Collection type constructor of the factory (e.g. `Seq`, `List`)
-    * @return A [[Factory]] that uses the given `factory` to build a collection of elements
-    *         of type `A`
-    */
+  /** Fixes the element type of `factory` to `A`.
+   *  @tparam A Type of elements
+   *  @tparam CC Collection type constructor of the factory (e.g. `Seq`, `List`)
+   *  @param factory The factory to fix the element type
+   *  @return A [[Factory]] that uses the given `factory` to build a collection of elements
+   *         of type `A`
+   */
   implicit def toFactory[A, CC[_]](factory: IterableFactory[CC]): Factory[A, CC[A]] = new ToFactory[A, CC](factory)
 
   @SerialVersionUID(3L)
@@ -294,8 +293,8 @@ object IterableFactory {
 }
 
 /**
-  * @tparam CC Collection type constructor (e.g. `List`)
-  */
+ *  @tparam CC Collection type constructor (e.g. `List`)
+ */
 trait SeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]] & caps.Pure] extends IterableFactory[CC] {
   import SeqFactory.UnapplySeqWrapper
   final def unapplySeq[A](x: CC[A] @uncheckedVariance): UnapplySeqWrapper[A] = new UnapplySeqWrapper(x) // TODO is uncheckedVariance sound here?
@@ -360,14 +359,14 @@ trait StrictOptimizedSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]] & caps.Pure] ex
 }
 
 /**
-  * @tparam A Type of elements (e.g. `Int`, `Boolean`, etc.)
-  * @tparam C Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
-  * @define factoryInfo
-  *   This object provides a set of operations to create $Coll values.
-  *
-  * @define coll collection
-  * @define Coll `Iterable`
-  */
+ *  @tparam A Type of elements (e.g. `Int`, `Boolean`, etc.)
+ *  @tparam C Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
+ *  @define factoryInfo
+ *   This object provides a set of operations to create $Coll values.
+ *
+ *  @define coll collection
+ *  @define Coll `Iterable`
+ */
 trait SpecificIterableFactory[-A, +C] extends Factory[A, C] {
   def empty: C
   def apply(xs: A*): C = fromSpecific(xs)
@@ -378,51 +377,40 @@ trait SpecificIterableFactory[-A, +C] extends Factory[A, C] {
 }
 
 /**
-  * @define factoryInfo
-  *   This object provides a set of operations to create $Coll values.
-  *
-  * @define coll collection
-  * @define Coll `Iterable`
-  */
+ *  @define factoryInfo
+ *   This object provides a set of operations to create $Coll values.
+ *
+ *  @define coll collection
+ *  @define Coll `Iterable`
+ */
 trait MapFactory[+CC[_, _]] extends Serializable { self =>
 
-  /**
-   * An empty Map.
-   */
+  /** An empty Map. */
   def empty[K, V]: CC[K, V]
 
-  /**
-   * A collection of type Map generated from given iterable object.
-   */
+  /** A collection of type Map generated from given iterable object. */
   def from[K, V](it: IterableOnce[(K, V)]^): CC[K, V]^{it}
 
-  /**
-   * A collection of type Map that contains given key/value bindings.
-   */
+  /** A collection of type Map that contains given key/value bindings. */
   def apply[K, V](elems: (K, V)*): CC[K, V] = from(elems)
 
-  /**
-   * The default builder for Map objects.
-   */
+  /** The default builder for Map objects. */
   def newBuilder[K, V]: Builder[(K, V), CC[K, V]]
 
-  /**
-   * The default Factory instance for maps.
-   */
+  /** The default Factory instance for maps. */
   implicit def mapFactory[K, V]: Factory[(K, V), CC[K, V]] = MapFactory.toFactory(this)
 }
 
 object MapFactory {
 
-  /**
-    * Fixes the key and value types of `factory` to `K` and `V`, respectively.
-    * @param factory The factory to fix the key and value types
-    * @tparam K Type of keys
-    * @tparam V Type of values
-    * @tparam CC Collection type constructor of the factory (e.g. `Map`, `HashMap`, etc.)
-    * @return A [[Factory]] that uses the given `factory` to build a map with keys of type `K`
-    *         and values of type `V`
-    */
+  /** Fixes the key and value types of `factory` to `K` and `V`, respectively.
+   *  @tparam K Type of keys
+   *  @tparam V Type of values
+   *  @tparam CC Collection type constructor of the factory (e.g. `Map`, `HashMap`, etc.)
+   *  @param factory The factory to fix the key and value types
+   *  @return A [[Factory]] that uses the given `factory` to build a map with keys of type `K`
+   *         and values of type `V`
+   */
   implicit def toFactory[K, V, CC[_, _]](factory: MapFactory[CC]): Factory[(K, V), CC[K, V]] = new ToFactory[K, V, CC](factory)
 
   @SerialVersionUID(3L)
@@ -447,16 +435,16 @@ object MapFactory {
 }
 
 /** Base trait for companion objects of collections that require an implicit evidence.
-  * @tparam CC Collection type constructor (e.g. `ArraySeq`)
-  * @tparam Ev Unary type constructor for the implicit evidence required for an element type
-  *            (typically `Ordering` or `ClassTag`)
-  *
-  * @define factoryInfo
-  *   This object provides a set of operations to create $Coll values.
-  *
-  * @define coll collection
-  * @define Coll `Iterable`
-  */
+ *  @tparam CC Collection type constructor (e.g. `ArraySeq`)
+ *  @tparam Ev Unary type constructor for the implicit evidence required for an element type
+ *            (typically `Ordering` or `ClassTag`)
+ *
+ *  @define factoryInfo
+ *   This object provides a set of operations to create $Coll values.
+ *
+ *  @define coll collection
+ *  @define Coll `Iterable`
+ */
 trait EvidenceIterableFactory[+CC[_], Ev[_]] extends Serializable, caps.Pure {
 
   def from[E : Ev](it: IterableOnce[E]^): CC[E]
@@ -466,38 +454,38 @@ trait EvidenceIterableFactory[+CC[_], Ev[_]] extends Serializable, caps.Pure {
   def apply[A : Ev](xs: A*): CC[A] = from(xs)
 
   /** Produces a $coll containing the results of some element computation a number of times.
-    *  @param   n  the number of elements contained in the $coll.
-    *  @param   elem the element computation
-    *  @return  A $coll that contains the results of `n` evaluations of `elem`.
-    */
+   *  @param   n  the number of elements contained in the $coll.
+   *  @param   elem the element computation
+   *  @return  A $coll that contains the results of `n` evaluations of `elem`.
+   */
   def fill[A : Ev](n: Int)(elem: => A): CC[A] = from(new View.Fill(n)(elem))
 
   /** Produces a $coll containing values of a given function over a range of integer values starting from 0.
-    *  @param  n   The number of elements in the $coll
-    *  @param  f   The function computing element values
-    *  @return A $coll consisting of elements `f(0), ..., f(n -1)`
-    */
+   *  @param  n   The number of elements in the $coll
+   *  @param  f   The function computing element values
+   *  @return A $coll consisting of elements `f(0), ..., f(n -1)`
+   */
   def tabulate[A : Ev](n: Int)(f: Int => A): CC[A] = from(new View.Tabulate(n)(f))
 
   /** Produces a $coll containing repeated applications of a function to a start value.
-    *
-    *  @param start the start value of the $coll
-    *  @param len   the number of elements contained in the $coll
-    *  @param f     the function that's repeatedly applied
-    *  @return      a $coll with `len` values in the sequence `start, f(start), f(f(start)), ...`
-    */
+   *
+   *  @param start the start value of the $coll
+   *  @param len   the number of elements contained in the $coll
+   *  @param f     the function that's repeatedly applied
+   *  @return      a $coll with `len` values in the sequence `start, f(start), f(f(start)), ...`
+   */
   def iterate[A : Ev](start: A, len: Int)(f: A => A): CC[A] = from(new View.Iterate(start, len)(f))
 
   /** Produces a $coll that uses a function `f` to produce elements of type `A`
-    * and update an internal state of type `S`.
-    *
-    * @param init State initial value
-    * @param f    Computes the next element (or returns `None` to signal
-    *             the end of the collection)
-    * @tparam A   Type of the elements
-    * @tparam S   Type of the internal state
-    * @return a $coll that produces elements using `f` until `f` returns `None`
-    */
+   *  and update an internal state of type `S`.
+   *
+   *  @tparam A   Type of the elements
+   *  @tparam S   Type of the internal state
+   *  @param init State initial value
+   *  @param f    Computes the next element (or returns `None` to signal
+   *             the end of the collection)
+   *  @return a $coll that produces elements using `f` until `f` returns `None`
+   */
   def unfold[A : Ev, S](init: S)(f: S => Option[(A, S)]): CC[A] = from(new View.Unfold(init)(f))
 
   def newBuilder[A : Ev]: Builder[A, CC[A]]
@@ -507,15 +495,14 @@ trait EvidenceIterableFactory[+CC[_], Ev[_]] extends Serializable, caps.Pure {
 
 object EvidenceIterableFactory {
 
-  /**
-    * Fixes the element type of `factory` to `A`.
-    * @param factory The factory to fix the element type
-    * @tparam A Type of elements
-    * @tparam CC Collection type constructor of the factory (e.g. `TreeSet`)
-    * @tparam Ev Type constructor of the evidence (usually `Ordering` or `ClassTag`)
-    * @return A [[Factory]] that uses the given `factory` to build a collection of elements
-    *         of type `A`
-    */
+  /** Fixes the element type of `factory` to `A`.
+   *  @tparam A Type of elements
+   *  @tparam CC Collection type constructor of the factory (e.g. `TreeSet`)
+   *  @tparam Ev Type constructor of the evidence (usually `Ordering` or `ClassTag`)
+   *  @param factory The factory to fix the element type
+   *  @return A [[Factory]] that uses the given `factory` to build a collection of elements
+   *         of type `A`
+   */
   implicit def toFactory[Ev[_], A: Ev, CC[_]](factory: EvidenceIterableFactory[CC, Ev]): Factory[A, CC[A]] = new ToFactory[Ev, A, CC](factory)
 
   @SerialVersionUID(3L)
@@ -540,8 +527,8 @@ object EvidenceIterableFactory {
 }
 
 /** Base trait for companion objects of collections that require an implicit `Ordering`.
-  * @tparam CC Collection type constructor (e.g. `SortedSet`)
-  */
+ *  @tparam CC Collection type constructor (e.g. `SortedSet`)
+ */
 trait SortedIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, Ordering]
 
 object SortedIterableFactory {
@@ -551,112 +538,112 @@ object SortedIterableFactory {
 }
 
 /** Base trait for companion objects of collections that require an implicit `ClassTag`.
-  * @tparam CC Collection type constructor (e.g. `ArraySeq`)
-  */
+ *  @tparam CC Collection type constructor (e.g. `ArraySeq`)
+ */
 trait ClassTagIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, ClassTag] {
 
   @`inline` private implicit def ccClassTag[X]: ClassTag[CC[X]] =
     ClassTag.AnyRef.asInstanceOf[ClassTag[CC[X]]] // Good enough for boxed vs primitive arrays
 
   /** Produces a $coll containing a sequence of increasing of integers.
-    *
-    *  @param start the first element of the $coll
-    *  @param end   the end value of the $coll (the first value NOT contained)
-    *  @return  a $coll with values `start, start + 1, ..., end - 1`
-    */
+   *
+   *  @param start the first element of the $coll
+   *  @param end   the end value of the $coll (the first value NOT contained)
+   *  @return  a $coll with values `start, start + 1, ..., end - 1`
+   */
   def range[A : Integral : ClassTag](start: A, end: A): CC[A] = from(NumericRange(start, end, implicitly[Integral[A]].one))
 
   /** Produces a $coll containing equally spaced values in some integer interval.
-    *  @param start the start value of the $coll
-    *  @param end   the end value of the $coll (the first value NOT contained)
-    *  @param step  the difference between successive elements of the $coll (must be positive or negative)
-    *  @return      a $coll with values `start, start + step, ...` up to, but excluding `end`
-    */
+   *  @param start the start value of the $coll
+   *  @param end   the end value of the $coll (the first value NOT contained)
+   *  @param step  the difference between successive elements of the $coll (must be positive or negative)
+   *  @return      a $coll with values `start, start + step, ...` up to, but excluding `end`
+   */
   def range[A : Integral : ClassTag](start: A, end: A, step: A): CC[A] = from(NumericRange(start, end, step))
 
   /** Produces a two-dimensional $coll containing the results of some element computation a number of times.
-    *  @param   n1  the number of elements in the 1st dimension
-    *  @param   n2  the number of elements in the 2nd dimension
-    *  @param   elem the element computation
-    *  @return  A $coll that contains the results of `n1 x n2` evaluations of `elem`.
-    */
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   elem the element computation
+   *  @return  A $coll that contains the results of `n1 x n2` evaluations of `elem`.
+   */
   def fill[A : ClassTag](n1: Int, n2: Int)(elem: => A): CC[CC[A] @uncheckedVariance] = fill(n1)(fill(n2)(elem))
 
   /** Produces a three-dimensional $coll containing the results of some element computation a number of times.
-    *  @param   n1  the number of elements in the 1st dimension
-    *  @param   n2  the number of elements in the 2nd dimension
-    *  @param   n3  the number of elements in the 3rd dimension
-    *  @param   elem the element computation
-    *  @return  A $coll that contains the results of `n1 x n2 x n3` evaluations of `elem`.
-    */
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   elem the element computation
+   *  @return  A $coll that contains the results of `n1 x n2 x n3` evaluations of `elem`.
+   */
   def fill[A : ClassTag](n1: Int, n2: Int, n3: Int)(elem: => A): CC[CC[CC[A]] @uncheckedVariance] = fill(n1)(fill(n2, n3)(elem))
 
   /** Produces a four-dimensional $coll containing the results of some element computation a number of times.
-    *  @param   n1  the number of elements in the 1st dimension
-    *  @param   n2  the number of elements in the 2nd dimension
-    *  @param   n3  the number of elements in the 3rd dimension
-    *  @param   n4  the number of elements in the 4th dimension
-    *  @param   elem the element computation
-    *  @return  A $coll that contains the results of `n1 x n2 x n3 x n4` evaluations of `elem`.
-    */
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   elem the element computation
+   *  @return  A $coll that contains the results of `n1 x n2 x n3 x n4` evaluations of `elem`.
+   */
   def fill[A : ClassTag](n1: Int, n2: Int, n3: Int, n4: Int)(elem: => A): CC[CC[CC[CC[A]]] @uncheckedVariance] =
     fill(n1)(fill(n2, n3, n4)(elem))
 
   /** Produces a five-dimensional $coll containing the results of some element computation a number of times.
-    *  @param   n1  the number of elements in the 1st dimension
-    *  @param   n2  the number of elements in the 2nd dimension
-    *  @param   n3  the number of elements in the 3rd dimension
-    *  @param   n4  the number of elements in the 4th dimension
-    *  @param   n5  the number of elements in the 5th dimension
-    *  @param   elem the element computation
-    *  @return  A $coll that contains the results of `n1 x n2 x n3 x n4 x n5` evaluations of `elem`.
-    */
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   n5  the number of elements in the 5th dimension
+   *  @param   elem the element computation
+   *  @return  A $coll that contains the results of `n1 x n2 x n3 x n4 x n5` evaluations of `elem`.
+   */
   def fill[A : ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(elem: => A): CC[CC[CC[CC[CC[A]]]] @uncheckedVariance] =
     fill(n1)(fill(n2, n3, n4, n5)(elem))
 
   /** Produces a two-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
-    *  @param   n1  the number of elements in the 1st dimension
-    *  @param   n2  the number of elements in the 2nd dimension
-    *  @param   f   The function computing element values
-    *  @return A $coll consisting of elements `f(i1, i2)`
-    *          for `0 <= i1 < n1` and `0 <= i2 < n2`.
-    */
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   f   The function computing element values
+   *  @return A $coll consisting of elements `f(i1, i2)`
+   *          for `0 <= i1 < n1` and `0 <= i2 < n2`.
+   */
   def tabulate[A : ClassTag](n1: Int, n2: Int)(f: (Int, Int) => A): CC[CC[A] @uncheckedVariance] =
     tabulate(n1)(i1 => tabulate(n2)(f(i1, _)))
 
   /** Produces a three-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
-    *  @param   n1  the number of elements in the 1st dimension
-    *  @param   n2  the number of elements in the 2nd dimension
-    *  @param   n3  the number of elements in the 3rd dimension
-    *  @param   f   The function computing element values
-    *  @return A $coll consisting of elements `f(i1, i2, i3)`
-    *          for `0 <= i1 < n1`, `0 <= i2 < n2`, and `0 <= i3 < n3`.
-    */
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   f   The function computing element values
+   *  @return A $coll consisting of elements `f(i1, i2, i3)`
+   *          for `0 <= i1 < n1`, `0 <= i2 < n2`, and `0 <= i3 < n3`.
+   */
   def tabulate[A : ClassTag](n1: Int, n2: Int, n3: Int)(f: (Int, Int, Int) => A): CC[CC[CC[A]] @uncheckedVariance] =
     tabulate(n1)(i1 => tabulate(n2, n3)(f(i1, _, _)))
 
   /** Produces a four-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
-    *  @param   n1  the number of elements in the 1st dimension
-    *  @param   n2  the number of elements in the 2nd dimension
-    *  @param   n3  the number of elements in the 3rd dimension
-    *  @param   n4  the number of elements in the 4th dimension
-    *  @param   f   The function computing element values
-    *  @return A $coll consisting of elements `f(i1, i2, i3, i4)`
-    *          for `0 <= i1 < n1`, `0 <= i2 < n2`, `0 <= i3 < n3`, and `0 <= i4 < n4`.
-    */
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   f   The function computing element values
+   *  @return A $coll consisting of elements `f(i1, i2, i3, i4)`
+   *          for `0 <= i1 < n1`, `0 <= i2 < n2`, `0 <= i3 < n3`, and `0 <= i4 < n4`.
+   */
   def tabulate[A : ClassTag](n1: Int, n2: Int, n3: Int, n4: Int)(f: (Int, Int, Int, Int) => A): CC[CC[CC[CC[A]]] @uncheckedVariance] =
     tabulate(n1)(i1 => tabulate(n2, n3, n4)(f(i1, _, _, _)))
 
   /** Produces a five-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
-    *  @param   n1  the number of elements in the 1st dimension
-    *  @param   n2  the number of elements in the 2nd dimension
-    *  @param   n3  the number of elements in the 3rd dimension
-    *  @param   n4  the number of elements in the 4th dimension
-    *  @param   n5  the number of elements in the 5th dimension
-    *  @param   f   The function computing element values
-    *  @return A $coll consisting of elements `f(i1, i2, i3, i4, i5)`
-    *          for `0 <= i1 < n1`, `0 <= i2 < n2`, `0 <= i3 < n3`, `0 <= i4 < n4`, and `0 <= i5 < n5`.
-    */
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   n5  the number of elements in the 5th dimension
+   *  @param   f   The function computing element values
+   *  @return A $coll consisting of elements `f(i1, i2, i3, i4, i5)`
+   *          for `0 <= i1 < n1`, `0 <= i2 < n2`, `0 <= i3 < n3`, `0 <= i4 < n4`, and `0 <= i5 < n5`.
+   */
   def tabulate[A : ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(f: (Int, Int, Int, Int, Int) => A): CC[CC[CC[CC[CC[A]]]] @uncheckedVariance] =
     tabulate(n1)(i1 => tabulate(n2, n3, n4, n5)(f(i1, _, _, _, _)))
 }
@@ -667,7 +654,8 @@ object ClassTagIterableFactory {
     extends EvidenceIterableFactory.Delegate[CC, ClassTag](delegate) with ClassTagIterableFactory[CC]
 
   /** An IterableFactory that uses ClassTag.Any as the evidence for every element type. This may or may not be
-    * sound depending on the use of the `ClassTag` by the collection implementation. */
+   *  sound depending on the use of the `ClassTag` by the collection implementation. 
+   */
   @SerialVersionUID(3L)
   class AnyIterableDelegate[CC[_]](delegate: ClassTagIterableFactory[CC]) extends IterableFactory[CC] {
     def empty[A]: CC[A] = delegate.empty(using ClassTag.Any).asInstanceOf[CC[A]]
@@ -684,8 +672,8 @@ object ClassTagIterableFactory {
 }
 
 /**
-  * @tparam CC Collection type constructor (e.g. `ArraySeq`)
-  */
+ *  @tparam CC Collection type constructor (e.g. `ArraySeq`)
+ */
 trait ClassTagSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]]] extends ClassTagIterableFactory[CC] {
   import SeqFactory.UnapplySeqWrapper
   final def unapplySeq[A](x: CC[A] @uncheckedVariance): UnapplySeqWrapper[A] = new UnapplySeqWrapper(x) // TODO is uncheckedVariance sound here?
@@ -697,7 +685,8 @@ object ClassTagSeqFactory {
     extends ClassTagIterableFactory.Delegate[CC](delegate) with ClassTagSeqFactory[CC]
 
   /** A SeqFactory that uses ClassTag.Any as the evidence for every element type. This may or may not be
-    * sound depending on the use of the `ClassTag` by the collection implementation. */
+   *  sound depending on the use of the `ClassTag` by the collection implementation. 
+   */
   @SerialVersionUID(3L)
   class AnySeqDelegate[CC[A] <: SeqOps[A, Seq, Seq[A]] & caps.Pure](delegate: ClassTagSeqFactory[CC])
     extends ClassTagIterableFactory.AnyIterableDelegate[CC](delegate) with SeqFactory[CC]
@@ -730,12 +719,12 @@ trait StrictOptimizedClassTagSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]]] extend
 }
 
 /**
-  * @define factoryInfo
-  *   This object provides a set of operations to create $Coll values.
-  *
-  * @define coll collection
-  * @define Coll `Iterable`
-  */
+ *  @define factoryInfo
+ *   This object provides a set of operations to create $Coll values.
+ *
+ *  @define coll collection
+ *  @define Coll `Iterable`
+ */
 trait SortedMapFactory[+CC[_, _]] extends Serializable { this: SortedMapFactory[CC] =>
 
   def empty[K : Ordering, V]: CC[K, V]
@@ -752,17 +741,16 @@ trait SortedMapFactory[+CC[_, _]] extends Serializable { this: SortedMapFactory[
 
 object SortedMapFactory {
 
-  /**
-    * Implicit conversion that fixes the key and value types of `factory` to `K` and `V`,
-    * respectively.
-    *
-    * @param factory The factory to fix the key and value types
-    * @tparam K Type of keys
-    * @tparam V Type of values
-    * @tparam CC Collection type constructor of the factory (e.g. `TreeMap`)
-    * @return A [[Factory]] that uses the given `factory` to build a map with keys of
-    *         type `K` and values of type `V`
-    */
+  /** Implicit conversion that fixes the key and value types of `factory` to `K` and `V`,
+   *  respectively.
+   *
+   *  @tparam K Type of keys
+   *  @tparam V Type of values
+   *  @tparam CC Collection type constructor of the factory (e.g. `TreeMap`)
+   *  @param factory The factory to fix the key and value types
+   *  @return A [[Factory]] that uses the given `factory` to build a map with keys of
+   *         type `K` and values of type `V`
+   */
   implicit def toFactory[K : Ordering, V, CC[_, _]](factory: SortedMapFactory[CC]): Factory[(K, V), CC[K, V]] = new ToFactory[K, V, CC](factory)
 
   @SerialVersionUID(3L)

--- a/library/src/scala/collection/Iterable.scala
+++ b/library/src/scala/collection/Iterable.scala
@@ -22,12 +22,12 @@ import scala.collection.mutable.Builder
 import scala.collection.View.{LeftPartitionMapped, RightPartitionMapped}
 
 /** Base trait for generic collections.
-  *
-  * @tparam A the element type of the collection
-  *
-  * @define Coll `Iterable`
-  * @define coll iterable collection
-  */
+ *
+ *  @tparam A the element type of the collection
+ *
+ *  @define Coll `Iterable`
+ *  @define coll iterable collection
+ */
 trait Iterable[+A] extends IterableOnce[A]
   with IterableOps[A, Iterable, Iterable[A]]
   with IterableFactoryDefaults[A, Iterable] {
@@ -44,100 +44,100 @@ trait Iterable[+A] extends IterableOnce[A]
   def seq: this.type = this
 
   /** Defines the prefix of this object's `toString` representation.
-    *
-    * It is recommended to return the name of the concrete collection type, but
-    * not implementation subclasses. For example, for `ListMap` this method should
-    * return `"ListMap"`, not `"Map"` (the supertype) or `"Node"` (an implementation
-    * subclass).
-    *
-    * The default implementation returns "Iterable". It is overridden for the basic
-    * collection kinds "Seq", "IndexedSeq", "LinearSeq", "Buffer", "Set", "Map",
-    * "SortedSet", "SortedMap" and "View".
-    *
-    *  @return  a string representation which starts the result of `toString`
-    *           applied to this $coll. By default the string prefix is the
-    *           simple name of the collection class $coll.
-    */
+   *
+   *  It is recommended to return the name of the concrete collection type, but
+   *  not implementation subclasses. For example, for `ListMap` this method should
+   *  return `"ListMap"`, not `"Map"` (the supertype) or `"Node"` (an implementation
+   *  subclass).
+   *
+   *  The default implementation returns "Iterable". It is overridden for the basic
+   *  collection kinds "Seq", "IndexedSeq", "LinearSeq", "Buffer", "Set", "Map",
+   *  "SortedSet", "SortedMap" and "View".
+   *
+   *  @return  a string representation which starts the result of `toString`
+   *           applied to this $coll. By default the string prefix is the
+   *           simple name of the collection class $coll.
+   */
   protected def className: String = stringPrefix
 
   /** Forwarder to `className` for use in `scala.runtime.ScalaRunTime`.
-    *
-    * This allows the proper visibility for `className` to be
-    * published, but provides the exclusive access needed by
-    * `scala.runtime.ScalaRunTime.stringOf` (and a few tests in
-    * the test suite).
-    */
+   *
+   *  This allows the proper visibility for `className` to be
+   *  published, but provides the exclusive access needed by
+   *  `scala.runtime.ScalaRunTime.stringOf` (and a few tests in
+   *  the test suite).
+   */
   private[scala] final def collectionClassName: String = className
 
   @deprecatedOverriding("Override className instead", "2.13.0")
   protected def stringPrefix: String = "Iterable"
 
   /** Converts this $coll to a string.
-    *
-    *  @return   a string representation of this collection. By default this
-    *            string consists of the `className` of this $coll, followed
-    *            by all elements separated by commas and enclosed in parentheses.
-    */
+   *
+   *  @return   a string representation of this collection. By default this
+   *            string consists of the `className` of this $coll, followed
+   *            by all elements separated by commas and enclosed in parentheses.
+   */
   override def toString() = mkString(className + "(", ", ", ")")
 
   /** Analogous to `zip` except that the elements in each collection are not consumed until a strict operation is
-    * invoked on the returned `LazyZip2` decorator.
-    *
-    * Calls to `lazyZip` can be chained to support higher arities (up to 4) without incurring the expense of
-    * constructing and deconstructing intermediary tuples.
-    *
-    * {{{
-    *    val xs = List(1, 2, 3)
-    *    val res = (xs lazyZip xs lazyZip xs lazyZip xs).map((a, b, c, d) => a + b + c + d)
-    *    // res == List(4, 8, 12)
-    * }}}
-    *
-    * @param that the iterable providing the second element of each eventual pair
-    * @tparam B   the type of the second element in each eventual pair
-    * @return a decorator `LazyZip2` that allows strict operations to be performed on the lazily evaluated pairs
-    *         or chained calls to `lazyZip`. Implicit conversion to `Iterable[(A, B)]` is also supported.
-    */
+   *  invoked on the returned `LazyZip2` decorator.
+   *
+   *  Calls to `lazyZip` can be chained to support higher arities (up to 4) without incurring the expense of
+   *  constructing and deconstructing intermediary tuples.
+   *
+   *  ```
+   *    val xs = List(1, 2, 3)
+   *    val res = (xs lazyZip xs lazyZip xs lazyZip xs).map((a, b, c, d) => a + b + c + d)
+   *    // res == List(4, 8, 12)
+   *  ```
+   *
+   *  @tparam B   the type of the second element in each eventual pair
+   *  @param that the iterable providing the second element of each eventual pair
+   *  @return a decorator `LazyZip2` that allows strict operations to be performed on the lazily evaluated pairs
+   *         or chained calls to `lazyZip`. Implicit conversion to `Iterable[(A, B)]` is also supported.
+   */
   def lazyZip[B](that: Iterable[B]^): LazyZip2[A, B, this.type]^{this, that} = new LazyZip2(this, this, that)
 }
 
 /** Base trait for Iterable operations
-  *
-  * =VarianceNote=
-  *
-  * We require that for all child classes of Iterable the variance of
-  * the child class and the variance of the `C` parameter passed to `IterableOps`
-  * are the same. We cannot express this since we lack variance polymorphism. That's
-  * why we have to resort at some places to write `C[A @uncheckedVariance]`.
-  *
-  * @tparam CC type constructor of the collection (e.g. `List`, `Set`). Operations returning a collection
-  *            with a different type of element `B` (e.g. `map`) return a `CC[B]`.
-  * @tparam C  type of the collection (e.g. `List[Int]`, `String`, `BitSet`). Operations returning a collection
-  *            with the same type of element (e.g. `drop`, `filter`) return a `C`.
-  *
-  * @define Coll Iterable
-  * @define coll iterable collection
-  * @define orderDependent
-  *
-  *    Note: might return different results for different runs, unless the underlying collection type is ordered.
-  * @define orderDependentFold
-  *
-  *    Note: might return different results for different runs, unless the
-  *    underlying collection type is ordered or the operator is associative
-  *    and commutative.
-  * @define mayNotTerminateInf
-  *
-  *    Note: may not terminate for infinite-sized collections.
-  * @define willNotTerminateInf
-  *
-  *    Note: will not terminate for infinite-sized collections.
-  * @define undefinedorder
-  *  The order in which operations are performed on elements is unspecified
-  *  and may be nondeterministic.
-  */
+ *
+ *  # VarianceNote
+ *
+ *  We require that for all child classes of Iterable the variance of
+ *  the child class and the variance of the `C` parameter passed to `IterableOps`
+ *  are the same. We cannot express this since we lack variance polymorphism. That's
+ *  why we have to resort at some places to write `C[A @uncheckedVariance]`.
+ *
+ *  @tparam CC type constructor of the collection (e.g. `List`, `Set`). Operations returning a collection
+ *            with a different type of element `B` (e.g. `map`) return a `CC[B]`.
+ *  @tparam C  type of the collection (e.g. `List[Int]`, `String`, `BitSet`). Operations returning a collection
+ *            with the same type of element (e.g. `drop`, `filter`) return a `C`.
+ *
+ *  @define Coll Iterable
+ *  @define coll iterable collection
+ *  @define orderDependent
+ *
+ *    Note: might return different results for different runs, unless the underlying collection type is ordered.
+ *  @define orderDependentFold
+ *
+ *    Note: might return different results for different runs, unless the
+ *    underlying collection type is ordered or the operator is associative
+ *    and commutative.
+ *  @define mayNotTerminateInf
+ *
+ *    Note: may not terminate for infinite-sized collections.
+ *  @define willNotTerminateInf
+ *
+ *    Note: will not terminate for infinite-sized collections.
+ *  @define undefinedorder
+ *  The order in which operations are performed on elements is unspecified
+ *  and may be nondeterministic.
+ */
 transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with IterableOnceOps[A, CC, C] {
   /**
-    * @return This collection as an `Iterable[A]`. No new collection will be built if `this` is already an `Iterable[A]`.
-    */
+   *  @return This collection as an `Iterable[A]`. No new collection will be built if `this` is already an `Iterable[A]`.
+   */
   // Should be `protected def asIterable`, or maybe removed altogether if it's not needed
   @deprecated("toIterable is internal and will be made protected; its name is similar to `toList` or `toSeq`, but it doesn't copy non-immutable collections", "2.13.7")
   def toIterable: Iterable[A]^{this}
@@ -152,69 +152,67 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
   override def isTraversableAgain: Boolean = true
 
   /**
-    * @return This collection as a `C`.
-    */
+   *  @return This collection as a `C`.
+   */
   protected def coll: C^{this}
 
   @deprecated("Use coll instead of repr in a collection implementation, use the collection value itself from the outside", "2.13.0")
   final def repr: C^{this} = coll
 
-  /**
-    * Defines how to turn a given `Iterable[A]` into a collection of type `C`.
-    *
-    * This process can be done in a strict way or a non-strict way (ie. without evaluating
-    * the elements of the resulting collections). In other words, this methods defines
-    * the evaluation model of the collection.
-    *
-    * @note When implementing a custom collection type and refining `C` to the new type, this
-    *       method needs to be overridden (the compiler will issue an error otherwise). In the
-    *       common case where `C =:= CC[A]`, this can be done by mixing in the
-    *       [[scala.collection.IterableFactoryDefaults]] trait, which implements the method using
-    *       [[iterableFactory]].
-    *
-    * @note As witnessed by the `@uncheckedVariance` annotation, using this method
-    *       might be unsound. However, as long as it is called with an
-    *       `Iterable[A]` obtained from `this` collection (as it is the case in the
-    *       implementations of operations where we use a `View[A]`), it is safe.
-    */
+  /** Defines how to turn a given `Iterable[A]` into a collection of type `C`.
+   *
+   *  This process can be done in a strict way or a non-strict way (ie. without evaluating
+   *  the elements of the resulting collections). In other words, this methods defines
+   *  the evaluation model of the collection.
+   *
+   *  @note When implementing a custom collection type and refining `C` to the new type, this
+   *       method needs to be overridden (the compiler will issue an error otherwise). In the
+   *       common case where `C =:= CC[A]`, this can be done by mixing in the
+   *       [[scala.collection.IterableFactoryDefaults]] trait, which implements the method using
+   *       [[iterableFactory]].
+   *
+   *  @note As witnessed by the `@uncheckedVariance` annotation, using this method
+   *       might be unsound. However, as long as it is called with an
+   *       `Iterable[A]` obtained from `this` collection (as it is the case in the
+   *       implementations of operations where we use a `View[A]`), it is safe.
+   */
   protected def fromSpecific(coll: IterableOnce[A @uncheckedVariance]^): C^{coll}
 
   /** The companion object of this ${coll}, providing various factory methods.
-    *
-    * @note When implementing a custom collection type and refining `CC` to the new type, this
-    *       method needs to be overridden to return a factory for the new type (the compiler will
-    *       issue an error otherwise).
-    */
+   *
+   *  @note When implementing a custom collection type and refining `CC` to the new type, this
+   *       method needs to be overridden to return a factory for the new type (the compiler will
+   *       issue an error otherwise).
+   */
   def iterableFactory: IterableFactory[CC]
 
   @deprecated("Use iterableFactory instead", "2.13.0")
   @deprecatedOverriding("Use iterableFactory instead", "2.13.0")
   @`inline` def companion: IterableFactory[CC] = iterableFactory
 
-  /**
-    * @return a strict builder for the same collection type.
-    *
-    * Note that in the case of lazy collections (e.g. [[scala.collection.View]] or [[scala.collection.immutable.LazyList]]),
-    * it is possible to implement this method but the resulting `Builder` will break laziness.
-    * As a consequence, operations should preferably be implemented with `fromSpecific`
-    * instead of this method.
-    *
-    * @note When implementing a custom collection type and refining `C` to the new type, this
-    *       method needs to be overridden (the compiler will issue an error otherwise). In the
-    *       common case where `C =:= CC[A]`, this can be done by mixing in the
-    *       [[scala.collection.IterableFactoryDefaults]] trait, which implements the method using
-    *       [[iterableFactory]].
-    *
-    * @note As witnessed by the `@uncheckedVariance` annotation, using this method might
-    *       be unsound. However, as long as the returned builder is only fed
-    *       with `A` values taken from `this` instance, it is safe.
-    */
+  /** Note that in the case of lazy collections (e.g. [[scala.collection.View]] or [[scala.collection.immutable.LazyList]]),
+   *  @return a strict builder for the same collection type.
+   *
+   *  it is possible to implement this method but the resulting `Builder` will break laziness.
+   *  As a consequence, operations should preferably be implemented with `fromSpecific`
+   *  instead of this method.
+   *
+   *  @note When implementing a custom collection type and refining `C` to the new type, this
+   *       method needs to be overridden (the compiler will issue an error otherwise). In the
+   *       common case where `C =:= CC[A]`, this can be done by mixing in the
+   *       [[scala.collection.IterableFactoryDefaults]] trait, which implements the method using
+   *       [[iterableFactory]].
+   *
+   *  @note As witnessed by the `@uncheckedVariance` annotation, using this method might
+   *       be unsound. However, as long as the returned builder is only fed
+   *       with `A` values taken from `this` instance, it is safe.
+   */
   protected def newSpecificBuilder: Builder[A @uncheckedVariance, C]
 
   /** The empty $coll.
-    *
-    * @return an empty iterable of type $Coll.
-    */
+   *
+   *  @return an empty iterable of type $Coll.
+   */
   def empty: C = fromSpecific(Nil)
 
   /** Selects the first element of this $coll.
@@ -235,10 +233,10 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
   }
 
   /** Selects the last element.
-    * $orderDependent
-    * @return The last element of this $coll.
-    * @throws NoSuchElementException If the $coll is empty.
-    */
+   *  $orderDependent
+   *  @return The last element of this $coll.
+   *  @throws NoSuchElementException If the $coll is empty.
+   */
   def last: A = {
     val it = iterator
     var lst = it.next()
@@ -260,11 +258,11 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
    *
    *  @param   otherSize the test value that gets compared with the size.
    *  @return  A value `x` where
-   *  {{{
+   *  ```
    *       x <  0       if this.size <  otherSize
    *       x == 0       if this.size == otherSize
    *       x >  0       if this.size >  otherSize
-   *  }}}
+   *  ```
    *
    *  The method as implemented here does not call `size` directly; its running time
    *  is `O(size min otherSize)` instead of `O(size)`. The method should be overridden
@@ -290,30 +288,30 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
     }
 
   /** Returns a value class containing operations for comparing the size of this $coll to a test value.
-    *
-    * These operations are implemented in terms of [[sizeCompare(Int) `sizeCompare(Int)`]], and
-    * allow the following more readable usages:
-    *
-    * {{{
-    * this.sizeIs < size     // this.sizeCompare(size) < 0
-    * this.sizeIs <= size    // this.sizeCompare(size) <= 0
-    * this.sizeIs == size    // this.sizeCompare(size) == 0
-    * this.sizeIs != size    // this.sizeCompare(size) != 0
-    * this.sizeIs >= size    // this.sizeCompare(size) >= 0
-    * this.sizeIs > size     // this.sizeCompare(size) > 0
-    * }}}
-    */
+   *
+   *  These operations are implemented in terms of [[sizeCompare(Int) `sizeCompare(Int)`]], and
+   *  allow the following more readable usages:
+   *
+   *  ```
+   *  this.sizeIs < size     // this.sizeCompare(size) < 0
+   *  this.sizeIs <= size    // this.sizeCompare(size) <= 0
+   *  this.sizeIs == size    // this.sizeCompare(size) == 0
+   *  this.sizeIs != size    // this.sizeCompare(size) != 0
+   *  this.sizeIs >= size    // this.sizeCompare(size) >= 0
+   *  this.sizeIs > size     // this.sizeCompare(size) > 0
+   *  ```
+   */
   @inline final def sizeIs: IterableOps.SizeCompareOps^{this} = new IterableOps.SizeCompareOps(caps.unsafe.unsafeAssumePure(this) /* see comment in SizeCompareOps*/)
 
   /** Compares the size of this $coll to the size of another `Iterable`.
    *
    *  @param   that the `Iterable` whose size is compared with this $coll's size.
    *  @return  A value `x` where
-   *  {{{
+   *  ```
    *       x <  0       if this.size <  that.size
    *       x == 0       if this.size == that.size
    *       x >  0       if this.size >  that.size
-   *  }}}
+   *  ```
    *
    *  The method as implemented here does not call `size` directly; its running time
    *  is `O(this.size min that.size)` instead of `O(this.size + that.size)`.
@@ -352,7 +350,7 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
    *  The resulting collection's type will be guided by the
    *  static type of $coll. For example:
    *
-   *  {{{
+   *  ```
    *  val xs = List(
    *             Set(1, 2, 3),
    *             Set(4, 5, 6)).transpose
@@ -368,15 +366,15 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
    *  //         Vector(1, 4),
    *  //         Vector(2, 5),
    *  //         Vector(3, 6))
-   *  }}}
+   *  ```
    *
    *  $willForceEvaluation
    *
    *  @tparam B the type of the elements of each iterable collection.
    *  @param  asIterable an implicit conversion which asserts that the
    *          element type of this $coll is an `Iterable`.
-   *  @return a two-dimensional $coll of ${coll}s which has as ''n''th row
-   *          the ''n''th column of this $coll.
+   *  @return a two-dimensional $coll of ${coll}s which has as *n*th row
+   *          the *n*th column of this $coll.
    *  @throws IllegalArgumentException if all collections in this $coll
    *          are not of the same size.
    */
@@ -406,19 +404,19 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
   def filterNot(pred: A => Boolean): C^{this, pred} = fromSpecific(new View.Filter(this, pred, isFlipped = true))
 
   /** Creates a non-strict filter of this $coll.
-    *
-    *  Note: the difference between `c filter p` and `c withFilter p` is that
-    *        the former creates a new collection, whereas the latter only
-    *        restricts the domain of subsequent `map`, `flatMap`, `foreach`,
-    *        and `withFilter` operations.
-    *  $orderDependent
-    *
-    *  @param p   the predicate used to test elements.
-    *  @return    an object of class `WithFilter`, which supports
-    *             `map`, `flatMap`, `foreach`, and `withFilter` operations.
-    *             All these operations apply to those elements of this $coll
-    *             which satisfy the predicate `p`.
-    */
+   *
+   *  Note: the difference between `c filter p` and `c withFilter p` is that
+   *        the former creates a new collection, whereas the latter only
+   *        restricts the domain of subsequent `map`, `flatMap`, `foreach`,
+   *        and `withFilter` operations.
+   *  $orderDependent
+   *
+   *  @param p   the predicate used to test elements.
+   *  @return    an object of class `WithFilter`, which supports
+   *             `map`, `flatMap`, `foreach`, and `withFilter` operations.
+   *             All these operations apply to those elements of this $coll
+   *             which satisfy the predicate `p`.
+   */
   def withFilter(p: A => Boolean): collection.WithFilter[A, CC]^{this, p} = new IterableOps.WithFilter(this, p)
 
   /** A pair of, first, all elements that satisfy predicate `p` and, second,
@@ -440,34 +438,34 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
 
   def take(n: Int): C^{this} = fromSpecific(new View.Take(this, n))
 
-  /** Selects the last ''n'' elements.
-    *  $orderDependent
-    *  @param  n    the number of elements to take from this $coll.
-    *  @return a $coll consisting only of the last `n` elements of this $coll,
-    *          or else the whole $coll, if it has less than `n` elements.
-    *          If `n` is negative, returns an empty $coll.
-    */
+  /** Selects the last *n* elements.
+   *  $orderDependent
+   *  @param  n    the number of elements to take from this $coll.
+   *  @return a $coll consisting only of the last `n` elements of this $coll,
+   *          or else the whole $coll, if it has less than `n` elements.
+   *          If `n` is negative, returns an empty $coll.
+   */
   def takeRight(n: Int): C^{this} = fromSpecific(new View.TakeRight(this, n))
 
   /** Takes longest prefix of elements that satisfy a predicate.
-    *  $orderDependent
-    *  @param   p  The predicate used to test elements.
-    *  @return  the longest prefix of this $coll whose elements all satisfy
-    *           the predicate `p`.
-    */
+   *  $orderDependent
+   *  @param   p  The predicate used to test elements.
+   *  @return  the longest prefix of this $coll whose elements all satisfy
+   *           the predicate `p`.
+   */
   def takeWhile(p: A => Boolean): C^{this, p} = fromSpecific(new View.TakeWhile(this, p))
 
   def span(p: A => Boolean): (C^{this, p}, C^{this, p}) = (takeWhile(p), dropWhile(p))
 
   def drop(n: Int): C^{this} = fromSpecific(new View.Drop(this, n))
 
-  /** Selects all elements except last ''n'' ones.
-    *  $orderDependent
-    *  @param  n    the number of elements to drop from this $coll.
-    *  @return a $coll consisting of all elements of this $coll except the last `n` ones, or else the
-    *          empty $coll, if this $coll has less than `n` elements.
-    *          If `n` is negative, don't drop any elements.
-    */
+  /** Selects all elements except last *n* ones.
+   *  $orderDependent
+   *  @param  n    the number of elements to drop from this $coll.
+   *  @return a $coll consisting of all elements of this $coll except the last `n` ones, or else the
+   *          empty $coll, if this $coll has less than `n` elements.
+   *          If `n` is negative, don't drop any elements.
+   */
   def dropRight(n: Int): C^{this} = fromSpecific(new View.DropRight(this, n))
 
   def dropWhile(p: A => Boolean): C^{this, p} = fromSpecific(new View.DropWhile(this, p))
@@ -483,45 +481,45 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
     iterator.grouped(size).map(fromSpecific)
 
   /** Groups elements in fixed size blocks by passing a "sliding window"
-    *  over them (as opposed to partitioning them, as is done in `grouped`).
-    *
-    *  An empty collection returns an empty iterator, and a non-empty
-    *  collection containing fewer elements than the window size returns
-    *  an iterator that will produce the original collection as its only
-    *  element.
-    *  @see [[scala.collection.Iterator]], method `sliding`
-    *
-    *  @param size the number of elements per group
-    *  @return An iterator producing ${coll}s of size `size`, except for a
-    *          non-empty collection with less than `size` elements, which
-    *          returns an iterator that produces the source collection itself
-    *          as its only element.
-    *  @example `List().sliding(2) = empty iterator`
-    *  @example `List(1).sliding(2) = Iterator(List(1))`
-    *  @example `List(1, 2).sliding(2) = Iterator(List(1, 2))`
-    *  @example `List(1, 2, 3).sliding(2) = Iterator(List(1, 2), List(2, 3))`
-    */
+   *  over them (as opposed to partitioning them, as is done in `grouped`).
+   *
+   *  An empty collection returns an empty iterator, and a non-empty
+   *  collection containing fewer elements than the window size returns
+   *  an iterator that will produce the original collection as its only
+   *  element.
+   *  @see [[scala.collection.Iterator]], method `sliding`
+   *
+   *  @param size the number of elements per group
+   *  @return An iterator producing ${coll}s of size `size`, except for a
+   *          non-empty collection with less than `size` elements, which
+   *          returns an iterator that produces the source collection itself
+   *          as its only element.
+   *  @example `List().sliding(2) = empty iterator`
+   *  @example `List(1).sliding(2) = Iterator(List(1))`
+   *  @example `List(1, 2).sliding(2) = Iterator(List(1, 2))`
+   *  @example `List(1, 2, 3).sliding(2) = Iterator(List(1, 2), List(2, 3))`
+   */
   def sliding(size: Int): Iterator[C^{this}]^{this} = sliding(size, 1)
 
   /** Groups elements in fixed size blocks by passing a "sliding window"
-    *  over them (as opposed to partitioning them, as is done in `grouped`).
-    *
-    *  The returned iterator will be empty when called on an empty collection.
-    *  The last element the iterator produces may be smaller than the window
-    *  size when the original collection isn't exhausted by the window before
-    *  it and its last element isn't skipped by the step before it.
-    *
-    *  @see [[scala.collection.Iterator]], method `sliding`
-    *
-    *  @param size the number of elements per group
-    *  @param step the distance between the first elements of successive
-    *         groups
-    *  @return An iterator producing ${coll}s of size `size`, except the last
-    *          element (which may be the only element) will be smaller
-    *          if there are fewer than `size` elements remaining to be grouped.
-    *  @example `List(1, 2, 3, 4, 5).sliding(2, 2) = Iterator(List(1, 2), List(3, 4), List(5))`
-    *  @example `List(1, 2, 3, 4, 5, 6).sliding(2, 3) = Iterator(List(1, 2), List(4, 5))`
-    */
+   *  over them (as opposed to partitioning them, as is done in `grouped`).
+   *
+   *  The returned iterator will be empty when called on an empty collection.
+   *  The last element the iterator produces may be smaller than the window
+   *  size when the original collection isn't exhausted by the window before
+   *  it and its last element isn't skipped by the step before it.
+   *
+   *  @see [[scala.collection.Iterator]], method `sliding`
+   *
+   *  @param size the number of elements per group
+   *  @param step the distance between the first elements of successive
+   *         groups
+   *  @return An iterator producing ${coll}s of size `size`, except the last
+   *          element (which may be the only element) will be smaller
+   *          if there are fewer than `size` elements remaining to be grouped.
+   *  @example `List(1, 2, 3, 4, 5).sliding(2, 2) = Iterator(List(1, 2), List(3, 4), List(5))`
+   *  @example `List(1, 2, 3, 4, 5, 6).sliding(2, 3) = Iterator(List(1, 2), List(4, 5))`
+   */
   def sliding(size: Int, step: Int): Iterator[C^{this}]^{this} =
     iterator.sliding(size, step).map(fromSpecific)
 
@@ -532,8 +530,8 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
   }
 
   /** The initial part of the collection without its last element.
-    * $willForceEvaluation
-    */
+   *  $willForceEvaluation
+   */
   def init: C^{this} = {
     if (isEmpty) throw new UnsupportedOperationException
     dropRight(1)
@@ -543,19 +541,18 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
     fromSpecific(new View.Drop(new View.Take(this, until), from))
 
   /** Partitions this $coll into a map of ${coll}s according to some discriminator function.
-    *
-    *  $willForceEvaluation
-    *
-    *  @param f     the discriminator function.
-    *  @tparam K    the type of keys returned by the discriminator function.
-    *  @return      A map from keys to ${coll}s such that the following invariant holds:
-    *               {{{
-    *                 (xs groupBy f)(k) = xs filter (x => f(x) == k)
-    *               }}}
-    *               That is, every key `k` is bound to a $coll of those elements `x`
-    *               for which `f(x)` equals `k`.
-    *
-    */
+   *
+   *  $willForceEvaluation
+   *
+   *  @tparam K    the type of keys returned by the discriminator function.
+   *  @param f     the discriminator function.
+   *  @return      A map from keys to ${coll}s such that the following invariant holds:
+   *               ```
+   *                 (xs groupBy f)(k) = xs filter (x => f(x) == k)
+   *               ```
+   *               That is, every key `k` is bound to a $coll of those elements `x`
+   *               for which `f(x)` equals `k`.
+   */
   def groupBy[K](f: A => K): immutable.Map[K, C] = {
     val m = mutable.Map.empty[K, Builder[A, C]]
     val it = iterator
@@ -574,26 +571,25 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
     result
   }
 
-  /**
-    * Partitions this $coll into a map of ${coll}s according to a discriminator function `key`.
-    * Each element in a group is transformed into a value of type `B` using the `value` function.
-    *
-    * It is equivalent to `groupBy(key).mapValues(_.map(f))`, but more efficient.
-    *
-    * {{{
-    *   case class User(name: String, age: Int)
-    *
-    *   def namesByAge(users: Seq[User]): Map[Int, Seq[String]] =
-    *     users.groupMap(_.age)(_.name)
-    * }}}
-    *
-    * $willForceEvaluation
-    *
-    * @param key the discriminator function
-    * @param f the element transformation function
-    * @tparam K the type of keys returned by the discriminator function
-    * @tparam B the type of values returned by the transformation function
-    */
+  /** Partitions this $coll into a map of ${coll}s according to a discriminator function `key`.
+   *  Each element in a group is transformed into a value of type `B` using the `value` function.
+   *
+   *  It is equivalent to `groupBy(key).mapValues(_.map(f))`, but more efficient.
+   *
+   *  ```
+   *   case class User(name: String, age: Int)
+   *
+   *   def namesByAge(users: Seq[User]): Map[Int, Seq[String]] =
+   *     users.groupMap(_.age)(_.name)
+   *  ```
+   *
+   *  $willForceEvaluation
+   *
+   *  @tparam K the type of keys returned by the discriminator function
+   *  @tparam B the type of values returned by the transformation function
+   *  @param key the discriminator function
+   *  @param f the element transformation function
+   */
   def groupMap[K, B](key: A => K)(f: A => B): immutable.Map[K, CC[B]] = {
     val m = mutable.Map.empty[K, Builder[B, CC[B]]]
     for (elem <- this) {
@@ -611,20 +607,19 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
     result.built
   }
 
-  /**
-    * Partitions this $coll into a map according to a discriminator function `key`. All the values that
-    * have the same discriminator are then transformed by the `f` function and then reduced into a
-    * single value with the `reduce` function.
-    *
-    * It is equivalent to `groupBy(key).mapValues(_.map(f).reduce(reduce))`, but more efficient.
-    *
-    * {{{
-    *   def occurrences[A](as: Seq[A]): Map[A, Int] =
-    *     as.groupMapReduce(identity)(_ => 1)(_ + _)
-    * }}}
-    *
-    * $willForceEvaluation
-    */
+  /** Partitions this $coll into a map according to a discriminator function `key`. All the values that
+   *  have the same discriminator are then transformed by the `f` function and then reduced into a
+   *  single value with the `reduce` function.
+   *
+   *  It is equivalent to `groupBy(key).mapValues(_.map(f).reduce(reduce))`, but more efficient.
+   *
+   *  ```
+   *   def occurrences[A](as: Seq[A]): Map[A, Int] =
+   *     as.groupMapReduce(identity)(_ => 1)(_ + _)
+   *  ```
+   *
+   *  $willForceEvaluation
+   */
   def groupMapReduce[K, B](key: A => K)(f: A => B)(reduce: (B, B) => B): immutable.Map[K, B] = {
     val m = mutable.Map.empty[K, B]
     for (elem <- this) {
@@ -640,35 +635,35 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
   }
 
   /** Computes a prefix scan of the elements of the collection.
-    *
-    *  Note: The neutral element `z` may be applied more than once.
-    *
-    *  @tparam B         element type of the resulting collection
-    *  @param z          neutral element for the operator `op`
-    *  @param op         the associative operator for the scan
-    *
-    *  @return           a new $coll containing the prefix scan of the elements in this $coll
-    */
+   *
+   *  Note: The neutral element `z` may be applied more than once.
+   *
+   *  @tparam B         element type of the resulting collection
+   *  @param z          neutral element for the operator `op`
+   *  @param op         the associative operator for the scan
+   *
+   *  @return           a new $coll containing the prefix scan of the elements in this $coll
+   */
   def scan[B >: A](z: B)(op: (B, B) => B): CC[B]^{this, op} = scanLeft(z)(op)
 
   def scanLeft[B](z: B)(op: (B, A) => B): CC[B]^{this, op} = iterableFactory.from(new View.ScanLeft(this, z, op))
 
   /** Produces a collection containing cumulative results of applying the operator going right to left.
-    *  The head of the collection is the last cumulative result.
-    *  $willNotTerminateInf
-    *  $orderDependent
-    *  $willForceEvaluation
-    *
-    *  Example:
-    *  {{{
-    *    List(1, 2, 3, 4).scanRight(0)(_ + _) == List(10, 9, 7, 4, 0)
-    *  }}}
-    *
-    *  @tparam B      the type of the elements in the resulting collection
-    *  @param z       the initial value
-    *  @param op      the binary operator applied to the intermediate result and the element
-    *  @return        collection with intermediate results
-    */
+   *  The head of the collection is the last cumulative result.
+   *  $willNotTerminateInf
+   *  $orderDependent
+   *  $willForceEvaluation
+   *
+   *  Example:
+   *  ```
+   *    List(1, 2, 3, 4).scanRight(0)(_ + _) == List(10, 9, 7, 4, 0)
+   *  ```
+   *
+   *  @tparam B      the type of the elements in the resulting collection
+   *  @param z       the initial value
+   *  @param op      the binary operator applied to the intermediate result and the element
+   *  @return        collection with intermediate results
+   */
   def scanRight[B](z: B)(op: (A, B) => B): CC[B]^{this, op} = {
     class Scanner extends runtime.AbstractFunction1[A, Unit] {
       var acc = z
@@ -693,26 +688,26 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
     iterableFactory.from(new View.Collect(this, pf))
 
   /** Applies a function `f` to each element of the $coll and returns a pair of ${coll}s: the first one
-    *  made of those values returned by `f` that were wrapped in [[scala.util.Left]], and the second
-    *  one made of those wrapped in [[scala.util.Right]].
-    *
-    *  Example:
-    *  {{{
-    *    val xs = $Coll(1, "one", 2, "two", 3, "three") partitionMap {
-    *     case i: Int => Left(i)
-    *     case s: String => Right(s)
-    *    }
-    *    // xs == ($Coll(1, 2, 3),
-    *    //        $Coll(one, two, three))
-    *  }}}
-    *
-    *  @tparam A1  the element type of the first resulting collection
-    *  @tparam A2  the element type of the second resulting collection
-    *  @param f    the 'split function' mapping the elements of this $coll to an [[scala.util.Either]]
-    *
-    *  @return     a pair of ${coll}s: the first one made of those values returned by `f` that were wrapped in [[scala.util.Left]],
-    *              and the second one made of those wrapped in [[scala.util.Right]].
-    */
+   *  made of those values returned by `f` that were wrapped in [[scala.util.Left]], and the second
+   *  one made of those wrapped in [[scala.util.Right]].
+   *
+   *  Example:
+   *  ```
+   *    val xs = $Coll(1, "one", 2, "two", 3, "three") partitionMap {
+   *     case i: Int => Left(i)
+   *     case s: String => Right(s)
+   *    }
+   *    // xs == ($Coll(1, 2, 3),
+   *    //        $Coll(one, two, three))
+   *  ```
+   *
+   *  @tparam A1  the element type of the first resulting collection
+   *  @tparam A2  the element type of the second resulting collection
+   *  @param f    the 'split function' mapping the elements of this $coll to an [[scala.util.Either]]
+   *
+   *  @return     a pair of ${coll}s: the first one made of those values returned by `f` that were wrapped in [[scala.util.Left]],
+   *              and the second one made of those wrapped in [[scala.util.Right]].
+   */
   def partitionMap[A1, A2](f: A => Either[A1, A2]): (CC[A1]^{this, f}, CC[A2]^{this, f}) = {
     val left: View[A1]^{this, f} = new LeftPartitionMapped(this, f)
     val right: View[A2]^{this, f} = new RightPartitionMapped(this, f)
@@ -723,8 +718,8 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
    *  right hand operand. The element type of the $ccoll is the most specific superclass encompassing
    *  the element types of the two operands.
    *
-   *  @param suffix   the iterable to append.
    *  @tparam B     the element type of the returned collection.
+   *  @param suffix   the iterable to append.
    *  @return       a new $coll which contains all elements
    *                of this $coll followed by all elements of `suffix`.
    */
@@ -742,8 +737,8 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
    *  by combining corresponding elements in pairs.
    *  If one of the two collections is longer than the other, its remaining elements are ignored.
    *
-   *  @param   that  The iterable providing the second half of each result pair
    *  @tparam  B     the type of the second half of the returned pairs
+   *  @param   that  The iterable providing the second half of each result pair
    *  @return        a new $ccoll containing pairs consisting of corresponding elements of this $coll and `that`.
    *                 The length of the returned collection is the minimum of the lengths of this $coll and `that`.
    */
@@ -755,40 +750,40 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
   def zipWithIndex: CC[(A @uncheckedVariance, Int)]^{this} = iterableFactory.from(new View.ZipWithIndex(this))
 
   /** Returns a $coll formed from this $coll and another iterable collection
-    *  by combining corresponding elements in pairs.
-    *  If one of the two collections is shorter than the other,
-    *  placeholder elements are used to extend the shorter collection to the length of the longer.
-    *
-    *  @param that     the iterable providing the second half of each result pair
-    *  @param thisElem the element to be used to fill up the result if this $coll is shorter than `that`.
-    *  @param thatElem the element to be used to fill up the result if `that` is shorter than this $coll.
-    *  @return        a new $coll containing pairs consisting of
-    *                 corresponding elements of this $coll and `that`. The length
-    *                 of the returned collection is the maximum of the lengths of this $coll and `that`.
-    *                 If this $coll is shorter than `that`, `thisElem` values are used to pad the result.
-    *                 If `that` is shorter than this $coll, `thatElem` values are used to pad the result.
-    */
+   *  by combining corresponding elements in pairs.
+   *  If one of the two collections is shorter than the other,
+   *  placeholder elements are used to extend the shorter collection to the length of the longer.
+   *
+   *  @param that     the iterable providing the second half of each result pair
+   *  @param thisElem the element to be used to fill up the result if this $coll is shorter than `that`.
+   *  @param thatElem the element to be used to fill up the result if `that` is shorter than this $coll.
+   *  @return        a new $coll containing pairs consisting of
+   *                 corresponding elements of this $coll and `that`. The length
+   *                 of the returned collection is the maximum of the lengths of this $coll and `that`.
+   *                 If this $coll is shorter than `that`, `thisElem` values are used to pad the result.
+   *                 If `that` is shorter than this $coll, `thatElem` values are used to pad the result.
+   */
   def zipAll[A1 >: A, B](that: Iterable[B]^, thisElem: A1, thatElem: B): CC[(A1, B)]^{this, that} = iterableFactory.from(new View.ZipAll(this, that, thisElem, thatElem))
 
   /** Converts this $coll of pairs into two collections of the first and second
-    *  half of each pair.
-    *
-    *    {{{
-    *    val xs = $Coll(
-    *               (1, "one"),
-    *               (2, "two"),
-    *               (3, "three")).unzip
-    *    // xs == ($Coll(1, 2, 3),
-    *    //        $Coll(one, two, three))
-    *    }}}
-    *
-    *  @tparam A1    the type of the first half of the element pairs
-    *  @tparam A2    the type of the second half of the element pairs
-    *  @param asPair an implicit conversion which asserts that the element type
-    *                of this $coll is a pair.
-    *  @return       a pair of ${coll}s, containing the first, respectively second
-    *                half of each element pair of this $coll.
-    */
+   *  half of each pair.
+   *
+   *    ```
+   *    val xs = $Coll(
+   *               (1, "one"),
+   *               (2, "two"),
+   *               (3, "three")).unzip
+   *    // xs == ($Coll(1, 2, 3),
+   *    //        $Coll(one, two, three))
+   *    ```
+   *
+   *  @tparam A1    the type of the first half of the element pairs
+   *  @tparam A2    the type of the second half of the element pairs
+   *  @param asPair an implicit conversion which asserts that the element type
+   *                of this $coll is a pair.
+   *  @return       a pair of ${coll}s, containing the first, respectively second
+   *                half of each element pair of this $coll.
+   */
   def unzip[A1, A2](implicit asPair: A -> (A1, A2)): (CC[A1]^{this}, CC[A2]^{this}) = {
     val first: View[A1]^{this} = new View.Map[A, A1](this, asPair(_)._1)
     val second: View[A2]^{this} = new View.Map[A, A2](this, asPair(_)._2)
@@ -796,26 +791,26 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
   }
 
   /** Converts this $coll of triples into three collections of the first, second,
-    *  and third element of each triple.
-    *
-    *    {{{
-    *    val xs = $Coll(
-    *               (1, "one", '1'),
-    *               (2, "two", '2'),
-    *               (3, "three", '3')).unzip3
-    *    // xs == ($Coll(1, 2, 3),
-    *    //        $Coll(one, two, three),
-    *    //        $Coll(1, 2, 3))
-    *    }}}
-    *
-    *  @tparam A1       the type of the first member of the element triples
-    *  @tparam A2       the type of the second member of the element triples
-    *  @tparam A3       the type of the third member of the element triples
-    *  @param asTriple  an implicit conversion which asserts that the element type
-    *                   of this $coll is a triple.
-    *  @return          a triple of ${coll}s, containing the first, second, respectively
-    *                   third member of each element triple of this $coll.
-    */
+   *  and third element of each triple.
+   *
+   *    ```
+   *    val xs = $Coll(
+   *               (1, "one", '1'),
+   *               (2, "two", '2'),
+   *               (3, "three", '3')).unzip3
+   *    // xs == ($Coll(1, 2, 3),
+   *    //        $Coll(one, two, three),
+   *    //        $Coll(1, 2, 3))
+   *    ```
+   *
+   *  @tparam A1       the type of the first member of the element triples
+   *  @tparam A2       the type of the second member of the element triples
+   *  @tparam A3       the type of the third member of the element triples
+   *  @param asTriple  an implicit conversion which asserts that the element type
+   *                   of this $coll is a triple.
+   *  @return          a triple of ${coll}s, containing the first, second, respectively
+   *                   third member of each element triple of this $coll.
+   */
   def unzip3[A1, A2, A3](implicit asTriple: A -> (A1, A2, A3)): (CC[A1]^{this}, CC[A2]^{this}, CC[A3]^{this}) = {
     val first: View[A1]^{this} = new View.Map[A, A1](this, asTriple(_)._1)
     val second: View[A2]^{this} = new View.Map[A, A2](this, asTriple(_)._2)
@@ -824,23 +819,23 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
   }
 
   /** Iterates over the tails of this $coll. The first value will be this
-    *  $coll and the final one will be an empty $coll, with the intervening
-    *  values the results of successive applications of `tail`.
-    *
-    *  @return   an iterator over all the tails of this $coll
-    *  @example  `List(1,2,3).tails = Iterator(List(1,2,3), List(2,3), List(3), Nil)`
-    */
+   *  $coll and the final one will be an empty $coll, with the intervening
+   *  values the results of successive applications of `tail`.
+   *
+   *  @return   an iterator over all the tails of this $coll
+   *  @example  `List(1,2,3).tails = Iterator(List(1,2,3), List(2,3), List(3), Nil)`
+   */
   def tails: Iterator[C^{this}]^{this} = iterateUntilEmpty(_.tail)
 
   /** Iterates over the inits of this $coll. The first value will be this
-    *  $coll and the final one will be an empty $coll, with the intervening
-    *  values the results of successive applications of `init`.
-    *
-    *  $willForceEvaluation
-    *
-    *  @return  an iterator over all the inits of this $coll
-    *  @example  `List(1,2,3).inits = Iterator(List(1,2,3), List(1,2), List(1), Nil)`
-    */
+   *  $coll and the final one will be an empty $coll, with the intervening
+   *  values the results of successive applications of `init`.
+   *
+   *  $willForceEvaluation
+   *
+   *  @return  an iterator over all the inits of this $coll
+   *  @example  `List(1,2,3).inits = Iterator(List(1,2,3), List(1,2), List(1), Nil)`
+   */
   def inits: Iterator[C^{this}]^{this} = iterateUntilEmpty(_.init)
 
   override def tapEach[U](f: A => U): C^{this, f} = fromSpecific(new View.Map(this, { (a: A) => f(a); a }))
@@ -864,10 +859,10 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
 object IterableOps {
 
   /** Operations for comparing the size of a collection to a test value.
-    *
-    * These operations are implemented in terms of
-    * [[scala.collection.IterableOps!.sizeCompare(Int):Int* `sizeCompare(Int)`]]
-    */
+   *
+   *  These operations are implemented in terms of
+   *  [[scala.collection.IterableOps!.sizeCompare(Int):Int* `sizeCompare(Int)`]]
+   */
   final class SizeCompareOps private[collection](val it: IterableOps[?, AnyConstr, ?]) extends AnyVal {
     // CC Problem: if we add the logically needed `^`s to the `it` parameter and the
     // self type, separation checking fails in the compiler-generated equals$extends
@@ -891,13 +886,13 @@ object IterableOps {
   }
 
   /** A trait that contains just the `map`, `flatMap`, `foreach` and `withFilter` methods
-    * of trait `Iterable`.
-    *
-    * @tparam A Element type (e.g. `Int`)
-    * @tparam CC Collection type constructor (e.g. `List`)
-    *
-    * @define coll collection
-    */
+   *  of trait `Iterable`.
+   *
+   *  @tparam A Element type (e.g. `Int`)
+   *  @tparam CC Collection type constructor (e.g. `List`)
+   *
+   *  @define coll collection
+   */
   @SerialVersionUID(3L)
   class WithFilter[+A, +CC[_]](
     self: IterableOps[A, CC, ?]^,
@@ -946,12 +941,12 @@ object Iterable extends IterableFactory.Delegate[Iterable](immutable.Iterable) {
 abstract class AbstractIterable[+A] extends Iterable[A]
 
 /** This trait provides default implementations for the factory methods `fromSpecific` and
-  * `newSpecificBuilder` that need to be refined when implementing a collection type that refines
-  * the `CC` and `C` type parameters.
-  *
-  * The default implementations in this trait can be used in the common case when `CC[A]` is the
-  * same as `C`.
-  */
+ *  `newSpecificBuilder` that need to be refined when implementing a collection type that refines
+ *  the `CC` and `C` type parameters.
+ *
+ *  The default implementations in this trait can be used in the common case when `CC[A]` is the
+ *  same as `C`.
+ */
 trait IterableFactoryDefaults[+A, +CC[x] <: IterableOps[x, CC, CC[x]]] extends IterableOps[A, CC, CC[A @uncheckedVariance]] {
   protected def fromSpecific(coll: IterableOnce[A @uncheckedVariance]^): CC[A @uncheckedVariance]^{coll} = iterableFactory.from(coll)
   protected def newSpecificBuilder: Builder[A @uncheckedVariance, CC[A @uncheckedVariance]] = iterableFactory.newBuilder[A]
@@ -961,13 +956,13 @@ trait IterableFactoryDefaults[+A, +CC[x] <: IterableOps[x, CC, CC[x]]] extends I
 }
 
 /** This trait provides default implementations for the factory methods `fromSpecific` and
-  * `newSpecificBuilder` that need to be refined when implementing a collection type that refines
-  * the `CC` and `C` type parameters. It is used for collections that have an additional constraint,
-  * expressed by the `evidenceIterableFactory` method.
-  *
-  * The default implementations in this trait can be used in the common case when `CC[A]` is the
-  * same as `C`.
-  */
+ *  `newSpecificBuilder` that need to be refined when implementing a collection type that refines
+ *  the `CC` and `C` type parameters. It is used for collections that have an additional constraint,
+ *  expressed by the `evidenceIterableFactory` method.
+ *
+ *  The default implementations in this trait can be used in the common case when `CC[A]` is the
+ *  same as `C`.
+ */
 trait EvidenceIterableFactoryDefaults[+A, +CC[x] <: IterableOps[x, CC, CC[x]], Ev[_]] extends IterableOps[A, CC, CC[A @uncheckedVariance]] {
   protected def evidenceIterableFactory: EvidenceIterableFactory[CC, Ev]
   implicit protected def iterableEvidence: Ev[A @uncheckedVariance]
@@ -977,17 +972,17 @@ trait EvidenceIterableFactoryDefaults[+A, +CC[x] <: IterableOps[x, CC, CC[x]], E
 }
 
 /** This trait provides default implementations for the factory methods `fromSpecific` and
-  * `newSpecificBuilder` that need to be refined when implementing a collection type that refines
-  * the `CC` and `C` type parameters. It is used for sorted sets.
-  *
-  * Note that in sorted sets, the `CC` type of the set is not the same as the `CC` type for the
-  * underlying iterable (which is fixed to `Set` in [[SortedSetOps]]). This trait has therefore
-  * two type parameters `CC` and `WithFilterCC`. The `withFilter` method inherited from
-  * `IterableOps` is overridden with a compatible default implementation.
-  *
-  * The default implementations in this trait can be used in the common case when `CC[A]` is the
-  * same as `C`.
-  */
+ *  `newSpecificBuilder` that need to be refined when implementing a collection type that refines
+ *  the `CC` and `C` type parameters. It is used for sorted sets.
+ *
+ *  Note that in sorted sets, the `CC` type of the set is not the same as the `CC` type for the
+ *  underlying iterable (which is fixed to `Set` in [[SortedSetOps]]). This trait has therefore
+ *  two type parameters `CC` and `WithFilterCC`. The `withFilter` method inherited from
+ *  `IterableOps` is overridden with a compatible default implementation.
+ *
+ *  The default implementations in this trait can be used in the common case when `CC[A]` is the
+ *  same as `C`.
+ */
 trait SortedSetFactoryDefaults[+A,
     +CC[X] <: SortedSet[X] & SortedSetOps[X, CC, CC[X]],
     +WithFilterCC[x] <: IterableOps[x, WithFilterCC, WithFilterCC[x]] & Set[x]] extends SortedSetOps[A @uncheckedVariance, CC, CC[A @uncheckedVariance]] {
@@ -1003,17 +998,17 @@ trait SortedSetFactoryDefaults[+A,
 
 
 /** This trait provides default implementations for the factory methods `fromSpecific` and
-  * `newSpecificBuilder` that need to be refined when implementing a collection type that refines
-  * the `CC` and `C` type parameters. It is used for maps.
-  *
-  * Note that in maps, the `CC` type of the map is not the same as the `CC` type for the
-  * underlying iterable (which is fixed to `Map` in [[MapOps]]). This trait has therefore
-  * two type parameters `CC` and `WithFilterCC`. The `withFilter` method inherited from
-  * `IterableOps` is overridden with a compatible default implementation.
-  *
-  * The default implementations in this trait can be used in the common case when `CC[A]` is the
-  * same as `C`.
-  */
+ *  `newSpecificBuilder` that need to be refined when implementing a collection type that refines
+ *  the `CC` and `C` type parameters. It is used for maps.
+ *
+ *  Note that in maps, the `CC` type of the map is not the same as the `CC` type for the
+ *  underlying iterable (which is fixed to `Map` in [[MapOps]]). This trait has therefore
+ *  two type parameters `CC` and `WithFilterCC`. The `withFilter` method inherited from
+ *  `IterableOps` is overridden with a compatible default implementation.
+ *
+ *  The default implementations in this trait can be used in the common case when `CC[A]` is the
+ *  same as `C`.
+ */
 trait MapFactoryDefaults[K, +V,
     +CC[x, y] <: IterableOps[(x, y), Iterable, Iterable[(x, y)]],
     +WithFilterCC[x] <: IterableOps[x, WithFilterCC, WithFilterCC[x]] & Iterable[x]] extends MapOps[K, V, CC, CC[K, V @uncheckedVariance]] with IterableOps[(K, V), WithFilterCC, CC[K, V @uncheckedVariance]] {
@@ -1031,17 +1026,17 @@ trait MapFactoryDefaults[K, +V,
 }
 
 /** This trait provides default implementations for the factory methods `fromSpecific` and
-  * `newSpecificBuilder` that need to be refined when implementing a collection type that refines
-  * the `CC` and `C` type parameters. It is used for sorted maps.
-  *
-  * Note that in sorted maps, the `CC` type of the map is not the same as the `CC` type for the
-  * underlying map (which is fixed to `Map` in [[SortedMapOps]]). This trait has therefore
-  * three type parameters `CC`, `WithFilterCC` and `UnsortedCC`. The `withFilter` method inherited
-  * from `IterableOps` is overridden with a compatible default implementation.
-  *
-  * The default implementations in this trait can be used in the common case when `CC[A]` is the
-  * same as `C`.
-  */
+ *  `newSpecificBuilder` that need to be refined when implementing a collection type that refines
+ *  the `CC` and `C` type parameters. It is used for sorted maps.
+ *
+ *  Note that in sorted maps, the `CC` type of the map is not the same as the `CC` type for the
+ *  underlying map (which is fixed to `Map` in [[SortedMapOps]]). This trait has therefore
+ *  three type parameters `CC`, `WithFilterCC` and `UnsortedCC`. The `withFilter` method inherited
+ *  from `IterableOps` is overridden with a compatible default implementation.
+ *
+ *  The default implementations in this trait can be used in the common case when `CC[A]` is the
+ *  same as `C`.
+ */
 trait SortedMapFactoryDefaults[K, +V,
     +CC[x, y] <:  Map[x, y] & SortedMapOps[x, y, CC, CC[x, y]] & UnsortedCC[x, y],
     +WithFilterCC[x] <: IterableOps[x, WithFilterCC, WithFilterCC[x]] & Iterable[x],

--- a/library/src/scala/collection/Iterator.scala
+++ b/library/src/scala/collection/Iterator.scala
@@ -22,106 +22,106 @@ import scala.runtime.Statics
 import caps.unsafe.untrackedCaptures
 
 /** Iterators are data structures that allow to iterate over a sequence
-  * of elements. They have a `hasNext` method for checking
-  * if there is a next element available, and a `next` method
-  * which returns the next element and advances the iterator.
-  *
-  * An iterator is mutable: most operations on it change its state. While it is often used
-  * to iterate through the elements of a collection, it can also be used without
-  * being backed by any collection (see constructors on the companion object).
-  *
-  * It is of particular importance to note that, unless stated otherwise, ''one should never
-  * use an iterator after calling a method on it''. The two most important exceptions
-  * are also the sole abstract methods: `next` and `hasNext`.
-  *
-  * Both these methods can be called any number of times without having to discard the
-  * iterator. Note that even `hasNext` may cause mutation -- such as when iterating
-  * from an input stream, where it will block until the stream is closed or some
-  * input becomes available.
-  *
-  * Consider this example for safe and unsafe use:
-  *
-  * {{{
-  * def f[A](it: Iterator[A]) = {
-  *   if (it.hasNext) {            // Safe to reuse "it" after "hasNext"
-  *     it.next()                  // Safe to reuse "it" after "next"
-  *     val remainder = it.drop(2) // it is *not* safe to use "it" again after this line!
-  *     remainder.take(2)          // it is *not* safe to use "remainder" after this line!
-  *   } else it
-  * }
-  * }}}
-  *
-  * @define mayNotTerminateInf
-  *  Note: may not terminate for infinite iterators.
-  * @define preservesIterator
-  *  The iterator remains valid for further use whatever result is returned.
-  * @define consumesIterator
-  *  After calling this method, one should discard the iterator it was called
-  *  on. Using it is undefined and subject to change.
-  * @define consumesAndProducesIterator
-  *  After calling this method, one should discard the iterator it was called
-  *  on, and use only the iterator that was returned. Using the old iterator
-  *  is undefined, subject to change, and may result in changes to the new
-  *  iterator as well.
-  * @define consumesTwoAndProducesOneIterator
-  *  After calling this method, one should discard the iterator it was called
-  *  on, as well as the one passed as a parameter, and use only the iterator
-  *  that was returned. Using the old iterators is undefined, subject to change,
-  *  and may result in changes to the new iterator as well.
-  * @define consumesOneAndProducesTwoIterators
-  *  After calling this method, one should discard the iterator it was called
-  *  on, and use only the iterators that were returned. Using the old iterator
-  *  is undefined, subject to change, and may result in changes to the new
-  *  iterators as well.
-  * @define coll iterator
-  */
+ *  of elements. They have a `hasNext` method for checking
+ *  if there is a next element available, and a `next` method
+ *  which returns the next element and advances the iterator.
+ *
+ *  An iterator is mutable: most operations on it change its state. While it is often used
+ *  to iterate through the elements of a collection, it can also be used without
+ *  being backed by any collection (see constructors on the companion object).
+ *
+ *  It is of particular importance to note that, unless stated otherwise, ''one should never
+ *  use an iterator after calling a method on it''. The two most important exceptions
+ *  are also the sole abstract methods: `next` and `hasNext`.
+ *
+ *  Both these methods can be called any number of times without having to discard the
+ *  iterator. Note that even `hasNext` may cause mutation -- such as when iterating
+ *  from an input stream, where it will block until the stream is closed or some
+ *  input becomes available.
+ *
+ *  Consider this example for safe and unsafe use:
+ *
+ *  ```
+ *  def f[A](it: Iterator[A]) = {
+ *   if (it.hasNext) {            // Safe to reuse "it" after "hasNext"
+ *     it.next()                  // Safe to reuse "it" after "next"
+ *     val remainder = it.drop(2) // it is *not* safe to use "it" again after this line!
+ *     remainder.take(2)          // it is *not* safe to use "remainder" after this line!
+ *   } else it
+ *  }
+ *  ```
+ *
+ *  @define mayNotTerminateInf
+ *  Note: may not terminate for infinite iterators.
+ *  @define preservesIterator
+ *  The iterator remains valid for further use whatever result is returned.
+ *  @define consumesIterator
+ *  After calling this method, one should discard the iterator it was called
+ *  on. Using it is undefined and subject to change.
+ *  @define consumesAndProducesIterator
+ *  After calling this method, one should discard the iterator it was called
+ *  on, and use only the iterator that was returned. Using the old iterator
+ *  is undefined, subject to change, and may result in changes to the new
+ *  iterator as well.
+ *  @define consumesTwoAndProducesOneIterator
+ *  After calling this method, one should discard the iterator it was called
+ *  on, as well as the one passed as a parameter, and use only the iterator
+ *  that was returned. Using the old iterators is undefined, subject to change,
+ *  and may result in changes to the new iterator as well.
+ *  @define consumesOneAndProducesTwoIterators
+ *  After calling this method, one should discard the iterator it was called
+ *  on, and use only the iterators that were returned. Using the old iterator
+ *  is undefined, subject to change, and may result in changes to the new
+ *  iterators as well.
+ *  @define coll iterator
+ */
 trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Iterator[A]] {
   self: Iterator[A]^ =>
 
   /** Checks if there is a next element available.
-    *
-    * @return `true` if there is a next element, `false` otherwise
-    * @note   Reuse: $preservesIterator
-    */
+   *
+   *  @return `true` if there is a next element, `false` otherwise
+   *  @note   Reuse: $preservesIterator
+   */
   def hasNext: Boolean
 
   @deprecated("hasDefiniteSize on Iterator is the same as isEmpty", "2.13.0")
   @`inline` override final def hasDefiniteSize = isEmpty
 
   /** Returns the next element and advance the iterator.
-    *
-    * @throws NoSuchElementException if there is no next element.
-    * @return the next element.
-    * @note   Reuse: Advances the iterator, which may exhaust the elements. It is valid to
-    *         make additional calls on the iterator.
-    */
+   *
+   *  @return the next element.
+   *  @throws NoSuchElementException if there is no next element.
+   *  @note   Reuse: Advances the iterator, which may exhaust the elements. It is valid to
+   *         make additional calls on the iterator.
+   */
   @throws[NoSuchElementException]
   def next(): A
 
   @inline final def iterator = this
 
   /** Wraps the value of `next()` in an option.
-    *
-    * @return `Some(next)` if a next element exists, `None` otherwise.
-    */
+   *
+   *  @return `Some(next)` if a next element exists, `None` otherwise.
+   */
   def nextOption(): Option[A] = if (hasNext) Some(next()) else None
 
   /** Tests whether this iterator contains a given value as an element.
-    *  $mayNotTerminateInf
-    *
-    *  @param elem  the element to test.
-    *  @return     `true` if this iterator produces some value that is
-    *               is equal (as determined by `==`) to `elem`, `false` otherwise.
-    *  @note        Reuse: $consumesIterator
-    */
+   *  $mayNotTerminateInf
+   *
+   *  @param elem  the element to test.
+   *  @return     `true` if this iterator produces some value that is
+   *               is equal (as determined by `==`) to `elem`, `false` otherwise.
+   *  @note        Reuse: $consumesIterator
+   */
   def contains(elem: Any): Boolean = exists(_ == elem)    // Note--this seems faster than manual inlining!
 
   /** Creates a buffered iterator from this iterator.
-    *
-    *  @see [[scala.collection.BufferedIterator]]
-    *  @return  a buffered iterator producing the same values as this iterator.
-    *  @note    Reuse: $consumesAndProducesIterator
-    */
+   *
+   *  @see [[scala.collection.BufferedIterator]]
+   *  @return  a buffered iterator producing the same values as this iterator.
+   *  @note    Reuse: $consumesAndProducesIterator
+   */
   def buffered: BufferedIterator[A]^{this} = new AbstractIterator[A] with BufferedIterator[A] {
     private var hd: A = compiletime.uninitialized
     private var hdDefined: Boolean = false
@@ -185,7 +185,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
      *  The by-name argument is evaluated for each fill element.
      *
      *  @param x The element that will be appended to the last segment, if necessary.
-     *  @return  The same iterator, and ''not'' a new iterator.
+     *  @return  The same iterator, and *not* a new iterator.
      *  @note    This method mutates the iterator it is called on, which can be safely used afterwards.
      *  @note    This method is mutually exclusive with `withPartial`.
      *  @group Configuration
@@ -207,7 +207,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
      *  A partial segment is either retained or dropped, per the flag.
      *
      *  @param x `true` if partial segments may be returned, `false` otherwise.
-     *  @return  The same iterator, and ''not'' a new iterator.
+     *  @return  The same iterator, and *not* a new iterator.
      *  @note    This method mutates the iterator it is called on, which can be safely used afterwards.
      *  @note    This method is mutually exclusive with `withPadding`.
      *  @group Configuration
@@ -290,9 +290,9 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
 
   /** A copy of this $coll with an element value appended until a given target length is reached.
    *
+   *  @tparam B      the element type of the returned $coll.
    *  @param   len   the target length
    *  @param   elem  the padding value
-   *  @tparam B      the element type of the returned $coll.
    *  @return a new $coll consisting of
    *          all elements of this $coll followed by the minimal number of occurrences of `elem` so
    *          that the resulting collection has a length of at least `len`.
@@ -334,7 +334,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
 
   /** Returns an iterator which groups this iterator into fixed size
    *  blocks.  Example usages:
-   *  {{{
+   *  ```
    *    // Returns List(List(1, 2, 3), List(4, 5, 6), List(7)))
    *    (1 to 7).iterator.grouped(3).toList
    *    // Returns List(List(1, 2, 3), List(4, 5, 6))
@@ -343,7 +343,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
    *    // Illustrating that withPadding's argument is by-name.
    *    val it2 = Iterator.iterate(20)(_ + 5)
    *    (1 to 7).iterator.grouped(3).withPadding(it2.next).toList
-   *  }}}
+   *  ```
    *
    *  @note Reuse: $consumesAndProducesIterator
    */
@@ -360,7 +360,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
    *  result entirely.
    *
    *  Example usages:
-   *  {{{
+   *  ```
    *    // Returns List(ArraySeq(1, 2, 3), ArraySeq(2, 3, 4), ArraySeq(3, 4, 5))
    *    (1 to 5).iterator.sliding(3).toList
    *    // Returns List(ArraySeq(1, 2, 3, 4), ArraySeq(4, 5))
@@ -371,7 +371,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
    *    // Illustrating that withPadding's argument is by-name.
    *    val it2 = Iterator.iterate(20)(_ + 5)
    *    (1 to 5).iterator.sliding(4, 3).withPadding(it2.next).toList
-   *  }}}
+   *  ```
    *
    *  @param size the number of elements per group
    *  @param step the distance between the first elements of successive
@@ -421,15 +421,15 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
   def scanRight[B](z: B)(op: (A, B) => B): Iterator[B]^{this, op} = ArrayBuffer.from(this).scanRight(z)(op).iterator
 
   /** Finds index of the first element satisfying some predicate after or at some start index.
-    *
-    *  $mayNotTerminateInf
-    *
-    *  @param  p     the predicate used to test elements.
-    *  @param  from   the start index
-    *  @return the index `>= from` of the first element of this $coll that satisfies the predicate `p`,
-    *           or `-1`, if none exists.
-    *  @note   Reuse: $consumesIterator
-    */
+   *
+   *  $mayNotTerminateInf
+   *
+   *  @param  p     the predicate used to test elements.
+   *  @param  from   the start index
+   *  @return the index `>= from` of the first element of this $coll that satisfies the predicate `p`,
+   *           or `-1`, if none exists.
+   *  @note   Reuse: $consumesIterator
+   */
   def indexWhere(p: A => Boolean, from: Int = 0): Int = {
     var i = math.max(from, 0)
     val dropped = drop(from)
@@ -441,27 +441,27 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
   }
 
   /** Returns the index of the first occurrence of the specified
-    *  object in this iterable object.
-    *  $mayNotTerminateInf
-    *
-    *  @param  elem  element to search for.
-    *  @return the index of the first occurrence of `elem` in the values produced by this iterator,
-    *          or -1 if such an element does not exist until the end of the iterator is reached.
-    *  @note   Reuse: $consumesIterator
-    */
+   *  object in this iterable object.
+   *  $mayNotTerminateInf
+   *
+   *  @param  elem  element to search for.
+   *  @return the index of the first occurrence of `elem` in the values produced by this iterator,
+   *          or -1 if such an element does not exist until the end of the iterator is reached.
+   *  @note   Reuse: $consumesIterator
+   */
   def indexOf[B >: A](elem: B): Int = indexOf(elem, 0)
 
   /** Returns the index of the first occurrence of the specified object in this iterable object
-    *  after or at some start index.
-    *  $mayNotTerminateInf
-    *
-    *  @param elem element to search for.
-    *  @param from the start index
-    *  @return the index `>= from` of the first occurrence of `elem` in the values produced by this
-    *          iterator, or -1 if such an element does not exist until the end of the iterator is
-    *          reached.
-    *  @note   Reuse: $consumesIterator
-    */
+   *  after or at some start index.
+   *  $mayNotTerminateInf
+   *
+   *  @param elem element to search for.
+   *  @param from the start index
+   *  @return the index `>= from` of the first occurrence of `elem` in the values produced by this
+   *          iterator, or -1 if such an element does not exist until the end of the iterator is
+   *          reached.
+   *  @note   Reuse: $consumesIterator
+   */
   def indexOf[B >: A](elem: B, from: Int): Int = {
     var i = 0
     while (i < from && hasNext) {
@@ -509,16 +509,16 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
   }
 
   /** Creates an iterator over all the elements of this iterator that
-    *  satisfy the predicate `p`. The order of the elements
-    *  is preserved.
-    *
-    *  '''Note:''' `withFilter` is the same as `filter` on iterators. It exists so that
-    *  for-expressions with filters work over iterators.
-    *
-    *  @param p the predicate used to test values.
-    *  @return  an iterator which produces those values of this iterator which satisfy the predicate `p`.
-    *  @note    Reuse: $consumesAndProducesIterator
-    */
+   *  satisfy the predicate `p`. The order of the elements
+   *  is preserved.
+   *
+   *  **Note:** `withFilter` is the same as `filter` on iterators. It exists so that
+   *  for-expressions with filters work over iterators.
+   *
+   *  @param p the predicate used to test values.
+   *  @return  an iterator which produces those values of this iterator which satisfy the predicate `p`.
+   *  @note    Reuse: $consumesAndProducesIterator
+   */
   def withFilter(p: A => Boolean): Iterator[A]^{this, p} = filter(p)
 
   def collect[B](pf: PartialFunction[A, B]^): Iterator[B]^{this, pf} = new AbstractIterator[B] with (A => B) {
@@ -551,24 +551,22 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     def next() = if (hasNext) { status = 0/*Seek*/; hd } else Iterator.empty.next()
   }
 
-  /**
-    *  Builds a new iterator from this one without any duplicated elements on it.
-    *  @return iterator with distinct elements
-    *
-    *  @note   Reuse: $consumesIterator
-    */
+  /** Builds a new iterator from this one without any duplicated elements on it.
+   *  @return iterator with distinct elements
+   *
+   *  @note   Reuse: $consumesIterator
+   */
   def distinct: Iterator[A]^{this} = distinctBy(identity)
 
-  /**
-    *  Builds a new iterator from this one without any duplicated elements as determined by `==` after applying
-    *  the transforming function `f`.
-    *
-    *  @param f The transforming function whose result is used to determine the uniqueness of each element
-    *  @tparam B the type of the elements after being transformed by `f`
-    *  @return iterator with distinct elements
-    *
-    *  @note   Reuse: $consumesIterator
-    */
+  /** Builds a new iterator from this one without any duplicated elements as determined by `==` after applying
+   *  the transforming function `f`.
+   *
+   *  @tparam B the type of the elements after being transformed by `f`
+   *  @param f The transforming function whose result is used to determine the uniqueness of each element
+   *  @return iterator with distinct elements
+   *
+   *  @note   Reuse: $consumesIterator
+   */
   def distinctBy[B](f: A -> B): Iterator[A]^{this} = new AbstractIterator[A] {
 
     private val traversedValues = mutable.HashSet.empty[B]
@@ -691,11 +689,10 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
       else Iterator.empty.next()
   }
 
-  /**
-    * @inheritdoc
-    *
-    * @note    Reuse: $consumesOneAndProducesTwoIterators
-    */
+  /** @inheritdoc
+   *
+   *  @note    Reuse: $consumesOneAndProducesTwoIterators
+   */
   def span(p: A => Boolean): (Iterator[A]^{this, p}, Iterator[A]^{this, p}) = {
     /*
      * Giving a name to following iterator (as opposed to trailing) because
@@ -847,8 +844,8 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
   /** Checks whether corresponding elements of the given iterable collection
    *  compare equal (with respect to `==`) to elements of this $coll.
    *
-   *  @param that  the collection to compare
    *  @tparam B    the type of the elements of collection `that`.
+   *  @param that  the collection to compare
    *  @return `true` if both collections contain equal elements in the same order, `false` otherwise.
    */
   def sameElements[B >: A](that: IterableOnce[B]^): Boolean = {
@@ -861,18 +858,18 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
   }
 
   /** Creates two new iterators that both iterate over the same elements
-    *  as this iterator (in the same order).  The duplicate iterators are
-    *  considered equal if they are positioned at the same element.
-    *
-    *  Given that most methods on iterators will make the original iterator
-    *  unfit for further use, this methods provides a reliable way of calling
-    *  multiple such methods on an iterator.
-    *
-    *  @return a pair of iterators
-    *  @note   The implementation may allocate temporary storage for elements
-    *          iterated by one iterator but not yet by the other.
-    *  @note   Reuse: $consumesOneAndProducesTwoIterators
-    */
+   *  as this iterator (in the same order).  The duplicate iterators are
+   *  considered equal if they are positioned at the same element.
+   *
+   *  Given that most methods on iterators will make the original iterator
+   *  unfit for further use, this methods provides a reliable way of calling
+   *  multiple such methods on an iterator.
+   *
+   *  @return a pair of iterators
+   *  @note   The implementation may allocate temporary storage for elements
+   *          iterated by one iterator but not yet by the other.
+   *  @note   Reuse: $consumesOneAndProducesTwoIterators
+   */
   def duplicate: (Iterator[A]^{this}, Iterator[A]^{this}) = {
     val gap = new scala.collection.mutable.Queue[A]
     var ahead: (Iterator[A]^{this}) | Null = null
@@ -909,15 +906,15 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
   }
 
   /** Returns this iterator with patched values.
-    * Patching at negative indices is the same as patching starting at 0.
-    * Patching at indices at or larger than the length of the original iterator appends the patch to the end.
-    * If more values are replaced than actually exist, the excess is ignored.
-    *
-    *  @param from       The start index from which to patch
-    *  @param patchElems The iterator of patch values
-    *  @param replaced   The number of values in the original iterator that are replaced by the patch.
-    *  @note           Reuse: $consumesTwoAndProducesOneIterator
-    */
+   *  Patching at negative indices is the same as patching starting at 0.
+   *  Patching at indices at or larger than the length of the original iterator appends the patch to the end.
+   *  If more values are replaced than actually exist, the excess is ignored.
+   *
+   *  @param from       The start index from which to patch
+   *  @param patchElems The iterator of patch values
+   *  @param replaced   The number of values in the original iterator that are replaced by the patch.
+   *  @note           Reuse: $consumesTwoAndProducesOneIterator
+   */
   def patch[B >: A](from: Int, patchElems: Iterator[B]^, replaced: Int): Iterator[B]^{this, patchElems} =
     new AbstractIterator[B] {
       // TODO We should be able to prove that origElems is safe even though it is
@@ -995,11 +992,11 @@ object Iterator extends IterableFactory[Iterator] {
   }
 
   /** Creates a target $coll from an existing source collection
-    *
-    * @param source Source collection
-    * @tparam A the type of the collection’s elements
-    * @return a new $coll with the elements of `source`
-    */
+   *
+   *  @tparam A the type of the collection’s elements
+   *  @param source Source collection
+   *  @return a new $coll with the elements of `source`
+   */
   override def from[A](source: IterableOnce[A]^): Iterator[A]^{source} = source.iterator
 
   /** The iterator which produces no values. */
@@ -1017,20 +1014,20 @@ object Iterator extends IterableFactory[Iterator] {
   override def apply[A](xs: A*): Iterator[A] = xs.iterator
 
   /**
-    * @return A builder for $Coll objects.
-    * @tparam A the type of the ${coll}’s elements
-    */
+   *  @tparam A the type of the ${coll}’s elements
+   *  @return A builder for $Coll objects.
+   */
   def newBuilder[A]: Builder[A, Iterator[A]] =
     new ImmutableBuilder[A, Iterator[A]](empty[A]) {
       override def addOne(elem: A): this.type = { elems = elems ++ single(elem); this }
     }
 
   /** Creates iterator that produces the results of some element computation a number of times.
-    *
-    *  @param   len  the number of elements returned by the iterator.
-    *  @param   elem the element computation
-    *  @return  An iterator that produces the results of `n` evaluations of `elem`.
-    */
+   *
+   *  @param   len  the number of elements returned by the iterator.
+   *  @param   elem the element computation
+   *  @return  An iterator that produces the results of `n` evaluations of `elem`.
+   */
   override def fill[A](len: Int)(elem: => A): Iterator[A]^{elem} = new AbstractIterator[A] {
     private var i = 0
     override def knownSize: Int = (len - i) max 0
@@ -1041,11 +1038,11 @@ object Iterator extends IterableFactory[Iterator] {
   }
 
   /** Creates an iterator producing the values of a given function over a range of integer values starting from 0.
-    *
-    *  @param  end The number of elements returned by the iterator
-    *  @param  f   The function computing element values
-    *  @return An iterator that produces the values `f(0), ..., f(n -1)`.
-    */
+   *
+   *  @param  end The number of elements returned by the iterator
+   *  @param  f   The function computing element values
+   *  @return An iterator that produces the values `f(0), ..., f(n -1)`.
+   */
   override def tabulate[A](end: Int)(f: Int => A): Iterator[A]^{f} = new AbstractIterator[A] {
     private var i = 0
     override def knownSize: Int = (end - i) max 0
@@ -1056,18 +1053,17 @@ object Iterator extends IterableFactory[Iterator] {
   }
 
   /** Creates an infinite-length iterator which returns successive values from some start value.
-
-    *  @param start the start value of the iterator
-    *  @return      the iterator producing the infinite sequence of values `start, start + 1, start + 2, ...`
-    */
+   *  @param start the start value of the iterator
+   *  @return      the iterator producing the infinite sequence of values `start, start + 1, start + 2, ...`
+   */
   def from(start: Int): Iterator[Int] = from(start, 1)
 
   /** Creates an infinite-length iterator returning values equally spaced apart.
-    *
-    *  @param start the start value of the iterator
-    *  @param step  the increment between successive values
-    *  @return      the iterator producing the infinite sequence of values `start, start + 1 * step, start + 2 * step, ...`
-    */
+   *
+   *  @param start the start value of the iterator
+   *  @param step  the increment between successive values
+   *  @return      the iterator producing the infinite sequence of values `start, start + 1 * step, start + 2 * step, ...`
+   */
   def from(start: Int, step: Int): Iterator[Int] = new AbstractIterator[Int] {
     private var i = start
     def hasNext: Boolean = true
@@ -1075,20 +1071,20 @@ object Iterator extends IterableFactory[Iterator] {
   }
 
   /** Creates nn iterator returning successive values in some integer interval.
-    *
-    *  @param start the start value of the iterator
-    *  @param end   the end value of the iterator (the first value NOT returned)
-    *  @return      the iterator producing values `start, start + 1, ..., end - 1`
-    */
+   *
+   *  @param start the start value of the iterator
+   *  @param end   the end value of the iterator (the first value NOT returned)
+   *  @return      the iterator producing values `start, start + 1, ..., end - 1`
+   */
   def range(start: Int, end: Int): Iterator[Int] = range(start, end, 1)
 
   /** An iterator producing equally spaced values in some integer interval.
-    *
-    *  @param start the start value of the iterator
-    *  @param end   the end value of the iterator (the first value NOT returned)
-    *  @param step  the increment value of the iterator (must be positive or negative)
-    *  @return      the iterator producing values `start, start + step, ...` up to, but excluding `end`
-    */
+   *
+   *  @param start the start value of the iterator
+   *  @param end   the end value of the iterator (the first value NOT returned)
+   *  @param step  the increment value of the iterator (must be positive or negative)
+   *  @return      the iterator producing values `start, start + step, ...` up to, but excluding `end`
+   */
   def range(start: Int, end: Int, step: Int): Iterator[Int] = new AbstractIterator[Int] {
     if (step == 0) throw new IllegalArgumentException("zero step")
     private var i = start
@@ -1114,11 +1110,11 @@ object Iterator extends IterableFactory[Iterator] {
   }
 
   /** Creates an infinite iterator that repeatedly applies a given function to the previous result.
-    *
-    *  @param start the start value of the iterator
-    *  @param f     the function that's repeatedly applied
-    *  @return      the iterator producing the infinite sequence of values `start, f(start), f(f(start)), ...`
-    */
+   *
+   *  @param start the start value of the iterator
+   *  @param f     the function that's repeatedly applied
+   *  @return      the iterator producing the infinite sequence of values `start, f(start), f(f(start)), ...`
+   */
   def iterate[T](start: T)(f: T => T): Iterator[T]^{f} = new AbstractIterator[T] {
     private var first = true
     private var acc = start
@@ -1132,23 +1128,23 @@ object Iterator extends IterableFactory[Iterator] {
   }
 
   /** Creates an Iterator that uses a function `f` to produce elements of type `A`
-    * and update an internal state of type `S`.
-    *
-    * @param init State initial value
-    * @param f    Computes the next element (or returns `None` to signal
-    *             the end of the collection)
-    * @tparam A   Type of the elements
-    * @tparam S   Type of the internal state
-    * @return an `Iterator` that produces elements using `f` until `f` returns `None`
-    */
+   *  and update an internal state of type `S`.
+   *
+   *  @tparam A   Type of the elements
+   *  @tparam S   Type of the internal state
+   *  @param init State initial value
+   *  @param f    Computes the next element (or returns `None` to signal
+   *             the end of the collection)
+   *  @return an `Iterator` that produces elements using `f` until `f` returns `None`
+   */
   override def unfold[A, S](init: S)(f: S => Option[(A, S)]): Iterator[A]^{f} = new UnfoldIterator(init)(f)
 
   /** Creates an infinite-length iterator returning the results of evaluating an expression.
-    *  The expression is recomputed for every element.
-    *
-    *  @param elem the element computation.
-    *  @return the iterator containing an infinite number of results of evaluating `elem`.
-    */
+   *  The expression is recomputed for every element.
+   *
+   *  @param elem the element computation.
+   *  @return the iterator containing an infinite number of results of evaluating `elem`.
+   */
   def continually[A](elem: => A): Iterator[A]^{elem} = new AbstractIterator[A] {
     def hasNext = true
     def next() = elem
@@ -1237,8 +1233,8 @@ object Iterator extends IterableFactory[Iterator] {
   }
 
   /** Creates a delegating iterator capped by a limit count. Negative limit means unbounded.
-    *  Lazily skip to start on first evaluation.  Avoids daisy-chained iterators due to slicing.
-    */
+   *  Lazily skip to start on first evaluation.  Avoids daisy-chained iterators due to slicing.
+   */
   private[scala] final class SliceIterator[A](val underlying: Iterator[A]^, start: Int, limit: Int) extends AbstractIterator[A] {
     private var remaining = limit
     private var dropping  = start
@@ -1296,8 +1292,8 @@ object Iterator extends IterableFactory[Iterator] {
   }
 
   /** Creates an iterator that uses a function `f` to produce elements of
-    * type `A` and update an internal state of type `S`.
-    */
+   *  type `A` and update an internal state of type `S`.
+   */
   private final class UnfoldIterator[A, S](init: S)(f: S => Option[(A, S)]) extends AbstractIterator[A] {
     private var state: S = init
     private var nextResult: Option[(A, S)] | Null = null

--- a/library/src/scala/collection/JavaConverters.scala
+++ b/library/src/scala/collection/JavaConverters.scala
@@ -27,44 +27,44 @@ import scala.language.implicitConversions
  *  The extension methods return adapters for the corresponding API.
  *
  *  The following conversions are supported via `asScala` and `asJava`:
- *{{{
+ *  ```
  *    scala.collection.Iterable       <=> java.lang.Iterable
  *    scala.collection.Iterator       <=> java.util.Iterator
  *    scala.collection.mutable.Buffer <=> java.util.List
  *    scala.collection.mutable.Set    <=> java.util.Set
  *    scala.collection.mutable.Map    <=> java.util.Map
  *    scala.collection.concurrent.Map <=> java.util.concurrent.ConcurrentMap
- *}}}
+ *  ```
  *  The following conversions are supported via `asScala` and through
  *  specially-named extension methods to convert to Java collections, as shown:
- *{{{
+ *  ```
  *    scala.collection.Iterable    <=> java.util.Collection   (via asJavaCollection)
  *    scala.collection.Iterator    <=> java.util.Enumeration  (via asJavaEnumeration)
  *    scala.collection.mutable.Map <=> java.util.Dictionary   (via asJavaDictionary)
- *}}}
+ *  ```
  *  In addition, the following one-way conversions are provided via `asJava`:
- *{{{
+ *  ```
  *    scala.collection.Seq         => java.util.List
  *    scala.collection.mutable.Seq => java.util.List
  *    scala.collection.Set         => java.util.Set
  *    scala.collection.Map         => java.util.Map
- *}}}
+ *  ```
  *  The following one way conversion is provided via `asScala`:
- *{{{
+ *  ```
  *    java.util.Properties => scala.collection.mutable.Map
- *}}}
+ *  ```
  *  In all cases, converting from a source type to a target type and back
  *  again will return the original source object. For example:
- *  {{{
+ *  ```
  *    import scala.collection.JavaConverters._
  *
  *    val source = new scala.collection.mutable.ListBuffer[Int]
  *    val target: java.util.List[Int] = source.asJava
  *    val other: scala.collection.mutable.Buffer[Int] = target.asScala
  *    assert(source eq other)
- *  }}}
+ *  ```
  *  Alternatively, the conversion methods have descriptive names and can be invoked explicitly.
- *  {{{
+ *  ```
  *    scala> val vs = java.util.Arrays.asList("hi", "bye")
  *    vs: java.util.List[String] = [hi, bye]
  *
@@ -76,7 +76,7 @@ import scala.language.implicitConversions
  *
  *    scala> val ss = asScalaBuffer(vs)
  *    ss: scala.collection.mutable.Buffer[String] = Buffer(hi, bye)
- *  }}}
+ *  ```
  */
 @deprecated("Use `scala.jdk.CollectionConverters` instead", "2.13.0")
 object JavaConverters extends AsJavaConverters with AsScalaConverters {
@@ -143,165 +143,142 @@ object JavaConverters extends AsJavaConverters with AsScalaConverters {
 
   // Deprecated implicit conversions for code that directly imports them
 
-  /**
-    * Adds an `asJava` method that implicitly converts a Scala `Iterator` to a Java `Iterator`.
-    * @see [[asJavaIterator]]
-    */
+  /** Adds an `asJava` method that implicitly converts a Scala `Iterator` to a Java `Iterator`.
+   *  @see [[asJavaIterator]]
+   */
   implicit def asJavaIteratorConverter[A](i : Iterator[A]): AsJava[ju.Iterator[A]] =
     new AsJava(asJavaIterator(i))
 
-  /**
-    * Adds an `asJavaEnumeration` method that implicitly converts a Scala `Iterator` to a Java `Enumeration`.
-    * @see [[asJavaEnumeration]]
-    */
+  /** Adds an `asJavaEnumeration` method that implicitly converts a Scala `Iterator` to a Java `Enumeration`.
+   *  @see [[asJavaEnumeration]]
+   */
   implicit def asJavaEnumerationConverter[A](i : Iterator[A]): AsJavaEnumeration[A] =
     new AsJavaEnumeration(i)
 
-  /**
-    * Adds an `asJava` method that implicitly converts a Scala `Iterable` to a Java `Iterable`.
-    * @see [[asJavaIterable]]
-    */
+  /** Adds an `asJava` method that implicitly converts a Scala `Iterable` to a Java `Iterable`.
+   *  @see [[asJavaIterable]]
+   */
   implicit def asJavaIterableConverter[A](i : Iterable[A]): AsJava[jl.Iterable[A]] =
     new AsJava(asJavaIterable(i))
 
-  /**
-    * Adds an `asJavaCollection` method that implicitly converts a Scala `Iterable` to an immutable Java `Collection`.
-    * @see [[asJavaCollection]]
-    */
+  /** Adds an `asJavaCollection` method that implicitly converts a Scala `Iterable` to an immutable Java `Collection`.
+   *  @see [[asJavaCollection]]
+   */
   implicit def asJavaCollectionConverter[A](i : Iterable[A]): AsJavaCollection[A] =
     new AsJavaCollection(i)
 
-  /**
-    * Adds an `asJava` method that implicitly converts a Scala mutable `Buffer` to a Java `List`.
-    * @see [[bufferAsJavaList]]
-    */
+  /** Adds an `asJava` method that implicitly converts a Scala mutable `Buffer` to a Java `List`.
+   *  @see [[bufferAsJavaList]]
+   */
   implicit def bufferAsJavaListConverter[A](b : mutable.Buffer[A]): AsJava[ju.List[A]] =
     new AsJava(bufferAsJavaList(b))
 
-  /**
-    * Adds an `asJava` method that implicitly converts a Scala mutable `Seq` to a Java `List`.
-    * @see [[mutableSeqAsJavaList]]
-    */
+  /** Adds an `asJava` method that implicitly converts a Scala mutable `Seq` to a Java `List`.
+   *  @see [[mutableSeqAsJavaList]]
+   */
   implicit def mutableSeqAsJavaListConverter[A](b : mutable.Seq[A]): AsJava[ju.List[A]] =
     new AsJava(mutableSeqAsJavaList(b))
 
-  /**
-    * Adds an `asJava` method that implicitly converts a Scala `Seq` to a Java `List`.
-    * @see [[seqAsJavaList]]
-    */
+  /** Adds an `asJava` method that implicitly converts a Scala `Seq` to a Java `List`.
+   *  @see [[seqAsJavaList]]
+   */
   implicit def seqAsJavaListConverter[A](b : Seq[A]): AsJava[ju.List[A]] =
     new AsJava(seqAsJavaList(b))
 
-  /**
-    * Adds an `asJava` method that implicitly converts a Scala mutable `Set` to a Java `Set`.
-    * @see [[mutableSetAsJavaSet]]
-    */
+  /** Adds an `asJava` method that implicitly converts a Scala mutable `Set` to a Java `Set`.
+   *  @see [[mutableSetAsJavaSet]]
+   */
   implicit def mutableSetAsJavaSetConverter[A](s : mutable.Set[A]): AsJava[ju.Set[A]] =
     new AsJava(mutableSetAsJavaSet(s))
 
-  /**
-    * Adds an `asJava` method that implicitly converts a Scala `Set` to a Java `Set`.
-    * @see [[setAsJavaSet]]
-    */
+  /** Adds an `asJava` method that implicitly converts a Scala `Set` to a Java `Set`.
+   *  @see [[setAsJavaSet]]
+   */
   implicit def setAsJavaSetConverter[A](s : Set[A]): AsJava[ju.Set[A]] =
     new AsJava(setAsJavaSet(s))
 
-  /**
-    * Adds an `asJava` method that implicitly converts a Scala mutable `Map` to a Java `Map`.
-    * @see [[mutableMapAsJavaMap]]
-    */
+  /** Adds an `asJava` method that implicitly converts a Scala mutable `Map` to a Java `Map`.
+   *  @see [[mutableMapAsJavaMap]]
+   */
   implicit def mutableMapAsJavaMapConverter[K, V](m : mutable.Map[K, V]): AsJava[ju.Map[K, V]] =
     new AsJava(mutableMapAsJavaMap(m))
 
-  /**
-    * Adds an `asJavaDictionary` method that implicitly converts a Scala mutable `Map` to a Java `Dictionary`.
-    * @see [[asJavaDictionary]]
-    */
+  /** Adds an `asJavaDictionary` method that implicitly converts a Scala mutable `Map` to a Java `Dictionary`.
+   *  @see [[asJavaDictionary]]
+   */
   implicit def asJavaDictionaryConverter[K, V](m : mutable.Map[K, V]): AsJavaDictionary[K, V] =
     new AsJavaDictionary(m)
 
-  /**
-    * Adds an `asJava` method that implicitly converts a Scala `Map` to a Java `Map`.
-    * @see [[mapAsJavaMap]]
-    */
+  /** Adds an `asJava` method that implicitly converts a Scala `Map` to a Java `Map`.
+   *  @see [[mapAsJavaMap]]
+   */
   implicit def mapAsJavaMapConverter[K, V](m : Map[K, V]): AsJava[ju.Map[K, V]] =
     new AsJava(mapAsJavaMap(m))
 
-  /**
-    * Adds an `asJava` method that implicitly converts a Scala mutable `concurrent.Map` to a Java `ConcurrentMap`.
-    * @see [[mapAsJavaConcurrentMap]].
-    */
+  /** Adds an `asJava` method that implicitly converts a Scala mutable `concurrent.Map` to a Java `ConcurrentMap`.
+   *  @see [[mapAsJavaConcurrentMap]].
+   */
   implicit def mapAsJavaConcurrentMapConverter[K, V](m: concurrent.Map[K, V]): AsJava[juc.ConcurrentMap[K, V]] =
     new AsJava(mapAsJavaConcurrentMap(m))
 
 
-  /**
-    * Adds an `asScala` method that implicitly converts a Java `Iterator` to a Scala `Iterator`.
-    * @see [[asScalaIterator]]
-    */
+  /** Adds an `asScala` method that implicitly converts a Java `Iterator` to a Scala `Iterator`.
+   *  @see [[asScalaIterator]]
+   */
   implicit def asScalaIteratorConverter[A](i : ju.Iterator[A]): AsScala[Iterator[A]] =
     new AsScala(asScalaIterator(i))
 
-  /**
-    * Adds an `asScala` method that implicitly converts a Java `Enumeration` to a Scala `Iterator`.
-    * @see [[enumerationAsScalaIterator]]
-    */
+  /** Adds an `asScala` method that implicitly converts a Java `Enumeration` to a Scala `Iterator`.
+   *  @see [[enumerationAsScalaIterator]]
+   */
   implicit def enumerationAsScalaIteratorConverter[A](i : ju.Enumeration[A]): AsScala[Iterator[A]] =
     new AsScala(enumerationAsScalaIterator(i))
 
-  /**
-    * Adds an `asScala` method that implicitly converts a Java `Iterable` to a Scala `Iterable`.
-    * @see [[iterableAsScalaIterable]]
-    */
+  /** Adds an `asScala` method that implicitly converts a Java `Iterable` to a Scala `Iterable`.
+   *  @see [[iterableAsScalaIterable]]
+   */
   implicit def iterableAsScalaIterableConverter[A](i : jl.Iterable[A]): AsScala[Iterable[A]] =
     new AsScala(iterableAsScalaIterable(i))
 
-  /**
-    * Adds an `asScala` method that implicitly converts a Java `Collection` to an Scala `Iterable`.
-    * @see [[collectionAsScalaIterable]]
-    */
+  /** Adds an `asScala` method that implicitly converts a Java `Collection` to an Scala `Iterable`.
+   *  @see [[collectionAsScalaIterable]]
+   */
   implicit def collectionAsScalaIterableConverter[A](i : ju.Collection[A]): AsScala[Iterable[A]] =
     new AsScala(collectionAsScalaIterable(i))
 
-  /**
-    * Adds an `asScala` method that implicitly converts a Java `List` to a Scala mutable `Buffer`.
-    * @see [[asScalaBuffer]]
-    */
+  /** Adds an `asScala` method that implicitly converts a Java `List` to a Scala mutable `Buffer`.
+   *  @see [[asScalaBuffer]]
+   */
   implicit def asScalaBufferConverter[A](l : ju.List[A]): AsScala[mutable.Buffer[A]] =
     new AsScala(asScalaBuffer(l))
 
-  /**
-    * Adds an `asScala` method that implicitly converts a Java `Set` to a Scala mutable `Set`.
-    * @see [[asScalaSet]]
-    */
+  /** Adds an `asScala` method that implicitly converts a Java `Set` to a Scala mutable `Set`.
+   *  @see [[asScalaSet]]
+   */
   implicit def asScalaSetConverter[A](s : ju.Set[A]): AsScala[mutable.Set[A]] =
     new AsScala(asScalaSet(s))
 
-  /**
-    * Adds an `asScala` method that implicitly converts a Java `Map` to a Scala mutable `Map`.
-    * @see [[mapAsScalaMap]]
-    */
+  /** Adds an `asScala` method that implicitly converts a Java `Map` to a Scala mutable `Map`.
+   *  @see [[mapAsScalaMap]]
+   */
   implicit def mapAsScalaMapConverter[K, V](m : ju.Map[K, V]): AsScala[mutable.Map[K, V]] =
     new AsScala(mapAsScalaMap(m))
 
-  /**
-    * Adds an `asScala` method that implicitly converts a Java `ConcurrentMap` to a Scala mutable `concurrent.Map`.
-    * @see [[mapAsScalaConcurrentMap]]
-    */
+  /** Adds an `asScala` method that implicitly converts a Java `ConcurrentMap` to a Scala mutable `concurrent.Map`.
+   *  @see [[mapAsScalaConcurrentMap]]
+   */
   implicit def mapAsScalaConcurrentMapConverter[K, V](m: juc.ConcurrentMap[K, V]): AsScala[concurrent.Map[K, V]] =
     new AsScala(mapAsScalaConcurrentMap(m))
 
-  /**
-    * Adds an `asScala` method that implicitly converts a Java `Dictionary` to a Scala mutable `Map`.
-    * @see [[dictionaryAsScalaMap]]
-    */
+  /** Adds an `asScala` method that implicitly converts a Java `Dictionary` to a Scala mutable `Map`.
+   *  @see [[dictionaryAsScalaMap]]
+   */
   implicit def dictionaryAsScalaMapConverter[K, V](p: ju.Dictionary[K, V]): AsScala[mutable.Map[K, V]] =
     new AsScala(dictionaryAsScalaMap(p))
 
-  /**
-    * Adds an `asScala` method that implicitly converts a Java `Properties` to a Scala mutable `Map[String, String]`.
-    * @see [[propertiesAsScalaMap]]
-    */
+  /** Adds an `asScala` method that implicitly converts a Java `Properties` to a Scala mutable `Map[String, String]`.
+   *  @see [[propertiesAsScalaMap]]
+   */
   implicit def propertiesAsScalaMapConverter(p: ju.Properties): AsScala[mutable.Map[String, String]] =
     new AsScala(propertiesAsScalaMap(p))
 

--- a/library/src/scala/collection/LazyZipOps.scala
+++ b/library/src/scala/collection/LazyZipOps.scala
@@ -17,22 +17,22 @@ import scala.language.implicitConversions
 import language.experimental.captureChecking
 
 /** Decorator representing lazily zipped pairs.
-  *
-  * @define coll pair
-  * @define willNotTerminateInf
-  *
-  *              Note: will not terminate for infinite-sized collections.
-  */
+ *
+ *  @define coll pair
+ *  @define willNotTerminateInf
+ *
+ *              Note: will not terminate for infinite-sized collections.
+ */
 final class LazyZip2[+El1, +El2, C1] private[collection](src: C1, coll1: Iterable[El1]^, coll2: Iterable[El2]^) {
 
   /** Zips `that` iterable collection with an existing `LazyZip2`. The elements in each collection are
-    * not consumed until a strict operation is invoked on the returned `LazyZip3` decorator.
-    *
-    * @param that the iterable providing the third element of each eventual triple
-    * @tparam B the type of the third element in each eventual triple
-    * @return a decorator `LazyZip3` that allows strict operations to be performed on the lazily evaluated tuples or
-    *         chained calls to `lazyZip`. Implicit conversion to `Iterable[(El1, El2, B)]` is also supported.
-    */
+   *  not consumed until a strict operation is invoked on the returned `LazyZip3` decorator.
+   *
+   *  @tparam B the type of the third element in each eventual triple
+   *  @param that the iterable providing the third element of each eventual triple
+   *  @return a decorator `LazyZip3` that allows strict operations to be performed on the lazily evaluated tuples or
+   *         chained calls to `lazyZip`. Implicit conversion to `Iterable[(El1, El2, B)]` is also supported.
+   */
   def lazyZip[B](that: Iterable[B]^): LazyZip3[El1, El2, B, C1]^{this, that} = new LazyZip3(src, coll1, coll2, that)
 
   def map[B, C](f: (El1, El2) => B)(implicit bf: BuildFrom[C1, B, C]): C^{this, f} = {
@@ -142,25 +142,25 @@ object LazyZip2 {
 
 
 /** Decorator representing lazily zipped triples.
-  *
-  * @define coll triple
-  * @define willNotTerminateInf
-  *
-  *              Note: will not terminate for infinite-sized collections.
-  */
+ *
+ *  @define coll triple
+ *  @define willNotTerminateInf
+ *
+ *              Note: will not terminate for infinite-sized collections.
+ */
 final class LazyZip3[+El1, +El2, +El3, C1] private[collection](src: C1,
                                                                coll1: Iterable[El1]^,
                                                                coll2: Iterable[El2]^,
                                                                coll3: Iterable[El3]^) {
 
   /** Zips `that` iterable collection with an existing `LazyZip3`. The elements in each collection are
-    * not consumed until a strict operation is invoked on the returned `LazyZip4` decorator.
-    *
-    * @param that the iterable providing the fourth element of each eventual 4-tuple
-    * @tparam B the type of the fourth element in each eventual 4-tuple
-    * @return a decorator `LazyZip4` that allows strict operations to be performed on the lazily evaluated tuples.
-    *         Implicit conversion to `Iterable[(El1, El2, El3, B)]` is also supported.
-    */
+   *  not consumed until a strict operation is invoked on the returned `LazyZip4` decorator.
+   *
+   *  @tparam B the type of the fourth element in each eventual 4-tuple
+   *  @param that the iterable providing the fourth element of each eventual 4-tuple
+   *  @return a decorator `LazyZip4` that allows strict operations to be performed on the lazily evaluated tuples.
+   *         Implicit conversion to `Iterable[(El1, El2, El3, B)]` is also supported.
+   */
   def lazyZip[B](that: Iterable[B]^): LazyZip4[El1, El2, El3, B, C1]^{this, that} = new LazyZip4(src, coll1, coll2, coll3, that)
 
   def map[B, C](f: (El1, El2, El3) => B)(implicit bf: BuildFrom[C1, B, C]): C^{this, f} = {
@@ -283,12 +283,12 @@ object LazyZip3 {
 
 
 /** Decorator representing lazily zipped 4-tuples.
-  *
-  * @define coll tuple
-  * @define willNotTerminateInf
-  *
-  *              Note: will not terminate for infinite-sized collections.
-  */
+ *
+ *  @define coll tuple
+ *  @define willNotTerminateInf
+ *
+ *              Note: will not terminate for infinite-sized collections.
+ */
 final class LazyZip4[+El1, +El2, +El3, +El4, C1] private[collection](src: C1,
                                                                      coll1: Iterable[El1]^,
                                                                      coll2: Iterable[El2]^,

--- a/library/src/scala/collection/LinearSeq.scala
+++ b/library/src/scala/collection/LinearSeq.scala
@@ -19,9 +19,9 @@ import language.experimental.captureChecking
 import scala.annotation.{nowarn, tailrec}
 
 /** Base trait for linearly accessed sequences that have efficient `head` and
-  *  `tail` operations.
-  *  Known subclasses: List, LazyList
-  */
+ *  `tail` operations.
+ *  Known subclasses: List, LazyList
+ */
 trait LinearSeq[+A] extends Seq[A]
   with LinearSeqOps[A, LinearSeq, LinearSeq[A]]
   with IterableFactoryDefaults[A, LinearSeq] {
@@ -287,8 +287,8 @@ transparent trait StrictOptimizedLinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: 
 }
 
 /** A specialized Iterator for LinearSeqs that is lazy enough for Stream and LazyList. This is accomplished by not
-  * evaluating the tail after returning the current head.
-  */
+ *  evaluating the tail after returning the current head.
+ */
 private[collection] final class LinearSeqIterator[A](coll: LinearSeqOps[A, LinearSeq, LinearSeq[A]]) extends AbstractIterator[A] {
   // A call-by-need cell
   private final class LazyCell(st: => LinearSeqOps[A, LinearSeq, LinearSeq[A]]) { lazy val v = st }

--- a/library/src/scala/collection/Map.scala
+++ b/library/src/scala/collection/Map.scala
@@ -33,23 +33,22 @@ trait Map[K, +V]
 
   def canEqual(that: Any): Boolean = true
 
-  /**
-   * Equality of maps is implemented using the lookup method [[get]]. This method returns `true` if
+  /** Equality of maps is implemented using the lookup method [[get]]. This method returns `true` if
    *   - the argument `o` is a `Map`,
    *   - the two maps have the same [[size]], and
    *   - for every `(key, value)` pair in this map, `other.get(key) == Some(value)`.
    *
-   * The implementation of `equals` checks the [[canEqual]] method, so subclasses of `Map` can narrow down the equality
-   * to specific map types. The `Map` implementations in the standard library can all be compared, their `canEqual`
-   * methods return `true`.
+   *  The implementation of `equals` checks the [[canEqual]] method, so subclasses of `Map` can narrow down the equality
+   *  to specific map types. The `Map` implementations in the standard library can all be compared, their `canEqual`
+   *  methods return `true`.
    *
-   * Note: The `equals` method only respects the equality laws (symmetry, transitivity) if the two maps use the same
-   * key equivalence function in their lookup operation. For example, the key equivalence operation in a
-   * [[scala.collection.immutable.TreeMap]] is defined by its ordering. Comparing a `TreeMap` with a `HashMap` leads
-   * to unexpected results if `ordering.equiv(k1, k2)` (used for lookup in `TreeMap`) is different from `k1 == k2`
-   * (used for lookup in `HashMap`).
+   *  Note: The `equals` method only respects the equality laws (symmetry, transitivity) if the two maps use the same
+   *  key equivalence function in their lookup operation. For example, the key equivalence operation in a
+   *  [[scala.collection.immutable.TreeMap]] is defined by its ordering. Comparing a `TreeMap` with a `HashMap` leads
+   *  to unexpected results if `ordering.equiv(k1, k2)` (used for lookup in `TreeMap`) is different from `k1 == k2`
+   *  (used for lookup in `HashMap`).
    *
-   * {{{
+   *  ```
    *   scala> import scala.collection.immutable._
    *   scala> val ord: Ordering[String] = _ compareToIgnoreCase _
    *
@@ -58,11 +57,11 @@ trait Map[K, +V]
    *
    *   scala> HashMap("a" -> 1) == TreeMap("A" -> 1)(ord)
    *   val res1: Boolean = true
-   * }}}
+   *  ```
    *
    *
-   * @param o The map to which this map is compared
-   * @return `true` if the two maps are equal according to the description
+   *  @param o The map to which this map is compared
+   *  @return `true` if the two maps are equal according to the description
    */
   override def equals(o: Any): Boolean =
     (this eq o.asInstanceOf[AnyRef]) || (o match {
@@ -90,16 +89,16 @@ trait Map[K, +V]
 }
 
 /** Base Map implementation type
-  *
-  * @tparam K Type of keys
-  * @tparam V Type of values
-  * @tparam CC type constructor of the map (e.g. `HashMap`). Operations returning a collection
-  *            with a different type of entries `(L, W)` (e.g. `map`) return a `CC[L, W]`.
-  * @tparam C  type of the map (e.g. `HashMap[Int, String]`). Operations returning a collection
-  *            with the same type of element (e.g. `drop`, `filter`) return a `C`.
-  * @define coll map
-  * @define Coll `Map`
-  */
+ *
+ *  @tparam K Type of keys
+ *  @tparam V Type of values
+ *  @tparam CC type constructor of the map (e.g. `HashMap`). Operations returning a collection
+ *            with a different type of entries `(L, W)` (e.g. `map`) return a `CC[L, W]`.
+ *  @tparam C  type of the map (e.g. `HashMap[Int, String]`). Operations returning a collection
+ *            with the same type of element (e.g. `drop`, `filter`) return a `C`.
+ *  @define coll map
+ *  @define Coll `Map`
+ */
 // Note: the upper bound constraint on CC is useful only to
 // erase CC to IterableOps instead of Object
 transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
@@ -133,32 +132,32 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
   }
 
   /** Similar to `fromIterable`, but returns a Map collection type.
-    * Note that the return type is now `CC[K2, V2]`.
-    */
+   *  Note that the return type is now `CC[K2, V2]`.
+   */
   @`inline` protected final def mapFromIterable[K2, V2](it: Iterable[(K2, V2)]^): CC[K2, V2]^{it} = mapFactory.from(it)
 
   /** The companion object of this map, providing various factory methods.
-    *
-    * @note When implementing a custom collection type and refining `CC` to the new type, this
-    *       method needs to be overridden to return a factory for the new type (the compiler will
-    *       issue an error otherwise).
-    */
+   *
+   *  @note When implementing a custom collection type and refining `CC` to the new type, this
+   *       method needs to be overridden to return a factory for the new type (the compiler will
+   *       issue an error otherwise).
+   */
   def mapFactory: MapFactory[CC]
 
   /** Optionally returns the value associated with a key.
-    *
-    *  @param  key    the key value
-    *  @return an option value containing the value associated with `key` in this map,
-    *          or `None` if none exists.
-    */
+   *
+   *  @param  key    the key value
+   *  @return an option value containing the value associated with `key` in this map,
+   *          or `None` if none exists.
+   */
   def get(key: K): Option[V]
 
-  /**  Returns the value associated with a key, or a default value if the key is not contained in the map.
-   *   @param   key      the key.
-   *   @param   default  a computation that yields a default value in case no binding for `key` is
+  /** Returns the value associated with a key, or a default value if the key is not contained in the map.
+   *  @tparam  V1       the result type of the default computation.
+   *  @param   key      the key.
+   *  @param   default  a computation that yields a default value in case no binding for `key` is
    *                     found in the map.
-   *   @tparam  V1       the result type of the default computation.
-   *   @return  the value associated with `key` if it exists,
+   *  @return  the value associated with `key` if it exists,
    *            otherwise the result of the `default` computation.
    */
   def getOrElse[V1 >: V](key: K, default: => V1): V1 = get(key) match {
@@ -167,14 +166,14 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
   }
 
   /** Retrieves the value which is associated with the given key. This
-    *  method invokes the `default` method of the map if there is no mapping
-    *  from the given key to a value. Unless overridden, the `default` method throws a
-    *  `NoSuchElementException`.
-    *
-    *  @param  key the key
-    *  @return     the value associated with the given key, or the result of the
-    *              map's `default` method, if none exists.
-    */
+   *  method invokes the `default` method of the map if there is no mapping
+   *  from the given key to a value. Unless overridden, the `default` method throws a
+   *  `NoSuchElementException`.
+   *
+   *  @param  key the key
+   *  @return     the value associated with the given key, or the result of the
+   *              map's `default` method, if none exists.
+   */
   @throws[NoSuchElementException]
   def apply(key: K): V = get(key) match {
     case None => default(key)
@@ -207,17 +206,16 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
       case s: mutable.MapOps[K, V, mutable.Map, mutable.Map[K, V]] => new LazyKeySet(s)
       case _ => new StrictKeySet(this)
 
-  /** The implementation class of the set returned by `keySet`.
-    */
+  /** The implementation class of the set returned by `keySet`. */
   @deprecated("KeySet is no longer used in the .keySet implementation", since = "3.8.0")
   protected class KeySet extends AbstractSet[K] with GenKeySet with DefaultSerializable {
     def diff(that: Set[K]): Set[K] = fromSpecific(this.view.filterNot(that))
   }
 
   /** A generic trait that is reused by keyset implementations.
-    * Note that this version of KeySet copies all the keys into an interval val.
-    * See [[MapOps.LazyKeySet]] for a version that lazily captures the map.
-    */
+   *  Note that this version of KeySet copies all the keys into an interval val.
+   *  See [[MapOps.LazyKeySet]] for a version that lazily captures the map.
+   */
   @deprecated("GenKeySet is not capture-safe, and so is deprecated and no longer used in .keySet implementations.", since = "3.8.0")
   protected trait GenKeySet @retains[MapOps.this.type] () { // todo change @retains to uses_init when we bootstrap with 3.8.2
     this: Set[K] =>
@@ -262,9 +260,9 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
   }
 
   /** Creates an iterator for all values in this map.
-    *
-    *  @return an iterator over all values that are associated with some key in this map.
-    */
+   *
+   *  @return an iterator over all values that are associated with some key in this map.
+   */
   def valuesIterator: Iterator[V]^{this} = new AbstractIterator[V] {
     val iter = MapOps.this.iterator
     def hasNext = iter.hasNext
@@ -283,18 +281,18 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
   }
 
   /** Filters this map by retaining only keys satisfying a predicate.
-    *  @param  p   the predicate used to test keys
-    *  @return an immutable map consisting only of those key value pairs of this map where the key satisfies
-    *          the predicate `p`. The resulting map wraps the original map without copying any elements.
-    */
+   *  @param  p   the predicate used to test keys
+   *  @return an immutable map consisting only of those key value pairs of this map where the key satisfies
+   *          the predicate `p`. The resulting map wraps the original map without copying any elements.
+   */
   @deprecated("Use .view.filterKeys(f). A future version will include a strict version of this method (for now, .view.filterKeys(p).toMap).", "2.13.0")
   def filterKeys(p: K => Boolean): MapView[K, V]^{this, p} = new MapView.FilterKeys(this, p)
 
   /** Transforms this map by applying a function to every retrieved value.
-    *  @param  f   the function used to transform values of this map.
-    *  @return a map view which maps every key of this map
-    *          to `f(this(key))`. The resulting map wraps the original map without copying any elements.
-    */
+   *  @param  f   the function used to transform values of this map.
+   *  @return a map view which maps every key of this map
+   *          to `f(this(key))`. The resulting map wraps the original map without copying any elements.
+   */
   @deprecated("Use .view.mapValues(f). A future version will include a strict version of this method (for now, .view.mapValues(f).toMap).", "2.13.0")
   def mapValues[W](f: V => W): MapView[K, W]^{this, f} = new MapView.MapValues(this, f)
 
@@ -312,10 +310,10 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
     throw new NoSuchElementException("key not found: " + key)
 
   /** Tests whether this map contains a binding for a key.
-    *
-    *  @param key the key
-    *  @return    `true` if there is a binding for `key` in this map, `false` otherwise.
-    */
+   *
+   *  @param key the key
+   *  @return    `true` if there is a binding for `key` in this map, `false` otherwise.
+   */
   def contains(key: K): Boolean =
     // TODO: I'm not sure what's happening here, need to investigate a bit further.
     // But this check should be fine: we of course can use a MapOps here.
@@ -323,52 +321,52 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
 
 
   /** Tests whether this map contains a binding for a key. This method,
-    *  which implements an abstract method of trait `PartialFunction`,
-    *  is equivalent to `contains`.
-    *
-    *  @param key the key
-    *  @return    `true` if there is a binding for `key` in this map, `false` otherwise.
-    */
+   *  which implements an abstract method of trait `PartialFunction`,
+   *  is equivalent to `contains`.
+   *
+   *  @param key the key
+   *  @return    `true` if there is a binding for `key` in this map, `false` otherwise.
+   */
   def isDefinedAt(key: K): Boolean = contains(key)
 
   /** Builds a new map by applying a function to all elements of this $coll.
-    *
-    *  @param f      the function to apply to each element.
-    *  @return       a new $coll resulting from applying the given function
-    *                `f` to each element of this $coll and collecting the results.
-    */
+   *
+   *  @param f      the function to apply to each element.
+   *  @return       a new $coll resulting from applying the given function
+   *                `f` to each element of this $coll and collecting the results.
+   */
   def map[K2, V2](f: ((K, V)) => (K2, V2)): CC[K2, V2]^{this, f} = mapFactory.from(new View.Map(this, f))
 
   /** Builds a new collection by applying a partial function to all elements of this $coll
-    *  on which the function is defined.
-    *
-    *  @param pf     the partial function which filters and maps the $coll.
-    *  @tparam K2    the key type of the returned $coll.
-    *  @tparam V2    the value type of the returned $coll.
-    *  @return       a new $coll resulting from applying the given partial function
-    *                `pf` to each element on which it is defined and collecting the results.
-    *                The order of the elements is preserved.
-    */
+   *  on which the function is defined.
+   *
+   *  @tparam K2    the key type of the returned $coll.
+   *  @tparam V2    the value type of the returned $coll.
+   *  @param pf     the partial function which filters and maps the $coll.
+   *  @return       a new $coll resulting from applying the given partial function
+   *                `pf` to each element on which it is defined and collecting the results.
+   *                The order of the elements is preserved.
+   */
   def collect[K2, V2](pf: PartialFunction[(K, V), (K2, V2)]^): CC[K2, V2]^{this, pf} =
     mapFactory.from(new View.Collect(this, pf))
 
   /** Builds a new map by applying a function to all elements of this $coll
-    *  and using the elements of the resulting collections.
-    *
-    *  @param f      the function to apply to each element.
-    *  @return       a new $coll resulting from applying the given collection-valued function
-    *                `f` to each element of this $coll and concatenating the results.
-    */
+   *  and using the elements of the resulting collections.
+   *
+   *  @param f      the function to apply to each element.
+   *  @return       a new $coll resulting from applying the given collection-valued function
+   *                `f` to each element of this $coll and concatenating the results.
+   */
   def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)]^): CC[K2, V2]^{this, f} = mapFactory.from(new View.FlatMap(this, f))
 
   /** Returns a new $coll containing the elements from the left hand operand followed by the elements from the
-    *  right hand operand. The element type of the $coll is the most specific superclass encompassing
-    *  the element types of the two operands.
-    *
-    *  @param suffix   the iterable to append.
-    *  @return       a new $coll which contains all elements
-    *                of this $coll followed by all elements of `suffix`.
-    */
+   *  right hand operand. The element type of the $coll is the most specific superclass encompassing
+   *  the element types of the two operands.
+   *
+   *  @param suffix   the iterable to append.
+   *  @return       a new $coll which contains all elements
+   *                of this $coll followed by all elements of `suffix`.
+   */
   def concat[V2 >: V](suffix: collection.IterableOnce[(K, V2)]^): CC[K, V2]^{this, suffix} = mapFactory.from(suffix match {
     case it: Iterable[(K, V2)] => new View.Concat(this, it)
     case _ => iterator.concat(suffix.iterator)
@@ -408,10 +406,10 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
 
 object MapOps {
   /** Specializes `WithFilter` for Map collection types by adding overloads to transformation
-    * operations that can return a Map.
-    *
-    * @define coll map collection
-    */
+   *  operations that can return a Map.
+   *
+   *  @define coll map collection
+   */
   @SerialVersionUID(3L)
   class WithFilter[K, +V, +IterableCC[_], +CC[_, _] <: IterableOps[?, AnyConstr, ?]](
     self: (MapOps[K, V, CC, ?] & IterableOps[(K, V), IterableCC, ?])^,
@@ -430,8 +428,7 @@ object MapOps {
   }
 
 
-  /** The implementation class of the set returned by `keySet`, for pure maps.
-    */
+  /** The implementation class of the set returned by `keySet`, for pure maps. */
   private[collection] class LazyKeySet[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C](mp: MapOps[K, V, CC, C]) extends AbstractSet[K] with DefaultSerializable {
     def iterator: Iterator[K] = mp.keysIterator
     def diff(that: Set[K]): Set[K] = LazyKeySet.this.fromSpecific(this.view.filterNot(that))
@@ -441,8 +438,7 @@ object MapOps {
     override def isEmpty: Boolean = mp.isEmpty
   }
 
-  /** The implementation class of the set returned by `keySet`, for impure maps (i.e. views).
-    */
+  /** The implementation class of the set returned by `keySet`, for impure maps (i.e. views). */
   private[collection] class StrictKeySet[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C](@annotation.constructorOnly mp: MapOps[K, V, CC, C]^) extends AbstractSet[K] with DefaultSerializable {
     val allKeys = mp.keysIterator.to(mutable.LinkedHashSet)
     def iterator: Iterator[K] = allKeys.iterator
@@ -454,11 +450,10 @@ object MapOps {
   }
 }
 
-/**
-  * $factoryInfo
-  * @define coll map
-  * @define Coll `Map`
-  */
+/** $factoryInfo
+ *  @define coll map
+ *  @define Coll `Map`
+ */
 @SerialVersionUID(3L)
 object Map extends MapFactory.Delegate[Map](immutable.Map) {
   private val DefaultSentinel: AnyRef = new AnyRef

--- a/library/src/scala/collection/MapView.scala
+++ b/library/src/scala/collection/MapView.scala
@@ -41,17 +41,17 @@ trait MapView[K, +V]
   override def values: Iterable[V]^{this} = new MapView.Values(this)
 
   /** Filters this map by retaining only keys satisfying a predicate.
-    *  @param  p   the predicate used to test keys
-    *  @return an immutable map consisting only of those key value pairs of this map where the key satisfies
-    *          the predicate `p`. The resulting map wraps the original map without copying any elements.
-    */
+   *  @param  p   the predicate used to test keys
+   *  @return an immutable map consisting only of those key value pairs of this map where the key satisfies
+   *          the predicate `p`. The resulting map wraps the original map without copying any elements.
+   */
   override def filterKeys(p: K => Boolean): MapView[K, V]^{this, p} = new MapView.FilterKeys(this, p)
 
   /** Transforms this map by applying a function to every retrieved value.
-    *  @param  f   the function used to transform values of this map.
-    *  @return a map view which maps every key of this map
-    *          to `f(this(key))`. The resulting map wraps the original map without copying any elements.
-    */
+   *  @param  f   the function used to transform values of this map.
+   *  @return a map view which maps every key of this map
+   *          to `f(this(key))`. The resulting map wraps the original map without copying any elements.
+   */
   override def mapValues[W](f: V => W): MapView[K, W]^{this, f} = new MapView.MapValues(this, f)
 
   override def filter(pred: ((K, V)) => Boolean): MapView[K, V]^{this, pred} = new MapView.Filter(this, isFlipped = false, pred)

--- a/library/src/scala/collection/Searching.scala
+++ b/library/src/scala/collection/Searching.scala
@@ -24,13 +24,14 @@ object Searching {
     *
     * Example usage:
     *
-    * {{{
+    * ```
     *   val list = List(1, 3, 4, 5) // list must be sorted before searching
     *   list.search(4) // Found(2)
     *   list.search(2) // InsertionPoint(1)
-    * }}}
+    * ```
     *
-    * */
+    *
+    */
   sealed abstract class SearchResult {
     /** The index corresponding to the element searched for in the sequence, if it was found,
       * or the index where the element would be inserted in the sequence, if it was not in the sequence */

--- a/library/src/scala/collection/Seq.scala
+++ b/library/src/scala/collection/Seq.scala
@@ -21,9 +21,9 @@ import Searching.{Found, InsertionPoint, SearchResult}
 import scala.annotation.nowarn
 
 /** Base trait for sequence collections
-  *
-  * @tparam A the element type of the collection
-  */
+ *
+ *  @tparam A the element type of the collection
+ */
 trait Seq[+A]
   extends Iterable[A]
     with PartialFunction[Int, A]
@@ -50,41 +50,41 @@ trait Seq[+A]
   override protected def stringPrefix: String = "Seq"
 }
 
-/**
-  * $factoryInfo
-  * @define coll sequence
-  * @define Coll `Seq`
-  */
+/** $factoryInfo
+ *  @define coll sequence
+ *  @define Coll `Seq`
+ */
 @SerialVersionUID(3L)
 object Seq extends SeqFactory.Delegate[Seq](immutable.Seq)
 
 /** Base trait for Seq operations
-  *
-  * @tparam A the element type of the collection
-  * @tparam CC type constructor of the collection (e.g. `List`, `Set`). Operations returning a collection
-  *             with a different type of element `B` (e.g. `map`) return a `CC[B]`.
-  * @tparam C  type of the collection (e.g. `List[Int]`, `String`, `BitSet`). Operations returning a collection
-  *             with the same type of element (e.g. `drop`, `filter`) return a `C`.
-  * @define orderDependent
-  * @define orderDependentFold
-  * @define mayNotTerminateInf
-  *
-  *    Note: may not terminate for infinite-sized collections.
-  *
-  * @define willNotTerminateInf
-  *
-  *    Note: will not terminate for infinite-sized collections.
-  *
-  * @define coll sequence
-  * @define Coll `Seq`
-  */
+ *
+ *  @tparam A the element type of the collection
+ *  @tparam CC type constructor of the collection (e.g. `List`, `Set`). Operations returning a collection
+ *             with a different type of element `B` (e.g. `map`) return a `CC[B]`.
+ *  @tparam C  type of the collection (e.g. `List[Int]`, `String`, `BitSet`). Operations returning a collection
+ *             with the same type of element (e.g. `drop`, `filter`) return a `C`.
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *
+ *    Note: may not terminate for infinite-sized collections.
+ *
+ *  @define willNotTerminateInf
+ *
+ *    Note: will not terminate for infinite-sized collections.
+ *
+ *  @define coll sequence
+ *  @define Coll `Seq`
+ */
 transparent trait SeqOps[+A, +CC[_], +C] extends Any
   with IterableOps[A, CC, C] { self: SeqOps[A, CC, C]^ =>
 
   override def view: SeqView[A]^{this} = new SeqView.Id[A](this)
 
   /** Gets the element at the specified index. This operation is provided for convenience in `Seq`. It should
-    * not be assumed to be efficient unless you have an `IndexedSeq`. */
+   *  not be assumed to be efficient unless you have an `IndexedSeq`. 
+   */
   @throws[IndexOutOfBoundsException]
   def apply(i: Int): A
 
@@ -92,78 +92,78 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
   def length: Int
 
   /** A copy of the $coll with an element prepended.
-    *
-    * Also, the original $coll is not modified, so you will want to capture the result.
-    *
-    *    Example:
-    *    {{{
-    *      scala> val x = List(1)
-    *      x: List[Int] = List(1)
-    *
-    *      scala> val y = 2 +: x
-    *      y: List[Int] = List(2, 1)
-    *
-    *      scala> println(x)
-    *      List(1)
-    *    }}}
-    *
-    *  @param  elem   the prepended element
-    *  @tparam B      the element type of the returned $coll.
-    *
-    *    @return a new $coll consisting of `value` followed
-    *            by all elements of this $coll.
-    */
+   *
+   *  Also, the original $coll is not modified, so you will want to capture the result.
+   *
+   *    Example:
+   *    ```
+   *      scala> val x = List(1)
+   *      x: List[Int] = List(1)
+   *
+   *      scala> val y = 2 +: x
+   *      y: List[Int] = List(2, 1)
+   *
+   *      scala> println(x)
+   *      List(1)
+   *    ```
+   *
+   *  @tparam B      the element type of the returned $coll.
+   *  @param  elem   the prepended element
+   *
+   *  @return a new $coll consisting of `value` followed
+   *            by all elements of this $coll.
+   */
   def prepended[B >: A](elem: B): CC[B]^{this} = iterableFactory.from(new View.Prepended(elem, this))
 
   /** Alias for `prepended`.
-    *
-    * Note that :-ending operators are right associative (see example).
-    * A mnemonic for `+:` vs. `:+` is: the COLon goes on the COLlection side.
-    */
+   *
+   *  Note that :-ending operators are right associative (see example).
+   *  A mnemonic for `+:` vs. `:+` is: the COLon goes on the COLlection side.
+   */
   @`inline` final def +: [B >: A](elem: B): CC[B]^{this} = prepended(elem)
 
   /** A copy of this $coll with an element appended.
-    *
-    * $willNotTerminateInf
-    *
-    * Example:
-    * {{{
-    *    scala> val a = List(1)
-    *    a: List[Int] = List(1)
-    *
-    *    scala> val b = a :+ 2
-    *    b: List[Int] = List(1, 2)
-    *
-    *    scala> println(a)
-    *    List(1)
-    * }}}
-    *
-    * @param  elem   the appended element
-    * @tparam B      the element type of the returned $coll.
-    * @return a new $coll consisting of
-    *         all elements of this $coll followed by `value`.
-    */
+   *
+   *  $willNotTerminateInf
+   *
+   *  Example:
+   *  ```
+   *    scala> val a = List(1)
+   *    a: List[Int] = List(1)
+   *
+   *    scala> val b = a :+ 2
+   *    b: List[Int] = List(1, 2)
+   *
+   *    scala> println(a)
+   *    List(1)
+   *  ```
+   *
+   *  @tparam B      the element type of the returned $coll.
+   *  @param  elem   the appended element
+   *  @return a new $coll consisting of
+   *         all elements of this $coll followed by `value`.
+   */
   def appended[B >: A](elem: B): CC[B]^{this} = iterableFactory.from(new View.Appended(this, elem))
 
   /** Alias for `appended`.
-    *
-    * Note that :-ending operators are right associative (see example).
-    * A mnemonic for `+:` vs. `:+` is: the COLon goes on the COLlection side.
-    */
+   *
+   *  Note that :-ending operators are right associative (see example).
+   *  A mnemonic for `+:` vs. `:+` is: the COLon goes on the COLlection side.
+   */
   @`inline` final def :+ [B >: A](elem: B): CC[B]^{this} = appended(elem)
 
   /** As with `:++`, returns a new collection containing the elements from the left operand followed by the
-    *  elements from the right operand.
-    *
-    *  It differs from `:++` in that the right operand determines the type of
-    *  the resulting collection rather than the left one.
-    *  Mnemonic: the COLon is on the side of the new COLlection type.
-    *
-    *  @param prefix   the iterable to prepend.
-    *  @tparam B     the element type of the returned collection.
-    *  @return       a new $coll which contains all elements of `prefix` followed
-    *                  by all the elements of this $coll.
-    */
+   *  elements from the right operand.
+   *
+   *  It differs from `:++` in that the right operand determines the type of
+   *  the resulting collection rather than the left one.
+   *  Mnemonic: the COLon is on the side of the new COLlection type.
+   *
+   *  @tparam B     the element type of the returned collection.
+   *  @param prefix   the iterable to prepend.
+   *  @return       a new $coll which contains all elements of `prefix` followed
+   *                  by all the elements of this $coll.
+   */
   def prependedAll[B >: A](prefix: IterableOnce[B]^): CC[B]^{this, prefix} = iterableFactory.from(prefix match {
     case prefix: Iterable[B] => new View.Concat(prefix, this)
     case _ => prefix.iterator ++ iterator
@@ -173,14 +173,14 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
   @inline override def ++: [B >: A](prefix: IterableOnce[B]^): CC[B]^{this, prefix} = prependedAll(prefix)
 
   /** Returns a new $coll containing the elements from the left hand operand followed by the elements from the
-    *  right hand operand. The element type of the $coll is the most specific superclass encompassing
-    *  the element types of the two operands.
-    *
-    *  @param suffix the iterable to append.
-    *  @tparam B     the element type of the returned collection.
-    *  @return       a new collection of type `CC[B]` which contains all elements
-    *                of this $coll followed by all elements of `suffix`.
-    */
+   *  right hand operand. The element type of the $coll is the most specific superclass encompassing
+   *  the element types of the two operands.
+   *
+   *  @tparam B     the element type of the returned collection.
+   *  @param suffix the iterable to append.
+   *  @return       a new collection of type `CC[B]` which contains all elements
+   *                of this $coll followed by all elements of `suffix`.
+   */
   def appendedAll[B >: A](suffix: IterableOnce[B]^): CC[B]^{this, suffix} = super.concat(suffix)
 
   /** Alias for `appendedAll`. */
@@ -191,31 +191,31 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
   @inline override def concat[B >: A](suffix: IterableOnce[B]^): CC[B]^{this, suffix} = appendedAll(suffix)
 
  /** Produces a new sequence which contains all elements of this $coll and also all elements of
-   *  a given sequence. `xs union ys`  is equivalent to `xs ++ ys`.
-   *
-   *  @param that   the sequence to add.
-   *  @tparam B     the element type of the returned $coll.
-   *  @return       a new collection which contains all elements of this $coll
-   *                followed by all elements of `that`.
-   */
+  *  a given sequence. `xs union ys`  is equivalent to `xs ++ ys`.
+  *
+  *  @tparam B     the element type of the returned $coll.
+  *  @param that   the sequence to add.
+  *  @return       a new collection which contains all elements of this $coll
+  *                followed by all elements of `that`.
+  */
   @deprecated("Use `concat` instead", "2.13.0")
   @inline final def union[B >: A](that: Seq[B]): CC[B]^{this} = concat(that)
 
   final override def size: Int = length
 
   /** Selects all the elements of this $coll ignoring the duplicates.
-    *
-    * @return a new $coll consisting of all the elements of this $coll without duplicates.
-    */
+   *
+   *  @return a new $coll consisting of all the elements of this $coll without duplicates.
+   */
   def distinct: C^{this} = distinctBy(identity)
 
   /** Selects all the elements of this $coll ignoring the duplicates as determined by `==` after applying
-    * the transforming function `f`.
-    *
-    * @param f The transforming function whose result is used to determine the uniqueness of each element
-    * @tparam B the type of the elements after being transformed by `f`
-    * @return a new $coll consisting of all the elements of this $coll without duplicates.
-    */
+   *  the transforming function `f`.
+   *
+   *  @tparam B the type of the elements after being transformed by `f`
+   *  @param f The transforming function whose result is used to determine the uniqueness of each element
+   *  @return a new $coll consisting of all the elements of this $coll without duplicates.
+   */
   def distinctBy[B](f: A -> B): C^{this} = fromSpecific(new View.DistinctBy(this, f))
 
   /** Returns a new $coll with the elements of this $coll in reverse order.
@@ -231,22 +231,22 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *
    *   $willNotTerminateInf
    *
-   * Note: `xs.reverseIterator` is the same as `xs.reverse.iterator` but might be more efficient.
+   *  Note: `xs.reverseIterator` is the same as `xs.reverse.iterator` but might be more efficient.
    *
    *  @return  an iterator yielding the elements of this $coll in reverse order.
    */
   def reverseIterator: Iterator[A]^{this} = reversed.iterator
 
   /** Tests whether this $coll contains the given sequence at a given index.
-    *
-    * '''Note''': If the both the receiver object `this` and the argument
-    * `that` are infinite sequences this method may not terminate.
-    *
-    * @param  that    the sequence to test
-    * @param  offset  the index where the sequence is searched.
-    * @return `true` if the sequence `that` is contained in this $coll at
-    *         index `offset`, otherwise `false`.
-    */
+   *
+   *  **Note**: If the both the receiver object `this` and the argument
+   *  `that` are infinite sequences this method may not terminate.
+   *
+   *  @param  that    the sequence to test
+   *  @param  offset  the index where the sequence is searched.
+   *  @return `true` if the sequence `that` is contained in this $coll at
+   *         index `offset`, otherwise `false`.
+   */
   def startsWith[B >: A](that: IterableOnce[B]^, offset: Int = 0): Boolean = {
     val i = iterator drop offset
     val j = that.iterator
@@ -258,10 +258,10 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
   }
 
   /** Tests whether this $coll ends with the given sequence.
-    *  $willNotTerminateInf
-    *  @param  that    the sequence to test
-    *  @return `true` if this $coll has `that` as a suffix, `false` otherwise.
-    */
+   *  $willNotTerminateInf
+   *  @param  that    the sequence to test
+   *  @return `true` if this $coll has `that` as a suffix, `false` otherwise.
+   */
   def endsWith[B >: A](that: Iterable[B]^): Boolean = {
     if (that.isEmpty) true
     else {
@@ -276,20 +276,20 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
   }
 
   /** Tests whether this $coll contains given index.
-    *
-    *  The implementations of methods `apply` and `isDefinedAt` turn a `Seq[A]` into
-    *  a `PartialFunction[Int, A]`.
-    *
-    * @param    idx     the index to test
-    * @return   `true` if this $coll contains an element at position `idx`, `false` otherwise.
-    */
+   *
+   *  The implementations of methods `apply` and `isDefinedAt` turn a `Seq[A]` into
+   *  a `PartialFunction[Int, A]`.
+   *
+   *  @param    idx     the index to test
+   *  @return   `true` if this $coll contains an element at position `idx`, `false` otherwise.
+   */
   def isDefinedAt(idx: Int): Boolean = idx >= 0 && lengthIs > idx
 
   /** A copy of this $coll with an element value appended until a given target length is reached.
    *
+   *  @tparam B      the element type of the returned $coll.
    *  @param   len   the target length
    *  @param   elem  the padding value
-   *  @tparam B      the element type of the returned $coll.
    *  @return a new $ccoll consisting of
    *          all elements of this $coll followed by the minimal number of occurrences of `elem` so
    *          that the resulting collection has a length of at least `len`.
@@ -297,26 +297,26 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
   def padTo[B >: A](len: Int, elem: B): CC[B]^{this} = iterableFactory.from(new View.PadTo(this, len, elem))
 
   /** Computes the length of the longest segment that starts from the first element
-    *  and whose elements all satisfy some predicate.
-    *
-    *  $mayNotTerminateInf
-    *
-    *  @param   p     the predicate used to test elements.
-    *  @return  the length of the longest segment of this $coll that starts from the first element
-    *           such that every element of the segment satisfies the predicate `p`.
-    */
+   *  and whose elements all satisfy some predicate.
+   *
+   *  $mayNotTerminateInf
+   *
+   *  @param   p     the predicate used to test elements.
+   *  @return  the length of the longest segment of this $coll that starts from the first element
+   *           such that every element of the segment satisfies the predicate `p`.
+   */
   final def segmentLength(p: A => Boolean): Int = segmentLength(p, 0)
 
   /** Computes the length of the longest segment that starts from some index
-    *  and whose elements all satisfy some predicate.
-    *
-    *  $mayNotTerminateInf
-    *
-    *  @param   p     the predicate used to test elements.
-    *  @param   from  the index where the search starts.
-    *  @return  the length of the longest segment of this $coll starting from index `from`
-    *           such that every element of the segment satisfies the predicate `p`.
-    */
+   *  and whose elements all satisfy some predicate.
+   *
+   *  $mayNotTerminateInf
+   *
+   *  @param   p     the predicate used to test elements.
+   *  @param   from  the index where the search starts.
+   *  @return  the length of the longest segment of this $coll starting from index `from`
+   *           such that every element of the segment satisfies the predicate `p`.
+   */
   def segmentLength(p: A => Boolean, from: Int): Int = {
     var i = 0
     val it = iterator.drop(from)
@@ -326,55 +326,55 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
   }
 
   /** Returns the length of the longest prefix whose elements all satisfy some predicate.
-    *
-    *  $mayNotTerminateInf
-    *
-    *  @param   p     the predicate used to test elements.
-    *  @return  the length of the longest prefix of this $coll
-    *           such that every element of the segment satisfies the predicate `p`.
-    */
+   *
+   *  $mayNotTerminateInf
+   *
+   *  @param   p     the predicate used to test elements.
+   *  @return  the length of the longest prefix of this $coll
+   *           such that every element of the segment satisfies the predicate `p`.
+   */
   @deprecated("Use segmentLength instead of prefixLength", "2.13.0")
   @`inline` final def prefixLength(p: A => Boolean): Int = segmentLength(p, 0)
 
   /** Finds index of the first element satisfying some predicate after or at some start index.
-    *
-    *  $mayNotTerminateInf
-    *
-    *  @param   p     the predicate used to test elements.
-    *  @param   from   the start index
-    *  @return  the index `>= from` of the first element of this $coll that satisfies the predicate `p`,
-    *           or `-1`, if none exists.
-    */
+   *
+   *  $mayNotTerminateInf
+   *
+   *  @param   p     the predicate used to test elements.
+   *  @param   from   the start index
+   *  @return  the index `>= from` of the first element of this $coll that satisfies the predicate `p`,
+   *           or `-1`, if none exists.
+   */
   def indexWhere(p: A => Boolean, from: Int): Int = iterator.indexWhere(p, from)
 
   /** Finds index of the first element satisfying some predicate.
-    *
-    *  $mayNotTerminateInf
-    *
-    *  @param   p     the predicate used to test elements.
-    *  @return  the index `>= 0` of the first element of this $coll that satisfies the predicate `p`,
-    *           or `-1`, if none exists.
-    */
+   *
+   *  $mayNotTerminateInf
+   *
+   *  @param   p     the predicate used to test elements.
+   *  @return  the index `>= 0` of the first element of this $coll that satisfies the predicate `p`,
+   *           or `-1`, if none exists.
+   */
   @deprecatedOverriding("Override indexWhere(p, from) instead - indexWhere(p) calls indexWhere(p, 0)", "2.13.0")
   def indexWhere(p: A => Boolean): Int = indexWhere(p, 0)
 
   /** Finds index of first occurrence of some value in this $coll after or at some start index.
-    *
-    *  @param   elem   the element value to search for.
-    *  @tparam  B      the type of the element `elem`.
-    *  @param   from   the start index
-    *  @return  the index `>= from` of the first element of this $coll that is equal (as determined by `==`)
-    *           to `elem`, or `-1`, if none exists.
-    */
+   *
+   *  @tparam  B      the type of the element `elem`.
+   *  @param   elem   the element value to search for.
+   *  @param   from   the start index
+   *  @return  the index `>= from` of the first element of this $coll that is equal (as determined by `==`)
+   *           to `elem`, or `-1`, if none exists.
+   */
   def indexOf[B >: A](elem: B, from: Int): Int = indexWhere(elem == _, from)
 
   /** Finds index of first occurrence of some value in this $coll.
-    *
-    *  @param   elem   the element value to search for.
-    *  @tparam  B      the type of the element `elem`.
-    *  @return  the index `>= 0` of the first element of this $coll that is equal (as determined by `==`)
-    *           to `elem`, or `-1`, if none exists.
-    */
+   *
+   *  @tparam  B      the type of the element `elem`.
+   *  @param   elem   the element value to search for.
+   *  @return  the index `>= 0` of the first element of this $coll that is equal (as determined by `==`)
+   *           to `elem`, or `-1`, if none exists.
+   */
   @deprecatedOverriding("Override indexOf(elem, from) instead - indexOf(elem) calls indexOf(elem, 0)", "2.13.0")
   def indexOf[B >: A](elem: B): Int = indexOf(elem, 0)
 
@@ -382,9 +382,9 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *
    *  $willNotTerminateInf
    *
+   *  @tparam  B      the type of the element `elem`.
    *  @param   elem   the element value to search for.
    *  @param   end    the end index.
-   *  @tparam  B      the type of the element `elem`.
    *  @return  the index `<= end` of the last element of this $coll that is equal (as determined by `==`)
    *           to `elem`, or `-1`, if none exists.
    */
@@ -456,11 +456,11 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
     }
 
   /** Finds first index where this $coll contains a given sequence as a slice.
-    *  $mayNotTerminateInf
-    *  @param  that    the sequence to test
-    *  @return  the first index `>= 0` such that the elements of this $coll starting at this index
-    *           match the elements of sequence `that`, or `-1` if no such subsequence exists.
-    */
+   *  $mayNotTerminateInf
+   *  @param  that    the sequence to test
+   *  @return  the first index `>= 0` such that the elements of this $coll starting at this index
+   *           match the elements of sequence `that`, or `-1` if no such subsequence exists.
+   */
   @deprecatedOverriding("Override indexOfSlice(that, from) instead - indexOfSlice(that) calls indexOfSlice(that, 0)", "2.13.0")
   def indexOfSlice[B >: A](that: Seq[B]): Int = indexOfSlice(that, 0)
 
@@ -485,13 +485,13 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
   }
 
   /** Finds last index where this $coll contains a given sequence as a slice.
-    *
-    *  $willNotTerminateInf
-    *
-    *  @param  that    the sequence to test
-    *  @return  the last index such that the elements of this $coll starting at this index
-    *           match the elements of sequence `that`, or `-1` if no such subsequence exists.
-    */
+   *
+   *  $willNotTerminateInf
+   *
+   *  @param  that    the sequence to test
+   *  @return  the last index such that the elements of this $coll starting at this index
+   *           match the elements of sequence `that`, or `-1` if no such subsequence exists.
+   */
   @deprecatedOverriding("Override lastIndexOfSlice(that, end) instead - lastIndexOfSlice(that) calls lastIndexOfSlice(that, Int.MaxValue)", "2.13.0")
   def lastIndexOfSlice[B >: A](that: Seq[B]): Int = lastIndexOfSlice(that, Int.MaxValue)
 
@@ -537,12 +537,12 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *  $willForceEvaluation
    *
    *  @return   An Iterator which traverses the distinct permutations of this $coll.
-   *  @example {{{
+   *  @example ```
    *    Seq('a', 'b', 'b').permutations.foreach(println)
    *    // List(a, b, b)
    *    // List(b, a, b)
    *    // List(b, b, a)
-   *  }}}
+   *  ```
    */
   def permutations: Iterator[C^{this}]^{this} =
     if (isEmpty) Iterator.single(coll)
@@ -550,7 +550,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
 
   /** Iterates over combinations of elements.
    *
-   *  A '''combination''' of length `n` is a sequence of `n` elements selected in order of their first index in this sequence.
+   *  A **combination** of length `n` is a sequence of `n` elements selected in order of their first index in this sequence.
    *
    *  For example, `"xyx"` has two combinations of length 2. The `x` is selected first: `"xx"`, `"xy"`.
    *  The sequence `"yx"` is not returned as a combination because it is subsumed by `"xy"`.
@@ -574,7 +574,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *  $willForceEvaluation
    *
    *  @return   An Iterator which traverses the n-element combinations of this $coll.
-   *  @example {{{
+   *  @example ```
    *    Seq('a', 'b', 'b', 'b', 'c').combinations(2).foreach(println)
    *    // List(a, b)
    *    // List(a, c)
@@ -583,7 +583,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *    Seq('b', 'a', 'b').combinations(2).foreach(println)
    *    // List(b, b)
    *    // List(b, a)
-   *  }}}
+   *  ```
    */
   def combinations(n: Int): Iterator[C^{this}]^{this} =
     if (n < 0 || n > size) Iterator.empty
@@ -685,10 +685,10 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
     }
 
     /** Rearrange seq to newSeq a0a0..a0a1..a1...ak..ak such that
-      *  seq.count(_ == aj) == cnts(j)
-      *
-      *  @return     (newSeq,cnts,nums)
-      */
+     *  seq.count(_ == aj) == cnts(j)
+     *
+     *  @return     (newSeq,cnts,nums)
+     */
     private def init(): (IndexedSeq[A], Array[Int], Array[Int]) = {
       val m = mutable.HashMap[A, Int]()
 
@@ -708,18 +708,18 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
   }
 
   /** Sorts this $coll according to an Ordering.
-    *
-    *  The sort is stable. That is, elements that are equal (as determined by
-    *  `ord.compare`) appear in the same order in the sorted sequence as in the original.
-    *
-    *  @see [[scala.math.Ordering]]
-    *
-    *  $willForceEvaluation
-    *
-    *  @param  ord the ordering to be used to compare elements.
-    *  @return     a $coll consisting of the elements of this $coll
-    *              sorted according to the ordering `ord`.
-    */
+   *
+   *  The sort is stable. That is, elements that are equal (as determined by
+   *  `ord.compare`) appear in the same order in the sorted sequence as in the original.
+   *
+   *  @see [[scala.math.Ordering]]
+   *
+   *  $willForceEvaluation
+   *
+   *  @param  ord the ordering to be used to compare elements.
+   *  @return     a $coll consisting of the elements of this $coll
+   *              sorted according to the ordering `ord`.
+   */
   def sorted[B >: A](implicit ord: Ordering[B]): C^{this} = {
     val len = this.length
     val b = newSpecificBuilder
@@ -752,97 +752,97 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *              the desired ordering.
    *  @return     a $coll consisting of the elements of this $coll
    *              sorted according to the comparison function `lt`.
-   *  @example {{{
+   *  @example ```
    *    List("Steve", "Bobby", "Tom", "John", "Bob").sortWith((x, y) => x.take(3).compareTo(y.take(3)) < 0) =
    *    List("Bobby", "Bob", "John", "Steve", "Tom")
-   *  }}}
+   *  ```
    */
   def sortWith(lt: (A, A) => Boolean): C^{this} = sorted(using Ordering.fromLessThan(lt))
 
   /** Sorts this $coll according to the Ordering which results from transforming
-    * an implicitly given Ordering with a transformation function.
-    * $willNotTerminateInf
-    * $willForceEvaluation
-    *
-    * The sort is stable. That is, elements that are equal (as determined by
-    * `ord.compare`) appear in the same order in the sorted sequence as in the original.
-    *
-    *  @see [[scala.math.Ordering]]
-    *  @param   f the transformation function mapping elements
-    *           to some other domain `B`.
-    *  @param   ord the ordering assumed on domain `B`.
-    *  @tparam  B the target type of the transformation `f`, and the type where
-    *           the ordering `ord` is defined.
-    *  @return  a $coll consisting of the elements of this $coll
-    *           sorted according to the ordering where `x < y` if
-    *           `ord.lt(f(x), f(y))`.
-    *
-    *  @example {{{
-    *    val words = "The quick brown fox jumped over the lazy dog".split(' ')
-    *    // this works because scala.Ordering will implicitly provide an Ordering[Tuple2[Int, Char]]
-    *    words.sortBy(x => (x.length, x.head))
-    *    res0: Array[String] = Array(The, dog, fox, the, lazy, over, brown, quick, jumped)
-    *  }}}
-    */
+   *  an implicitly given Ordering with a transformation function.
+   *  $willNotTerminateInf
+   *  $willForceEvaluation
+   *
+   *  The sort is stable. That is, elements that are equal (as determined by
+   *  `ord.compare`) appear in the same order in the sorted sequence as in the original.
+   *
+   *  @see [[scala.math.Ordering]]
+   *  @tparam  B the target type of the transformation `f`, and the type where
+   *           the ordering `ord` is defined.
+   *  @param   f the transformation function mapping elements
+   *           to some other domain `B`.
+   *  @param   ord the ordering assumed on domain `B`.
+   *  @return  a $coll consisting of the elements of this $coll
+   *           sorted according to the ordering where `x < y` if
+   *           `ord.lt(f(x), f(y))`.
+   *
+   *  @example ```
+   *    val words = "The quick brown fox jumped over the lazy dog".split(' ')
+   *    // this works because scala.Ordering will implicitly provide an Ordering[Tuple2[Int, Char]]
+   *    words.sortBy(x => (x.length, x.head))
+   *    res0: Array[String] = Array(The, dog, fox, the, lazy, over, brown, quick, jumped)
+   *  ```
+   */
   def sortBy[B](f: A => B)(implicit ord: Ordering[B]): C^{this} = sorted(using ord.on(f))
 
   /** Produces the range of all indices of this sequence.
-    * $willForceEvaluation
-    *
-    *  @return  a `Range` value from `0` to one less than the length of this $coll.
-    */
+   *  $willForceEvaluation
+   *
+   *  @return  a `Range` value from `0` to one less than the length of this $coll.
+   */
   def indices: Range = Range(0, length)
 
   override final def sizeCompare(otherSize: Int): Int = lengthCompare(otherSize)
 
   /** Compares the length of this $coll to a test value.
-    *
-    *   @param   len   the test value that gets compared with the length.
-    *   @return  A value `x` where
-    *   {{{
-    *        x <  0       if this.length <  len
-    *        x == 0       if this.length == len
-    *        x >  0       if this.length >  len
-    *   }}}
-    *  The method as implemented here does not call `length` directly; its running time
-    *  is `O(length min len)` instead of `O(length)`. The method should be overridden
-    *  if computing `length` is cheap and `knownSize` returns `-1`.
-    *
-    *  @see [[lengthIs]]
-    */
+   *
+   *  @param   len   the test value that gets compared with the length.
+   *  @return  A value `x` where
+   *   ```
+   *        x <  0       if this.length <  len
+   *        x == 0       if this.length == len
+   *        x >  0       if this.length >  len
+   *   ```
+   *  The method as implemented here does not call `length` directly; its running time
+   *  is `O(length min len)` instead of `O(length)`. The method should be overridden
+   *  if computing `length` is cheap and `knownSize` returns `-1`.
+   *
+   *  @see [[lengthIs]]
+   */
   def lengthCompare(len: Int): Int = super.sizeCompare(len)
 
   override final def sizeCompare(that: Iterable[?]^): Int = lengthCompare(that)
 
   /** Compares the length of this $coll to the size of another `Iterable`.
-    *
-    *   @param   that the `Iterable` whose size is compared with this $coll's length.
-    *   @return  A value `x` where
-    *   {{{
-    *        x <  0       if this.length <  that.size
-    *        x == 0       if this.length == that.size
-    *        x >  0       if this.length >  that.size
-    *   }}}
-    *  The method as implemented here does not call `length` or `size` directly; its running time
-    *  is `O(this.length min that.size)` instead of `O(this.length + that.size)`.
-    *  The method should be overridden if computing `size` is cheap and `knownSize` returns `-1`.
-    */
+   *
+   *  @param   that the `Iterable` whose size is compared with this $coll's length.
+   *  @return  A value `x` where
+   *   ```
+   *        x <  0       if this.length <  that.size
+   *        x == 0       if this.length == that.size
+   *        x >  0       if this.length >  that.size
+   *   ```
+   *  The method as implemented here does not call `length` or `size` directly; its running time
+   *  is `O(this.length min that.size)` instead of `O(this.length + that.size)`.
+   *  The method should be overridden if computing `size` is cheap and `knownSize` returns `-1`.
+   */
   def lengthCompare(that: Iterable[?]^): Int = super.sizeCompare(that)
 
   /** Returns a value class containing operations for comparing the length of this $coll to a test value.
-    *
-    * These operations are implemented in terms of [[lengthCompare(Int) `lengthCompare(Int)`]], and
-    * allow the following more readable usages:
-    *
-    * {{{
-    * this.lengthIs < len     // this.lengthCompare(len) < 0
-    * this.lengthIs <= len    // this.lengthCompare(len) <= 0
-    * this.lengthIs == len    // this.lengthCompare(len) == 0
-    * this.lengthIs != len    // this.lengthCompare(len) != 0
-    * this.lengthIs >= len    // this.lengthCompare(len) >= 0
-    * this.lengthIs > len     // this.lengthCompare(len) > 0
-    * }}}
-    */
+   *
+   *  These operations are implemented in terms of [[lengthCompare(Int) `lengthCompare(Int)`]], and
+   *  allow the following more readable usages:
+   *
+   *  ```
+   *  this.lengthIs < len     // this.lengthCompare(len) < 0
+   *  this.lengthIs <= len    // this.lengthCompare(len) <= 0
+   *  this.lengthIs == len    // this.lengthCompare(len) == 0
+   *  this.lengthIs != len    // this.lengthCompare(len) != 0
+   *  this.lengthIs >= len    // this.lengthCompare(len) >= 0
+   *  this.lengthIs > len     // this.lengthCompare(len) > 0
+   *  ```
+   */
   @inline final def lengthIs: IterableOps.SizeCompareOps^{this} = new IterableOps.SizeCompareOps(caps.unsafe.unsafeAssumePure(this) /* see comment in SizeCompareOps*/)
 
   override def isEmpty: Boolean = lengthCompare(0) == 0
@@ -850,8 +850,8 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
   /** Checks whether corresponding elements of the given iterable collection
    *  compare equal (with respect to `==`) to elements of this $coll.
    *
-   *  @param that  the collection to compare
    *  @tparam B    the type of the elements of collection `that`.
+   *  @param that  the collection to compare
    *  @return `true` if both collections contain equal elements in the same order, `false` otherwise.
    */
   def sameElements[B >: A](that: IterableOnce[B]^): Boolean = {
@@ -867,15 +867,15 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
   }
 
   /** Tests whether every element of this $coll relates to the
-    * corresponding element of another sequence by satisfying a test predicate.
-    *
-    *  @param   that  the other sequence
-    *  @param   p     the test predicate, which relates elements from both sequences
-    *  @tparam  B     the type of the elements of `that`
-    *  @return  `true` if both sequences have the same length and
-    *                  `p(x, y)` is `true` for all corresponding elements `x` of this $coll
-    *                  and `y` of `that`, otherwise `false`.
-    */
+   *  corresponding element of another sequence by satisfying a test predicate.
+   *
+   *  @tparam  B     the type of the elements of `that`
+   *  @param   that  the other sequence
+   *  @param   p     the test predicate, which relates elements from both sequences
+   *  @return  `true` if both sequences have the same length and
+   *                  `p(x, y)` is `true` for all corresponding elements `x` of this $coll
+   *                  and `y` of `that`, otherwise `false`.
+   */
   def corresponds[B](that: Seq[B])(p: (A, B) => Boolean): Boolean = {
     val i = iterator
     val j = that.iterator
@@ -886,14 +886,14 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
   }
 
   /** Computes the multiset difference between this $coll and another sequence.
-    *
-    *  @param that   the sequence of elements to remove
-    *  @return       a new $coll which contains all elements of this $coll
-    *                except some of the occurrences of elements that also appear in `that`.
-    *                If an element value `x` appears
-    *                ''n'' times in `that`, then the first ''n'' occurrences of `x` will not form
-    *                part of the result, but any following occurrences will.
-    */
+   *
+   *  @param that   the sequence of elements to remove
+   *  @return       a new $coll which contains all elements of this $coll
+   *                except some of the occurrences of elements that also appear in `that`.
+   *                If an element value `x` appears
+   *                *n* times in `that`, then the first *n* occurrences of `x` will not form
+   *                part of the result, but any following occurrences will.
+   */
   def diff[B >: A](that: Seq[B]): C^{this} = {
     val occ = occCounts(that)
     fromSpecific(iterator.filter { x =>
@@ -911,14 +911,14 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
   }
 
   /** Computes the multiset intersection between this $coll and another sequence.
-    *
-    *  @param that   the sequence of elements to intersect with.
-    *  @return       a new $coll which contains all elements of this $coll
-    *                which also appear in `that`.
-    *                If an element value `x` appears
-    *                ''n'' times in `that`, then the first ''n'' occurrences of `x` will be retained
-    *                in the result, but any following occurrences will be omitted.
-    */
+   *
+   *  @param that   the sequence of elements to intersect with.
+   *  @return       a new $coll which contains all elements of this $coll
+   *                which also appear in `that`.
+   *                If an element value `x` appears
+   *                *n* times in `that`, then the first *n* occurrences of `x` will be retained
+   *                in the result, but any following occurrences will be omitted.
+   */
   def intersect[B >: A](that: Seq[B]): C^{this} = {
     val occ = occCounts(that)
     fromSpecific(iterator.filter { x =>
@@ -936,31 +936,31 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
   }
 
   /** Produces a new $coll where a slice of elements in this $coll is replaced by another sequence.
-    *
-    * Patching at negative indices is the same as patching starting at 0.
-    * Patching at indices at or larger than the length of the original $coll appends the patch to the end.
-    * If the `replaced` count would exceed the available elements, the difference in excess is ignored.
-    *
-    *  @param  from     the index of the first replaced element
-    *  @param  other    the replacement sequence
-    *  @param  replaced the number of elements to drop in the original $coll
-    *  @tparam B        the element type of the returned $coll.
-    *  @return          a new $coll consisting of all elements of this $coll
-    *                   except that `replaced` elements starting from `from` are replaced
-    *                   by all the elements of `other`.
-    */
+   *
+   *  Patching at negative indices is the same as patching starting at 0.
+   *  Patching at indices at or larger than the length of the original $coll appends the patch to the end.
+   *  If the `replaced` count would exceed the available elements, the difference in excess is ignored.
+   *
+   *  @tparam B        the element type of the returned $coll.
+   *  @param  from     the index of the first replaced element
+   *  @param  other    the replacement sequence
+   *  @param  replaced the number of elements to drop in the original $coll
+   *  @return          a new $coll consisting of all elements of this $coll
+   *                   except that `replaced` elements starting from `from` are replaced
+   *                   by all the elements of `other`.
+   */
   def patch[B >: A](from: Int, other: IterableOnce[B]^, replaced: Int): CC[B]^{this, other} =
     iterableFactory.from(new View.Patched(this, from, other, replaced))
 
   /** A copy of this $coll with one single replaced element.
-    *  @param  index  the position of the replacement
-    *  @param  elem   the replacing element
-    *  @tparam B        the element type of the returned $coll.
-    *  @return a new $coll which is a copy of this $coll with the element at position `index` replaced by `elem`.
-    *  @throws IndexOutOfBoundsException if `index` does not satisfy `0 <= index < length`. In case of a
-    *                                    lazy collection this exception may be thrown at a later time or not at
-    *                                    all (if the end of the collection is never evaluated).
-    */
+   *  @tparam B        the element type of the returned $coll.
+   *  @param  index  the position of the replacement
+   *  @param  elem   the replacing element
+   *  @return a new $coll which is a copy of this $coll with the element at position `index` replaced by `elem`.
+   *  @throws IndexOutOfBoundsException if `index` does not satisfy `0 <= index < length`. In case of a
+   *                                    lazy collection this exception may be thrown at a later time or not at
+   *                                    all (if the end of the collection is never evaluated).
+   */
   def updated[B >: A](index: Int, elem: B): CC[B]^{this} = {
     if(index < 0) throw new IndexOutOfBoundsException(index.toString)
     val k = knownSize
@@ -978,48 +978,48 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
   }
 
   /** Searches this sorted sequence for a specific element. If the sequence is an
-    * `IndexedSeq`, a binary search is used. Otherwise, a linear search is used.
-    *
-    * The sequence should be sorted with the same `Ordering` before calling; otherwise,
-    * the results are undefined.
-    *
-    * @see [[scala.collection.IndexedSeq]]
-    * @see [[scala.math.Ordering]]
-    * @see [[scala.collection.SeqOps]], method `sorted`
-    *
-    * @param elem the element to find.
-    * @param ord  the ordering to be used to compare elements.
-    *
-    * @return a `Found` value containing the index corresponding to the element in the
-    *         sequence, or the `InsertionPoint` where the element would be inserted if
-    *         the element is not in the sequence.
-    */
+   *  `IndexedSeq`, a binary search is used. Otherwise, a linear search is used.
+   *
+   *  The sequence should be sorted with the same `Ordering` before calling; otherwise,
+   *  the results are undefined.
+   *
+   *  @see [[scala.collection.IndexedSeq]]
+   *  @see [[scala.math.Ordering]]
+   *  @see [[scala.collection.SeqOps]], method `sorted`
+   *
+   *  @param elem the element to find.
+   *  @param ord  the ordering to be used to compare elements.
+   *
+   *  @return a `Found` value containing the index corresponding to the element in the
+   *         sequence, or the `InsertionPoint` where the element would be inserted if
+   *         the element is not in the sequence.
+   */
   def search[B >: A](elem: B)(implicit ord: Ordering[B]): SearchResult =
     linearSearch(view, elem, 0)(using ord)
 
   /** Searches within an interval in this sorted sequence for a specific element. If this
-    * sequence is an `IndexedSeq`, a binary search is used. Otherwise, a linear search
-    * is used.
-    *
-    * The sequence should be sorted with the same `Ordering` before calling; otherwise,
-    * the results are undefined.
-    *
-    * @see [[scala.collection.IndexedSeq]]
-    * @see [[scala.math.Ordering]]
-    * @see [[scala.collection.SeqOps]], method `sorted`
-    *
-    * @param elem the element to find.
-    * @param from the index where the search starts.
-    * @param to   the index following where the search ends.
-    * @param ord  the ordering to be used to compare elements.
-    *
-    * @return a `Found` value containing the index corresponding to the element in the
-    *         sequence, or the `InsertionPoint` where the element would be inserted if
-    *         the element is not in the sequence.
-    *
-    * @note if `to <= from`, the search space is empty, and an `InsertionPoint` at `from`
-    *       is returned
-    */
+   *  sequence is an `IndexedSeq`, a binary search is used. Otherwise, a linear search
+   *  is used.
+   *
+   *  The sequence should be sorted with the same `Ordering` before calling; otherwise,
+   *  the results are undefined.
+   *
+   *  @see [[scala.collection.IndexedSeq]]
+   *  @see [[scala.math.Ordering]]
+   *  @see [[scala.collection.SeqOps]], method `sorted`
+   *
+   *  @param elem the element to find.
+   *  @param from the index where the search starts.
+   *  @param to   the index following where the search ends.
+   *  @param ord  the ordering to be used to compare elements.
+   *
+   *  @return a `Found` value containing the index corresponding to the element in the
+   *         sequence, or the `InsertionPoint` where the element would be inserted if
+   *         the element is not in the sequence.
+   *
+   *  @note if `to <= from`, the search space is empty, and an `InsertionPoint` at `from`
+   *       is returned
+   */
   def search[B >: A](elem: B, from: Int, to: Int) (implicit ord: Ordering[B]): SearchResult =
     linearSearch(view.slice(from, to), elem, math.max(0, from))(using ord)
 
@@ -1041,18 +1041,18 @@ object SeqOps {
 
   // KMP search utilities
 
- /**  A KMP implementation, based on the undoubtedly reliable wikipedia entry.
-   *  Note: I made this private to keep it from entering the API.  That can be reviewed.
-   *
-   *  @param  S       Sequence that may contain target
-   *  @param  m0      First index of S to consider
-   *  @param  m1      Last index of S to consider (exclusive)
-   *  @param  W       Target sequence
-   *  @param  n0      First index of W to match
-   *  @param  n1      Last index of W to match (exclusive)
-   *  @param  forward Direction of search (from beginning==true, from end==false)
-   *  @return Index of start of sequence if found, -1 if not (relative to beginning of S, not m0).
-   */
+ /** A KMP implementation, based on the undoubtedly reliable wikipedia entry.
+  *  Note: I made this private to keep it from entering the API.  That can be reviewed.
+  *
+  *  @param  S       Sequence that may contain target
+  *  @param  m0      First index of S to consider
+  *  @param  m1      Last index of S to consider (exclusive)
+  *  @param  W       Target sequence
+  *  @param  n0      First index of W to match
+  *  @param  n1      Last index of W to match (exclusive)
+  *  @param  forward Direction of search (from beginning==true, from end==false)
+  *  @return Index of start of sequence if found, -1 if not (relative to beginning of S, not m0).
+  */
   private def kmpSearch[B](S: scala.collection.Seq[B], m0: Int, m1: Int, W: scala.collection.Seq[B], n0: Int, n1: Int, forward: Boolean): Int = {
     // Check for redundant case when target has single valid element
     def clipR(x: Int, y: Int) = if (x < y) x else -1
@@ -1168,11 +1168,11 @@ object SeqOps {
   }
 
  /** Makes a jump table for KMP search.
-   *
-   *  @param  Wopt The target sequence
-   *  @param  wlen Just in case we're only IndexedSeq and not IndexedSeqOptimized
-   *  @return KMP jump table for target sequence
-   */
+  *
+  *  @param  Wopt The target sequence
+  *  @param  wlen Just in case we're only IndexedSeq and not IndexedSeqOptimized
+  *  @return KMP jump table for target sequence
+  */
   private def kmpJumpTable[B](Wopt: IndexedSeqView[B]^, wlen: Int) = {
     val arr = new Array[Int](wlen)
     var pos = 2

--- a/library/src/scala/collection/Set.scala
+++ b/library/src/scala/collection/Set.scala
@@ -21,8 +21,7 @@ import java.lang.String
 
 import scala.annotation.nowarn
 
-/** Base trait for set collections.
-  */
+/** Base trait for set collections. */
 trait Set[A]
   extends Iterable[A]
     with SetOps[A, Set, Set[A]]
@@ -32,23 +31,22 @@ trait Set[A]
 
   def canEqual(that: Any) = true
 
-  /**
-   * Equality of sets is implemented using the lookup method [[contains]]. This method returns `true` if
+  /** Equality of sets is implemented using the lookup method [[contains]]. This method returns `true` if
    *   - the argument `that` is a `Set`,
    *   - the two sets have the same [[size]], and
    *   - for every `element` this set, `other.contains(element) == true`.
    *
-   * The implementation of `equals` checks the [[canEqual]] method, so subclasses of `Set` can narrow down the equality
-   * to specific set types. The `Set` implementations in the standard library can all be compared, their `canEqual`
-   * methods return `true`.
+   *  The implementation of `equals` checks the [[canEqual]] method, so subclasses of `Set` can narrow down the equality
+   *  to specific set types. The `Set` implementations in the standard library can all be compared, their `canEqual`
+   *  methods return `true`.
    *
-   * Note: The `equals` method only respects the equality laws (symmetry, transitivity) if the two sets use the same
-   * element equivalence function in their lookup operation. For example, the element equivalence operation in a
-   * [[scala.collection.immutable.TreeSet]] is defined by its ordering. Comparing a `TreeSet` with a `HashSet` leads
-   * to unexpected results if `ordering.equiv(e1, e2)` (used for lookup in `TreeSet`) is different from `e1 == e2`
-   * (used for lookup in `HashSet`).
+   *  Note: The `equals` method only respects the equality laws (symmetry, transitivity) if the two sets use the same
+   *  element equivalence function in their lookup operation. For example, the element equivalence operation in a
+   *  [[scala.collection.immutable.TreeSet]] is defined by its ordering. Comparing a `TreeSet` with a `HashSet` leads
+   *  to unexpected results if `ordering.equiv(e1, e2)` (used for lookup in `TreeSet`) is different from `e1 == e2`
+   *  (used for lookup in `HashSet`).
    *
-   * {{{
+   *  ```
    *   scala> import scala.collection.immutable._
    *   scala> val ord: Ordering[String] = _ compareToIgnoreCase _
    *
@@ -57,11 +55,11 @@ trait Set[A]
    *
    *   scala> HashSet("a") == TreeSet("A")(ord)
    *   val res1: Boolean = true
-   * }}}
+   *  ```
    *
    *
-   * @param that The set to which this set is compared
-   * @return `true` if the two sets are equal according to the description
+   *  @param that The set to which this set is compared
+   *  @return `true` if the two sets are equal according to the description
    */
   override def equals(that: Any): Boolean =
     (this eq that.asInstanceOf[AnyRef]) || (that match {
@@ -85,10 +83,10 @@ trait Set[A]
 }
 
 /** Base trait for set operations
-  *
-  * @define coll set
-  * @define Coll `Set`
-  */
+ *
+ *  @define coll set
+ *  @define Coll `Set`
+ */
 transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   extends IterableOps[A, CC, C]
      with (A => Boolean)
@@ -97,36 +95,36 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   def contains(elem: A): Boolean
 
   /** Tests if some element is contained in this set.
-    *
-    *  This method is equivalent to `contains`. It allows sets to be interpreted as predicates.
-    *  @param elem the element to test for membership.
-    *  @return  `true` if `elem` is contained in this set, `false` otherwise.
-    */
+   *
+   *  This method is equivalent to `contains`. It allows sets to be interpreted as predicates.
+   *  @param elem the element to test for membership.
+   *  @return  `true` if `elem` is contained in this set, `false` otherwise.
+   */
   @`inline` final def apply(elem: A): Boolean = this.contains(elem)
 
   /** Tests whether this set is a subset of another set.
-    *
-    *  @param that  the set to test.
-    *  @return     `true` if this set is a subset of `that`, i.e. if
-    *              every element of this set is also an element of `that`.
-    */
+   *
+   *  @param that  the set to test.
+   *  @return     `true` if this set is a subset of `that`, i.e. if
+   *              every element of this set is also an element of `that`.
+   */
   def subsetOf(that: Set[A]): Boolean = this.forall(that)
 
   /** An iterator over all subsets of this set of the given size.
-    *  If the requested size is impossible, an empty iterator is returned.
-    *
-    *  @param len  the size of the subsets.
-    *  @return     the iterator.
-    */
+   *  If the requested size is impossible, an empty iterator is returned.
+   *
+   *  @param len  the size of the subsets.
+   *  @return     the iterator.
+   */
   def subsets(len: Int): Iterator[C] = {
     if (len < 0 || len > size) Iterator.empty
     else new SubsetsItr(this.to(IndexedSeq), len)
   }
 
   /** An iterator over all subsets of this set.
-    *
-    *  @return     the iterator.
-    */
+   *
+   *  @return     the iterator.
+   */
   def subsets(): Iterator[C] = new AbstractIterator[C] {
     private val elms = SetOps.this.to(IndexedSeq)
     private var len = 0
@@ -147,12 +145,11 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   }
 
   /** An Iterator including all subsets containing exactly len elements.
-    *  If the elements in 'This' type is ordered, then the subsets will also be in the same order.
-    *  ListSet(1,2,3).subsets => {{1},{2},{3},{1,2},{1,3},{2,3},{1,2,3}}
-    *
-    *  $willForceEvaluation
-    *
-    */
+   *  If the elements in 'This' type is ordered, then the subsets will also be in the same order.
+   *  ListSet(1,2,3).subsets => {{1},{2},{3},{1,2},{1,3},{2,3},{1,2,3}}
+   *
+   *  $willForceEvaluation
+   */
   private class SubsetsItr(elms: IndexedSeq[A], len: Int) extends AbstractIterator[C] {
     private val idxs = Array.range(0, len+1)
     private var _hasNext = true
@@ -182,22 +179,22 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   }
 
   /** Computes the intersection between this set and another set.
-    *
-    *  @param   that  the set to intersect with.
-    *  @return  a new set consisting of all elements that are both in this
-    *  set and in the given set `that`.
-    */
+   *
+   *  @param   that  the set to intersect with.
+   *  @return  a new set consisting of all elements that are both in this
+   *  set and in the given set `that`.
+   */
   def intersect(that: Set[A]): C = this.filter(that)
 
   /** Alias for `intersect`. */
   @`inline` final def & (that: Set[A]): C = intersect(that)
 
   /** Computes the difference of this set and another set.
-    *
-    *  @param that the set of elements to exclude.
-    *  @return     a set containing those elements of this
-    *              set that are not also contained in the given set `that`.
-    */
+   *
+   *  @param that the set of elements to exclude.
+   *  @return     a set containing those elements of this
+   *              set that are not also contained in the given set `that`.
+   */
   def diff(that: Set[A]): C
 
   /** Alias for `diff`. */
@@ -216,16 +213,16 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   def - (elem1: A, elem2: A, elems: A*): C = diff(elems.toSet + elem1 + elem2)
 
   /** Creates a new $ccoll by adding all elements contained in another collection to this $coll, omitting duplicates.
-    *
-    * Example:
-    *  {{{
-    *    scala> val a = Set(1, 2) concat Set(2, 3)
-    *    a: scala.collection.immutable.Set[Int] = Set(1, 2, 3)
-    *  }}}
-    *
-    *  @param that     the collection containing the elements to add.
-    *  @return a new $coll with the given elements added, omitting duplicates.
-    */
+   *
+   *  Example:
+   *  ```
+   *    scala> val a = Set(1, 2) concat Set(2, 3)
+   *    a: scala.collection.immutable.Set[Int] = Set(1, 2, 3)
+   *  ```
+   *
+   *  @param that     the collection containing the elements to add.
+   *  @return a new $coll with the given elements added, omitting duplicates.
+   */
   def concat(that: collection.IterableOnce[A]^): C = this match {
     case optimizedSet @ (_ : scala.collection.immutable.Set.Set1[A] | _: scala.collection.immutable.Set.Set2[A] | _: scala.collection.immutable.Set.Set3[A] | _: scala.collection.immutable.Set.Set4[A]) =>
       // StrictOptimizedSetOps optimization of concat (these Sets cannot extend StrictOptimizedSetOps because of binary-incompatible return type; cf. PR #10036)
@@ -249,22 +246,21 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   @`inline` final def ++ (that: collection.IterableOnce[A]^): C = concat(that)
 
   /** Computes the union between of set and another set.
-    *
-    *  @param   that  the set to form the union with.
-    *  @return  a new set consisting of all elements that are in this
-    *  set or in the given set `that`.
-    */
+   *
+   *  @param   that  the set to form the union with.
+   *  @return  a new set consisting of all elements that are in this
+   *  set or in the given set `that`.
+   */
   @`inline` final def union(that: Set[A]): C = concat(that)
 
   /** Alias for `union`. */
   @`inline` final def | (that: Set[A]): C = concat(that)
 }
 
-/**
-  * $factoryInfo
-  * @define coll set
-  * @define Coll `Set`
-  */
+/** $factoryInfo
+ *  @define coll set
+ *  @define Coll `Set`
+ */
 @SerialVersionUID(3L)
 object Set extends IterableFactory.Delegate[Set](immutable.Set)
 

--- a/library/src/scala/collection/SortedMap.scala
+++ b/library/src/scala/collection/SortedMap.scala
@@ -56,69 +56,66 @@ transparent trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y
      with caps.Pure {
 
   /** The companion object of this sorted map, providing various factory methods.
-    *
-    * @note When implementing a custom collection type and refining `CC` to the new type, this
-    *       method needs to be overridden to return a factory for the new type (the compiler will
-    *       issue an error otherwise).
-    */
+   *
+   *  @note When implementing a custom collection type and refining `CC` to the new type, this
+   *       method needs to be overridden to return a factory for the new type (the compiler will
+   *       issue an error otherwise).
+   */
   def sortedMapFactory: SortedMapFactory[CC]
 
   /** Similar to `mapFromIterable`, but returns a SortedMap collection type.
-    * Note that the return type is now `CC[K2, V2]`.
-    */
+   *  Note that the return type is now `CC[K2, V2]`.
+   */
   @`inline` protected final def sortedMapFromIterable[K2, V2](it: Iterable[(K2, V2)]^)(implicit ordering: Ordering[K2]): CC[K2, V2] = sortedMapFactory.from(it)
 
   def unsorted: Map[K, V]
 
-  /**
-    * Creates an iterator over all the key/value pairs
-    * contained in this map having a key greater than or
-    * equal to `start` according to the ordering of
-    * this map. x.iteratorFrom(y) is equivalent
-    * to but often more efficient than x.from(y).iterator.
-    *
-    * @param start The lower bound (inclusive)
-    * on the keys to be returned
-    */
+  /** Creates an iterator over all the key/value pairs
+   *  contained in this map having a key greater than or
+   *  equal to `start` according to the ordering of
+   *  this map. x.iteratorFrom(y) is equivalent
+   *  to but often more efficient than x.from(y).iterator.
+   *
+   *  @param start The lower bound (inclusive)
+   *  on the keys to be returned
+   */
   def iteratorFrom(start: K): Iterator[(K, V)]
 
-  /**
-    * Creates an iterator over all the keys(or elements)  contained in this
-    * collection greater than or equal to `start`
-    * according to the ordering of this collection. x.keysIteratorFrom(y)
-    * is equivalent to but often more efficient than
-    * x.from(y).keysIterator.
-    *
-    * @param start The lower bound (inclusive)
-    * on the keys to be returned
-    */
+  /** Creates an iterator over all the keys(or elements)  contained in this
+   *  collection greater than or equal to `start`
+   *  according to the ordering of this collection. x.keysIteratorFrom(y)
+   *  is equivalent to but often more efficient than
+   *  x.from(y).keysIterator.
+   *
+   *  @param start The lower bound (inclusive)
+   *  on the keys to be returned
+   */
   def keysIteratorFrom(start: K): Iterator[K]
 
-  /**
-    * Creates an iterator over all the values contained in this
-    * map that are associated with a key greater than or equal to `start`
-    * according to the ordering of this map. x.valuesIteratorFrom(y) is
-    * equivalent to but often more efficient than
-    * x.from(y).valuesIterator.
-    *
-    * @param start The lower bound (inclusive)
-    * on the keys to be returned
-    */
+  /** Creates an iterator over all the values contained in this
+   *  map that are associated with a key greater than or equal to `start`
+   *  according to the ordering of this map. x.valuesIteratorFrom(y) is
+   *  equivalent to but often more efficient than
+   *  x.from(y).valuesIterator.
+   *
+   *  @param start The lower bound (inclusive)
+   *  on the keys to be returned
+   */
   def valuesIteratorFrom(start: K): Iterator[V] = iteratorFrom(start).map(_._2)
 
   def firstKey: K = head._1
   def lastKey: K = last._1
 
   /** Finds the element with smallest key larger than or equal to a given key.
-    * @param key The given key.
-    * @return `None` if there is no such node.
-    */
+   *  @param key The given key.
+   *  @return `None` if there is no such node.
+   */
   def minAfter(key: K): Option[(K, V)] = rangeFrom(key).headOption
 
   /** Finds the element with largest key less than a given key.
-    * @param key The given key.
-    * @return `None` if there is no such node.
-    */
+   *  @param key The given key.
+   *  @return `None` if there is no such node.
+   */
   def maxBefore(key: K): Option[(K, V)] = rangeUntil(key).lastOption
 
   def rangeTo(to: K): C = {
@@ -165,32 +162,32 @@ transparent trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y
 
   // And finally, we add new overloads taking an ordering
   /** Builds a new sorted map by applying a function to all elements of this $coll.
-    *
-    *  @param f      the function to apply to each element.
-    *  @return       a new $coll resulting from applying the given function
-    *                `f` to each element of this $coll and collecting the results.
-    */
+   *
+   *  @param f      the function to apply to each element.
+   *  @return       a new $coll resulting from applying the given function
+   *                `f` to each element of this $coll and collecting the results.
+   */
   def map[K2, V2](f: ((K, V)) => (K2, V2))(implicit @implicitNotFound(SortedMapOps.ordMsg) ordering: Ordering[K2]): CC[K2, V2] =
     sortedMapFactory.from(new View.Map[(K, V), (K2, V2)](this, f))
 
   /** Builds a new sorted map by applying a function to all elements of this $coll
-    *  and using the elements of the resulting collections.
-    *
-    *  @param f      the function to apply to each element.
-    *  @return       a new $coll resulting from applying the given collection-valued function
-    *                `f` to each element of this $coll and concatenating the results.
-    */
+   *  and using the elements of the resulting collections.
+   *
+   *  @param f      the function to apply to each element.
+   *  @return       a new $coll resulting from applying the given collection-valued function
+   *                `f` to each element of this $coll and concatenating the results.
+   */
   def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)]^)(implicit @implicitNotFound(SortedMapOps.ordMsg) ordering: Ordering[K2]): CC[K2, V2] =
     sortedMapFactory.from(new View.FlatMap(this, f))
 
   /** Builds a new sorted map by applying a partial function to all elements of this $coll
-    *  on which the function is defined.
-    *
-    *  @param pf     the partial function which filters and maps the $coll.
-    *  @return       a new $coll resulting from applying the given partial function
-    *                `pf` to each element on which it is defined and collecting the results.
-    *                The order of the elements is preserved.
-    */
+   *  on which the function is defined.
+   *
+   *  @param pf     the partial function which filters and maps the $coll.
+   *  @return       a new $coll resulting from applying the given partial function
+   *                `pf` to each element on which it is defined and collecting the results.
+   *                The order of the elements is preserved.
+   */
   def collect[K2, V2](pf: PartialFunction[(K, V), (K2, V2)]^)(implicit @implicitNotFound(SortedMapOps.ordMsg) ordering: Ordering[K2]): CC[K2, V2] =
     sortedMapFactory.from(new View.Collect(this, pf))
 
@@ -213,9 +210,9 @@ object SortedMapOps {
   private[collection] final val ordMsg = "No implicit Ordering[${K2}] found to build a SortedMap[${K2}, ${V2}]. You may want to upcast to a Map[${K}, ${V}] first by calling `unsorted`."
 
   /** Specializes `MapWithFilter` for sorted Map collections
-    *
-    * @define coll sorted map collection
-    */
+   *
+   *  @define coll sorted map collection
+   */
   class WithFilter[K, +V, +IterableCC[_], +MapCC[X, Y] <: Map[X, Y], +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y, CC, ?]](
     self: SortedMapOps[K, V, CC, ?] & MapOps[K, V, MapCC, ?] & IterableOps[(K, V), IterableCC, ?],
     p: ((K, V)) => Boolean

--- a/library/src/scala/collection/SortedOps.scala
+++ b/library/src/scala/collection/SortedOps.scala
@@ -32,31 +32,31 @@ transparent trait SortedOps[A, +C] {
   @inline def compare(k0: A, k1: A): Int = ordering.compare(k0, k1)
 
   /** Creates a ranged projection of this collection. Any mutations in the
-    *  ranged projection will update this collection and vice versa.
-    *
-    *  Note: keys are not guaranteed to be consistent between this collection
-    *  and the projection. This is the case for buffers where indexing is
-    *  relative to the projection.
-    *
-    *  @param from  The lower-bound (inclusive) of the ranged projection.
-    *               `None` if there is no lower bound.
-    *  @param until The upper-bound (exclusive) of the ranged projection.
-    *               `None` if there is no upper bound.
-    */
+   *  ranged projection will update this collection and vice versa.
+   *
+   *  Note: keys are not guaranteed to be consistent between this collection
+   *  and the projection. This is the case for buffers where indexing is
+   *  relative to the projection.
+   *
+   *  @param from  The lower-bound (inclusive) of the ranged projection.
+   *               `None` if there is no lower bound.
+   *  @param until The upper-bound (exclusive) of the ranged projection.
+   *               `None` if there is no upper bound.
+   */
   def rangeImpl(from: Option[A], until: Option[A]): C
 
   /** Creates a ranged projection of this collection with both a lower-bound
-    *  and an upper-bound.
-    *
-    *  @param from The lower-bound (inclusive) of the ranged projection.
-    *  @param until The upper-bound (exclusive) of the ranged projection.
-    */
+   *  and an upper-bound.
+   *
+   *  @param from The lower-bound (inclusive) of the ranged projection.
+   *  @param until The upper-bound (exclusive) of the ranged projection.
+   */
   def range(from: A, until: A): C = rangeImpl(Some(from), Some(until))
 
   /** Creates a ranged projection of this collection with no upper-bound.
-    *
-    *  @param from The lower-bound (inclusive) of the ranged projection.
-    */
+   *
+   *  @param from The lower-bound (inclusive) of the ranged projection.
+   */
   @deprecated("Use rangeFrom", "2.13.0")
   final def from(from: A): C = rangeFrom(from)
 
@@ -67,9 +67,9 @@ transparent trait SortedOps[A, +C] {
   def rangeFrom(from: A): C = rangeImpl(Some(from), None)
 
   /** Creates a ranged projection of this collection with no lower-bound.
-    *
-    *  @param until The upper-bound (exclusive) of the ranged projection.
-    */
+   *
+   *  @param until The upper-bound (exclusive) of the ranged projection.
+   */
   @deprecated("Use rangeUntil", "2.13.0")
   final def until(until: A): C = rangeUntil(until)
 
@@ -80,13 +80,13 @@ transparent trait SortedOps[A, +C] {
   def rangeUntil(until: A): C = rangeImpl(None, Some(until))
 
   /** Creates a range projection of this collection with no lower-bound.
-    *  @param to The upper-bound (inclusive) of the ranged projection.
-    */
+   *  @param to The upper-bound (inclusive) of the ranged projection.
+   */
   @deprecated("Use rangeTo", "2.13.0")
   final def to(to: A): C = rangeTo(to)
 
   /** Creates a range projection of this collection with no lower-bound.
-    *  @param to The upper-bound (inclusive) of the ranged projection.
-    */
+   *  @param to The upper-bound (inclusive) of the ranged projection.
+   */
   def rangeTo(to: A): C
 }

--- a/library/src/scala/collection/SortedSet.scala
+++ b/library/src/scala/collection/SortedSet.scala
@@ -53,24 +53,23 @@ transparent trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, 
      with SortedOps[A, C] {
 
   /** The companion object of this sorted set, providing various factory methods.
-    *
-    * @note When implementing a custom collection type and refining `CC` to the new type, this
-    *       method needs to be overridden to return a factory for the new type (the compiler will
-    *       issue an error otherwise).
-    */
+   *
+   *  @note When implementing a custom collection type and refining `CC` to the new type, this
+   *       method needs to be overridden to return a factory for the new type (the compiler will
+   *       issue an error otherwise).
+   */
   def sortedIterableFactory: SortedIterableFactory[CC]
 
   /** Widens the type of this set to its unsorted counterpart. */
   def unsorted: Set[A]
 
-  /**
-    * Creates an iterator that contains all values from this collection
-    * greater than or equal to `start` according to the ordering of
-    * this collection. x.iteratorFrom(y) is equivalent to but will usually
-    * be more efficient than x.from(y).iterator
-    *
-    * @param start The lower-bound (inclusive) of the iterator
-    */
+  /** Creates an iterator that contains all values from this collection
+   *  greater than or equal to `start` according to the ordering of
+   *  this collection. x.iteratorFrom(y) is equivalent to but will usually
+   *  be more efficient than x.from(y).iterator
+   *
+   *  @param start The lower-bound (inclusive) of the iterator
+   */
   def iteratorFrom(start: A): Iterator[A]
   
   @deprecated("Use `iteratorFrom` instead.", "2.13.0")
@@ -80,15 +79,15 @@ transparent trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, 
   def lastKey: A = last
 
   /** Finds the smallest element larger than or equal to a given key.
-    * @param key The given key.
-    * @return `None` if there is no such node.
-    */
+   *  @param key The given key.
+   *  @return `None` if there is no such node.
+   */
   def minAfter(key: A): Option[A] = rangeFrom(key).headOption
 
   /** Finds the largest element less than a given key.
-    * @param key The given key.
-    * @return `None` if there is no such node.
-    */
+   *  @param key The given key.
+   *  @return `None` if there is no such node.
+   */
   def maxBefore(key: A): Option[A] = rangeUntil(key).lastOption
 
   override def min[B >: A](implicit ord: Ordering[B]): A =
@@ -115,35 +114,35 @@ transparent trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, 
   }
 
   /** Builds a new sorted collection by applying a function to all elements of this $coll.
-    *
-    *  @param f      the function to apply to each element.
-    *  @tparam B     the element type of the returned collection.
-    *  @return       a new $coll resulting from applying the given function
-    *                `f` to each element of this $coll and collecting the results.
-    */
+   *
+   *  @tparam B     the element type of the returned collection.
+   *  @param f      the function to apply to each element.
+   *  @return       a new $coll resulting from applying the given function
+   *                `f` to each element of this $coll and collecting the results.
+   */
   def map[B](f: A => B)(implicit @implicitNotFound(SortedSetOps.ordMsg) ev: Ordering[B]): CC[B] =
     sortedIterableFactory.from(new View.Map(this, f))
 
   /** Builds a new sorted collection by applying a function to all elements of this $coll
-    *  and using the elements of the resulting collections.
-    *
-    *  @param f      the function to apply to each element.
-    *  @tparam B     the element type of the returned collection.
-    *  @return       a new $coll resulting from applying the given collection-valued function
-    *                `f` to each element of this $coll and concatenating the results.
-    */
+   *  and using the elements of the resulting collections.
+   *
+   *  @tparam B     the element type of the returned collection.
+   *  @param f      the function to apply to each element.
+   *  @return       a new $coll resulting from applying the given collection-valued function
+   *                `f` to each element of this $coll and concatenating the results.
+   */
   def flatMap[B](f: A => IterableOnce[B]^)(implicit @implicitNotFound(SortedSetOps.ordMsg) ev: Ordering[B]): CC[B] =
     sortedIterableFactory.from(new View.FlatMap(this, f))
 
   /** Returns a $coll formed from this $coll and another iterable collection
-    *  by combining corresponding elements in pairs.
-    *  If one of the two collections is longer than the other, its remaining elements are ignored.
-    *
-    *  @param   that  The iterable providing the second half of each result pair
-    *  @tparam  B     the type of the second half of the returned pairs
-    *  @return        a new $coll containing pairs consisting of corresponding elements of this $coll and `that`.
-    *                 The length of the returned collection is the minimum of the lengths of this $coll and `that`.
-    */
+   *  by combining corresponding elements in pairs.
+   *  If one of the two collections is longer than the other, its remaining elements are ignored.
+   *
+   *  @tparam  B     the type of the second half of the returned pairs
+   *  @param   that  The iterable providing the second half of each result pair
+   *  @return        a new $coll containing pairs consisting of corresponding elements of this $coll and `that`.
+   *                 The length of the returned collection is the minimum of the lengths of this $coll and `that`.
+   */
   def zip[B](that: IterableOnce[B]^)(implicit @implicitNotFound(SortedSetOps.zipOrdMsg) ev: Ordering[(A @uncheckedVariance, B)]): CC[(A @uncheckedVariance, B)] = // sound bcs of VarianceNote
     sortedIterableFactory.from(that match {
       case that: Iterable[B] => new View.Zip(this, that)
@@ -151,14 +150,14 @@ transparent trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, 
     })
 
   /** Builds a new sorted collection by applying a partial function to all elements of this $coll
-    *  on which the function is defined.
-    *
-    *  @param pf     the partial function which filters and maps the $coll.
-    *  @tparam B     the element type of the returned collection.
-    *  @return       a new $coll resulting from applying the given partial function
-    *                `pf` to each element on which it is defined and collecting the results.
-    *                The order of the elements is preserved.
-    */
+   *  on which the function is defined.
+   *
+   *  @tparam B     the element type of the returned collection.
+   *  @param pf     the partial function which filters and maps the $coll.
+   *  @return       a new $coll resulting from applying the given partial function
+   *                `pf` to each element on which it is defined and collecting the results.
+   *                The order of the elements is preserved.
+   */
   def collect[B](pf: scala.PartialFunction[A, B]^)(implicit @implicitNotFound(SortedSetOps.ordMsg) ev: Ordering[B]): CC[B] =
     sortedIterableFactory.from(new View.Collect(this, pf))
 }
@@ -168,9 +167,9 @@ object SortedSetOps {
   private[collection] final val zipOrdMsg = "No implicit Ordering[${B}] found to build a SortedSet[(${A}, ${B})]. You may want to upcast to a Set[${A}] first by calling `unsorted`."
 
   /** Specialize `WithFilter` for sorted collections
-    *
-    * @define coll sorted collection
-    */
+   *
+   *  @define coll sorted collection
+   */
   class WithFilter[+A, +IterableCC[_], +CC[X] <: SortedSet[X]](
     self: SortedSetOps[A, CC, ?] & IterableOps[A, IterableCC, ?],
     p: A => Boolean

--- a/library/src/scala/collection/Stepper.scala
+++ b/library/src/scala/collection/Stepper.scala
@@ -22,24 +22,24 @@ import java.{lang => jl}
 import scala.collection.Stepper.EfficientSplit
 
 /** Steppers exist to enable creating Java streams over Scala collections, see
-  * [[scala.jdk.StreamConverters]]. Besides that use case, they allow iterating over collections
-  * holding unboxed primitives (e.g., `Array[Int]`) without boxing the elements.
-  *
-  * Steppers have an iterator-like interface with methods `hasStep` and `nextStep()`. The difference
-  * to iterators - and the reason `Stepper` is not a subtype of `Iterator` - is that there are
-  * hand-specialized variants of `Stepper` for `Int`, `Long` and `Double` ([[IntStepper]], etc.).
-  * These enable iterating over collections holding unboxed primitives (e.g., Arrays,
-  * [[scala.jdk.Accumulator]]s) without boxing the elements.
-  *
-  * The selection of primitive types (`Int`, `Long` and `Double`) matches the hand-specialized
-  * variants of Java Streams ([[java.util.stream.Stream]], [[java.util.stream.IntStream]], etc.)
-  * and the corresponding Java Spliterators ([[java.util.Spliterator]], [[java.util.Spliterator.OfInt]], etc.).
-  *
-  * Steppers can be converted to Scala Iterators, Java Iterators and Java Spliterators. Primitive
-  * Steppers are converted to the corresponding primitive Java Iterators and Spliterators.
-  *
-  * @tparam A the element type of the Stepper
-  */
+ *  [[scala.jdk.StreamConverters]]. Besides that use case, they allow iterating over collections
+ *  holding unboxed primitives (e.g., `Array[Int]`) without boxing the elements.
+ *
+ *  Steppers have an iterator-like interface with methods `hasStep` and `nextStep()`. The difference
+ *  to iterators - and the reason `Stepper` is not a subtype of `Iterator` - is that there are
+ *  hand-specialized variants of `Stepper` for `Int`, `Long` and `Double` ([[IntStepper]], etc.).
+ *  These enable iterating over collections holding unboxed primitives (e.g., Arrays,
+ *  [[scala.jdk.Accumulator]]s) without boxing the elements.
+ *
+ *  The selection of primitive types (`Int`, `Long` and `Double`) matches the hand-specialized
+ *  variants of Java Streams ([[java.util.stream.Stream]], [[java.util.stream.IntStream]], etc.)
+ *  and the corresponding Java Spliterators ([[java.util.Spliterator]], [[java.util.Spliterator.OfInt]], etc.).
+ *
+ *  Steppers can be converted to Scala Iterators, Java Iterators and Java Spliterators. Primitive
+ *  Steppers are converted to the corresponding primitive Java Iterators and Spliterators.
+ *
+ *  @tparam A the element type of the Stepper
+ */
 trait Stepper[@specialized(Double, Int, Long) +A] {
   /** Checks if there's an element available. */
   def hasStep: Boolean
@@ -48,43 +48,43 @@ trait Stepper[@specialized(Double, Int, Long) +A] {
   def nextStep(): A
 
   /** Splits this stepper, if applicable. The elements of the current Stepper are split up between
-    * the resulting Stepper and the current stepper.
-    *
-    * May return `null`, in which case the current Stepper yields the same elements as before.
-    *
-    * See method `trySplit` in [[java.util.Spliterator]].
-    */
+   *  the resulting Stepper and the current stepper.
+   *
+   *  May return `null`, in which case the current Stepper yields the same elements as before.
+   *
+   *  See method `trySplit` in [[java.util.Spliterator]].
+   */
   def trySplit(): Stepper[A]^{this} | Null
 
   /** Returns an estimate of the number of elements of this Stepper, or [[Long.MaxValue]]. See
-    * method `estimateSize` in [[java.util.Spliterator]].
-    */
+   *  method `estimateSize` in [[java.util.Spliterator]].
+   */
   def estimateSize: Long
 
   /** Returns a set of characteristics of this Stepper and its elements. See method
-    * `characteristics` in [[java.util.Spliterator]].
-    */
+   *  `characteristics` in [[java.util.Spliterator]].
+   */
   def characteristics: Int
 
   /** Returns a [[java.util.Spliterator]] corresponding to this Stepper.
-    *
-    * Note that the return type is `Spliterator[_]` instead of `Spliterator[A]` to allow returning
-    * a [[java.util.Spliterator.OfInt]] (which is a `Spliterator[Integer]`) in the subclass [[IntStepper]]
-    * (which is a `Stepper[Int]`).
-    */
+   *
+   *  Note that the return type is `Spliterator[_]` instead of `Spliterator[A]` to allow returning
+   *  a [[java.util.Spliterator.OfInt]] (which is a `Spliterator[Integer]`) in the subclass [[IntStepper]]
+   *  (which is a `Stepper[Int]`).
+   */
   def spliterator[B >: A]: Spliterator[?]^{this}
 
   /** Returns a Java [[java.util.Iterator]] corresponding to this Stepper.
-    *
-    * Note that the return type is `Iterator[_]` instead of `Iterator[A]` to allow returning
-    * a [[java.util.PrimitiveIterator.OfInt]] (which is a `Iterator[Integer]`) in the subclass
-    * [[IntStepper]] (which is a `Stepper[Int]`).
-    */
+   *
+   *  Note that the return type is `Iterator[_]` instead of `Iterator[A]` to allow returning
+   *  a [[java.util.PrimitiveIterator.OfInt]] (which is a `Iterator[Integer]`) in the subclass
+   *  [[IntStepper]] (which is a `Stepper[Int]`).
+   */
   def javaIterator[B >: A]: JIterator[?]^{this}
 
   /** Returns an [[Iterator]] corresponding to this Stepper. Note that Iterators corresponding to
-    * primitive Steppers box the elements.
-    */
+   *  primitive Steppers box the elements.
+   */
   def iterator: Iterator[A]^{this} = new AbstractIterator[A] {
     def hasNext: Boolean = hasStep
     def next(): A = nextStep()
@@ -93,10 +93,10 @@ trait Stepper[@specialized(Double, Int, Long) +A] {
 
 object Stepper {
   /** A marker trait that indicates that a `Stepper` can call `trySplit` with at worst O(log N) time
-    * and space complexity, and that the division is likely to be reasonably even. Steppers marked
-    * with `EfficientSplit` can be converted to parallel streams with the `asJavaParStream` method
-    * defined in [[scala.jdk.StreamConverters]].
-    */
+   *  and space complexity, and that the division is likely to be reasonably even. Steppers marked
+   *  with `EfficientSplit` can be converted to parallel streams with the `asJavaParStream` method
+   *  defined in [[scala.jdk.StreamConverters]].
+   */
   trait EfficientSplit
 
   private[collection] final def throwNSEE(): Nothing = throw new NoSuchElementException("Empty Stepper")

--- a/library/src/scala/collection/StepperShape.scala
+++ b/library/src/scala/collection/StepperShape.scala
@@ -20,18 +20,20 @@ import language.experimental.captureChecking
 import scala.collection.Stepper.EfficientSplit
 
 /** An implicit StepperShape instance is used in the [[IterableOnce.stepper]] to return a possibly
-  * specialized Stepper `S` according to the element type `T`.
-  */
+ *  specialized Stepper `S` according to the element type `T`.
+ */
 sealed trait StepperShape[-T, S <: Stepper[?]] { self =>
   /** Returns the Int constant (as defined in the `StepperShape` companion object) for this `StepperShape`. */
   def shape: StepperShape.Shape
 
   /** Creates an unboxing primitive sequential Stepper from a boxed `AnyStepper`.
-   * This is an identity operation for reference shapes. */
+   *  This is an identity operation for reference shapes. 
+   */
   def seqUnbox(st: AnyStepper[T]^): S^{st}
 
   /** Creates an unboxing primitive parallel (i.e. `with EfficientSplit`) Stepper from a boxed `AnyStepper`.
-   * This is an identity operation for reference shapes. */
+   *  This is an identity operation for reference shapes. 
+   */
   def parUnbox(st: (AnyStepper[T] & EfficientSplit)^): (S & EfficientSplit)^{st}
 }
 

--- a/library/src/scala/collection/StrictOptimizedIterableOps.scala
+++ b/library/src/scala/collection/StrictOptimizedIterableOps.scala
@@ -20,13 +20,12 @@ import scala.annotation.nowarn
 import scala.annotation.unchecked.uncheckedVariance
 import scala.runtime.Statics
 
-/**
-  * Trait that overrides iterable operations to take advantage of strict builders.
-  *
-  * @tparam A  Elements type
-  * @tparam CC Collection type constructor
-  * @tparam C  Collection type
-  */
+/** Trait that overrides iterable operations to take advantage of strict builders.
+ *
+ *  @tparam A  Elements type
+ *  @tparam CC Collection type constructor
+ *  @tparam C  Collection type
+ */
 transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
   extends Any
     with IterableOps[A, CC, C] {
@@ -91,12 +90,12 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     strictOptimizedMap(iterableFactory.newBuilder, f)
 
   /**
-    * @param b Builder to use to build the resulting collection
-    * @param f Element transformation function
-    * @tparam B Type of elements of the resulting collection (e.g. `String`)
-    * @tparam C2 Type of the resulting collection (e.g. `List[String]`)
-    * @return The resulting collection
-    */
+   *  @tparam B Type of elements of the resulting collection (e.g. `String`)
+   *  @tparam C2 Type of the resulting collection (e.g. `List[String]`)
+   *  @param b Builder to use to build the resulting collection
+   *  @param f Element transformation function
+   *  @return The resulting collection
+   */
   @inline protected final def strictOptimizedMap[B, C2](b: mutable.Builder[B, C2], f: A => B): C2 = {
     val it = iterator
     while (it.hasNext) {
@@ -109,12 +108,12 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     strictOptimizedFlatMap(iterableFactory.newBuilder, f)
 
   /**
-    * @param b Builder to use to build the resulting collection
-    * @param f Element transformation function
-    * @tparam B Type of elements of the resulting collection (e.g. `String`)
-    * @tparam C2 Type of the resulting collection (e.g. `List[String]`)
-    * @return The resulting collection
-    */
+   *  @tparam B Type of elements of the resulting collection (e.g. `String`)
+   *  @tparam C2 Type of the resulting collection (e.g. `List[String]`)
+   *  @param b Builder to use to build the resulting collection
+   *  @param f Element transformation function
+   *  @return The resulting collection
+   */
   @inline protected final def strictOptimizedFlatMap[B, C2](b: mutable.Builder[B, C2]^, f: A => IterableOnce[B]^): C2 = {
     val it = iterator
     while (it.hasNext) {
@@ -124,12 +123,12 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
   }
 
   /**
-    * @param that Elements to concatenate to this collection
-    * @param b Builder to use to build the resulting collection
-    * @tparam B Type of elements of the resulting collections (e.g. `Int`)
-    * @tparam C2 Type of the resulting collection (e.g. `List[Int]`)
-    * @return The resulting collection
-    */
+   *  @tparam B Type of elements of the resulting collections (e.g. `Int`)
+   *  @tparam C2 Type of the resulting collection (e.g. `List[Int]`)
+   *  @param that Elements to concatenate to this collection
+   *  @param b Builder to use to build the resulting collection
+   *  @return The resulting collection
+   */
   @inline protected final def strictOptimizedConcat[B >: A, C2](that: IterableOnce[B]^, b: mutable.Builder[B, C2]^): C2 = {
     b ++= this
     b ++= that
@@ -140,12 +139,12 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     strictOptimizedCollect(iterableFactory.newBuilder, pf)
 
   /**
-    * @param b Builder to use to build the resulting collection
-    * @param pf Element transformation partial function
-    * @tparam B Type of elements of the resulting collection (e.g. `String`)
-    * @tparam C2 Type of the resulting collection (e.g. `List[String]`)
-    * @return The resulting collection
-    */
+   *  @tparam B Type of elements of the resulting collection (e.g. `String`)
+   *  @tparam C2 Type of the resulting collection (e.g. `List[String]`)
+   *  @param b Builder to use to build the resulting collection
+   *  @param pf Element transformation partial function
+   *  @return The resulting collection
+   */
   @inline protected final def strictOptimizedCollect[B, C2](b: mutable.Builder[B, C2]^, pf: PartialFunction[A, B]^): C2 = {
     val marker = Statics.pfMarker
     val it = iterator
@@ -161,12 +160,12 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     strictOptimizedFlatten(iterableFactory.newBuilder)
 
   /**
-    * @param b Builder to use to build the resulting collection
-    * @param toIterableOnce Evidence that `A` can be seen as an `IterableOnce[B]`
-    * @tparam B Type of elements of the resulting collection (e.g. `Int`)
-    * @tparam C2 Type of the resulting collection (e.g. `List[Int]`)
-    * @return The resulting collection
-    */
+   *  @tparam B Type of elements of the resulting collection (e.g. `Int`)
+   *  @tparam C2 Type of the resulting collection (e.g. `List[Int]`)
+   *  @param b Builder to use to build the resulting collection
+   *  @param toIterableOnce Evidence that `A` can be seen as an `IterableOnce[B]`
+   *  @return The resulting collection
+   */
   @inline protected final def strictOptimizedFlatten[B, C2](b: mutable.Builder[B, C2])(implicit toIterableOnce: A => IterableOnce[B]): C2 = {
     val it = iterator
     while (it.hasNext) {
@@ -179,12 +178,12 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     strictOptimizedZip(that, iterableFactory.newBuilder[(A, B)])
 
   /**
-    * @param that Collection to zip with this collection
-    * @param b Builder to use to build the resulting collection
-    * @tparam B Type of elements of the second collection (e.g. `String`)
-    * @tparam C2 Type of the resulting collection (e.g. `List[(Int, String)]`)
-    * @return The resulting collection
-    */
+   *  @tparam B Type of elements of the second collection (e.g. `String`)
+   *  @tparam C2 Type of the resulting collection (e.g. `List[(Int, String)]`)
+   *  @param that Collection to zip with this collection
+   *  @param b Builder to use to build the resulting collection
+   *  @return The resulting collection
+   */
   @inline protected final def strictOptimizedZip[B, C2](that: IterableOnce[B]^, b: mutable.Builder[(A, B), C2]^): C2 = {
     val it1 = iterator
     val it2 = that.iterator
@@ -254,8 +253,8 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
   }
 
   /** A collection containing the last `n` elements of this collection.
-    * $willForceEvaluation
-    */
+   *  $willForceEvaluation
+   */
   override def takeRight(n: Int): C = {
     val b = newSpecificBuilder
     b.sizeHintBounded(n, toIterable: @nowarn("cat=deprecation"))
@@ -270,9 +269,9 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
   }
 
   /** The rest of the collection without its `n` last elements. For
-    *  linear, immutable collections this should avoid making a copy.
-    *  $willForceEvaluation
-    */
+   *  linear, immutable collections this should avoid making a copy.
+   *  $willForceEvaluation
+   */
   override def dropRight(n: Int): C = {
     val b = newSpecificBuilder
     if (n >= 0) b.sizeHint(this, delta = -n)

--- a/library/src/scala/collection/StrictOptimizedMapOps.scala
+++ b/library/src/scala/collection/StrictOptimizedMapOps.scala
@@ -15,14 +15,13 @@ package scala.collection
 import scala.language.`2.13`
 import language.experimental.captureChecking
 
-/**
-  * Trait that overrides map operations to take advantage of strict builders.
-  *
-  * @tparam K  Type of keys
-  * @tparam V  Type of values
-  * @tparam CC Collection type constructor
-  * @tparam C  Collection type
-  */
+/** Trait that overrides map operations to take advantage of strict builders.
+ *
+ *  @tparam K  Type of keys
+ *  @tparam V  Type of values
+ *  @tparam CC Collection type constructor
+ *  @tparam C  Collection type
+ */
 transparent trait StrictOptimizedMapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
   extends MapOps[K, V, CC, C]
     with StrictOptimizedIterableOps[(K, V), Iterable, C] {

--- a/library/src/scala/collection/StrictOptimizedSeqOps.scala
+++ b/library/src/scala/collection/StrictOptimizedSeqOps.scala
@@ -15,10 +15,9 @@ package scala.collection
 import scala.language.`2.13`
 import language.experimental.captureChecking
 
-/**
-  * Trait that overrides operations on sequences in order
-  * to take advantage of strict builders.
-  */
+/** Trait that overrides operations on sequences in order
+ *  to take advantage of strict builders.
+ */
 transparent trait StrictOptimizedSeqOps [+A, +CC[_] <: caps.Pure, +C]
   extends Any with SeqOps[A, CC, C] with StrictOptimizedIterableOps[A, CC, C] with caps.Pure {
 

--- a/library/src/scala/collection/StrictOptimizedSetOps.scala
+++ b/library/src/scala/collection/StrictOptimizedSetOps.scala
@@ -15,13 +15,12 @@ package scala.collection
 import scala.language.`2.13`
 import language.experimental.captureChecking
 
-/**
-  * Trait that overrides set operations to take advantage of strict builders.
-  *
-  * @tparam A  Elements type
-  * @tparam CC Collection type constructor
-  * @tparam C  Collection type
-  */
+/** Trait that overrides set operations to take advantage of strict builders.
+ *
+ *  @tparam A  Elements type
+ *  @tparam CC Collection type constructor
+ *  @tparam C  Collection type
+ */
 transparent trait StrictOptimizedSetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   extends SetOps[A, CC, C]
     with StrictOptimizedIterableOps[A, CC, C] {

--- a/library/src/scala/collection/StrictOptimizedSortedMapOps.scala
+++ b/library/src/scala/collection/StrictOptimizedSortedMapOps.scala
@@ -17,14 +17,13 @@ import language.experimental.captureChecking
 
 import scala.annotation.implicitNotFound
 
-/**
-  * Trait that overrides sorted map operations to take advantage of strict builders.
-  *
-  * @tparam K  Type of keys
-  * @tparam V  Type of values
-  * @tparam CC Collection type constructor
-  * @tparam C  Collection type
-  */
+/** Trait that overrides sorted map operations to take advantage of strict builders.
+ *
+ *  @tparam K  Type of keys
+ *  @tparam V  Type of values
+ *  @tparam CC Collection type constructor
+ *  @tparam C  Collection type
+ */
 transparent trait StrictOptimizedSortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y, CC, ?], +C <: SortedMapOps[K, V, CC, C]]
   extends SortedMapOps[K, V, CC, C]
     with StrictOptimizedMapOps[K, V, Map, C] {

--- a/library/src/scala/collection/StrictOptimizedSortedSetOps.scala
+++ b/library/src/scala/collection/StrictOptimizedSortedSetOps.scala
@@ -19,13 +19,12 @@ import language.experimental.captureChecking
 import scala.annotation.implicitNotFound
 import scala.annotation.unchecked.uncheckedVariance
 
-/**
-  * Trait that overrides sorted set operations to take advantage of strict builders.
-  *
-  * @tparam A  Elements type
-  * @tparam CC Collection type constructor
-  * @tparam C  Collection type
-  */
+/** Trait that overrides sorted set operations to take advantage of strict builders.
+ *
+ *  @tparam A  Elements type
+ *  @tparam CC Collection type constructor
+ *  @tparam C  Collection type
+ */
 transparent trait StrictOptimizedSortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
   extends SortedSetOps[A, CC, C]
     with StrictOptimizedSetOps[A, Set, C] {

--- a/library/src/scala/collection/StringOps.scala
+++ b/library/src/scala/collection/StringOps.scala
@@ -68,8 +68,8 @@ object StringOps {
   class WithFilter(p: Char => Boolean, s: String) {
 
     /** Applies `f` to each element for its side effects.
-      * Note: [U] parameter needed to help scalac's type inference.
-      */
+     *  Note: [U] parameter needed to help scalac's type inference.
+     */
     def foreach[U](f: Char => U): Unit = {
       val len = s.length
       var i = 0
@@ -81,11 +81,11 @@ object StringOps {
     }
 
     /** Builds a new collection by applying a function to all chars of this filtered string.
-      *
-      *  @param f      the function to apply to each char.
-      *  @return       a new collection resulting from applying the given function
-      *                `f` to each char of this string and collecting the results.
-      */
+     *
+     *  @param f      the function to apply to each char.
+     *  @return       a new collection resulting from applying the given function
+     *                `f` to each char of this string and collecting the results.
+     */
     def map[B](f: Char => B): immutable.IndexedSeq[B] = {
       val len = s.length
       val b = immutable.IndexedSeq.newBuilder[B]
@@ -100,11 +100,11 @@ object StringOps {
     }
 
     /** Builds a new string by applying a function to all chars of this filtered string.
-      *
-      *  @param f      the function to apply to each char.
-      *  @return       a new string resulting from applying the given function
-      *                `f` to each char of this string and collecting the results.
-      */
+     *
+     *  @param f      the function to apply to each char.
+     *  @return       a new string resulting from applying the given function
+     *                `f` to each char of this string and collecting the results.
+     */
     def map(f: Char => Char): String = {
       val len = s.length
       val sb = new JStringBuilder(len)
@@ -118,12 +118,12 @@ object StringOps {
     }
 
     /** Builds a new collection by applying a function to all chars of this filtered string
-      * and using the elements of the resulting collections.
-      *
-      *  @param f      the function to apply to each char.
-      *  @return       a new collection resulting from applying the given collection-valued function
-      *                `f` to each char of this string and concatenating the results.
-      */
+     *  and using the elements of the resulting collections.
+     *
+     *  @param f      the function to apply to each char.
+     *  @return       a new collection resulting from applying the given collection-valued function
+     *                `f` to each char of this string and concatenating the results.
+     */
     def flatMap[B](f: Char => IterableOnce[B]^): immutable.IndexedSeq[B] = {
       val len = s.length
       val b = immutable.IndexedSeq.newBuilder[B]
@@ -137,12 +137,12 @@ object StringOps {
     }
 
     /** Builds a new string by applying a function to all chars of this filtered string
-      * and using the elements of the resulting Strings.
-      *
-      *  @param f      the function to apply to each char.
-      *  @return       a new string resulting from applying the given string-valued function
-      *                `f` to each char of this string and concatenating the results.
-      */
+     *  and using the elements of the resulting Strings.
+     *
+     *  @param f      the function to apply to each char.
+     *  @return       a new string resulting from applying the given string-valued function
+     *                `f` to each char of this string and concatenating the results.
+     */
     def flatMap(f: Char => String): String = {
       val len = s.length
       val sb = new JStringBuilder
@@ -164,20 +164,20 @@ object StringOps {
 }
 
 /** Provides extension methods for strings.
-  *
-  * Some of these methods treat strings as a plain collection of [[Char]]s
-  * without any regard for Unicode handling. Unless the user takes Unicode
-  * handling in to account or makes sure the strings don't require such handling,
-  * these methods may result in unpaired or invalidly paired surrogate code
-  * units.
-  *
-  * @define unicodeunaware This method treats a string as a plain sequence of
-  *                        Char code units and makes no attempt to keep
-  *                        surrogate pairs or codepoint sequences together.
-  *                        The user is responsible for making sure such cases
-  *                        are handled correctly. Failing to do so may result in
-  *                        an invalid Unicode string.
-  */
+ *
+ *  Some of these methods treat strings as a plain collection of [[Char]]s
+ *  without any regard for Unicode handling. Unless the user takes Unicode
+ *  handling in to account or makes sure the strings don't require such handling,
+ *  these methods may result in unpaired or invalidly paired surrogate code
+ *  units.
+ *
+ *  @define unicodeunaware This method treats a string as a plain sequence of
+ *                        Char code units and makes no attempt to keep
+ *                        surrogate pairs or codepoint sequences together.
+ *                        The user is responsible for making sure such cases
+ *                        are handled correctly. Failing to do so may result in
+ *                        an invalid Unicode string.
+ */
 final class StringOps(private val s: String) extends AnyVal { self =>
   import StringOps._
 
@@ -199,11 +199,11 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   def lengthIs: Int = s.length
 
   /** Builds a new collection by applying a function to all chars of this string.
-    *
-    *  @param f      the function to apply to each char.
-    *  @return       a new collection resulting from applying the given function
-    *                `f` to each char of this string and collecting the results.
-    */
+   *
+   *  @param f      the function to apply to each char.
+   *  @return       a new collection resulting from applying the given function
+   *                `f` to each char of this string and collecting the results.
+   */
   def map[B](f: Char => B): immutable.IndexedSeq[B] = {
     val len = s.length
     val dst = new Array[AnyRef](len)
@@ -216,11 +216,11 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   }
 
   /** Builds a new string by applying a function to all chars of this string.
-    *
-    *  @param f      the function to apply to each char.
-    *  @return       a new string resulting from applying the given function
-    *                `f` to each char of this string and collecting the results.
-    */
+   *
+   *  @param f      the function to apply to each char.
+   *  @return       a new string resulting from applying the given function
+   *                `f` to each char of this string and collecting the results.
+   */
   def map(f: Char => Char): String = {
     val len = s.length
     val dst = new Array[Char](len)
@@ -233,12 +233,12 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   }
 
   /** Builds a new collection by applying a function to all chars of this string
-    * and using the elements of the resulting collections.
-    *
-    *  @param f      the function to apply to each char.
-    *  @return       a new collection resulting from applying the given collection-valued function
-    *                `f` to each char of this string and concatenating the results.
-    */
+   *  and using the elements of the resulting collections.
+   *
+   *  @param f      the function to apply to each char.
+   *  @return       a new collection resulting from applying the given collection-valued function
+   *                `f` to each char of this string and concatenating the results.
+   */
   def flatMap[B](f: Char => IterableOnce[B]^): immutable.IndexedSeq[B] = {
     val len = s.length
     val b = immutable.IndexedSeq.newBuilder[B]
@@ -251,12 +251,12 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   }
 
   /** Builds a new string by applying a function to all chars of this string
-    * and using the elements of the resulting strings.
-    *
-    *  @param f      the function to apply to each char.
-    *  @return       a new string resulting from applying the given string-valued function
-    *                `f` to each char of this string and concatenating the results.
-    */
+   *  and using the elements of the resulting strings.
+   *
+   *  @param f      the function to apply to each char.
+   *  @return       a new string resulting from applying the given string-valued function
+   *                `f` to each char of this string and concatenating the results.
+   */
   def flatMap(f: Char => String): String = {
     val len = s.length
     val sb = new JStringBuilder
@@ -269,12 +269,12 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   }
 
   /** Builds a new String by applying a partial function to all chars of this String
-    * on which the function is defined.
-    *
-    *  @param pf     the partial function which filters and maps the String.
-    *  @return       a new String resulting from applying the given partial function
-    *                `pf` to each char on which it is defined and collecting the results.
-    */
+   *  on which the function is defined.
+   *
+   *  @param pf     the partial function which filters and maps the String.
+   *  @return       a new String resulting from applying the given partial function
+   *                `pf` to each char on which it is defined and collecting the results.
+   */
   def collect(pf: PartialFunction[Char, Char]^): String = {
     val fallback: Any => Any = StringOps.fallback
     var i = 0
@@ -288,13 +288,13 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   }
 
   /** Builds a new collection by applying a partial function to all chars of this String
-    * on which the function is defined.
-    *
-    *  @param pf     the partial function which filters and maps the String.
-    *  @tparam B     the element type of the returned collection.
-    *  @return       a new collection resulting from applying the given partial function
-    *                `pf` to each char on which it is defined and collecting the results.
-    */
+   *  on which the function is defined.
+   *
+   *  @tparam B     the element type of the returned collection.
+   *  @param pf     the partial function which filters and maps the String.
+   *  @return       a new collection resulting from applying the given partial function
+   *                `pf` to each char on which it is defined and collecting the results.
+   */
   def collect[B](pf: PartialFunction[Char, B]^): immutable.IndexedSeq[B] = {
     val fallback: Any => Any = StringOps.fallback
     var i = 0
@@ -308,12 +308,12 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   }
 
   /** Returns a new collection containing the chars from this string followed by the elements from the
-    * right hand operand.
-    *
-    *  @param suffix the collection to append.
-    *  @return       a new collection which contains all chars
-    *                of this string followed by all elements of `suffix`.
-    */
+   *  right hand operand.
+   *
+   *  @param suffix the collection to append.
+   *  @return       a new collection which contains all chars
+   *                of this string followed by all elements of `suffix`.
+   */
   def concat[B >: Char](suffix: IterableOnce[B]^): immutable.IndexedSeq[B] = {
     val b = immutable.IndexedSeq.newBuilder[B]
     val k = suffix.knownSize
@@ -324,12 +324,12 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   }
 
   /** Returns a new string containing the chars from this string followed by the chars from the
-    * right hand operand.
-    *
-    *  @param suffix the collection to append.
-    *  @return       a new string which contains all chars
-    *                of this string followed by all chars of `suffix`.
-    */
+   *  right hand operand.
+   *
+   *  @param suffix the collection to append.
+   *  @return       a new string which contains all chars
+   *                of this string followed by all chars of `suffix`.
+   */
   def concat(suffix: IterableOnce[Char]^): String = {
     val k = suffix.knownSize
     val sb = new JStringBuilder(s.length + (if(k >= 0) k else 16))
@@ -339,12 +339,12 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   }
 
   /** Returns a new string containing the chars from this string followed by the chars from the
-    * right hand operand.
-    *
-    *  @param suffix the string to append.
-    *  @return       a new string which contains all chars
-    *                of this string followed by all chars of `suffix`.
-    */
+   *  right hand operand.
+   *
+   *  @param suffix the string to append.
+   *  @return       a new string which contains all chars
+   *                of this string followed by all chars of `suffix`.
+   */
   @inline def concat(suffix: String): String = s + suffix
 
   /** Alias for `concat`. */
@@ -357,13 +357,13 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   def ++(xs: String): String = concat(xs)
 
   /** Returns a collection with an element appended until a given target length is reached.
-    *
-    *  @param  len   the target length
-    *  @param  elem  the padding value
-    *  @return a collection consisting of
-    *          this string followed by the minimal number of occurrences of `elem` so
-    *          that the resulting collection has a length of at least `len`.
-    */
+   *
+   *  @param  len   the target length
+   *  @param  elem  the padding value
+   *  @return a collection consisting of
+   *          this string followed by the minimal number of occurrences of `elem` so
+   *          that the resulting collection has a length of at least `len`.
+   */
   def padTo[B >: Char](len: Int, elem: B): immutable.IndexedSeq[B]  = {
     val sLen = s.length
     if (sLen >= len) new WrappedString(s) else {
@@ -380,13 +380,13 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   }
 
   /** Returns a string with a char appended until a given target length is reached.
-    *
-    *  @param   len   the target length
-    *  @param   elem  the padding value
-    *  @return a string consisting of
-    *          this string followed by the minimal number of occurrences of `elem` so
-    *          that the resulting string has a length of at least `len`.
-    */
+   *
+   *  @param   len   the target length
+   *  @param   elem  the padding value
+   *  @return a string consisting of
+   *          this string followed by the minimal number of occurrences of `elem` so
+   *          that the resulting string has a length of at least `len`.
+   */
   def padTo(len: Int, elem: Char): String = {
     val sLen = s.length
     if (sLen >= len) s else {
@@ -469,18 +469,18 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   @inline def :++ (suffix: String): String = s + suffix
 
   /** Produces a new collection where a slice of characters in this string is replaced by another collection.
-    *
-    * Patching at negative indices is the same as patching starting at 0.
-    * Patching at indices at or larger than the length of the original string appends the patch to the end.
-    * If more values are replaced than actually exist, the excess is ignored.
-    *
-    *  @param  from     the index of the first replaced char
-    *  @param  other    the replacement collection
-    *  @param  replaced the number of chars to drop in the original string
-    *  @return          a new collection consisting of all chars of this string
-    *                   except that `replaced` chars starting from `from` are replaced
-    *                   by `other`.
-    */
+   *
+   *  Patching at negative indices is the same as patching starting at 0.
+   *  Patching at indices at or larger than the length of the original string appends the patch to the end.
+   *  If more values are replaced than actually exist, the excess is ignored.
+   *
+   *  @param  from     the index of the first replaced char
+   *  @param  other    the replacement collection
+   *  @param  replaced the number of chars to drop in the original string
+   *  @return          a new collection consisting of all chars of this string
+   *                   except that `replaced` chars starting from `from` are replaced
+   *                   by `other`.
+   */
   def patch[B >: Char](from: Int, other: IterableOnce[B]^, replaced: Int): immutable.IndexedSeq[B] = {
     val len = s.length
     @inline def slc(off: Int, length: Int): WrappedString =
@@ -497,36 +497,36 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   }
 
   /** Produces a new collection where a slice of characters in this string is replaced by another collection.
-    *
-    * Patching at negative indices is the same as patching starting at 0.
-    * Patching at indices at or larger than the length of the original string appends the patch to the end.
-    * If more values are replaced than actually exist, the excess is ignored.
-    *
-    *  @param  from     the index of the first replaced char
-    *  @param  other    the replacement string
-    *  @param  replaced the number of chars to drop in the original string
-    *  @return          a new string consisting of all chars of this string
-    *                   except that `replaced` chars starting from `from` are replaced
-    *                   by `other`.
-    *  @note            $unicodeunaware
-    */
+   *
+   *  Patching at negative indices is the same as patching starting at 0.
+   *  Patching at indices at or larger than the length of the original string appends the patch to the end.
+   *  If more values are replaced than actually exist, the excess is ignored.
+   *
+   *  @param  from     the index of the first replaced char
+   *  @param  other    the replacement string
+   *  @param  replaced the number of chars to drop in the original string
+   *  @return          a new string consisting of all chars of this string
+   *                   except that `replaced` chars starting from `from` are replaced
+   *                   by `other`.
+   *  @note            $unicodeunaware
+   */
   def patch(from: Int, other: IterableOnce[Char]^, replaced: Int): String =
     patch(from, other.iterator.mkString, replaced)
 
   /** Produces a new string where a slice of characters in this string is replaced by another string.
-    *
-    * Patching at negative indices is the same as patching starting at 0.
-    * Patching at indices at or larger than the length of the original string appends the patch to the end.
-    * If more values are replaced than actually exist, the excess is ignored.
-    *
-    *  @param  from     the index of the first replaced char
-    *  @param  other    the replacement string
-    *  @param  replaced the number of chars to drop in the original string
-    *  @return          a new string consisting of all chars of this string
-    *                   except that `replaced` chars starting from `from` are replaced
-    *                   by `other`.
-    *  @note            $unicodeunaware
-    */
+   *
+   *  Patching at negative indices is the same as patching starting at 0.
+   *  Patching at indices at or larger than the length of the original string appends the patch to the end.
+   *  If more values are replaced than actually exist, the excess is ignored.
+   *
+   *  @param  from     the index of the first replaced char
+   *  @param  other    the replacement string
+   *  @param  replaced the number of chars to drop in the original string
+   *  @return          a new string consisting of all chars of this string
+   *                   except that `replaced` chars starting from `from` are replaced
+   *                   by `other`.
+   *  @note            $unicodeunaware
+   */
   def patch(from: Int, other: String, replaced: Int): String = {
     val len = s.length
     val sb = new JStringBuilder(len + other.size - replaced)
@@ -539,12 +539,12 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   }
 
   /** A copy of this string with one single replaced element.
-    *  @param  index  the position of the replacement
-    *  @param  elem   the replacing element
-    *  @return a new string which is a copy of this string with the element at position `index` replaced by `elem`.
-    *  @throws IndexOutOfBoundsException if `index` does not satisfy `0 <= index < length`.
-    *  @note   $unicodeunaware
-    */
+   *  @param  index  the position of the replacement
+   *  @param  elem   the replacing element
+   *  @return a new string which is a copy of this string with the element at position `index` replaced by `elem`.
+   *  @throws IndexOutOfBoundsException if `index` does not satisfy `0 <= index < length`.
+   *  @note   $unicodeunaware
+   */
   def updated(index: Int, elem: Char): String = {
     val sb = new JStringBuilder(s.length).append(s)
     sb.setCharAt(index, elem)
@@ -552,35 +552,35 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   }
 
   /** Tests whether this string contains the given character.
-    *
-    *  @param elem  the character to test.
-    *  @return     `true` if this string has an element that is equal (as
-    *              determined by `==`) to `elem`, `false` otherwise.
-    */
+   *
+   *  @param elem  the character to test.
+   *  @return     `true` if this string has an element that is equal (as
+   *              determined by `==`) to `elem`, `false` otherwise.
+   */
   def contains(elem: Char): Boolean = s.indexOf(elem) >= 0
 
   /** Displays all elements of this string in a string using start, end, and
-    * separator strings.
-    *
-    *  @param start the starting string.
-    *  @param sep   the separator string.
-    *  @param end   the ending string.
-    *  @return      The resulting string
-    *               begins with the string `start` and ends with the string
-    *               `end`. Inside, the string chars of this string are separated by
-    *               the string `sep`.
-    *  @note        $unicodeunaware
-    */
+   *  separator strings.
+   *
+   *  @param start the starting string.
+   *  @param sep   the separator string.
+   *  @param end   the ending string.
+   *  @return      The resulting string
+   *               begins with the string `start` and ends with the string
+   *               `end`. Inside, the string chars of this string are separated by
+   *               the string `sep`.
+   *  @note        $unicodeunaware
+   */
   final def mkString(start: String, sep: String, end: String): String =
     addString(new StringBuilder(), start, sep, end).toString
 
   /** Displays all elements of this string in a string using a separator string.
-    *
-    *  @param sep   the separator string.
-    *  @return      In the resulting string
-    *               the chars of this string are separated by the string `sep`.
-    *  @note        $unicodeunaware
-    */
+   *
+   *  @param sep   the separator string.
+   *  @return      In the resulting string
+   *               the chars of this string are separated by the string `sep`.
+   *  @note        $unicodeunaware
+   */
   @inline final def mkString(sep: String): String =
     if (sep.isEmpty || s.length < 2) s
     else mkString("", sep, "")
@@ -618,18 +618,18 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   }
 
   /** Selects an interval of elements.  The returned string is made up
-    *  of all elements `x` which satisfy the invariant:
-    *  {{{
-    *    from <= indexOf(x) < until
-    *  }}}
-    *
-    *  @param from   the lowest index to include from this string.
-    *  @param until  the lowest index to EXCLUDE from this string.
-    *  @return  a string containing the elements greater than or equal to
-    *           index `from` extending up to (but not including) index `until`
-    *           of this string.
-    *  @note    $unicodeunaware
-    */
+   *  of all elements `x` which satisfy the invariant:
+   *  ```
+   *    from <= indexOf(x) < until
+   *  ```
+   *
+   *  @param from   the lowest index to include from this string.
+   *  @param until  the lowest index to EXCLUDE from this string.
+   *  @return  a string containing the elements greater than or equal to
+   *           index `from` extending up to (but not including) index `until`
+   *           of this string.
+   *  @note    $unicodeunaware
+   */
   def slice(from: Int, until: Int): String = {
     val start = from max 0
     val end   = until min s.length
@@ -638,8 +638,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
     else s.substring(start, end)
   }
 
-  /** Returns the current string concatenated `n` times.
-   */
+  /** Returns the current string concatenated `n` times. */
   def *(n: Int): String =
     if (n <= 0) {
       ""
@@ -701,49 +700,49 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   }
 
   /** Returns all lines in this string in an iterator, excluding trailing line
-    *  end characters; i.e., apply `.stripLineEnd` to all lines
-    *  returned by `linesWithSeparators`.
-    */
+   *  end characters; i.e., apply `.stripLineEnd` to all lines
+   *  returned by `linesWithSeparators`.
+   */
   @deprecated("Use `linesIterator`, because JDK 11 adds a `lines` method on String", "2.13.0")
   def lines: Iterator[String] = linesIterator
 
   /** Returns this string with first character converted to upper case.
-    * If the first character of the string is capitalized, it is returned unchanged.
-    * This method does not convert characters outside the Basic Multilingual Plane (BMP).
-    */
+   *  If the first character of the string is capitalized, it is returned unchanged.
+   *  This method does not convert characters outside the Basic Multilingual Plane (BMP).
+   */
   def capitalize: String =
     if (s == null || s.length == 0 || !s.charAt(0).isLower) s
     else updated(0, s.charAt(0).toUpper)
 
   /** Returns this string with the given `prefix` stripped. If this string does not
-    *  start with `prefix`, it is returned unchanged.
-    */
+   *  start with `prefix`, it is returned unchanged.
+   */
   def stripPrefix(prefix: String): String =
     if (s.startsWith(prefix)) s.substring(prefix.length)
     else s
 
   /** Returns this string with the given `suffix` stripped. If this string does not
-    *  end with `suffix`, it is returned unchanged.
-    */
+   *  end with `suffix`, it is returned unchanged.
+   */
   def stripSuffix(suffix: String): String =
     if (s.endsWith(suffix)) s.substring(0, s.length - suffix.length)
     else s
 
   /** Replaces all literal occurrences of `literal` with the literal string `replacement`.
-    * This method is equivalent to [[java.lang.String#replace(CharSequence,CharSequence)]].
-    *
-    * @param    literal     the string which should be replaced everywhere it occurs
-    * @param    replacement the replacement string
-    * @return               the resulting string
-    */
+   *  This method is equivalent to [[java.lang.String#replace(CharSequence,CharSequence)]].
+   *
+   *  @param    literal     the string which should be replaced everywhere it occurs
+   *  @param    replacement the replacement string
+   *  @return               the resulting string
+   */
   @deprecated("Use `s.replace` as an exact replacement", "2.13.2")
   def replaceAllLiterally(literal: String, replacement: String): String = s.replace(literal, replacement)
 
   /** For every line in this string:
-    *
-    *  Strip a leading prefix consisting of blanks or control characters
-    *  followed by `marginChar` from the line.
-    */
+   *
+   *  Strip a leading prefix consisting of blanks or control characters
+   *  followed by `marginChar` from the line.
+   */
   def stripMargin(marginChar: Char): String = {
     val sb = new JStringBuilder(s.length)
     for (line <- linesWithSeparators) {
@@ -759,10 +758,10 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   }
 
   /** For every line in this string:
-    *
-    *  Strip a leading prefix consisting of blanks or control characters
-    *  followed by `|` from the line.
-    */
+   *
+   *  Strip a leading prefix consisting of blanks or control characters
+   *  followed by `|` from the line.
+   */
   def stripMargin: String = stripMargin('|')
 
   private def escape(ch: Char): String = if (
@@ -772,54 +771,54 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   else "\\" + ch
 
   /** Splits this string around the separator character
-    *
-    * If this string is the empty string, returns an array of strings
-    * that contains a single empty string.
-    *
-    * If this string is not the empty string, returns an array containing
-    * the substrings terminated by the start of the string, the end of the
-    * string or the separator character, excluding empty trailing substrings
-    *
-    * If the separator character is a surrogate character, only split on
-    * matching surrogate characters if they are not part of a surrogate pair
-    *
-    * The behaviour follows, and is implemented in terms of <a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html#split(java.lang.String)">String.split(re: String)</a>
-    *
-    *
-    * @example {{{
-    * "a.b".split('.') //returns Array("a", "b")
-    *
-    * //splitting the empty string always returns the array with a single
-    * //empty string
-    * "".split('.') //returns Array("")
-    *
-    * //only trailing empty substrings are removed
-    * "a.".split('.') //returns Array("a")
-    * ".a.".split('.') //returns Array("", "a")
-    * "..a..".split('.') //returns Array("", "", "a")
-    *
-    * //all parts are empty and trailing
-    * ".".split('.') //returns Array()
-    * "..".split('.') //returns Array()
-    *
-    * //surrogate pairs
-    * val high = 0xD852.toChar
-    * val low = 0xDF62.toChar
-    * val highstring = high.toString
-    * val lowstring = low.toString
-    *
-    * //well-formed surrogate pairs are not split
-    * val highlow = highstring + lowstring
-    * highlow.split(high) //returns Array(highlow)
-    *
-    * //bare surrogate characters are split
-    * val bare = "_" + highstring + "_"
-    * bare.split(high) //returns Array("_", "_")
-    *
-    *  }}}
-    *
-    * @param separator the character used as a delimiter
-    */
+   *
+   *  If this string is the empty string, returns an array of strings
+   *  that contains a single empty string.
+   *
+   *  If this string is not the empty string, returns an array containing
+   *  the substrings terminated by the start of the string, the end of the
+   *  string or the separator character, excluding empty trailing substrings
+   *
+   *  If the separator character is a surrogate character, only split on
+   *  matching surrogate characters if they are not part of a surrogate pair
+   *
+   *  The behaviour follows, and is implemented in terms of <a href="https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/String.html#split(java.lang.String)">String.split(re: String)</a>
+   *
+   *
+   *  @example ```
+   *  "a.b".split('.') //returns Array("a", "b")
+   *
+   *  //splitting the empty string always returns the array with a single
+   *  //empty string
+   *  "".split('.') //returns Array("")
+   *
+   *  //only trailing empty substrings are removed
+   *  "a.".split('.') //returns Array("a")
+   *  ".a.".split('.') //returns Array("", "a")
+   *  "..a..".split('.') //returns Array("", "", "a")
+   *
+   *  //all parts are empty and trailing
+   *  ".".split('.') //returns Array()
+   *  "..".split('.') //returns Array()
+   *
+   *  //surrogate pairs
+   *  val high = 0xD852.toChar
+   *  val low = 0xDF62.toChar
+   *  val highstring = high.toString
+   *  val lowstring = low.toString
+   *
+   *  //well-formed surrogate pairs are not split
+   *  val highlow = highstring + lowstring
+   *  highlow.split(high) //returns Array(highlow)
+   *
+   *  //bare surrogate characters are split
+   *  val bare = "_" + highstring + "_"
+   *  bare.split(high) //returns Array("_", "_")
+   *
+   *  ```
+   *
+   *  @param separator the character used as a delimiter
+   */
   def split(separator: Char): Array[String] = s.split(escape(separator))
 
   @throws(classOf[java.util.regex.PatternSyntaxException])
@@ -829,118 +828,105 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   }
 
   /** You can follow a string with `.r`, turning it into a `Regex`. E.g.
-    *
-    *  `"""A\w*""".r`   is the regular expression for ASCII-only identifiers starting with `A`.
-    *
-    *  `"""(?<month>\d\d)-(?<day>\d\d)-(?<year>\d\d\d\d)""".r` matches dates
-    *  and provides its subcomponents through groups named "month", "day" and
-    *  "year".
-    */
+   *
+   *  `"""A\w*""".r`   is the regular expression for ASCII-only identifiers starting with `A`.
+   *
+   *  `"""(?<month>\d\d)-(?<day>\d\d)-(?<year>\d\d\d\d)""".r` matches dates
+   *  and provides its subcomponents through groups named "month", "day" and
+   *  "year".
+   */
   def r: Regex = new Regex(s)
 
   /** You can follow a string with `.r(g1, ... , gn)`, turning it into a `Regex`,
-    *  with group names g1 through gn.
-    *
-    *  `"""(\d\d)-(\d\d)-(\d\d\d\d)""".r("month", "day", "year")` matches dates
-    *  and provides its subcomponents through groups named "month", "day" and
-    *  "year".
-    *
-    *  @param groupNames The names of the groups in the pattern, in the order they appear.
-    */
+   *  with group names g1 through gn.
+   *
+   *  `"""(\d\d)-(\d\d)-(\d\d\d\d)""".r("month", "day", "year")` matches dates
+   *  and provides its subcomponents through groups named "month", "day" and
+   *  "year".
+   *
+   *  @param groupNames The names of the groups in the pattern, in the order they appear.
+   */
   @deprecated("use inline group names like (?<year>X) instead", "2.13.7")
   def r(groupNames: String*): Regex = new Regex(s, groupNames*)
 
   /**
-   * @throws java.lang.IllegalArgumentException  If the string does not contain a parsable `Boolean`.
+   *  @throws java.lang.IllegalArgumentException  If the string does not contain a parsable `Boolean`.
    */
   def toBoolean: Boolean               = toBooleanImpl(s)
 
-  /**
-   * Tries to parse as a `Boolean`.
-   * @return `Some(true)` if the string is "true" case insensitive,
-   * `Some(false)` if the string is "false" case insensitive,
-   * and `None` if the string is anything else
-   * @throws java.lang.NullPointerException if the string is `null`
+  /** Tries to parse as a `Boolean`.
+   *  @return `Some(true)` if the string is "true" case insensitive,
+   *  `Some(false)` if the string is "false" case insensitive,
+   *  and `None` if the string is anything else
+   *  @throws java.lang.NullPointerException if the string is `null`
    */
   def toBooleanOption: Option[Boolean] = StringParsers.parseBool(s)
 
-  /**
-    * Parses as a `Byte` (string must contain only decimal digits and optional leading `-` or `+`).
-    * @throws java.lang.NumberFormatException  If the string does not contain a parsable `Byte`.
-    */
+  /** Parses as a `Byte` (string must contain only decimal digits and optional leading `-` or `+`).
+   *  @throws java.lang.NumberFormatException  If the string does not contain a parsable `Byte`.
+   */
   def toByte: Byte                     = java.lang.Byte.parseByte(s)
 
-  /**
-   * Tries to parse as a `Byte`.
-   * @return `Some(value)` if the string contains a valid byte value, otherwise `None`
-   * @throws java.lang.NullPointerException if the string is `null`
+  /** Tries to parse as a `Byte`.
+   *  @return `Some(value)` if the string contains a valid byte value, otherwise `None`
+   *  @throws java.lang.NullPointerException if the string is `null`
    */
   def toByteOption: Option[Byte]       = StringParsers.parseByte(s)
 
-  /**
-    * Parses as a `Short` (string must contain only decimal digits and optional leading `-` or `+`).
-    * @throws java.lang.NumberFormatException  If the string does not contain a parsable `Short`.
-    */
+  /** Parses as a `Short` (string must contain only decimal digits and optional leading `-` or `+`).
+   *  @throws java.lang.NumberFormatException  If the string does not contain a parsable `Short`.
+   */
   def toShort: Short                   = java.lang.Short.parseShort(s)
 
-  /**
-   * Tries to parse as a `Short`.
-   * @return `Some(value)` if the string contains a valid short value, otherwise `None`
-   * @throws java.lang.NullPointerException if the string is `null`
+  /** Tries to parse as a `Short`.
+   *  @return `Some(value)` if the string contains a valid short value, otherwise `None`
+   *  @throws java.lang.NullPointerException if the string is `null`
    */
   def toShortOption: Option[Short]     = StringParsers.parseShort(s)
 
-  /**
-    * Parses as an `Int` (string must contain only decimal digits and optional leading `-` or `+`).
-    * @throws java.lang.NumberFormatException  If the string does not contain a parsable `Int`.
-    */
+  /** Parses as an `Int` (string must contain only decimal digits and optional leading `-` or `+`).
+   *  @throws java.lang.NumberFormatException  If the string does not contain a parsable `Int`.
+   */
   def toInt: Int                       = java.lang.Integer.parseInt(s)
 
-  /**
-   * Tries to parse as an `Int`.
-   * @return `Some(value)` if the string contains a valid Int value, otherwise `None`
-   * @throws java.lang.NullPointerException if the string is `null`
+  /** Tries to parse as an `Int`.
+   *  @return `Some(value)` if the string contains a valid Int value, otherwise `None`
+   *  @throws java.lang.NullPointerException if the string is `null`
    */
   def toIntOption: Option[Int]         = StringParsers.parseInt(s)
 
-  /**
-    * Parses as a `Long` (string must contain only decimal digits and optional leading `-` or `+`).
-    * @throws java.lang.NumberFormatException  If the string does not contain a parsable `Long`.
-    */
+  /** Parses as a `Long` (string must contain only decimal digits and optional leading `-` or `+`).
+   *  @throws java.lang.NumberFormatException  If the string does not contain a parsable `Long`.
+   */
   def toLong: Long                     = java.lang.Long.parseLong(s)
 
-  /**
-   * Tries to parse as a `Long`.
-   * @return `Some(value)` if the string contains a valid long value, otherwise `None`
-   * @throws java.lang.NullPointerException if the string is `null`
+  /** Tries to parse as a `Long`.
+   *  @return `Some(value)` if the string contains a valid long value, otherwise `None`
+   *  @throws java.lang.NullPointerException if the string is `null`
    */
   def toLongOption: Option[Long]       = StringParsers.parseLong(s)
 
-  /**
-    * Parses as a `Float` (surrounding whitespace is removed with a `trim`).
-    * @throws java.lang.NumberFormatException  If the string does not contain a parsable `Float`.
-    * @throws java.lang.NullPointerException  If the string is null.
-    */
+  /** Parses as a `Float` (surrounding whitespace is removed with a `trim`).
+   *  @throws java.lang.NumberFormatException  If the string does not contain a parsable `Float`.
+   *  @throws java.lang.NullPointerException  If the string is null.
+   */
   def toFloat: Float                   = java.lang.Float.parseFloat(s)
 
-  /**
-   * Tries to parse as a `Float`.
-   * @return `Some(value)` if the string is a parsable `Float`, `None` otherwise
-   * @throws java.lang.NullPointerException If the string is null
+  /** Tries to parse as a `Float`.
+   *  @return `Some(value)` if the string is a parsable `Float`, `None` otherwise
+   *  @throws java.lang.NullPointerException If the string is null
    */
   def toFloatOption: Option[Float]     = StringParsers.parseFloat(s)
 
-  /**
-    * Parses as a `Double` (surrounding whitespace is removed with a `trim`).
-    * @throws java.lang.NumberFormatException  If the string does not contain a parsable `Double`.
-    * @throws java.lang.NullPointerException  If the string is null.
-    */
+  /** Parses as a `Double` (surrounding whitespace is removed with a `trim`).
+   *  @throws java.lang.NumberFormatException  If the string does not contain a parsable `Double`.
+   *  @throws java.lang.NullPointerException  If the string is null.
+   */
   def toDouble: Double                 = java.lang.Double.parseDouble(s)
 
-  /**
-   * Tries to parse as a `Double`.
-   * @return `Some(value)` if the string is a parsable `Double`, `None` otherwise
-   * @throws java.lang.NullPointerException If the string is null
+  /** Tries to parse as a `Double`.
+   *  @return `Some(value)` if the string is a parsable `Double`, `None` otherwise
+   *  @throws java.lang.NullPointerException If the string is null
    */
   def toDoubleOption: Option[Double]   = StringParsers.parseDouble(s)
 
@@ -1019,8 +1005,8 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   }
 
   /** Applies `f` to each element for its side effects.
-    * Note: [U] parameter needed to help scalac's type inference.
-    */
+   *  Note: [U] parameter needed to help scalac's type inference.
+   */
   def foreach[U](f: Char => U): Unit = {
     val len = s.length
     var i = 0
@@ -1031,11 +1017,11 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   }
 
   /** Tests whether a predicate holds for all chars of this string.
-    *
-    *  @param   p     the predicate used to test elements.
-    *  @return        `true` if this string is empty or the given predicate `p`
-    *                 holds for all chars of this string, otherwise `false`.
-    */
+   *
+   *  @param   p     the predicate used to test elements.
+   *  @return        `true` if this string is empty or the given predicate `p`
+   *                 holds for all chars of this string, otherwise `false`.
+   */
   def forall(@deprecatedName("f", "2.13.3") p: Char => Boolean): Boolean = {
     var i = 0
     val len = s.length
@@ -1053,10 +1039,10 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *  If `x,,1,,`, `x,,2,,`, ..., `x,,n,,` are the chars in this string, the
    *  result is `op( op( ... op( op(z, x,,1,,), x,,2,,) ... ), x,,n,,)`.
    *
-   *   @param    z       An initial value.
-   *   @param    op      A binary operator.
-   *   @tparam   B       The result type of the binary operator.
-   *   @return           The result of applying `op` to `z` and all chars in this string,
+   *  @tparam   B       The result type of the binary operator.
+   *  @param    z       An initial value.
+   *  @param    op      A binary operator.
+   *  @return           The result of applying `op` to `z` and all chars in this string,
    *                     going left to right. Returns `z` if this string is empty.
    */
   def foldLeft[B](z: B)(op: (B, Char) => B): B = {
@@ -1077,10 +1063,10 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *  If `x,,1,,`, `x,,2,,`, ..., `x,,n,,` are the chars in this string, the
    *  result is `op(x,,1,,, op(x,,2,,, op( ... op(x,,n,,, z) ... )))`.
    *
-   *   @param    z       An initial value.
-   *   @param    op      A binary operator.
-   *   @tparam   B       The result type of the binary operator.
-   *   @return           The result of applying `op` to all chars in this string
+   *  @tparam   B       The result type of the binary operator.
+   *  @param    z       An initial value.
+   *  @param    op      A binary operator.
+   *  @return           The result of applying `op` to all chars in this string
    *                     and `z`, going right to left. Returns `z` if this string
    *                     is empty.
    */
@@ -1099,92 +1085,91 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *  The type parameter is more restrictive than for `foldLeft` to be
    *  consistent with [[IterableOnceOps.fold]].
    *
-   *   @tparam A1     The type parameter for the binary operator, a supertype of `Char`.
-   *   @param z       An initial value.
-   *   @param op      A binary operator.
-   *   @return        The result of applying `op` to `z` and all chars in this string,
+   *  @tparam A1     The type parameter for the binary operator, a supertype of `Char`.
+   *  @param z       An initial value.
+   *  @param op      A binary operator.
+   *  @return        The result of applying `op` to `z` and all chars in this string,
    *                  going left to right. Returns `z` if this string is empty.
    */
   @inline def fold[A1 >: Char](z: A1)(op: (A1, A1) => A1): A1 = foldLeft(z)(op)
 
   /** Selects the first char of this string.
-    *  @return  the first char of this string.
-    *  @throws NoSuchElementException if the string is empty.
-    */
+   *  @return  the first char of this string.
+   *  @throws NoSuchElementException if the string is empty.
+   */
   def head: Char = if(s.isEmpty) throw new NoSuchElementException("head of empty String") else s.charAt(0)
 
   /** Optionally selects the first char.
-    *  @return  the first char of this string if it is nonempty,
-    *           `None` if it is empty.
-    */
+   *  @return  the first char of this string if it is nonempty,
+   *           `None` if it is empty.
+   */
   def headOption: Option[Char] =
     if(s.isEmpty) None else Some(s.charAt(0))
 
   /** Selects the last char of this string.
-    *  @return  the last char of this string.
-    *  @throws NoSuchElementException if the string is empty.
-    */
+   *  @return  the last char of this string.
+   *  @throws NoSuchElementException if the string is empty.
+   */
   def last: Char = if(s.isEmpty) throw new NoSuchElementException("last of empty String") else s.charAt(s.length-1)
 
   /** Optionally selects the last char.
-    *  @return  the last char of this string if it is nonempty,
-    *           `None` if it is empty.
-    */
+   *  @return  the last char of this string if it is nonempty,
+   *           `None` if it is empty.
+   */
   def lastOption: Option[Char] =
     if(s.isEmpty) None else Some(s.charAt(s.length-1))
 
   /** Produces the range of all indices of this string.
-    *
-    *  @return  a `Range` value from `0` to one less than the length of this string.
-    */
+   *
+   *  @return  a `Range` value from `0` to one less than the length of this string.
+   */
   def indices: Range = Range(0, s.length)
 
   /** Iterator can be used only once. */
   def iterator: Iterator[Char] = new StringIterator(s)
 
   /** Stepper can be used with Java 8 Streams. This method is equivalent to a call to
-    * [[charStepper]]. See also [[codePointStepper]].
-    */
+   *  [[charStepper]]. See also [[codePointStepper]].
+   */
   @inline def stepper: IntStepper & EfficientSplit = charStepper
 
   /** Steps over characters in this string. Values are packed in `Int` for efficiency
-    * and compatibility with Java 8 Streams which have an efficient specialization for `Int`.
-    */
+   *  and compatibility with Java 8 Streams which have an efficient specialization for `Int`.
+   */
   @inline def charStepper: IntStepper & EfficientSplit = new CharStringStepper(s, 0, s.length)
 
-  /** Steps over code points in this string.
-    */
+  /** Steps over code points in this string. */
   @inline def codePointStepper: IntStepper & EfficientSplit = new CodePointStringStepper(s, 0, s.length)
 
   /** Tests whether the string is not empty. */
   @inline def nonEmpty: Boolean = !s.isEmpty
 
   /** Returns new sequence with elements in reversed order.
-    * @note $unicodeunaware
-    */
+   *  @note $unicodeunaware
+   */
   def reverse: String = new JStringBuilder(s).reverse().toString
 
   /** An iterator yielding chars in reversed order.
-    *
-    * Note: `xs.reverseIterator` is the same as `xs.reverse.iterator` but implemented more efficiently.
-    *
-    *  @return  an iterator yielding the chars of this string in reversed order
-    */
+   *
+   *  Note: `xs.reverseIterator` is the same as `xs.reverse.iterator` but implemented more efficiently.
+   *
+   *  @return  an iterator yielding the chars of this string in reversed order
+   */
   def reverseIterator: Iterator[Char] = new ReverseIterator(s)
 
   /** Creates a non-strict filter of this string.
-    *
-    *  @note the difference between `c filter p` and `c withFilter p` is that
-    *        the former creates a new string, whereas the latter only
-    *        restricts the domain of subsequent `map`, `flatMap`, `foreach`,
-    *        and `withFilter` operations.
-    *
-    *  @param p   the predicate used to test elements.
-    *  @return    an object of class `stringOps.WithFilter`, which supports
-    *             `map`, `flatMap`, `foreach`, and `withFilter` operations.
-    *             All these operations apply to those chars of this string
-    *             which satisfy the predicate `p`.
-    */
+   *
+   *  @note the difference between `c filter p` and `c withFilter p` is that
+   *        the former creates a new string, whereas the latter only
+   *        restricts the domain of subsequent `map`, `flatMap`, `foreach`,
+   *        and `withFilter` operations.
+   *
+   *  @param p   the predicate used to test elements.
+   *  @return    an object of class `stringOps.WithFilter`, which supports
+   *             `map`, `flatMap`, `foreach`, and `withFilter` operations.
+   *             All these operations apply to those chars of this string
+   *             which satisfy the predicate `p`.
+   */
   def withFilter(p: Char => Boolean): StringOps.WithFilter^{p} = new StringOps.WithFilter(p, s)
 
   /** The rest of the string without its first char.
@@ -1195,46 +1180,46 @@ final class StringOps(private val s: String) extends AnyVal { self =>
 
   /** The initial part of the string without its last char.
    *  @throws UnsupportedOperationException if the string is empty.
-   * @note $unicodeunaware
+   *  @note $unicodeunaware
    */
   def init: String = if(s.isEmpty) throw new UnsupportedOperationException("init of empty String") else slice(0, s.length-1)
 
   /** A string containing the first `n` chars of this string.
-    * @note $unicodeunaware
-    */
+   *  @note $unicodeunaware
+   */
   def take(n: Int): String = slice(0, min(n, s.length))
 
   /** The rest of the string without its `n` first chars.
-    * @note $unicodeunaware
-    */
+   *  @note $unicodeunaware
+   */
   def drop(n: Int): String = slice(min(n, s.length), s.length)
 
   /** A string containing the last `n` chars of this string.
-    * @note $unicodeunaware
-    */
+   *  @note $unicodeunaware
+   */
   def takeRight(n: Int): String = drop(s.length - max(n, 0))
 
   /** The rest of the string without its `n` last chars.
-    * @note $unicodeunaware
-    */
+   *  @note $unicodeunaware
+   */
   def dropRight(n: Int): String = take(s.length - max(n, 0))
 
   /** Iterates over the tails of this string. The first value will be this
-    * string and the final one will be an empty string, with the intervening
-    * values the results of successive applications of `tail`.
-    *
-    *  @return   an iterator over all the tails of this string
-    *  @note     $unicodeunaware
-    */
+   *  string and the final one will be an empty string, with the intervening
+   *  values the results of successive applications of `tail`.
+   *
+   *  @return   an iterator over all the tails of this string
+   *  @note     $unicodeunaware
+   */
   def tails: Iterator[String] = iterateUntilEmpty(_.tail)
 
   /** Iterates over the inits of this string. The first value will be this
-    * string and the final one will be an empty string, with the intervening
-    * values the results of successive applications of `init`.
-    *
-    *  @return  an iterator over all the inits of this string
-    *  @note    $unicodeunaware
-    */
+   *  string and the final one will be an empty string, with the intervening
+   *  values the results of successive applications of `init`.
+   *
+   *  @return  an iterator over all the inits of this string
+   *  @note    $unicodeunaware
+   */
   def inits: Iterator[String] = iterateUntilEmpty(_.init)
 
   // A helper for tails and inits.
@@ -1258,35 +1243,35 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   @inline def filterNot(pred: Char => Boolean): String = filter(c => !pred(c))
 
   /** Copies chars of this string to an array.
-    * Fills the given array `xs` starting at index 0.
-    * Copying will stop once either the entire string has been copied
-    * or the end of the array is reached
-    *
-    *  @param  xs     the array to fill.
-    */
+   *  Fills the given array `xs` starting at index 0.
+   *  Copying will stop once either the entire string has been copied
+   *  or the end of the array is reached
+   *
+   *  @param  xs     the array to fill.
+   */
   @inline def copyToArray(xs: Array[Char]): Int =
     copyToArray(xs, 0, Int.MaxValue)
 
   /** Copies chars of this string to an array.
-    * Fills the given array `xs` starting at index `start`.
-    * Copying will stop once either the entire string has been copied
-    * or the end of the array is reached
-    *
-    *  @param  xs     the array to fill.
-    *  @param  start  the starting index.
-    */
+   *  Fills the given array `xs` starting at index `start`.
+   *  Copying will stop once either the entire string has been copied
+   *  or the end of the array is reached
+   *
+   *  @param  xs     the array to fill.
+   *  @param  start  the starting index.
+   */
   @inline def copyToArray(xs: Array[Char], start: Int): Int =
     copyToArray(xs, start, Int.MaxValue)
 
   /** Copies chars of this string to an array.
-    * Fills the given array `xs` starting at index `start` with at most `len` chars.
-    * Copying will stop once either the entire string has been copied,
-    * or the end of the array is reached or `len` chars have been copied.
-    *
-    *  @param  xs     the array to fill.
-    *  @param  start  the starting index.
-    *  @param  len    the maximal number of elements to copy.
-    */
+   *  Fills the given array `xs` starting at index `start` with at most `len` chars.
+   *  Copying will stop once either the entire string has been copied,
+   *  or the end of the array is reached or `len` chars have been copied.
+   *
+   *  @param  xs     the array to fill.
+   *  @param  start  the starting index.
+   *  @param  len    the maximal number of elements to copy.
+   */
   def copyToArray(xs: Array[Char], start: Int, len: Int): Int = {
     val copied = IterableOnce.elemsToCopyToArray(s.length, xs.length, start, len)
     if (copied > 0) {
@@ -1296,12 +1281,12 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   }
 
   /** Finds index of the first char satisfying some predicate after or at some start index.
-    *
-    *  @param   p     the predicate used to test elements.
-    *  @param   from   the start index
-    *  @return  the index `>= from` of the first element of this string that satisfies the predicate `p`,
-    *           or `-1`, if none exists.
-    */
+   *
+   *  @param   p     the predicate used to test elements.
+   *  @param   from   the start index
+   *  @return  the index `>= from` of the first element of this string that satisfies the predicate `p`,
+   *           or `-1`, if none exists.
+   */
   def indexWhere(p: Char => Boolean, from: Int = 0): Int = {
     val len = s.length
     var i = from
@@ -1313,12 +1298,12 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   }
 
   /** Finds index of the last char satisfying some predicate before or at some end index.
-    *
-    *  @param   p     the predicate used to test elements.
-    *  @param   end   the end index
-    *  @return  the index `<= end` of the last element of this string that satisfies the predicate `p`,
-    *           or `-1`, if none exists.
-    */
+   *
+   *  @param   p     the predicate used to test elements.
+   *  @param   end   the end index
+   *  @return  the index `<= end` of the last element of this string that satisfies the predicate `p`,
+   *           or `-1`, if none exists.
+   */
   def lastIndexWhere(p: Char => Boolean, end: Int = Int.MaxValue): Int = {
     val len = s.length
     var i = min(end, len-1)
@@ -1333,22 +1318,22 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   def exists(p: Char => Boolean): Boolean = indexWhere(p) != -1
 
   /** Finds the first char of the string satisfying a predicate, if any.
-    *
-    *  @param p       the predicate used to test elements.
-    *  @return        an option value containing the first element in the string
-    *                 that satisfies `p`, or `None` if none exists.
-    */
+   *
+   *  @param p       the predicate used to test elements.
+   *  @return        an option value containing the first element in the string
+   *                 that satisfies `p`, or `None` if none exists.
+   */
   def find(p: Char => Boolean): Option[Char] = indexWhere(p) match {
     case -1 => None
     case i => Some(s.charAt(i))
   }
 
   /** Drops longest prefix of chars that satisfy a predicate.
-    *
-    *  @param   p  The predicate used to test elements.
-    *  @return  the longest suffix of this string whose first element
-    *           does not satisfy the predicate `p`.
-    */
+   *
+   *  @param   p  The predicate used to test elements.
+   *  @return  the longest suffix of this string whose first element
+   *           does not satisfy the predicate `p`.
+   */
   def dropWhile(p: Char => Boolean): String = indexWhere(c => !p(c)) match {
     case -1 => ""
     case i => s.substring(i)
@@ -1361,38 +1346,38 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   }
 
   /** Splits this string into two at a given position.
-    * Note: `c splitAt n` is equivalent to `(c take n, c drop n)`.
-    *
-    *  @param n the position at which to split.
-    *  @return  a pair of strings consisting of the first `n`
-    *           chars of this string, and the other chars.
-    *  @note    $unicodeunaware
-    */
+   *  Note: `c splitAt n` is equivalent to `(c take n, c drop n)`.
+   *
+   *  @param n the position at which to split.
+   *  @return  a pair of strings consisting of the first `n`
+   *           chars of this string, and the other chars.
+   *  @note    $unicodeunaware
+   */
   def splitAt(n: Int): (String, String) = (take(n), drop(n))
 
   /** Splits this string into a prefix/suffix pair according to a predicate.
-    *
-    *  Note: `c span p`  is equivalent to (but more efficient than)
-    *  `(c takeWhile p, c dropWhile p)`, provided the evaluation of the
-    *  predicate `p` does not cause any side-effects.
-    *
-    *  @param p the test predicate
-    *  @return  a pair consisting of the longest prefix of this string whose
-    *           chars all satisfy `p`, and the rest of this string.
-    */
+   *
+   *  Note: `c span p`  is equivalent to (but more efficient than)
+   *  `(c takeWhile p, c dropWhile p)`, provided the evaluation of the
+   *  predicate `p` does not cause any side-effects.
+   *
+   *  @param p the test predicate
+   *  @return  a pair consisting of the longest prefix of this string whose
+   *           chars all satisfy `p`, and the rest of this string.
+   */
   def span(p: Char => Boolean): (String, String) = indexWhere(c => !p(c)) match {
     case -1 => (s, "")
     case i => (s.substring(0, i), s.substring(i))
   }
 
   /** Partitions elements in fixed size strings.
-    *  @see [[scala.collection.Iterator]], method `grouped`
-    *
-    *  @param size the number of elements per group
-    *  @return An iterator producing strings of size `size`, except the
-    *          last will be less than size `size` if the elements don't divide evenly.
-    *  @note $unicodeunaware
-    */
+   *  @see [[scala.collection.Iterator]], method `grouped`
+   *
+   *  @param size the number of elements per group
+   *  @return An iterator producing strings of size `size`, except the
+   *          last will be less than size `size` if the elements don't divide evenly.
+   *  @note $unicodeunaware
+   */
   def grouped(size: Int): Iterator[String] = new StringOps.GroupedIterator(s, size)
 
   /** A pair of, first, all chars that satisfy predicate `p` and, second, all chars that do not. */
@@ -1409,22 +1394,22 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   }
 
   /** Applies a function `f` to each character of the string and returns a pair of strings: the first one
-    *  made of those characters returned by `f` that were wrapped in [[scala.util.Left]], and the second
-    *  one made of those wrapped in [[scala.util.Right]].
-    *
-    *  Example:
-    *  {{{
-    *    val xs = "1one2two3three" partitionMap { c =>
-    *      if (c > 'a') Left(c) else Right(c)
-    *    }
-    *    // xs == ("onetwothree", "123")
-    *  }}}
-    *
-    *  @param f    the 'split function' mapping the elements of this string to an [[scala.util.Either]]
-    *
-    *  @return     a pair of strings: the first one made of those characters returned by `f` that were wrapped in [[scala.util.Left]],
-    *              and the second one made of those wrapped in [[scala.util.Right]].
-    */
+   *  made of those characters returned by `f` that were wrapped in [[scala.util.Left]], and the second
+   *  one made of those wrapped in [[scala.util.Right]].
+   *
+   *  Example:
+   *  ```
+   *    val xs = "1one2two3three" partitionMap { c =>
+   *      if (c > 'a') Left(c) else Right(c)
+   *    }
+   *    // xs == ("onetwothree", "123")
+   *  ```
+   *
+   *  @param f    the 'split function' mapping the elements of this string to an [[scala.util.Either]]
+   *
+   *  @return     a pair of strings: the first one made of those characters returned by `f` that were wrapped in [[scala.util.Left]],
+   *              and the second one made of those wrapped in [[scala.util.Right]].
+   */
   def partitionMap(f: Char => Either[Char,Char]): (String, String) = {
     val res1, res2 = new JStringBuilder
     var i = 0
@@ -1440,22 +1425,22 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   }
 
   /** Analogous to `zip` except that the elements in each collection are not consumed until a strict operation is
-    * invoked on the returned `LazyZip2` decorator.
-    *
-    * Calls to `lazyZip` can be chained to support higher arities (up to 4) without incurring the expense of
-    * constructing and deconstructing intermediary tuples.
-    *
-    * {{{
-    *    val xs = List(1, 2, 3)
-    *    val res = (xs lazyZip xs lazyZip xs lazyZip xs).map((a, b, c, d) => a + b + c + d)
-    *    // res == List(4, 8, 12)
-    * }}}
-    *
-    * @param that the iterable providing the second element of each eventual pair
-    * @tparam B   the type of the second element in each eventual pair
-    * @return a decorator `LazyZip2` that allows strict operations to be performed on the lazily evaluated pairs
-    *         or chained calls to `lazyZip`. Implicit conversion to `Iterable[(A, B)]` is also supported.
-    */
+   *  invoked on the returned `LazyZip2` decorator.
+   *
+   *  Calls to `lazyZip` can be chained to support higher arities (up to 4) without incurring the expense of
+   *  constructing and deconstructing intermediary tuples.
+   *
+   *  ```
+   *    val xs = List(1, 2, 3)
+   *    val res = (xs lazyZip xs lazyZip xs lazyZip xs).map((a, b, c, d) => a + b + c + d)
+   *    // res == List(4, 8, 12)
+   *  ```
+   *
+   *  @tparam B   the type of the second element in each eventual pair
+   *  @param that the iterable providing the second element of each eventual pair
+   *  @return a decorator `LazyZip2` that allows strict operations to be performed on the lazily evaluated pairs
+   *         or chained calls to `lazyZip`. Implicit conversion to `Iterable[(A, B)]` is also supported.
+   */
   def lazyZip[B](that: Iterable[B]^): LazyZip2[Char, B, String]^{that} = new LazyZip2(s, new WrappedString(s), that)
 
 
@@ -1467,122 +1452,122 @@ final class StringOps(private val s: String) extends AnyVal { self =>
 
 
   /** Computes the multiset difference between this string and another sequence.
-    *
-    *  @param that   the sequence of chars to remove
-    *  @return       a new string which contains all chars of this string
-    *                except some of occurrences of elements that also appear in `that`.
-    *                If an element value `x` appears
-    *                ''n'' times in `that`, then the first ''n'' occurrences of `x` will not form
-    *                part of the result, but any following occurrences will.
-    *  @note         $unicodeunaware
-    */
+   *
+   *  @param that   the sequence of chars to remove
+   *  @return       a new string which contains all chars of this string
+   *                except some of occurrences of elements that also appear in `that`.
+   *                If an element value `x` appears
+   *                *n* times in `that`, then the first *n* occurrences of `x` will not form
+   *                part of the result, but any following occurrences will.
+   *  @note         $unicodeunaware
+   */
   def diff[B >: Char](that: Seq[B]): String = new WrappedString(s).diff(that).unwrap
 
   /** Computes the multiset intersection between this string and another sequence.
-    *
-    *  @param that   the sequence of chars to intersect with.
-    *  @return       a new string which contains all chars of this string
-    *                which also appear in `that`.
-    *                If an element value `x` appears
-    *                ''n'' times in `that`, then the first ''n'' occurrences of `x` will be retained
-    *                in the result, but any following occurrences will be omitted.
-    * @note          $unicodeunaware
-    */
+   *
+   *  @param that   the sequence of chars to intersect with.
+   *  @return       a new string which contains all chars of this string
+   *                which also appear in `that`.
+   *                If an element value `x` appears
+   *                *n* times in `that`, then the first *n* occurrences of `x` will be retained
+   *                in the result, but any following occurrences will be omitted.
+   *  @note          $unicodeunaware
+   */
   def intersect[B >: Char](that: Seq[B]): String = new WrappedString(s).intersect(that).unwrap
 
   /** Selects all distinct chars of this string ignoring the duplicates.
-    *
-    * @note $unicodeunaware
-    */
+   *
+   *  @note $unicodeunaware
+   */
   def distinct: String = new WrappedString(s).distinct.unwrap
 
   /** Selects all distinct chars of this string ignoring the duplicates as determined by `==` after applying
-    * the transforming function `f`.
-    *
-    * @param f The transforming function whose result is used to determine the uniqueness of each element
-    * @tparam B the type of the elements after being transformed by `f`
-    * @return a new string consisting of all the chars of this string without duplicates.
-    * @note $unicodeunaware
-    */
+   *  the transforming function `f`.
+   *
+   *  @tparam B the type of the elements after being transformed by `f`
+   *  @param f The transforming function whose result is used to determine the uniqueness of each element
+   *  @return a new string consisting of all the chars of this string without duplicates.
+   *  @note $unicodeunaware
+   */
   def distinctBy[B](f: Char -> B): String = new WrappedString(s).distinctBy(f).unwrap
 
   /** Sorts the characters of this string according to an Ordering.
-    *
-    *  The sort is stable. That is, elements that are equal (as determined by
-    *  `ord.compare`) appear in the same order in the sorted sequence as in the original.
-    *
-    *  @see [[scala.math.Ordering]]
-    *
-    *  @param  ord the ordering to be used to compare elements.
-    *  @return     a string consisting of the chars of this string
-    *              sorted according to the ordering `ord`.
-    *  @note       $unicodeunaware
-    */
+   *
+   *  The sort is stable. That is, elements that are equal (as determined by
+   *  `ord.compare`) appear in the same order in the sorted sequence as in the original.
+   *
+   *  @see [[scala.math.Ordering]]
+   *
+   *  @param  ord the ordering to be used to compare elements.
+   *  @return     a string consisting of the chars of this string
+   *              sorted according to the ordering `ord`.
+   *  @note       $unicodeunaware
+   */
   def sorted[B >: Char](implicit ord: Ordering[B]): String = new WrappedString(s).sorted(using ord).unwrap
 
   /** Sorts this string according to a comparison function.
-    *
-    *  The sort is stable. That is, elements that are equal (as determined by
-    *  `lt`) appear in the same order in the sorted sequence as in the original.
-    *
-    *  @param  lt  the comparison function which tests whether
-    *              its first argument precedes its second argument in
-    *              the desired ordering.
-    *  @return     a string consisting of the elements of this string
-    *              sorted according to the comparison function `lt`.
-    *  @note       $unicodeunaware
-    */
+   *
+   *  The sort is stable. That is, elements that are equal (as determined by
+   *  `lt`) appear in the same order in the sorted sequence as in the original.
+   *
+   *  @param  lt  the comparison function which tests whether
+   *              its first argument precedes its second argument in
+   *              the desired ordering.
+   *  @return     a string consisting of the elements of this string
+   *              sorted according to the comparison function `lt`.
+   *  @note       $unicodeunaware
+   */
   def sortWith(lt: (Char, Char) => Boolean): String = new WrappedString(s).sortWith(lt).unwrap
 
   /** Sorts this string according to the Ordering which results from transforming
-    * an implicitly given Ordering with a transformation function.
-    *
-    * The sort is stable. That is, elements that are equal (as determined by
-    * `ord.compare`) appear in the same order in the sorted sequence as in the original.
-    *
-    *  @see [[scala.math.Ordering]]
-    *  @param   f the transformation function mapping elements
-    *           to some other domain `B`.
-    *  @param   ord the ordering assumed on domain `B`.
-    *  @tparam  B the target type of the transformation `f`, and the type where
-    *           the ordering `ord` is defined.
-    *  @return  a string consisting of the chars of this string
-    *           sorted according to the ordering where `x < y` if
-    *           `ord.lt(f(x), f(y))`.
-    *  @note    $unicodeunaware
-    */
+   *  an implicitly given Ordering with a transformation function.
+   *
+   *  The sort is stable. That is, elements that are equal (as determined by
+   *  `ord.compare`) appear in the same order in the sorted sequence as in the original.
+   *
+   *  @see [[scala.math.Ordering]]
+   *  @tparam  B the target type of the transformation `f`, and the type where
+   *           the ordering `ord` is defined.
+   *  @param   f the transformation function mapping elements
+   *           to some other domain `B`.
+   *  @param   ord the ordering assumed on domain `B`.
+   *  @return  a string consisting of the chars of this string
+   *           sorted according to the ordering where `x < y` if
+   *           `ord.lt(f(x), f(y))`.
+   *  @note    $unicodeunaware
+   */
   def sortBy[B](f: Char => B)(implicit ord: Ordering[B]): String = new WrappedString(s).sortBy(f)(using ord).unwrap
 
   /** Partitions this string into a map of strings according to some discriminator function.
-    *
-    *  @param f     the discriminator function.
-    *  @tparam K    the type of keys returned by the discriminator function.
-    *  @return      A map from keys to strings such that the following invariant holds:
-    *               {{{
-    *                 (xs groupBy f)(k) = xs filter (x => f(x) == k)
-    *               }}}
-    *               That is, every key `k` is bound to a string of those elements `x`
-    *               for which `f(x)` equals `k`.
-    *  @note        $unicodeunaware
-    */
+   *
+   *  @tparam K    the type of keys returned by the discriminator function.
+   *  @param f     the discriminator function.
+   *  @return      A map from keys to strings such that the following invariant holds:
+   *               ```
+   *                 (xs groupBy f)(k) = xs filter (x => f(x) == k)
+   *               ```
+   *               That is, every key `k` is bound to a string of those elements `x`
+   *               for which `f(x)` equals `k`.
+   *  @note        $unicodeunaware
+   */
   def groupBy[K](f: Char => K): immutable.Map[K, String] = new WrappedString(s).groupBy(f).view.mapValues(_.unwrap).toMap
 
   /** Groups chars in fixed size blocks by passing a "sliding window"
-    *  over them (as opposed to partitioning them, as is done in grouped.)
-    *  @see [[scala.collection.Iterator]], method `sliding`
-    *
-    *  @param size the number of chars per group
-    *  @param step the distance between the first chars of successive groups
-    *  @return An iterator producing strings of size `size`, except the
-    *          last element (which may be the only element) will be truncated
-    *          if there are fewer than `size` chars remaining to be grouped.
-    * @note    $unicodeunaware
-    */
+   *  over them (as opposed to partitioning them, as is done in grouped.)
+   *  @see [[scala.collection.Iterator]], method `sliding`
+   *
+   *  @param size the number of chars per group
+   *  @param step the distance between the first chars of successive groups
+   *  @return An iterator producing strings of size `size`, except the
+   *          last element (which may be the only element) will be truncated
+   *          if there are fewer than `size` chars remaining to be grouped.
+   *  @note    $unicodeunaware
+   */
   def sliding(size: Int, step: Int = 1): Iterator[String] = new WrappedString(s).sliding(size, step).map(_.unwrap)
 
   /** Iterates over combinations of elements.
    *
-   *  A '''combination''' of length `n` is a sequence of `n` elements selected in order of their first index in this sequence.
+   *  A **combination** of length `n` is a sequence of `n` elements selected in order of their first index in this sequence.
    *
    *  For example, `"xyx"` has two combinations of length 2. The `x` is selected first: `"xx"`, `"xy"`.
    *  The sequence `"yx"` is not returned as a combination because it is subsumed by `"xy"`.
@@ -1604,7 +1589,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *  the order of each `x` element is also arbitrary.
    *
    *  @return   An Iterator which traverses the n-element combinations of this string.
-   *  @example {{{
+   *  @example ```
    *    "abbbc".combinations(2).foreach(println)
    *    // ab
    *    // ac
@@ -1613,7 +1598,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *    "bab".combinations(2).foreach(println)
    *    // bb
    *    // ba
-   *  }}}
+   *  ```
    *  @note     $unicodeunaware
    */
   def combinations(n: Int): Iterator[String] = new WrappedString(s).combinations(n).map(_.unwrap)
@@ -1621,12 +1606,12 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   /** Iterates over distinct permutations of elements.
    *
    *  @return   An Iterator which traverses the distinct permutations of this string.
-   *  @example {{{
+   *  @example ```
    *    "abb".permutations.foreach(println)
    *    // abb
    *    // bab
    *    // bba
-   *  }}}
+   *  ```
    *  @note     $unicodeunaware
    */
   def permutations: Iterator[String] = new WrappedString(s).permutations.map(_.unwrap)

--- a/library/src/scala/collection/View.scala
+++ b/library/src/scala/collection/View.scala
@@ -22,11 +22,11 @@ import scala.runtime.ScalaRunTime.nullForGC
 import caps.unsafe.unsafeAssumePure
 
 /** Views are collections whose transformation operations are non strict: the resulting elements
-  * are evaluated only when the view is effectively traversed (e.g. using `foreach` or `foldLeft`),
-  * or when the view is converted to a strict collection type (using the `to` operation).
-  * @define coll view
-  * @define Coll `View`
-  */
+ *  are evaluated only when the view is effectively traversed (e.g. using `foreach` or `foldLeft`),
+ *  or when the view is converted to a strict collection type (using the `to` operation).
+ *  @define coll view
+ *  @define Coll `View`
+ */
 trait View[+A] extends Iterable[A] with IterableOps[A, View, View[A]] with IterableFactoryDefaults[A, View] with Serializable {
 
   override def view: View[A]^{this} = this
@@ -45,33 +45,33 @@ trait View[+A] extends Iterable[A] with IterableOps[A, View, View[A]] with Itera
 }
 
 /** This object reifies operations on views as case classes
-  *
-  * @define Coll View
-  * @define coll view
-  */
+ *
+ *  @define Coll View
+ *  @define coll view
+ */
 @SerialVersionUID(3L)
 object View extends IterableFactory[View] {
 
   /**
-    * @return A `View[A]` whose underlying iterator is provided by the `it` parameter-less function.
-    *
-    * @param it Function creating the iterator to be used by the view. This function must always return
-    *           a fresh `Iterator`, otherwise the resulting view will be effectively iterable only once.
-    *
-    * @tparam A View element type
-    */
+   *  @tparam A View element type
+   *
+   *  @param it Function creating the iterator to be used by the view. This function must always return
+   *           a fresh `Iterator`, otherwise the resulting view will be effectively iterable only once.
+   *
+   *  @return A `View[A]` whose underlying iterator is provided by the `it` parameter-less function.
+   */
   def fromIteratorProvider[A](it: () => Iterator[A]^): View[A]^{it} = new AbstractView[A] {
     def iterator = it()
   }
 
   /**
-    * @return A view iterating over the given `Iterable`
-    *
-    * @param it The `IterableOnce` to view. A proper `Iterable` is used directly. If it is really only
-    *           `IterableOnce` it gets memoized on the first traversal.
-    *
-    * @tparam E View element type
-    */
+   *  @tparam E View element type
+   *
+   *  @param it The `IterableOnce` to view. A proper `Iterable` is used directly. If it is really only
+   *           `IterableOnce` it gets memoized on the first traversal.
+   *
+   *  @return A view iterating over the given `Iterable`
+   */
   def from[E](it: IterableOnce[E]^): View[E]^{it} = it match {
     case it: (View[E]^{it})     => it
     case it: (Iterable[E]^{it}) => View.fromIteratorProvider(() => it.iterator)
@@ -133,8 +133,8 @@ object View extends IterableFactory[View] {
   }
 
   /** A view that uses a function `f` to produce elements of type `A` and update
-    * an internal state `S`.
-    */
+   *  an internal state `S`.
+   */
   @SerialVersionUID(3L)
   class Unfold[A, S](initial: S)(f: S => Option[(A, S)]) extends AbstractView[A] {
     def iterator: Iterator[A]^{f} = Iterator.unfold(initial)(f)
@@ -338,8 +338,8 @@ object View extends IterableFactory[View] {
   }
 
   /** A view that zips elements of the underlying collection with the elements
-    *  of another collection.
-    */
+   *  of another collection.
+   */
   @SerialVersionUID(3L)
   class Zip[A, B](underlying: SomeIterableOps[A]^, other: Iterable[B]^) extends AbstractView[(A, B)] {
     def iterator = underlying.iterator.zip(other)
@@ -354,9 +354,9 @@ object View extends IterableFactory[View] {
   }
 
   /** A view that zips elements of the underlying collection with the elements
-    *  of another collection. If one of the two collections is shorter than the other,
-    *  placeholder elements are used to extend the shorter collection to the length of the longer.
-    */
+   *  of another collection. If one of the two collections is shorter than the other,
+   *  placeholder elements are used to extend the shorter collection to the length of the longer.
+   */
   @SerialVersionUID(3L)
   class ZipAll[A, B](underlying: SomeIterableOps[A]^, other: Iterable[B]^, thisElem: A, thatElem: B) extends AbstractView[(A, B)] {
     def iterator = underlying.iterator.zipAll(other, thisElem, thatElem)

--- a/library/src/scala/collection/concurrent/Map.scala
+++ b/library/src/scala/collection/concurrent/Map.scala
@@ -22,7 +22,7 @@ import scala.annotation.tailrec
   *
   *  $concurrentmapinfo
   *
-  *  @see [[https://docs.scala-lang.org/overviews/collections-2.13/concrete-mutable-collection-classes.html#concurrent_maps "Scala's Collection Library overview"]]
+  *  @see ["Scala's Collection Library overview"](https://docs.scala-lang.org/overviews/collections-2.13/concrete-mutable-collection-classes.html#concurrent_maps)
   *  section on `Concurrent Maps` for more information.
   *
   *  @tparam K  the key type of the map

--- a/library/src/scala/collection/concurrent/TrieMap.scala
+++ b/library/src/scala/collection/concurrent/TrieMap.scala
@@ -104,9 +104,9 @@ private[collection] final class INode[K, V](bn: MainNode[K, V] | Null, g: Gen, e
   }
 
   /** Inserts a key value pair, overwriting the old pair if the keys match.
-    *
-    *  @return        true if successful, false otherwise
-    */
+   *
+   *  @return        true if successful, false otherwise
+   */
   @tailrec def rec_insert(k: K, v: V, hc: Int, lev: Int, parent: INode[K, V] | Null, startgen: Gen, ct: TrieMap[K, V]): Boolean = {
     val m = GCAS_READ(ct) // use -Yinline!
 
@@ -153,16 +153,16 @@ private[collection] final class INode[K, V](bn: MainNode[K, V] | Null, g: Gen, e
 
 
   /** Inserts a new key value pair, given that a specific condition is met.
-    *
-    *  @param cond KEY_PRESENT_OR_ABSENT - don't care if the key was there, insert or overwrite
-    *              KEY_ABSENT - key wasn't there, insert only, do not overwrite
-    *              KEY_PRESENT - key was there, overwrite only, do not insert
-    *              other value `v` - only overwrite if the current value is this
-   *   @param fullEquals whether to use reference or full equals when comparing `v` to the current value
-    *  @param hc the hashcode of `k`
-    *
-    *  @return     null if unsuccessful, Option[V] otherwise (indicating previous value bound to the key)
-    */
+   *
+   *  @param cond KEY_PRESENT_OR_ABSENT - don't care if the key was there, insert or overwrite
+   *              KEY_ABSENT - key wasn't there, insert only, do not overwrite
+   *              KEY_PRESENT - key was there, overwrite only, do not insert
+   *              other value `v` - only overwrite if the current value is this
+   *  @param fullEquals whether to use reference or full equals when comparing `v` to the current value
+   *  @param hc the hashcode of `k`
+   *
+   *  @return     null if unsuccessful, Option[V] otherwise (indicating previous value bound to the key)
+   */
   @tailrec def rec_insertif(k: K, v: V, hc: Int, cond: AnyRef, fullEquals: Boolean, lev: Int, parent: INode[K, V] | Null, startgen: Gen, ct: TrieMap[K, V]): Option[V] | Null = {
     val m = GCAS_READ(ct)  // use -Yinline!
 
@@ -253,12 +253,12 @@ private[collection] final class INode[K, V](bn: MainNode[K, V] | Null, g: Gen, e
   }
 
   /** Looks up the value associated with the key.
-    *
-    *  @param hc        the hashcode of `k`
-    *
-    *  @return          NO_SUCH_ELEMENT_SENTINEL if no value has been found, RESTART if the operation wasn't successful,
-    *                   or any other value otherwise
-    */
+   *
+   *  @param hc        the hashcode of `k`
+   *
+   *  @return          NO_SUCH_ELEMENT_SENTINEL if no value has been found, RESTART if the operation wasn't successful,
+   *                   or any other value otherwise
+   */
   @tailrec def rec_lookup(k: K, hc: Int, lev: Int, parent: INode[K, V] | Null, startgen: Gen, ct: TrieMap[K, V]): AnyRef = {
     val m = GCAS_READ(ct) // use -Yinline!
 
@@ -300,14 +300,14 @@ private[collection] final class INode[K, V](bn: MainNode[K, V] | Null, g: Gen, e
   }
 
   /** Removes the key associated with the given value.
-    *
-    *  @param hc            the hashcode of `k`
-    *
-    * @param removalPolicy policy deciding whether to remove `k` based on `v` and the
-    *                       current value associated with `k` (Always, FullEquals, or ReferenceEq)
-    *
-    *  @return              null if not successful, an Option[V] indicating the previous value otherwise
-    */
+   *
+   *  @param hc            the hashcode of `k`
+   *
+   *  @param removalPolicy policy deciding whether to remove `k` based on `v` and the
+   *                       current value associated with `k` (Always, FullEquals, or ReferenceEq)
+   *
+   *  @return              null if not successful, an Option[V] indicating the previous value otherwise
+   */
   def rec_remove(
     k: K,
     v: V,
@@ -586,8 +586,8 @@ private[collection] final class CNode[K, V](val bitmap: Int, val array: Array[Ba
   }
 
   /** Returns a copy of this cnode such that all the i-nodes below it are copied
-    *  to the specified generation `ngen`.
-    */
+   *  to the specified generation `ngen`.
+   */
   def renewed(ngen: Gen, ct: TrieMap[K, V]) = {
     var i = 0
     val arr = array
@@ -680,15 +680,15 @@ private[concurrent] case class RDCSS_Descriptor[K, V](old: INode[K, V], expected
 
 
 /** A concurrent hash-trie or TrieMap is a concurrent thread-safe lock-free
-  *  implementation of a hash array mapped trie. It is used to implement the
-  *  concurrent map abstraction. It has particularly scalable concurrent insert
-  *  and remove operations and is memory-efficient. It supports O(1), atomic,
-  *  lock-free snapshots which are used to implement linearizable lock-free size,
-  *  iterator and clear operations. The cost of evaluating the (lazy) snapshot is
-  *  distributed across subsequent updates, thus making snapshot evaluation horizontally scalable.
-  *
-  *  For details, see: [[http://lampwww.epfl.ch/~prokopec/ctries-snapshot.pdf]]
-  */
+ *  implementation of a hash array mapped trie. It is used to implement the
+ *  concurrent map abstraction. It has particularly scalable concurrent insert
+ *  and remove operations and is memory-efficient. It supports O(1), atomic,
+ *  lock-free snapshots which are used to implement linearizable lock-free size,
+ *  iterator and clear operations. The cost of evaluating the (lazy) snapshot is
+ *  distributed across subsequent updates, thus making snapshot evaluation horizontally scalable.
+ *
+ *  For details, see: [[http://lampwww.epfl.ch/~prokopec/ctries-snapshot.pdf]]
+ */
 @SerialVersionUID(-5212455458703321708L)
 final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater[TrieMap[K, V], AnyRef] | Null, hashf: Hashing[K], ef: Equiv[K])
   extends scala.collection.mutable.AbstractMap[K, V]
@@ -810,12 +810,12 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
   }
 
   /** Finds the value associated with this key
-    *
-    * @param k  the key to look up
-    * @param hc the hashcode of `k`
-    *
-    * @return the value: V associated with `k`, if it exists. Otherwise, INodeBase.NO_SUCH_ELEMENT_SENTINEL
-    */
+   *
+   *  @param k  the key to look up
+   *  @param hc the hashcode of `k`
+   *
+   *  @return the value: V associated with `k`, if it exists. Otherwise, INodeBase.NO_SUCH_ELEMENT_SENTINEL
+   */
   @tailrec private def lookuphc(k: K, hc: Int): AnyRef = {
     val r = RDCSS_READ_ROOT()
     val res = r.rec_lookup(k, hc, 0, null, r.gen, this)
@@ -824,13 +824,13 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
   }
 
   /** Removes a key-value pair from the map
-    *
-    * @param k the key to remove
-    * @param v the value compare with the value found associated with the key
-    * @param removalPolicy policy deciding whether to remove `k` based on `v` and the
+   *
+   *  @param k the key to remove
+   *  @param v the value compare with the value found associated with the key
+   *  @param removalPolicy policy deciding whether to remove `k` based on `v` and the
    *                       current value associated with `k` (Always, FullEquals, or ReferenceEq)
-    * @return an `Option[V]` indicating the previous value
-    */
+   *  @return an `Option[V]` indicating the previous value
+   */
   @tailrec private def removehc(k: K, v: V, removalPolicy: Int, hc: Int): Option[V] = {
     val r = RDCSS_READ_ROOT()
     val res = r.rec_remove(k, v, removalPolicy, hc, 0, null, r.gen, this)
@@ -848,14 +848,14 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
   def nonReadOnly = rootupdater ne null
 
   /** Returns a snapshot of this TrieMap.
-    *  This operation is lock-free and linearizable.
-    *
-    *  The snapshot is lazily updated - the first time some branch
-    *  in the snapshot or this TrieMap are accessed, they are rewritten.
-    *  This means that the work of rebuilding both the snapshot and this
-    *  TrieMap is distributed across all the threads doing updates or accesses
-    *  subsequent to the snapshot creation.
-    */
+   *  This operation is lock-free and linearizable.
+   *
+   *  The snapshot is lazily updated - the first time some branch
+   *  in the snapshot or this TrieMap are accessed, they are rewritten.
+   *  This means that the work of rebuilding both the snapshot and this
+   *  TrieMap is distributed across all the threads doing updates or accesses
+   *  subsequent to the snapshot creation.
+   */
   @tailrec def snapshot(): TrieMap[K, V] = {
     val r = RDCSS_READ_ROOT()
     val expmain = r.gcasRead(this)
@@ -864,17 +864,17 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
   }
 
   /** Returns a read-only snapshot of this TrieMap.
-    *  This operation is lock-free and linearizable.
-    *
-    *  The snapshot is lazily updated - the first time some branch
-    *  of this TrieMap are accessed, it is rewritten. The work of creating
-    *  the snapshot is thus distributed across subsequent updates
-    *  and accesses on this TrieMap by all threads.
-    *  Note that the snapshot itself is never rewritten unlike when calling
-    *  the `snapshot` method, but the obtained snapshot cannot be modified.
-    *
-    *  This method is used by other methods such as `size` and `iterator`.
-    */
+   *  This operation is lock-free and linearizable.
+   *
+   *  The snapshot is lazily updated - the first time some branch
+   *  of this TrieMap are accessed, it is rewritten. The work of creating
+   *  the snapshot is thus distributed across subsequent updates
+   *  and accesses on this TrieMap by all threads.
+   *  Note that the snapshot itself is never rewritten unlike when calling
+   *  the `snapshot` method, but the obtained snapshot cannot be modified.
+   *
+   *  This method is used by other methods such as `size` and `iterator`.
+   */
   @tailrec def readOnlySnapshot(): scala.collection.Map[K, V] = {
     val r = RDCSS_READ_ROOT()
     val expmain = r.gcasRead(this)
@@ -1160,8 +1160,8 @@ private[collection] class TrieMapIterator[K, V](var level: Int, private var ct: 
   }
 
   /** Returns a sequence of iterators over subsets of this iterator.
-    *  It's used to ease the implementation of splitters for a parallel version of the TrieMap.
-    */
+   *  It's used to ease the implementation of splitters for a parallel version of the TrieMap.
+   */
   protected def subdivide(): Seq[Iterator[(K, V)]] = if (subiter ne null) {
     // the case where an LNode is being iterated
     val it = newIterator(level + 1, ct, _mustInit = false)

--- a/library/src/scala/collection/convert/AsJavaConverters.scala
+++ b/library/src/scala/collection/convert/AsJavaConverters.scala
@@ -23,8 +23,8 @@ import java.{lang => jl, util => ju}
 import scala.{unchecked => uc}
 
 /** Defines converter methods from Scala to Java collections.
-  * These methods are available through the [[scala.jdk.javaapi.CollectionConverters]] object.
-  */
+ *  These methods are available through the [[scala.jdk.javaapi.CollectionConverters]] object.
+ */
 trait AsJavaConverters {
   import JavaCollectionWrappers._
 
@@ -33,17 +33,16 @@ trait AsJavaConverters {
   // We intentionally keep this signature to discourage passing nulls implicitly while preserving the
   // previous behavior for backward compatibility.
 
-  /**
-   * Converts a Scala `Iterator` to a Java `Iterator`.
+  /** Converts a Scala `Iterator` to a Java `Iterator`.
    *
-   * The returned Java `Iterator` is backed by the provided Scala `Iterator` and any side-effects of
-   * using it via the Java interface will be visible via the Scala interface and vice versa.
+   *  The returned Java `Iterator` is backed by the provided Scala `Iterator` and any side-effects of
+   *  using it via the Java interface will be visible via the Scala interface and vice versa.
    *
-   * If the Scala `Iterator` was previously obtained from an implicit or explicit call of
-   * `asScala` then the original Java `Iterator` will be returned.
+   *  If the Scala `Iterator` was previously obtained from an implicit or explicit call of
+   *  `asScala` then the original Java `Iterator` will be returned.
    *
-   * @param i The Scala `Iterator` to be converted.
-   * @return  A Java `Iterator` view of the argument.
+   *  @param i The Scala `Iterator` to be converted.
+   *  @return  A Java `Iterator` view of the argument.
    */
   def asJava[A](i: Iterator[A]): ju.Iterator[A] = (i: Iterator[A] | Null) match {
     case null                             => null.asInstanceOf[ju.Iterator[A]]
@@ -51,17 +50,16 @@ trait AsJavaConverters {
     case _                                => new IteratorWrapper(i)
   }
 
-  /**
-   * Converts a Scala `Iterator` to a Java `Enumeration`.
+  /** Converts a Scala `Iterator` to a Java `Enumeration`.
    *
-   * The returned Java `Enumeration` is backed by the provided Scala `Iterator` and any side-effects
-   * of using it via the Java interface will be visible via the Scala interface and vice versa.
+   *  The returned Java `Enumeration` is backed by the provided Scala `Iterator` and any side-effects
+   *  of using it via the Java interface will be visible via the Scala interface and vice versa.
    *
-   * If the Scala `Iterator` was previously obtained from an implicit or explicit call of
-   * `asScala` then the original Java `Enumeration` will be returned.
+   *  If the Scala `Iterator` was previously obtained from an implicit or explicit call of
+   *  `asScala` then the original Java `Enumeration` will be returned.
    *
-   * @param i The Scala `Iterator` to be converted.
-   * @return  A Java `Enumeration` view of the argument.
+   *  @param i The Scala `Iterator` to be converted.
+   *  @return  A Java `Enumeration` view of the argument.
    */
   def asJavaEnumeration[A](i: Iterator[A]): ju.Enumeration[A] = (i: Iterator[A] | Null) match {
     case null                                => null.asInstanceOf[ju.Enumeration[A]]
@@ -69,17 +67,16 @@ trait AsJavaConverters {
     case _                                   => new IteratorWrapper(i)
   }
 
-  /**
-   * Converts a Scala `Iterable` to a Java `Iterable`.
+  /** Converts a Scala `Iterable` to a Java `Iterable`.
    *
-   * The returned Java `Iterable` is backed by the provided Scala `Iterable` and any side-effects of
-   * using it via the Java interface will be visible via the Scala interface and vice versa.
+   *  The returned Java `Iterable` is backed by the provided Scala `Iterable` and any side-effects of
+   *  using it via the Java interface will be visible via the Scala interface and vice versa.
    *
-   * If the Scala `Iterable` was previously obtained from an implicit or explicit call of
-   * `asScala` then the original Java `Iterable` will be returned.
+   *  If the Scala `Iterable` was previously obtained from an implicit or explicit call of
+   *  `asScala` then the original Java `Iterable` will be returned.
    *
-   * @param i The Scala `Iterable` to be converted.
-   * @return  A Java `Iterable` view of the argument.
+   *  @param i The Scala `Iterable` to be converted.
+   *  @return  A Java `Iterable` view of the argument.
    */
   def asJava[A](i: Iterable[A]): jl.Iterable[A] = (i: Iterable[A] | Null) match {
     case null                             => null.asInstanceOf[jl.Iterable[A]]
@@ -87,14 +84,13 @@ trait AsJavaConverters {
     case _                                => new IterableWrapper(i)
   }
 
-  /**
-   * Converts a Scala `Iterable` to an immutable Java `Collection`.
+  /** Converts a Scala `Iterable` to an immutable Java `Collection`.
    *
-   * If the Scala `Iterable` was previously obtained from an implicit or explicit call of
-   * `asScala` then the original Java `Collection` will be returned.
+   *  If the Scala `Iterable` was previously obtained from an implicit or explicit call of
+   *  `asScala` then the original Java `Collection` will be returned.
    *
-   * @param i The Scala `Iterable` to be converted.
-   * @return  A Java `Collection` view of the argument.
+   *  @param i The Scala `Iterable` to be converted.
+   *  @return  A Java `Collection` view of the argument.
    */
   def asJavaCollection[A](i: Iterable[A]): ju.Collection[A] = (i: Iterable[A] | Null) match {
     case null                               => null.asInstanceOf[ju.Collection[A]]
@@ -102,17 +98,16 @@ trait AsJavaConverters {
     case _                                  => new IterableWrapper(i)
   }
 
-  /**
-   * Converts a Scala mutable `Buffer` to a Java List.
+  /** Converts a Scala mutable `Buffer` to a Java List.
    *
-   * The returned Java List is backed by the provided Scala `Buffer` and any side-effects of using
-   * it via the Java interface will be visible via the Scala interface and vice versa.
+   *  The returned Java List is backed by the provided Scala `Buffer` and any side-effects of using
+   *  it via the Java interface will be visible via the Scala interface and vice versa.
    *
-   * If the Scala `Buffer` was previously obtained from an implicit or explicit call of
-   * `asScala` then the original Java `List` will be returned.
+   *  If the Scala `Buffer` was previously obtained from an implicit or explicit call of
+   *  `asScala` then the original Java `List` will be returned.
    *
-   * @param b The Scala `Buffer` to be converted.
-   * @return A Java `List` view of the argument.
+   *  @param b The Scala `Buffer` to be converted.
+   *  @return A Java `List` view of the argument.
    */
   def asJava[A](b: mutable.Buffer[A]): ju.List[A] = (b: mutable.Buffer[A] | Null) match {
     case null                         => null.asInstanceOf[ju.List[A]]
@@ -120,17 +115,16 @@ trait AsJavaConverters {
     case _                            => new MutableBufferWrapper(b)
   }
 
-  /**
-   * Converts a Scala mutable `Seq` to a Java `List`.
+  /** Converts a Scala mutable `Seq` to a Java `List`.
    *
-   * The returned Java `List` is backed by the provided Scala `Seq` and any side-effects of using it
-   * via the Java interface will be visible via the Scala interface and vice versa.
+   *  The returned Java `List` is backed by the provided Scala `Seq` and any side-effects of using it
+   *  via the Java interface will be visible via the Scala interface and vice versa.
    *
-   * If the Scala `Seq` was previously obtained from an implicit or explicit call of
-   * `asScala` then the original Java `List` will be returned.
+   *  If the Scala `Seq` was previously obtained from an implicit or explicit call of
+   *  `asScala` then the original Java `List` will be returned.
    *
-   * @param s The Scala `Seq` to be converted.
-   * @return  A Java `List` view of the argument.
+   *  @param s The Scala `Seq` to be converted.
+   *  @return  A Java `List` view of the argument.
    */
   def asJava[A](s: mutable.Seq[A]): ju.List[A] = (s: mutable.Seq[A] | Null) match {
     case null                         => null.asInstanceOf[ju.List[A]]
@@ -138,17 +132,16 @@ trait AsJavaConverters {
     case _                            => new MutableSeqWrapper(s)
   }
 
-  /**
-   * Converts a Scala `Seq` to a Java `List`.
+  /** Converts a Scala `Seq` to a Java `List`.
    *
-   * The returned Java `List` is backed by the provided Scala `Seq` and any side-effects of using it
-   * via the Java interface will be visible via the Scala interface and vice versa.
+   *  The returned Java `List` is backed by the provided Scala `Seq` and any side-effects of using it
+   *  via the Java interface will be visible via the Scala interface and vice versa.
    *
-   * If the Scala `Seq` was previously obtained from an implicit or explicit call of
-   * `asScala` then the original Java `List` will be returned.
+   *  If the Scala `Seq` was previously obtained from an implicit or explicit call of
+   *  `asScala` then the original Java `List` will be returned.
    *
-   * @param s The Scala `Seq` to be converted.
-   * @return  A Java `List` view of the argument.
+   *  @param s The Scala `Seq` to be converted.
+   *  @return  A Java `List` view of the argument.
    */
   def asJava[A](s: Seq[A]): ju.List[A] = (s: Seq[A] | Null) match {
     case null                         => null.asInstanceOf[ju.List[A]]
@@ -156,17 +149,16 @@ trait AsJavaConverters {
     case _                            => new SeqWrapper(s)
   }
 
-  /**
-   * Converts a Scala mutable `Set` to a Java `Set`.
+  /** Converts a Scala mutable `Set` to a Java `Set`.
    *
-   * The returned Java `Set` is backed by the provided Scala `Set` and any side-effects of using it
-   * via the Java interface will be visible via the Scala interface and vice versa.
+   *  The returned Java `Set` is backed by the provided Scala `Set` and any side-effects of using it
+   *  via the Java interface will be visible via the Scala interface and vice versa.
    *
-   * If the Scala `Set` was previously obtained from an implicit or explicit call of
-   * `asScala` then the original Java `Set` will be returned.
+   *  If the Scala `Set` was previously obtained from an implicit or explicit call of
+   *  `asScala` then the original Java `Set` will be returned.
    *
-   * @param s The Scala mutable `Set` to be converted.
-   * @return  A Java `Set` view of the argument.
+   *  @param s The Scala mutable `Set` to be converted.
+   *  @return  A Java `Set` view of the argument.
    */
   def asJava[A](s: mutable.Set[A]): ju.Set[A] = (s: mutable.Set[A] | Null) match {
     case null                        => null.asInstanceOf[ju.Set[A]]
@@ -174,17 +166,16 @@ trait AsJavaConverters {
     case _                           => new MutableSetWrapper(s)
   }
 
-    /**
-   * Converts a Scala `Set` to a Java `Set`.
+  /** Converts a Scala `Set` to a Java `Set`.
    *
-   * The returned Java `Set` is backed by the provided Scala `Set` and any side-effects of using it
-   * via the Java interface will be visible via the Scala interface and vice versa.
+   *  The returned Java `Set` is backed by the provided Scala `Set` and any side-effects of using it
+   *  via the Java interface will be visible via the Scala interface and vice versa.
    *
-   * If the Scala `Set` was previously obtained from an implicit or explicit call of
-   * `asScala` then the original Java `Set` will be returned.
+   *  If the Scala `Set` was previously obtained from an implicit or explicit call of
+   *  `asScala` then the original Java `Set` will be returned.
    *
-   * @param s The Scala `Set` to be converted.
-   * @return  A Java `Set` view of the argument.
+   *  @param s The Scala `Set` to be converted.
+   *  @return  A Java `Set` view of the argument.
    */
   def asJava[A](s: Set[A]): ju.Set[A] = (s: Set[A] | Null) match {
     case null                        => null.asInstanceOf[ju.Set[A]]
@@ -192,17 +183,16 @@ trait AsJavaConverters {
     case _                           => new SetWrapper(s)
   }
 
-  /**
-   * Converts a Scala mutable `Map` to a Java `Map`.
+  /** Converts a Scala mutable `Map` to a Java `Map`.
    *
-   * The returned Java `Map` is backed by the provided Scala `Map` and any side-effects of using it
-   * via the Java interface will be visible via the Scala interface and vice versa.
+   *  The returned Java `Map` is backed by the provided Scala `Map` and any side-effects of using it
+   *  via the Java interface will be visible via the Scala interface and vice versa.
    *
-   * If the Scala `Map` was previously obtained from an implicit or explicit call of
-   * `asScala` then the original Java `Map` will be returned.
+   *  If the Scala `Map` was previously obtained from an implicit or explicit call of
+   *  `asScala` then the original Java `Map` will be returned.
    *
-   * @param m The Scala mutable `Map` to be converted.
-   * @return  A Java `Map` view of the argument.
+   *  @param m The Scala mutable `Map` to be converted.
+   *  @return  A Java `Map` view of the argument.
    */
   def asJava[K, V](m: mutable.Map[K, V]): ju.Map[K, V] = (m: mutable.Map[K, V] | Null) match {
     case null                               => null.asInstanceOf[ju.Map[K, V]]
@@ -210,18 +200,17 @@ trait AsJavaConverters {
     case _                                  => new MutableMapWrapper(m)
   }
 
-  /**
-   * Converts a Scala mutable `Map` to a Java `Dictionary`.
+  /** Converts a Scala mutable `Map` to a Java `Dictionary`.
    *
-   * The returned Java `Dictionary` is backed by the provided Scala `Dictionary` and any
-   * side-effects of using it via the Java interface will be visible via the Scala interface and
-   * vice versa.
+   *  The returned Java `Dictionary` is backed by the provided Scala `Dictionary` and any
+   *  side-effects of using it via the Java interface will be visible via the Scala interface and
+   *  vice versa.
    *
-   * If the Scala `Map` was previously obtained from an implicit or explicit call of
-   * `asScala` then the original Java `Dictionary` will be returned.
+   *  If the Scala `Map` was previously obtained from an implicit or explicit call of
+   *  `asScala` then the original Java `Dictionary` will be returned.
    *
-   * @param m The Scala `Map` to be converted.
-   * @return  A Java `Dictionary` view of the argument.
+   *  @param m The Scala `Map` to be converted.
+   *  @return  A Java `Dictionary` view of the argument.
    */
   def asJavaDictionary[K, V](m: mutable.Map[K, V]): ju.Dictionary[K, V] = (m: mutable.Map[K, V] | Null) match {
     case null                                      => null.asInstanceOf[ju.Dictionary[K, V]]
@@ -229,17 +218,16 @@ trait AsJavaConverters {
     case _                                         => new DictionaryWrapper(m)
   }
 
-  /**
-   * Converts a Scala `Map` to a Java `Map`.
+  /** Converts a Scala `Map` to a Java `Map`.
    *
-   * The returned Java `Map` is backed by the provided Scala `Map` and any side-effects of using it
-   * via the Java interface will be visible via the Scala interface and vice versa.
+   *  The returned Java `Map` is backed by the provided Scala `Map` and any side-effects of using it
+   *  via the Java interface will be visible via the Scala interface and vice versa.
    *
-   * If the Scala `Map` was previously obtained from an implicit or explicit call of
-   * `asScala` then the original Java `Map` will be returned.
+   *  If the Scala `Map` was previously obtained from an implicit or explicit call of
+   *  `asScala` then the original Java `Map` will be returned.
    *
-   * @param m The Scala `Map` to be converted.
-   * @return  A Java `Map` view of the argument.
+   *  @param m The Scala `Map` to be converted.
+   *  @return  A Java `Map` view of the argument.
    */
   def asJava[K, V](m: Map[K, V]): ju.Map[K, V] = (m: Map[K, V] | Null) match {
     case null                               => null.asInstanceOf[ju.Map[K, V]]
@@ -247,18 +235,17 @@ trait AsJavaConverters {
     case _                                  => new MapWrapper(m)
   }
 
-  /**
-   * Converts a Scala mutable `concurrent.Map` to a Java `ConcurrentMap`.
+  /** Converts a Scala mutable `concurrent.Map` to a Java `ConcurrentMap`.
    *
-   * The returned Java `ConcurrentMap` is backed by the provided Scala `concurrent.Map` and any
-   * side-effects of using it via the Java interface will be visible via the Scala interface and
-   * vice versa.
+   *  The returned Java `ConcurrentMap` is backed by the provided Scala `concurrent.Map` and any
+   *  side-effects of using it via the Java interface will be visible via the Scala interface and
+   *  vice versa.
    *
-   * If the Scala `concurrent.Map` was previously obtained from an implicit or explicit call of
-   * `asScala` then the original Java `ConcurrentMap` will be returned.
+   *  If the Scala `concurrent.Map` was previously obtained from an implicit or explicit call of
+   *  `asScala` then the original Java `ConcurrentMap` will be returned.
    *
-   * @param m The Scala `concurrent.Map` to be converted.
-   * @return  A Java `ConcurrentMap` view of the argument.
+   *  @param m The Scala `concurrent.Map` to be converted.
+   *  @return  A Java `ConcurrentMap` view of the argument.
    */
   def asJava[K, V](m: concurrent.Map[K, V]): juc.ConcurrentMap[K, V] = (m: concurrent.Map[K, V] | Null) match {
     case null                                         => null.asInstanceOf[juc.ConcurrentMap[K, V]]

--- a/library/src/scala/collection/convert/AsScalaConverters.scala
+++ b/library/src/scala/collection/convert/AsScalaConverters.scala
@@ -24,8 +24,8 @@ import java.{lang => jl, util => ju}
 import scala.{unchecked => uc}
 
 /** Defines converter methods from Java to Scala collections.
-  * These methods are available through the [[scala.jdk.javaapi.CollectionConverters]] object.
-  */
+ *  These methods are available through the [[scala.jdk.javaapi.CollectionConverters]] object.
+ */
 trait AsScalaConverters {
   import JavaCollectionWrappers._
 
@@ -34,17 +34,16 @@ trait AsScalaConverters {
   // We intentionally keep this signature to discourage passing nulls implicitly while preserving the
   // previous behavior for backward compatibility.
 
-  /**
-   * Converts a Java `Iterator` to a Scala `Iterator`.
+  /** Converts a Java `Iterator` to a Scala `Iterator`.
    *
-   * The returned Scala `Iterator` is backed by the provided Java `Iterator` and any side-effects of
-   * using it via the Scala interface will be visible via the Java interface and vice versa.
+   *  The returned Scala `Iterator` is backed by the provided Java `Iterator` and any side-effects of
+   *  using it via the Scala interface will be visible via the Java interface and vice versa.
    *
-   * If the Java `Iterator` was previously obtained from an implicit or explicit call of
-   * `asJava` then the original Scala `Iterator` will be returned.
+   *  If the Java `Iterator` was previously obtained from an implicit or explicit call of
+   *  `asJava` then the original Scala `Iterator` will be returned.
    *
-   * @param i The Java `Iterator` to be converted.
-   * @return  A Scala `Iterator` view of the argument.
+   *  @param i The Java `Iterator` to be converted.
+   *  @return  A Scala `Iterator` view of the argument.
    */
   def asScala[A](i: ju.Iterator[A]): Iterator[A] = (i: ju.Iterator[A] | Null) match {
     case null                            => null.asInstanceOf[Iterator[A]]
@@ -52,17 +51,16 @@ trait AsScalaConverters {
     case _                               => new JIteratorWrapper(i)
   }
 
-  /**
-   * Converts a Java `Enumeration` to a Scala `Iterator`.
+  /** Converts a Java `Enumeration` to a Scala `Iterator`.
    *
-   * The returned Scala `Iterator` is backed by the provided Java `Enumeration` and any side-effects
-   * of using it via the Scala interface will be visible via the Java interface and vice versa.
+   *  The returned Scala `Iterator` is backed by the provided Java `Enumeration` and any side-effects
+   *  of using it via the Scala interface will be visible via the Java interface and vice versa.
    *
-   * If the Java `Enumeration` was previously obtained from an implicit or explicit call of
-   * `asJavaEnumeration` then the original Scala `Iterator` will be returned.
+   *  If the Java `Enumeration` was previously obtained from an implicit or explicit call of
+   *  `asJavaEnumeration` then the original Scala `Iterator` will be returned.
    *
-   * @param e The Java `Enumeration` to be converted.
-   * @return  A Scala `Iterator` view of the argument.
+   *  @param e The Java `Enumeration` to be converted.
+   *  @return  A Scala `Iterator` view of the argument.
    */
   def asScala[A](e: ju.Enumeration[A]): Iterator[A] = (e: ju.Enumeration[A] | Null) match {
     case null                            => null.asInstanceOf[Iterator[A]]
@@ -70,17 +68,16 @@ trait AsScalaConverters {
     case _                               => new JEnumerationWrapper(e)
   }
 
-  /**
-   * Converts a Java `Iterable` to a Scala `Iterable`.
+  /** Converts a Java `Iterable` to a Scala `Iterable`.
    *
-   * The returned Scala `Iterable` is backed by the provided Java `Iterable` and any side-effects of
-   * using it via the Scala interface will be visible via the Java interface and vice versa.
+   *  The returned Scala `Iterable` is backed by the provided Java `Iterable` and any side-effects of
+   *  using it via the Scala interface will be visible via the Java interface and vice versa.
    *
-   * If the Java `Iterable` was previously obtained from an implicit or explicit call of
-   * `asJava` then the original Scala `Iterable` will be returned.
+   *  If the Java `Iterable` was previously obtained from an implicit or explicit call of
+   *  `asJava` then the original Scala `Iterable` will be returned.
    *
-   * @param i The Java `Iterable` to be converted.
-   * @return  A Scala `Iterable` view of the argument.
+   *  @param i The Java `Iterable` to be converted.
+   *  @return  A Scala `Iterable` view of the argument.
    */
   def asScala[A](i: jl.Iterable[A]): Iterable[A] = (i: jl.Iterable[A] | Null) match {
     case null                            => null.asInstanceOf[Iterable[A]]
@@ -88,14 +85,13 @@ trait AsScalaConverters {
     case _                               => new JIterableWrapper(i)
   }
 
-  /**
-   * Converts a Java `Collection` to a Scala `Iterable`.
+  /** Converts a Java `Collection` to a Scala `Iterable`.
    *
-   * If the Java `Collection` was previously obtained from an implicit or explicit call of
-   * `asJavaCollection` then the original Scala `Iterable` will be returned.
+   *  If the Java `Collection` was previously obtained from an implicit or explicit call of
+   *  `asJavaCollection` then the original Scala `Iterable` will be returned.
    *
-   * @param c The Java `Collection` to be converted.
-   * @return  A Scala `Iterable` view of the argument.
+   *  @param c The Java `Collection` to be converted.
+   *  @return  A Scala `Iterable` view of the argument.
    */
   def asScala[A](c: ju.Collection[A]): Iterable[A] = (c: ju.Collection[A] | Null) match {
     case null                            => null.asInstanceOf[Iterable[A]]
@@ -103,17 +99,16 @@ trait AsScalaConverters {
     case _                               => new JCollectionWrapper(c)
   }
 
-  /**
-   * Converts a Java `List` to a Scala mutable `Buffer`.
+  /** Converts a Java `List` to a Scala mutable `Buffer`.
    *
-   * The returned Scala `Buffer` is backed by the provided Java `List` and any side-effects of using
-   * it via the Scala interface will be visible via the Java interface and vice versa.
+   *  The returned Scala `Buffer` is backed by the provided Java `List` and any side-effects of using
+   *  it via the Scala interface will be visible via the Java interface and vice versa.
    *
-   * If the Java `List` was previously obtained from an implicit or explicit call of
-   * `asJava` then the original Scala `Buffer` will be returned.
+   *  If the Java `List` was previously obtained from an implicit or explicit call of
+   *  `asJava` then the original Scala `Buffer` will be returned.
    *
-   * @param l The Java `List` to be converted.
-   * @return A Scala mutable `Buffer` view of the argument.
+   *  @param l The Java `List` to be converted.
+   *  @return A Scala mutable `Buffer` view of the argument.
    */
   def asScala[A](l: ju.List[A]): mutable.Buffer[A] = (l: ju.List[A] | Null) match {
     case null                                 => null.asInstanceOf[mutable.Buffer[A]]
@@ -121,17 +116,16 @@ trait AsScalaConverters {
     case _                                    => new JListWrapper(l)
   }
 
-  /**
-   * Converts a Java `Set` to a Scala mutable `Set`.
+  /** Converts a Java `Set` to a Scala mutable `Set`.
    *
-   * The returned Scala `Set` is backed by the provided Java `Set` and any side-effects of using it
-   * via the Scala interface will be visible via the Java interface and vice versa.
+   *  The returned Scala `Set` is backed by the provided Java `Set` and any side-effects of using it
+   *  via the Scala interface will be visible via the Java interface and vice versa.
    *
-   * If the Java `Set` was previously obtained from an implicit or explicit call of
-   * `asJava` then the original Scala `Set` will be returned.
+   *  If the Java `Set` was previously obtained from an implicit or explicit call of
+   *  `asJava` then the original Scala `Set` will be returned.
    *
-   * @param s The Java `Set` to be converted.
-   * @return  A Scala mutable `Set` view of the argument.
+   *  @param s The Java `Set` to be converted.
+   *  @return  A Scala mutable `Set` view of the argument.
    */
   def asScala[A](s: ju.Set[A]): mutable.Set[A] = (s: ju.Set[A] | Null) match {
     case null                              => null.asInstanceOf[mutable.Set[A]]
@@ -139,22 +133,21 @@ trait AsScalaConverters {
     case _                                 => new JSetWrapper(s)
   }
 
-  /**
-   * Converts a Java `Map` to a Scala mutable `Map`.
+  /** Converts a Java `Map` to a Scala mutable `Map`.
    *
-   * The returned Scala `Map` is backed by the provided Java `Map` and any side-effects of using it
-   * via the Scala interface will be visible via the Java interface and vice versa.
+   *  The returned Scala `Map` is backed by the provided Java `Map` and any side-effects of using it
+   *  via the Scala interface will be visible via the Java interface and vice versa.
    *
-   * If the Java `Map` was previously obtained from an implicit or explicit call of
-   * `asJava` then the original Scala `Map` will be returned.
+   *  If the Java `Map` was previously obtained from an implicit or explicit call of
+   *  `asJava` then the original Scala `Map` will be returned.
    *
-   * If the wrapped map is synchronized (e.g. from `java.util.Collections.synchronizedMap`), it is
-   * your responsibility to wrap all non-atomic operations with `underlying.synchronized`.
-   * This includes `get`, as `java.util.Map`'s API does not allow for an atomic `get` when `null`
-   * values may be present.
+   *  If the wrapped map is synchronized (e.g. from `java.util.Collections.synchronizedMap`), it is
+   *  your responsibility to wrap all non-atomic operations with `underlying.synchronized`.
+   *  This includes `get`, as `java.util.Map`'s API does not allow for an atomic `get` when `null`
+   *  values may be present.
    *
-   * @param m The Java `Map` to be converted.
-   * @return  A Scala mutable `Map` view of the argument.
+   *  @param m The Java `Map` to be converted.
+   *  @return  A Scala mutable `Map` view of the argument.
    */
   def asScala[K, V](m: ju.Map[K, V]): mutable.Map[K, V] = (m: ju.Map[K, V] | Null) match {
     case null                                     => null.asInstanceOf[mutable.Map[K, V]]
@@ -162,18 +155,17 @@ trait AsScalaConverters {
     case _                                        => new JMapWrapper(m)
   }
 
-  /**
-   * Converts a Java `ConcurrentMap` to a Scala mutable `ConcurrentMap`.
+  /** Converts a Java `ConcurrentMap` to a Scala mutable `ConcurrentMap`.
    *
-   * The returned Scala `ConcurrentMap` is backed by the provided Java `ConcurrentMap` and any
-   * side-effects of using it via the Scala interface will be visible via the Java interface and
-   * vice versa.
+   *  The returned Scala `ConcurrentMap` is backed by the provided Java `ConcurrentMap` and any
+   *  side-effects of using it via the Scala interface will be visible via the Java interface and
+   *  vice versa.
    *
-   * If the Java `ConcurrentMap` was previously obtained from an implicit or explicit call of
-   * `asJava` then the original Scala `ConcurrentMap` will be returned.
+   *  If the Java `ConcurrentMap` was previously obtained from an implicit or explicit call of
+   *  `asJava` then the original Scala `ConcurrentMap` will be returned.
    *
-   * @param m The Java `ConcurrentMap` to be converted.
-   * @return  A Scala mutable `ConcurrentMap` view of the argument.
+   *  @param m The Java `ConcurrentMap` to be converted.
+   *  @return  A Scala mutable `ConcurrentMap` view of the argument.
    */
   def asScala[K, V](m: juc.ConcurrentMap[K, V]): concurrent.Map[K, V] = (m: juc.ConcurrentMap[K, V] | Null) match {
     case null                                        => null.asInstanceOf[concurrent.Map[K, V]]
@@ -181,17 +173,16 @@ trait AsScalaConverters {
     case _                                           => new JConcurrentMapWrapper(m)
   }
 
-    /**
-   * Converts a Java `Dictionary` to a Scala mutable `Map`.
+  /** Converts a Java `Dictionary` to a Scala mutable `Map`.
    *
-   * The returned Scala `Map` is backed by the provided Java `Dictionary` and any side-effects of
-   * using it via the Scala interface will be visible via the Java interface and vice versa.
+   *  The returned Scala `Map` is backed by the provided Java `Dictionary` and any side-effects of
+   *  using it via the Scala interface will be visible via the Java interface and vice versa.
    *
-   * If the Java `Dictionary` was previously obtained from an implicit or explicit call of
-   * `asJavaDictionary` then the original Scala `Map` will be returned.
+   *  If the Java `Dictionary` was previously obtained from an implicit or explicit call of
+   *  `asJavaDictionary` then the original Scala `Map` will be returned.
    *
-   * @param d The Java `Dictionary` to be converted.
-   * @return  A Scala mutable `Map` view of the argument.
+   *  @param d The Java `Dictionary` to be converted.
+   *  @return  A Scala mutable `Map` view of the argument.
    */
   def asScala[K, V](d: ju.Dictionary[K, V]): mutable.Map[K, V] = (d: ju.Dictionary[K, V] | Null) match {
     case null                                     => null.asInstanceOf[mutable.Map[K, V]]
@@ -199,15 +190,14 @@ trait AsScalaConverters {
     case _                                        => new JDictionaryWrapper(d)
   }
 
-  /**
-   * Converts a Java `Properties` to a Scala mutable `Map[String, String]`.
+  /** Converts a Java `Properties` to a Scala mutable `Map[String, String]`.
    *
-   * The returned Scala `Map[String, String]` is backed by the provided Java `Properties` and any
-   * side-effects of using it via the Scala interface will be visible via the Java interface and
-   * vice versa.
+   *  The returned Scala `Map[String, String]` is backed by the provided Java `Properties` and any
+   *  side-effects of using it via the Scala interface will be visible via the Java interface and
+   *  vice versa.
    *
-   * @param p The Java `Properties` to be converted.
-   * @return  A Scala mutable `Map[String, String]` view of the argument.
+   *  @param p The Java `Properties` to be converted.
+   *  @return  A Scala mutable `Map[String, String]` view of the argument.
    */
   def asScala(p: ju.Properties): mutable.Map[String, String] = (p: ju.Properties | Null) match {
     case null => null.asInstanceOf[mutable.Map[String, String]]

--- a/library/src/scala/collection/convert/ImplicitConversions.scala
+++ b/library/src/scala/collection/convert/ImplicitConversions.scala
@@ -172,15 +172,16 @@ object ImplicitConversionsToScala extends ToScalaImplicits
  * It is recommended to use explicit conversions provided by [[collection.JavaConverters]] instead.
  * Implicit conversions may cause unexpected issues. Example:
  *
- * {{{
+ * ```
  *   import collection.convert.ImplicitConversions._
  *   case class StringBox(s: String)
  *   val m = Map(StringBox("one") -> "uno")
  *   m.get("one")
- * }}}
+ * ```
  *
  * The above example returns `null` instead of producing a type error at compile-time. The map is
  * implicitly converted to a `java.util.Map` which provides a method `get(x: AnyRef)`.
+ 
  */
 @deprecated("Use `scala.jdk.CollectionConverters` instead", "2.13.0")
 object ImplicitConversions extends ToScalaImplicits with ToJavaImplicits

--- a/library/src/scala/collection/convert/StreamExtensions.scala
+++ b/library/src/scala/collection/convert/StreamExtensions.scala
@@ -27,17 +27,17 @@ import scala.jdk.CollectionConverters._
 import scala.jdk._
 
 /** Defines extension methods to create Java Streams for Scala collections, available through
-  * [[scala.jdk.javaapi.StreamConverters]].
-  */
+ *  [[scala.jdk.javaapi.StreamConverters]].
+ */
 trait StreamExtensions {
   this: StreamExtensions =>
   // collections
 
   implicit class IterableHasSeqStream[A](cc: IterableOnce[A]) {
     /** Creates a sequential [[java.util.stream.Stream Java Stream]] for this collection. If the
-      * collection contains primitive values, a corresponding specialized Stream is returned (e.g.,
-      * [[java.util.stream.IntStream `IntStream`]]).
-      */
+     *  collection contains primitive values, a corresponding specialized Stream is returned (e.g.,
+     *  [[java.util.stream.IntStream `IntStream`]]).
+     */
     def asJavaSeqStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit s: StreamShape[A, S, St], st: StepperShape[A, St]): S =
       s.fromStepper(cc.stepper, par = false)
   }
@@ -49,9 +49,9 @@ trait StreamExtensions {
     }
 
     /** Creates a parallel [[java.util.stream.Stream Java Stream]] for this collection. If the
-      * collection contains primitive values, a corresponding specialized Stream is returned (e.g.,
-      * [[java.util.stream.IntStream `IntStream`]]).
-      */
+     *  collection contains primitive values, a corresponding specialized Stream is returned (e.g.,
+     *  [[java.util.stream.IntStream `IntStream`]]).
+     */
     def asJavaParStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit
         s: StreamShape[A, S, St],
         st: StepperShape[A, St],
@@ -64,23 +64,23 @@ trait StreamExtensions {
 
   implicit class MapHasSeqKeyValueStream[K, V, CC[X, Y] <: collection.MapOps[X, Y, collection.Map, ?]](cc: CC[K, V]) {
     /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the keys of this map. If
-      * the keys are primitive values, a corresponding specialized Stream is returned (e.g.,
-      * [[java.util.stream.IntStream `IntStream`]]).
-      */
+     *  the keys are primitive values, a corresponding specialized Stream is returned (e.g.,
+     *  [[java.util.stream.IntStream `IntStream`]]).
+     */
     def asJavaSeqKeyStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit s: StreamShape[K, S, St], st: StepperShape[K, St]): S =
       s.fromStepper(cc.keyStepper, par = false)
 
     /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the values of this map. If
-      * the values are primitives, a corresponding specialized Stream is returned (e.g.,
-      * [[java.util.stream.IntStream `IntStream`]]).
-      */
+     *  the values are primitives, a corresponding specialized Stream is returned (e.g.,
+     *  [[java.util.stream.IntStream `IntStream`]]).
+     */
     def asJavaSeqValueStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit s: StreamShape[V, S, St], st: StepperShape[V, St]): S =
       s.fromStepper(cc.valueStepper, par = false)
 
     // The asJavaSeqStream extension method for IterableOnce doesn't apply because its `CC` takes a single type parameter, whereas the one here takes two
     /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the `(key, value)` pairs of
-      * this map.
-      */
+     *  this map.
+     */
     def asJavaSeqStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit s: StreamShape[(K, V), S, St], st: StepperShape[(K, V), St]): S =
       s.fromStepper(cc.stepper, par = false)
   }
@@ -92,9 +92,9 @@ trait StreamExtensions {
     private type MapOpsWithEfficientStepper = collection.MapOps[K, V, collection.Map, ?] { def stepper[S <: Stepper[?]](implicit shape : StepperShape[(K, V), S]) : S & EfficientSplit }
 
     /** Creates a parallel [[java.util.stream.Stream Java Stream]] for the keys of this map. If
-      * the keys are primitive values, a corresponding specialized Stream is returned (e.g.,
-      * [[java.util.stream.IntStream `IntStream`]]).
-      */
+     *  the keys are primitive values, a corresponding specialized Stream is returned (e.g.,
+     *  [[java.util.stream.IntStream `IntStream`]]).
+     */
     def asJavaParKeyStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit
         s: StreamShape[K, S, St],
         st: StepperShape[K, St],
@@ -103,9 +103,9 @@ trait StreamExtensions {
       s.fromStepper(cc.keyStepper, par = true)
 
     /** Creates a parallel [[java.util.stream.Stream Java Stream]] for the values of this map. If
-      * the values are primitives, a corresponding specialized Stream is returned (e.g.,
-      * [[java.util.stream.IntStream `IntStream`]]).
-      */
+     *  the values are primitives, a corresponding specialized Stream is returned (e.g.,
+     *  [[java.util.stream.IntStream `IntStream`]]).
+     */
     def asJavaParValueStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit
         s: StreamShape[V, S, St],
         st: StepperShape[V, St],
@@ -115,8 +115,8 @@ trait StreamExtensions {
 
     // The asJavaParStream extension method for IterableOnce doesn't apply because its `CC` takes a single type parameter, whereas the one here takes two
     /** Creates a parallel [[java.util.stream.Stream Java Stream]] for the `(key, value)` pairs of
-      * this map.
-      */
+     *  this map.
+     */
     def asJavaParStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit
         s: StreamShape[(K, V), S, St],
         st: StepperShape[(K, V), St],
@@ -129,9 +129,9 @@ trait StreamExtensions {
 
   implicit class StepperHasSeqStream[A](stepper: Stepper[A]) {
     /** Creates a sequential [[java.util.stream.Stream Java Stream]] for this stepper. If the
-      * stepper yields primitive values, a corresponding specialized Stream is returned (e.g.,
-      * [[java.util.stream.IntStream `IntStream`]]).
-      */
+     *  stepper yields primitive values, a corresponding specialized Stream is returned (e.g.,
+     *  [[java.util.stream.IntStream `IntStream`]]).
+     */
     def asJavaSeqStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit s: StreamShape[A, S, St], st: StepperShape[A, St]): S = {
       val sStepper = stepper match {
         case as: AnyStepper[A] => st.seqUnbox(as)
@@ -143,9 +143,9 @@ trait StreamExtensions {
 
   implicit class StepperHasParStream[A](stepper: Stepper[A] & EfficientSplit) {
     /** Creates a parallel [[java.util.stream.Stream Java Stream]] for this stepper. If the
-      * stepper yields primitive values, a corresponding specialized Stream is returned (e.g.,
-      * [[java.util.stream.IntStream `IntStream`]]).
-      */
+     *  stepper yields primitive values, a corresponding specialized Stream is returned (e.g.,
+     *  [[java.util.stream.IntStream `IntStream`]]).
+     */
     def asJavaParStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit s: StreamShape[A, S, St], st: StepperShape[A, St]): S = {
       val sStepper = (stepper: @unchecked) match {
         case as: (AnyStepper[A] & EfficientSplit) => st.parUnbox(as)
@@ -222,14 +222,12 @@ trait StreamExtensions {
   // strings
 
   implicit class StringHasSeqParStream(s: String) {
-    /**
-     * A sequential stream on the characters of a string, same as [[asJavaSeqCharStream]]. See also
-     * [[asJavaSeqCodePointStream]].
+    /** A sequential stream on the characters of a string, same as [[asJavaSeqCharStream]]. See also
+     *  [[asJavaSeqCodePointStream]].
      */
     def asJavaSeqStream: IntStream = StreamSupport.intStream(s.stepper.spliterator, /* par = */ false)
-    /**
-     * A parallel stream on the characters of a string, same as [[asJavaParCharStream]]. See also
-     * [[asJavaParCodePointStream]].
+    /** A parallel stream on the characters of a string, same as [[asJavaParCharStream]]. See also
+     *  [[asJavaParCodePointStream]].
      */
     def asJavaParStream: IntStream = StreamSupport.intStream(s.stepper.spliterator, /* par = */ true)
 
@@ -247,22 +245,21 @@ trait StreamExtensions {
   // toScala for streams
 
   implicit class StreamHasToScala[A](stream: Stream[A]) {
-    /**
-     * Copies the elements of this stream into a Scala collection.
+    /** Copies the elements of this stream into a Scala collection.
      *
-     * Converting a parallel streams to an [[scala.jdk.Accumulator]] using `stream.toScala(Accumulator)`
-     * builds the result in parallel.
+     *  Converting a parallel streams to an [[scala.jdk.Accumulator]] using `stream.toScala(Accumulator)`
+     *  builds the result in parallel.
      *
-     * A `toScala(Accumulator)` call automatically converts streams of boxed integers, longs or
-     * doubles are converted to the primitive accumulators ([[scala.jdk.IntAccumulator]], etc.).
+     *  A `toScala(Accumulator)` call automatically converts streams of boxed integers, longs or
+     *  doubles are converted to the primitive accumulators ([[scala.jdk.IntAccumulator]], etc.).
      *
-     * When converting a parallel stream to a different Scala collection, the stream is first
-     * converted into an [[scala.jdk.Accumulator]], which supports parallel building. The accumulator is
-     * then converted to the target collection. Note that the stream is processed eagerly while
-     * building the accumulator, even if the target collection is lazy.
+     *  When converting a parallel stream to a different Scala collection, the stream is first
+     *  converted into an [[scala.jdk.Accumulator]], which supports parallel building. The accumulator is
+     *  then converted to the target collection. Note that the stream is processed eagerly while
+     *  building the accumulator, even if the target collection is lazy.
      *
-     * Sequential streams are directly converted to the target collection. If the target collection
-     * is lazy, the conversion is lazy as well.
+     *  Sequential streams are directly converted to the target collection. If the target collection
+     *  is lazy, the conversion is lazy as well.
      */
     def toScala[C1](factory: collection.Factory[A, C1])(implicit info: AccumulatorFactoryInfo[A, C1]): C1 = {
 
@@ -276,28 +273,27 @@ trait StreamExtensions {
     }
 
     /** Converts a generic Java Stream wrapping a primitive type to a corresponding primitive
-      * Stream.
-      */
+     *  Stream.
+     */
     def asJavaPrimitiveStream[S](implicit unboxer: StreamUnboxer[A, S]): S = unboxer(stream)
   }
 
   implicit class IntStreamHasToScala(stream: IntStream) {
-    /**
-     * Copies the elements of this stream into a Scala collection.
+    /** Copies the elements of this stream into a Scala collection.
      *
-     * Converting a parallel streams to an [[scala.jdk.Accumulator]] using `stream.toScala(Accumulator)`
-     * builds the result in parallel.
+     *  Converting a parallel streams to an [[scala.jdk.Accumulator]] using `stream.toScala(Accumulator)`
+     *  builds the result in parallel.
      *
-     * A `toScala(Accumulator)` call automatically converts the `IntStream` to a primitive
-     * [[scala.jdk.IntAccumulator]].
+     *  A `toScala(Accumulator)` call automatically converts the `IntStream` to a primitive
+     *  [[scala.jdk.IntAccumulator]].
      *
-     * When converting a parallel stream to a different Scala collection, the stream is first
-     * converted into an [[scala.jdk.Accumulator]], which supports parallel building. The accumulator is
-     * then converted to the target collection. Note that the stream is processed eagerly while
-     * building the accumulator, even if the target collection is lazy.
+     *  When converting a parallel stream to a different Scala collection, the stream is first
+     *  converted into an [[scala.jdk.Accumulator]], which supports parallel building. The accumulator is
+     *  then converted to the target collection. Note that the stream is processed eagerly while
+     *  building the accumulator, even if the target collection is lazy.
      *
-     * Sequential streams are directly converted to the target collection. If the target collection
-     * is lazy, the conversion is lazy as well.
+     *  Sequential streams are directly converted to the target collection. If the target collection
+     *  is lazy, the conversion is lazy as well.
      */
     def toScala[C1](factory: collection.Factory[Int, C1])(implicit info: AccumulatorFactoryInfo[Int, C1]): C1 = {
       def intAcc = stream.collect(IntAccumulator.supplier, IntAccumulator.adder, IntAccumulator.merger)
@@ -309,22 +305,21 @@ trait StreamExtensions {
   }
 
   implicit class LongStreamHasToScala(stream: LongStream) {
-    /**
-     * Copies the elements of this stream into a Scala collection.
+    /** Copies the elements of this stream into a Scala collection.
      *
-     * Converting a parallel streams to an [[scala.jdk.Accumulator]] using `stream.toScala(Accumulator)`
-     * builds the result in parallel.
+     *  Converting a parallel streams to an [[scala.jdk.Accumulator]] using `stream.toScala(Accumulator)`
+     *  builds the result in parallel.
      *
-     * A `toScala(Accumulator)` call automatically converts the `LongStream` to a primitive
-     * [[scala.jdk.LongAccumulator]].
+     *  A `toScala(Accumulator)` call automatically converts the `LongStream` to a primitive
+     *  [[scala.jdk.LongAccumulator]].
      *
-     * When converting a parallel stream to a different Scala collection, the stream is first
-     * converted into an [[scala.jdk.Accumulator]], which supports parallel building. The accumulator is
-     * then converted to the target collection. Note that the stream is processed eagerly while
-     * building the accumulator, even if the target collection is lazy.
+     *  When converting a parallel stream to a different Scala collection, the stream is first
+     *  converted into an [[scala.jdk.Accumulator]], which supports parallel building. The accumulator is
+     *  then converted to the target collection. Note that the stream is processed eagerly while
+     *  building the accumulator, even if the target collection is lazy.
      *
-     * Sequential streams are directly converted to the target collection. If the target collection
-     * is lazy, the conversion is lazy as well.
+     *  Sequential streams are directly converted to the target collection. If the target collection
+     *  is lazy, the conversion is lazy as well.
      */
     def toScala[C1](factory: collection.Factory[Long, C1])(implicit info: AccumulatorFactoryInfo[Long, C1]): C1 = {
       def longAcc = stream.collect(LongAccumulator.supplier, LongAccumulator.adder, LongAccumulator.merger)
@@ -336,22 +331,21 @@ trait StreamExtensions {
   }
 
   implicit class DoubleStreamHasToScala(stream: DoubleStream) {
-    /**
-     * Copies the elements of this stream into a Scala collection.
+    /** Copies the elements of this stream into a Scala collection.
      *
-     * Converting a parallel streams to an [[scala.jdk.Accumulator]] using `stream.toScala(Accumulator)`
-     * builds the result in parallel.
+     *  Converting a parallel streams to an [[scala.jdk.Accumulator]] using `stream.toScala(Accumulator)`
+     *  builds the result in parallel.
      *
-     * A `toScala(Accumulator)` call automatically converts the `DoubleStream` to a primitive
-     * [[scala.jdk.DoubleAccumulator]].
+     *  A `toScala(Accumulator)` call automatically converts the `DoubleStream` to a primitive
+     *  [[scala.jdk.DoubleAccumulator]].
      *
-     * When converting a parallel stream to a different Scala collection, the stream is first
-     * converted into an [[scala.jdk.Accumulator]], which supports parallel building. The accumulator is
-     * then converted to the target collection. Note that the stream is processed eagerly while
-     * building the accumulator, even if the target collection is lazy.
+     *  When converting a parallel stream to a different Scala collection, the stream is first
+     *  converted into an [[scala.jdk.Accumulator]], which supports parallel building. The accumulator is
+     *  then converted to the target collection. Note that the stream is processed eagerly while
+     *  building the accumulator, even if the target collection is lazy.
      *
-     * Sequential streams are directly converted to the target collection. If the target collection
-     * is lazy, the conversion is lazy as well.
+     *  Sequential streams are directly converted to the target collection. If the target collection
+     *  is lazy, the conversion is lazy as well.
      */
     def toScala[C1](factory: collection.Factory[Double, C1])(implicit info: AccumulatorFactoryInfo[Double, C1]): C1 = {
       def doubleAcc = stream.collect(DoubleAccumulator.supplier, DoubleAccumulator.adder, DoubleAccumulator.merger)
@@ -365,9 +359,9 @@ trait StreamExtensions {
 
 object StreamExtensions {
   /** An implicit StreamShape instance connects element types with the corresponding specialized
-    * Stream and Stepper types. This is used in `asJavaStream` extension methods to create
-    * generic or primitive streams according to the element type.
-    */
+   *  Stream and Stepper types. This is used in `asJavaStream` extension methods to create
+   *  generic or primitive streams according to the element type.
+   */
   sealed trait StreamShape[T, S <: BaseStream[?, ?], St <: Stepper[?]] {
     final def fromStepper(st: St, par: Boolean): S = mkStream(st, par)
     protected def mkStream(st: St, par: Boolean): S
@@ -418,8 +412,8 @@ object StreamExtensions {
   }
 
   /** Connects a stream element type `A` to the corresponding, potentially specialized, Stream type.
-    * Used in the `stream.asJavaPrimitiveStream` extension method.
-    */
+   *  Used in the `stream.asJavaPrimitiveStream` extension method.
+   */
   sealed trait StreamUnboxer[A, S] {
     def apply(s: Stream[A]): S
   }
@@ -443,12 +437,12 @@ object StreamExtensions {
 
 
   /** An implicit `AccumulatorFactoryInfo` connects primitive element types to the corresponding
-    * specialized [[scala.jdk.Accumulator]] factory. This is used in the `stream.toScala` extension methods
-    * to ensure collecting a primitive stream into a primitive accumulator does not box.
-    *
-    * When converting to a collection other than `Accumulator`, the generic
-    * `noAccumulatorFactoryInfo` is passed.
-    */
+   *  specialized [[scala.jdk.Accumulator]] factory. This is used in the `stream.toScala` extension methods
+   *  to ensure collecting a primitive stream into a primitive accumulator does not box.
+   *
+   *  When converting to a collection other than `Accumulator`, the generic
+   *  `noAccumulatorFactoryInfo` is passed.
+   */
   trait AccumulatorFactoryInfo[A, C] {
     val companion: AnyRef | Null
   }

--- a/library/src/scala/collection/convert/impl/BinaryTreeStepper.scala
+++ b/library/src/scala/collection/convert/impl/BinaryTreeStepper.scala
@@ -28,33 +28,33 @@ private[collection] object BinaryTreeStepper {
 
 
 /** A generic stepper that can traverse ordered binary trees.
-  * The tree is assumed to have all the stuff on the left first, then the root, then everything on the right.
-  *
-  * Splits occur at the root of whatever has not yet been traversed (the substepper steps up to but
-  * does not include the root).
-  *
-  * The stepper maintains an internal stack, not relying on the tree traversal to be reversible.  Trees with
-  * nodes that maintain a parent pointer may be traversed slightly faster without a stack, but splitting is
-  * more awkward.
-  *
-  * Algorithmically, this class implements a simple state machine that unrolls the left-leaning links in
-  * a binary tree onto a stack.  At all times, the machine should be in one of these states:
-  * 1. Empty: `myCurrent` is `null` and `index` is `-1`.  `stack` should also be `Array.empty` then.
-  * 2. Ready: `myCurrent` is not `null` and contains the next `A` to be extracted
-  * 3. Pending: `myCurrent` is `null` and `stack(index)` contains the next node to visit
-  *
-  * Subclasses should allow this class to do all the work of maintaining state; `next` should simply
-  * reduce `maxLength` by one, and consume `myCurrent` and set it to `null` if `hasNext` is true.
-  */
+ *  The tree is assumed to have all the stuff on the left first, then the root, then everything on the right.
+ *
+ *  Splits occur at the root of whatever has not yet been traversed (the substepper steps up to but
+ *  does not include the root).
+ *
+ *  The stepper maintains an internal stack, not relying on the tree traversal to be reversible.  Trees with
+ *  nodes that maintain a parent pointer may be traversed slightly faster without a stack, but splitting is
+ *  more awkward.
+ *
+ *  Algorithmically, this class implements a simple state machine that unrolls the left-leaning links in
+ *  a binary tree onto a stack.  At all times, the machine should be in one of these states:
+ *  1. Empty: `myCurrent` is `null` and `index` is `-1`.  `stack` should also be `Array.empty` then.
+ *  2. Ready: `myCurrent` is not `null` and contains the next `A` to be extracted
+ *  3. Pending: `myCurrent` is `null` and `stack(index)` contains the next node to visit
+ *
+ *  Subclasses should allow this class to do all the work of maintaining state; `next` should simply
+ *  reduce `maxLength` by one, and consume `myCurrent` and set it to `null` if `hasNext` is true.
+ */
 private[collection] abstract class BinaryTreeStepperBase[A, T <: AnyRef, Sub, Semi <: Sub & BinaryTreeStepperBase[A, T, ?, ?]](
   protected var maxLength: Int, protected var myCurrent: T | Null, protected var stack: Array[AnyRef | Null], protected var index: Int,
   protected val left: T => T | Null, protected val right: T => T | Null
 )
 extends EfficientSplit {
   /** Unrolls a subtree onto the stack starting from a particular node, returning
-    * the last node found.  This final node is _not_ placed on the stack, and
-    * may have things to its right.
-    */
+   *  the last node found.  This final node is _not_ placed on the stack, and
+   *  may have things to its right.
+   */
   @tailrec protected final def unroll(from: T): T = {
     val l = left(from)
     if (l eq null) from
@@ -67,11 +67,11 @@ extends EfficientSplit {
   }
 
   /** Takes a subtree whose left side, if any, has already been visited, and unrolls
-    * the right side of the tree onto the stack, thereby detaching that node of
-    * the subtree from the stack entirely (so it is ready to use).  It returns
-    * the node that is being detached. Note that the node must _not_ already be
-    * on the stack.
-    */
+   *  the right side of the tree onto the stack, thereby detaching that node of
+   *  the subtree from the stack entirely (so it is ready to use).  It returns
+   *  the node that is being detached. Note that the node must _not_ already be
+   *  on the stack.
+   */
   protected final def detach(node: T): node.type = {
     val r = right(node)
     if (r ne null) {
@@ -84,11 +84,11 @@ extends EfficientSplit {
   }
 
   /** Given an empty state and the root of a new tree, initialize the tree properly
-    * to be in an (appropriate) ready state.  Will do all sorts of wrong stuff if the
-    * tree is not already empty.
-    *
-    * Right now overwrites everything so could allow reuse, but isn't used for it.
-    */
+   *  to be in an (appropriate) ready state.  Will do all sorts of wrong stuff if the
+   *  tree is not already empty.
+   *
+   *  Right now overwrites everything so could allow reuse, but isn't used for it.
+   */
   private[impl] final def initialize(root: T | Null, size: Int): Unit =
     if (root eq null) {
       maxLength = 0
@@ -119,10 +119,10 @@ extends EfficientSplit {
   })
 
   /** Splits the tree at the root by giving everything unrolled on the stack to a new stepper,
-    * detaching the root, and leaving the right-hand side of the root unrolled.
-    *
-    * If the tree is empty or only has one element left, it returns `null` instead of splitting.
-    */
+   *  detaching the root, and leaving the right-hand side of the root unrolled.
+   *
+   *  If the tree is empty or only has one element left, it returns `null` instead of splitting.
+   */
   def trySplit(): Sub | Null =
     if (!hasStep || index < 0) null
     else {

--- a/library/src/scala/collection/convert/impl/ChampStepper.scala
+++ b/library/src/scala/collection/convert/impl/ChampStepper.scala
@@ -19,9 +19,9 @@ import scala.collection._
 import scala.collection.immutable.Node
 
 /** A stepper that is a slightly elaborated version of the ChampBaseIterator;
-  * the main difference is that it knows when it should stop instead of running
-  * to the end of all trees.
-  */
+ *  the main difference is that it knows when it should stop instead of running
+ *  to the end of all trees.
+ */
 private[collection] abstract class ChampStepperBase[
   A, T <: Node[T], Sub, Semi <: Sub & ChampStepperBase[A, T, ?, ?]
 ](protected var maxSize: Int)
@@ -71,10 +71,9 @@ extends EfficientSplit {
     currentStackLevel = currentStackLevel - 1
   }
 
-  /**
-    * Searches for next node that contains payload values,
-    * and pushes encountered sub-nodes on a stack for depth-first traversal.
-    */
+  /** Searches for next node that contains payload values,
+   *  and pushes encountered sub-nodes on a stack for depth-first traversal.
+   */
   private final def searchNextValueNode(): Boolean = {
     while (currentStackLevel >= 0) {
       val cursorIndex = currentStackLevel * 2

--- a/library/src/scala/collection/convert/impl/InOrderStepperBase.scala
+++ b/library/src/scala/collection/convert/impl/InOrderStepperBase.scala
@@ -19,19 +19,18 @@ import java.util.Spliterator
 import scala.collection.Stepper.EfficientSplit
 
 /** Abstracts all the generic operations of stepping over a collection
-  * that has an indexable ordering but may have gaps.
-  *
-  * For collections that are guaranteed to not have gaps, use `IndexedStepperBase` instead.
-  */
+ *  that has an indexable ordering but may have gaps.
+ *
+ *  For collections that are guaranteed to not have gaps, use `IndexedStepperBase` instead.
+ */
 private[convert] abstract class InOrderStepperBase[Sub, Semi <: Sub](protected var i0: Int, protected var iN: Int)
 extends EfficientSplit {
-  /** Sets `true` if the element at `i0` is known to be there.  `false` if either not known or is a gap.
-    */
+  /** Sets `true` if the element at `i0` is known to be there.  `false` if either not known or is a gap. */
   protected def found: Boolean
 
   /** Advance `i0` over any gaps, updating internal state so `found` is correct at the new position.
-    * Returns the new value of `found`.
-    */
+   *  Returns the new value of `found`.
+   */
   protected def findNext(): Boolean
 
   protected def semiclone(half: Int): Semi

--- a/library/src/scala/collection/convert/impl/RangeStepper.scala
+++ b/library/src/scala/collection/convert/impl/RangeStepper.scala
@@ -17,9 +17,9 @@ import scala.language.`2.13`
 import scala.collection.{IntStepper, Stepper}
 
 /** Implements Stepper on an integer Range.  You don't actually need the Range to do this,
-  * so only the relevant parts are included.  Because the arguments are protected, they are
-  * not error-checked; `Range` is required to provide valid arguments.
-  */
+ *  so only the relevant parts are included.  Because the arguments are protected, they are
+ *  not error-checked; `Range` is required to provide valid arguments.
+ */
 private[collection] final class RangeStepper(protected var myNext: Int, myStep: Int, _i0: Int, _iN: Int)
 extends IndexedStepperBase[IntStepper, RangeStepper](_i0, _iN)
 with IntStepper {

--- a/library/src/scala/collection/convert/impl/StringStepper.scala
+++ b/library/src/scala/collection/convert/impl/StringStepper.scala
@@ -20,8 +20,7 @@ import java.util.Spliterator
 import scala.collection.Stepper.EfficientSplit
 import scala.collection.{IntStepper, Stepper}
 
-/** Implements `Stepper` on a `String` where you step through chars packed into `Int`.
-  */
+/** Implements `Stepper` on a `String` where you step through chars packed into `Int`. */
 private[collection] final class CharStringStepper(underlying: String, _i0: Int, _iN: Int)
 extends IndexedStepperBase[IntStepper, CharStringStepper](_i0, _iN)
 with IntStepper {
@@ -32,8 +31,7 @@ with IntStepper {
   def semiclone(half: Int): CharStringStepper = new CharStringStepper(underlying, i0, half)
 }
 
-/** Implements `Stepper` on a `String` where you step through code points.
-  */
+/** Implements `Stepper` on a `String` where you step through code points. */
 private[collection] final class CodePointStringStepper(underlying: String, private var i0: Int, private var iN: Int)
 extends IntStepper with EfficientSplit {
   def characteristics: Int = Spliterator.IMMUTABLE | Spliterator.NONNULL | Spliterator.ORDERED

--- a/library/src/scala/collection/generic/CommonErrors.scala
+++ b/library/src/scala/collection/generic/CommonErrors.scala
@@ -16,8 +16,7 @@ package generic
 import scala.language.`2.13`
 import language.experimental.captureChecking
 
-/** Some precomputed common errors to reduce the generated code size.
-  */
+/** Some precomputed common errors to reduce the generated code size. */
 private[collection] object CommonErrors {
   /** IndexOutOfBounds exception with a known max index. */
   @noinline

--- a/library/src/scala/collection/generic/IsIterable.scala
+++ b/library/src/scala/collection/generic/IsIterable.scala
@@ -26,21 +26,21 @@ import caps.unsafe.untrackedCaptures
  *  extension methods that work both on collection types and on `String`s (`String`s
  *  do not extend `Iterable`, but can be converted to `Iterable`)
  *
- * `IsIterable` provides three members:
+ *  `IsIterable` provides three members:
  *
  *  1. type member `A`, which represents the element type of the target `Iterable[A]`
  *  1. type member `C`, which represents the type returned by transformation operations that preserve the collection’s elements type
  *  1. method `apply`, which provides a way to convert between the type we wish to add extension methods to, `Repr`, and `IterableOps[A, Iterable, C]`.
  *
- * ===Usage===
+ *  ### Usage
  *
- * One must provide `IsIterable` as an implicit parameter type of an implicit
- * conversion. Its usage is shown below. Our objective in the following example
- * is to provide a generic extension method `mapReduce` to any type that extends
- * or can be converted to `Iterable`. In our example, this includes
- * `String`.
+ *  One must provide `IsIterable` as an implicit parameter type of an implicit
+ *  conversion. Its usage is shown below. Our objective in the following example
+ *  is to provide a generic extension method `mapReduce` to any type that extends
+ *  or can be converted to `Iterable`. In our example, this includes
+ *  `String`.
  *
- * {{{
+ *  ```
  *    import scala.collection.{Iterable, IterableOps}
  *    import scala.collection.generic.IsIterable
  *
@@ -60,67 +60,67 @@ import caps.unsafe.untrackedCaptures
  *  // See it in action!
  *  List(1, 2, 3).mapReduce(_ * 2)(_ + _) // res0: Int = 12
  *  "Yeah, well, you know, that's just, like, your opinion, man.".mapReduce(x => 1)(_ + _) // res1: Int = 59
- *}}}
+ *  ```
  *
- * Here, we begin by creating a class `ExtensionMethods` which contains our
- * `mapReduce` extension method.
+ *  Here, we begin by creating a class `ExtensionMethods` which contains our
+ *  `mapReduce` extension method.
  *
- * Note that `ExtensionMethods` takes a constructor argument `coll` of type `Repr`, where
- * `Repr` represents (typically) the collection type, and an argument `it` of a subtype of `IsIterable[Repr]`.
- * The body of the method starts by converting the `coll` argument to an `IterableOps` in order to
- * call the `iterator` method on it.
- * The remaining of the implementation is straightforward.
+ *  Note that `ExtensionMethods` takes a constructor argument `coll` of type `Repr`, where
+ *  `Repr` represents (typically) the collection type, and an argument `it` of a subtype of `IsIterable[Repr]`.
+ *  The body of the method starts by converting the `coll` argument to an `IterableOps` in order to
+ *  call the `iterator` method on it.
+ *  The remaining of the implementation is straightforward.
  *
- * The `withExtensions` implicit conversion makes the `mapReduce` operation available
- * on any type `Repr` for which it exists an implicit `IsIterable[Repr]` instance.
- * Note how we keep track of the precise type of the implicit `it` argument by using the
- * `it.type` singleton type, rather than the wider `IsIterable[Repr]` type. We do that
- * so that the information carried by the type members `A` and `C` of the `it` argument
- * is not lost.
+ *  The `withExtensions` implicit conversion makes the `mapReduce` operation available
+ *  on any type `Repr` for which it exists an implicit `IsIterable[Repr]` instance.
+ *  Note how we keep track of the precise type of the implicit `it` argument by using the
+ *  `it.type` singleton type, rather than the wider `IsIterable[Repr]` type. We do that
+ *  so that the information carried by the type members `A` and `C` of the `it` argument
+ *  is not lost.
  *
- * When the `mapReduce` method is called on some type of which it is not
- * a member, implicit search is triggered. Because implicit conversion
- * `withExtensions` is generic, it will be applied as long as an implicit
- * value of type `IsIterable[Repr]` can be found. Given that the
- * `IsIterable` companion object contains implicit members that return values of type
- * `IsIterable`, this requirement is typically satisfied, and the chain
- * of interactions described in the previous paragraph is set into action.
- * (See the `IsIterable` companion object, which contains a precise
- * specification of the available implicits.)
+ *  When the `mapReduce` method is called on some type of which it is not
+ *  a member, implicit search is triggered. Because implicit conversion
+ *  `withExtensions` is generic, it will be applied as long as an implicit
+ *  value of type `IsIterable[Repr]` can be found. Given that the
+ *  `IsIterable` companion object contains implicit members that return values of type
+ *  `IsIterable`, this requirement is typically satisfied, and the chain
+ *  of interactions described in the previous paragraph is set into action.
+ *  (See the `IsIterable` companion object, which contains a precise
+ *  specification of the available implicits.)
  *
- * ''Note'': Currently, it's not possible to combine the implicit conversion and
- * the class with the extension methods into an implicit class due to
- * limitations of type inference.
+ *  *Note*: Currently, it's not possible to combine the implicit conversion and
+ *  the class with the extension methods into an implicit class due to
+ *  limitations of type inference.
  *
- * ===Implementing `IsIterable` for New Types===
+ *  ### Implementing `IsIterable` for New Types
  *
- * One must simply provide an implicit value of type `IsIterable`
- * specific to the new type, or an implicit conversion which returns an
- * instance of `IsIterable` specific to the new type.
+ *  One must simply provide an implicit value of type `IsIterable`
+ *  specific to the new type, or an implicit conversion which returns an
+ *  instance of `IsIterable` specific to the new type.
  *
- * Below is an example of an implementation of the `IsIterable` trait
- * where the `Repr` type is `Range`.
+ *  Below is an example of an implementation of the `IsIterable` trait
+ *  where the `Repr` type is `Range`.
  *
- *{{{
- * implicit val rangeRepr: IsIterable[Range] { type A = Int; type C = IndexedSeq[Int] } =
+ *  ```
+ *  implicit val rangeRepr: IsIterable[Range] { type A = Int; type C = IndexedSeq[Int] } =
  *   new IsIterable[Range] {
  *     type A = Int
  *     type C = IndexedSeq[Int]
  *     def apply(coll: Range): IterableOps[Int, IndexedSeq, IndexedSeq[Int]] = coll
  *   }
- *}}}
+ *  ```
  *
- * (Note that in practice the `IsIterable[Range]` instance is already provided by
- * the standard library, and it is defined as an `IsSeq[Range]` instance)
+ *  (Note that in practice the `IsIterable[Range]` instance is already provided by
+ *  the standard library, and it is defined as an `IsSeq[Range]` instance)
  */
 transparent trait IsIterable[Repr] extends IsIterableOnce[Repr] {
 
   /** The type returned by transformation operations that preserve the same elements
-    * type (e.g. `filter`, `take`).
-    *
-    * In practice, this type is often `Repr` itself, excepted in the case
-    * of `SeqView[A]` (and other `View[A]` subclasses), where it is “only” `View[A]`.
-    */
+   *  type (e.g. `filter`, `take`).
+   *
+   *  In practice, this type is often `Repr` itself, excepted in the case
+   *  of `SeqView[A]` (and other `View[A]` subclasses), where it is “only” `View[A]`.
+   */
   type C
 
   @deprecated("'conversion' is now a method named 'apply'", "2.13.0")

--- a/library/src/scala/collection/generic/IsIterableOnce.scala
+++ b/library/src/scala/collection/generic/IsIterableOnce.scala
@@ -26,7 +26,7 @@ import caps.unsafe.untrackedCaptures
  *  framework in their implementation.
  *
  *  Example usage,
- * {{{
+ *  ```
  *    extension [Repr, I <: IsIterableOnce[Repr]](coll: Repr)(using it: I) {
  *      final def filterMap[B, That](f: it.A => Option[B])(using bf: BuildFrom[Repr, B, That]): That = {
  *        val b = bf.newBuilder(coll)
@@ -37,7 +37,7 @@ import caps.unsafe.untrackedCaptures
  *
  *    List(1, 2, 3, 4, 5).filterMap(i => if(i % 2 == 0) Some(i) else None)
  *    // == List(2, 4)
- * }}}
+ *  ```
  */
 transparent trait IsIterableOnce[Repr] {
 

--- a/library/src/scala/collection/generic/IsMap.scala
+++ b/library/src/scala/collection/generic/IsMap.scala
@@ -19,16 +19,15 @@ import language.experimental.captureChecking
 import IsMap.Tupled
 import scala.collection.immutable.{IntMap, LongMap}
 
-/**
-  * Type class witnessing that a collection type `Repr`
-  * has keys of type `K`, values of type `V` and has a conversion to
-  * `MapOps[K, V, Iterable, C]`, for some types `K`, `V` and `C`.
-  *
-  * This type enables simple enrichment of `Map`s with extension methods.
-  *
-  * @see [[scala.collection.generic.IsIterable]]
-  * @tparam Repr Collection type (e.g. `Map[Int, String]`)
-  */
+/** Type class witnessing that a collection type `Repr`
+ *  has keys of type `K`, values of type `V` and has a conversion to
+ *  `MapOps[K, V, Iterable, C]`, for some types `K`, `V` and `C`.
+ *
+ *  This type enables simple enrichment of `Map`s with extension methods.
+ *
+ *  @see [[scala.collection.generic.IsIterable]]
+ *  @tparam Repr Collection type (e.g. `Map[Int, String]`)
+ */
 transparent trait IsMap[Repr] extends IsIterable[Repr] {
 
   /** The type of keys. */
@@ -40,11 +39,11 @@ transparent trait IsMap[Repr] extends IsIterable[Repr] {
   type A = (K, V)
 
   /** A conversion from the type `Repr` to `MapOps[K, V, Iterable, C]`
-    *
-    * @note The third type parameter of the returned `MapOps` value is
-    *       still `Iterable` (and not `Map`) because `MapView[K, V]` only
-    *       extends `MapOps[K, V, View, View[A]]`.
-    */
+   *
+   *  @note The third type parameter of the returned `MapOps` value is
+   *       still `Iterable` (and not `Map`) because `MapView[K, V]` only
+   *       extends `MapOps[K, V, View, View[A]]`.
+   */
   override def apply(c: Repr): MapOps[K, V, Tupled[Iterable]#Ap, C]
 
 }
@@ -52,11 +51,11 @@ transparent trait IsMap[Repr] extends IsIterable[Repr] {
 object IsMap {
 
   /** Convenient type level function that takes a unary type constructor `F[_]`
-    * and returns a binary type constructor that tuples its parameters and passes
-    * them to `F`.
-    *
-    * `Tupled[F]#Ap` is equivalent to `({ type Ap[X, +Y] = F[(X, Y)] })#Ap`.
-    */
+   *  and returns a binary type constructor that tuples its parameters and passes
+   *  them to `F`.
+   *
+   *  `Tupled[F]#Ap` is equivalent to `({ type Ap[X, +Y] = F[(X, Y)] })#Ap`.
+   */
   type Tupled[F[+_]] = { type Ap[X, Y] = F[(X, Y)] }
 
   // Map collections

--- a/library/src/scala/collection/generic/IsSeq.scala
+++ b/library/src/scala/collection/generic/IsSeq.scala
@@ -20,15 +20,15 @@ import caps.unsafe.untrackedCaptures
 import scala.reflect.ClassTag
 
 /** Type class witnessing that a collection representation type `Repr` has
-  * elements of type `A` and has a conversion to `SeqOps[A, Iterable, C]`, for
-  * some types `A` and `C`.
-  *
-  * This type enables simple enrichment of `Seq`s with extension methods which
-  * can make full use of the mechanics of the Scala collections framework in
-  * their implementation.
-  *
-  * @see [[scala.collection.generic.IsIterable]]
-  */
+ *  elements of type `A` and has a conversion to `SeqOps[A, Iterable, C]`, for
+ *  some types `A` and `C`.
+ *
+ *  This type enables simple enrichment of `Seq`s with extension methods which
+ *  can make full use of the mechanics of the Scala collections framework in
+ *  their implementation.
+ *
+ *  @see [[scala.collection.generic.IsIterable]]
+ */
 transparent trait IsSeq[Repr] extends IsIterable[Repr] {
 
   @deprecated("'conversion' is now a method named 'apply'", "2.13.0")
@@ -36,11 +36,11 @@ transparent trait IsSeq[Repr] extends IsIterable[Repr] {
   override val conversion: Repr => SeqOps[A, Iterable, C] = apply(_)
 
   /** A conversion from the type `Repr` to `SeqOps[A, Iterable, C]`
-    *
-    * @note The second type parameter of the returned `SeqOps` value is
-    *       still `Iterable` (and not `Seq`) because `SeqView[A]` only
-    *       extends `SeqOps[A, View, View[A]]`.
-    */
+   *
+   *  @note The second type parameter of the returned `SeqOps` value is
+   *       still `Iterable` (and not `Seq`) because `SeqView[A]` only
+   *       extends `SeqOps[A, View, View[A]]`.
+   */
   def apply(coll: Repr): SeqOps[A, Iterable, C]
 }
 

--- a/library/src/scala/collection/immutable/ArraySeq.scala
+++ b/library/src/scala/collection/immutable/ArraySeq.scala
@@ -27,14 +27,13 @@ import scala.runtime.ScalaRunTime
 import scala.util.Sorting
 import scala.util.hashing.MurmurHash3
 
-/**
-  * An immutable array.
-  *
-  * Supports efficient indexed access and has a small memory footprint.
-  *
-  * @define coll immutable array
-  * @define Coll `ArraySeq`
-  */
+/** An immutable array.
+ *
+ *  Supports efficient indexed access and has a small memory footprint.
+ *
+ *  @define coll immutable array
+ *  @define Coll `ArraySeq`
+ */
 sealed abstract class ArraySeq[+A]
   extends AbstractSeq[A]
     with IndexedSeq[A]
@@ -44,16 +43,18 @@ sealed abstract class ArraySeq[+A]
     with Serializable{
 
   /** The tag of the element type. This does not have to be equal to the element type of this ArraySeq. A primitive
-    * ArraySeq can be backed by an array of boxed values and a reference ArraySeq can be backed by an array of a supertype
-    * or subtype of the element type. */
+   *  ArraySeq can be backed by an array of boxed values and a reference ArraySeq can be backed by an array of a supertype
+   *  or subtype of the element type. 
+   */
   protected def elemTag: ClassTag[?]
 
   override def iterableFactory: SeqFactory[ArraySeq] = ArraySeq.untagged
 
   /** The wrapped mutable `Array` that backs this `ArraySeq`. Any changes to this array will break
-    * the expected immutability. Its element type does not have to be equal to the element type of this ArraySeq.
-    * A primitive ArraySeq can be backed by an array of boxed values and a reference ArraySeq can be backed by an
-    * array of a supertype or subtype of the element type. */
+   *  the expected immutability. Its element type does not have to be equal to the element type of this ArraySeq.
+   *  A primitive ArraySeq can be backed by an array of boxed values and a reference ArraySeq can be backed by an
+   *  array of a supertype or subtype of the element type. 
+   */
   def unsafeArray: Array[?]
 
   protected def evidenceIterableFactory: ArraySeq.type = ArraySeq
@@ -88,9 +89,9 @@ sealed abstract class ArraySeq[+A]
     ArraySeq.unsafeWrapArray(unsafeArray.appended[Any](elem)).asInstanceOf[ArraySeq[B]]
 
   /** Fast concatenation of two [[ArraySeq]]s.
-    *
-    * @return null if optimisation not possible.
-    */
+   *
+   *  @return null if optimisation not possible.
+   */
   private def appendedAllArraySeq[B >: A](that: ArraySeq[B]): ArraySeq[B] | Null = {
     // Optimise concatenation of two ArraySeqs
     // For ArraySeqs with sizes of [100, 1000, 10000] this is [3.5, 4.1, 5.2]x as fast
@@ -267,11 +268,10 @@ sealed abstract class ArraySeq[+A]
     }
 }
 
-/**
-  * $factoryInfo
-  * @define coll immutable array
-  * @define Coll `ArraySeq`
-  */
+/** $factoryInfo
+ *  @define coll immutable array
+ *  @define Coll `ArraySeq`
+ */
 @SerialVersionUID(3L)
 object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
   val untagged: SeqFactory[ArraySeq] = new ClassTagSeqFactory.AnySeqDelegate(self)
@@ -300,17 +300,16 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
     ArraySeq.unsafeWrapArray(elements)
   }
 
-  /**
-   * Wraps an existing `Array` into an `ArraySeq` of the proper primitive specialization type
-   * without copying. Any changes to wrapped array will break the expected immutability.
+  /** Wraps an existing `Array` into an `ArraySeq` of the proper primitive specialization type
+   *  without copying. Any changes to wrapped array will break the expected immutability.
    *
-   * Note that an array containing boxed primitives can be wrapped in an `ArraySeq` without
-   * copying. For example, `val a: Array[Any] = Array(1)` is an array of `Object` at runtime,
-   * containing `Integer`s. An `ArraySeq[Int]` can be obtained with a cast:
-   * `ArraySeq.unsafeWrapArray(a).asInstanceOf[ArraySeq[Int]]`. The values are still
-   * boxed, the resulting instance is an [[ArraySeq.ofRef]]. Writing
-   * `ArraySeq.unsafeWrapArray(a.asInstanceOf[Array[Int]])` does not work, it throws a
-   * `ClassCastException` at runtime.
+   *  Note that an array containing boxed primitives can be wrapped in an `ArraySeq` without
+   *  copying. For example, `val a: Array[Any] = Array(1)` is an array of `Object` at runtime,
+   *  containing `Integer`s. An `ArraySeq[Int]` can be obtained with a cast:
+   *  `ArraySeq.unsafeWrapArray(a).asInstanceOf[ArraySeq[Int]]`. The values are still
+   *  boxed, the resulting instance is an [[ArraySeq.ofRef]]. Writing
+   *  `ArraySeq.unsafeWrapArray(a.asInstanceOf[Array[Int]])` does not work, it throws a
+   *  `ClassCastException` at runtime.
    */
   def unsafeWrapArray[T](x: Array[T]): ArraySeq[T] = ((x: @unchecked) match {
     case null              => null

--- a/library/src/scala/collection/immutable/BitSet.scala
+++ b/library/src/scala/collection/immutable/BitSet.scala
@@ -22,13 +22,13 @@ import mutable.Builder
 import scala.annotation.{implicitNotFound, nowarn}
 
 /** A class for immutable bitsets.
-  *  $bitsetinfo
-  *  @see [[https://docs.scala-lang.org/overviews/collections-2.13/concrete-immutable-collection-classes.html#immutable-bitsets "Scala's Collection Library overview"]]
-  *  section on `Immutable BitSets` for more information.
-  *
-  *  @define Coll `immutable.BitSet`
-  *  @define coll immutable bitset
-  */
+ *  $bitsetinfo
+ *  @see ["Scala's Collection Library overview"](https://docs.scala-lang.org/overviews/collections-2.13/concrete-immutable-collection-classes.html#immutable-bitsets)
+ *  section on `Immutable BitSets` for more information.
+ *
+ *  @define Coll `immutable.BitSet`
+ *  @define coll immutable bitset
+ */
 sealed abstract class BitSet
   extends AbstractSet[Int]
     with SortedSet[Int]
@@ -65,8 +65,7 @@ sealed abstract class BitSet
     } else this
   }
 
-  /** Updates word at index `idx`; enlarges set if `idx` outside range of set.
-    */
+  /** Updates word at index `idx`; enlarges set if `idx` outside range of set. */
   protected def updateWord(idx: Int, w: Long): BitSet
 
   override def map(f: Int => Int): BitSet = strictOptimizedMap(newSpecificBuilder, f)
@@ -88,11 +87,10 @@ sealed abstract class BitSet
   protected def writeReplace(): AnyRef = new BitSet.SerializationProxy(this)
 }
 
-/**
-  * $factoryInfo
-  * @define Coll `immutable.BitSet`
-  * @define coll immutable bitset
-  */
+/** $factoryInfo
+ *  @define Coll `immutable.BitSet`
+ *  @define coll immutable bitset
+ */
 @nowarn("cat=deprecation&msg=Implementation classes of BitSet should not be accessed directly")
 @SerialVersionUID(3L)
 object BitSet extends SpecificIterableFactory[Int, BitSet] {
@@ -123,8 +121,8 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
   }
 
   /** A bitset containing all the bits in an array, wrapping the existing
-    *  array without copying.
-    */
+   *  array without copying.
+   */
   def fromBitMaskNoCopy(elems: Array[Long]): BitSet = {
     val len = elems.length
     if (len == 0) empty

--- a/library/src/scala/collection/immutable/ChampCommon.scala
+++ b/library/src/scala/collection/immutable/ChampCommon.scala
@@ -100,13 +100,12 @@ private[collection] abstract class Node[T <: Node[T]] {
   }
 }
 
-/**
-  * Base class for fixed-stack iterators that traverse a hash-trie. The iterator performs a
-  * depth-first pre-order traversal, which yields first all payload elements of the current
-  * node before traversing sub-nodes (left to right).
-  *
-  * @tparam T the trie node type we are iterating over
-  */
+/** Base class for fixed-stack iterators that traverse a hash-trie. The iterator performs a
+ *  depth-first pre-order traversal, which yields first all payload elements of the current
+ *  node before traversing sub-nodes (left to right).
+ *
+ *  @tparam T the trie node type we are iterating over
+ */
 private[immutable] abstract class ChampBaseIterator[A, T <: Node[T]] extends AbstractIterator[A] {
 
   import Node.MaxDepth
@@ -158,10 +157,9 @@ private[immutable] abstract class ChampBaseIterator[A, T <: Node[T]] extends Abs
     currentStackLevel = currentStackLevel - 1
   }
 
-  /**
-    * Searches for next node that contains payload values,
-    * and pushes encountered sub-nodes on a stack for depth-first traversal.
-    */
+  /** Searches for next node that contains payload values,
+   *  and pushes encountered sub-nodes on a stack for depth-first traversal.
+   */
   private final def searchNextValueNode(): Boolean = {
     while (currentStackLevel >= 0) {
       val cursorIndex = currentStackLevel * 2
@@ -189,12 +187,11 @@ private[immutable] abstract class ChampBaseIterator[A, T <: Node[T]] extends Abs
 
 }
 
-/**
-  * Base class for fixed-stack iterators that traverse a hash-trie in reverse order. The base
-  * iterator performs a depth-first post-order traversal, traversing sub-nodes (right to left).
-  *
-  * @tparam T the trie node type we are iterating over
-  */
+/** Base class for fixed-stack iterators that traverse a hash-trie in reverse order. The base
+ *  iterator performs a depth-first post-order traversal, traversing sub-nodes (right to left).
+ *
+ *  @tparam T the trie node type we are iterating over
+ */
 private[immutable] abstract class ChampBaseReverseIterator[A, T <: Node[T]] extends AbstractIterator[A] {
 
   import Node.MaxDepth
@@ -228,10 +225,9 @@ private[immutable] abstract class ChampBaseReverseIterator[A, T <: Node[T]] exte
     currentStackLevel = currentStackLevel - 1
   }
 
-  /**
-    * Searches for rightmost node that contains payload values,
-    * and pushes encountered sub-nodes on a stack for depth-first traversal.
-    */
+  /** Searches for rightmost node that contains payload values,
+   *  and pushes encountered sub-nodes on a stack for depth-first traversal.
+   */
   private final def searchNextValueNode(): Boolean = {
     while (currentStackLevel >= 0) {
       val nodeCursor = nodeIndex(currentStackLevel) ; nodeIndex(currentStackLevel) = nodeCursor - 1

--- a/library/src/scala/collection/immutable/HashMap.scala
+++ b/library/src/scala/collection/immutable/HashMap.scala
@@ -30,14 +30,14 @@ import scala.runtime.Statics.releaseFence
 import scala.util.hashing.MurmurHash3
 
 /** This class implements immutable maps using a Compressed Hash-Array Mapped Prefix-tree.
-  * See paper https://michael.steindorfer.name/publications/oopsla15.pdf for more details.
-  *
-  *  @tparam K      the type of the keys contained in this hash set.
-  *  @tparam V      the type of the values associated with the keys in this hash map.
-  *
-  *  @define Coll `immutable.HashMap`
-  *  @define coll immutable champ hash map
-  */
+ *  See paper https://michael.steindorfer.name/publications/oopsla15.pdf for more details.
+ *
+ *  @tparam K      the type of the keys contained in this hash set.
+ *  @tparam V      the type of the values associated with the keys in this hash map.
+ *
+ *  @define Coll `immutable.HashMap`
+ *  @define coll immutable champ hash map
+ */
 
 final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: BitmapIndexedMapNode[K, V])
   extends AbstractMap[K, V]
@@ -298,45 +298,45 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
   override protected def className = "HashMap"
 
   /** Merges this HashMap with an other HashMap by combining all key-value pairs of both maps, and delegating to a merge
-    * function to resolve any key collisions between the two HashMaps.
-    *
-    * @example {{{
-    *   val left = HashMap(1 -> 1, 2 -> 1)
-    *   val right = HashMap(2 -> 2, 3 -> 2)
-    *
-    *   val merged = left.merged(right){ case ((k0, v0), (k1, v1)) => (k0 + k1) -> (v0 + v1) }
-    *     // HashMap(1 -> 1, 3 -> 2, 4 -> 3)
-    *
-    * }}}
-    *
-    * @param that the HashMap to merge this HashMap with
-    * @param mergef the merge function which resolves collisions between the two HashMaps. If `mergef` is null, then
-    *               keys from `this` will overwrite keys from `that`, making the behaviour equivalent to
-    *               `that.concat(this)`
-    *
-    * @note In cases where `mergef` returns keys which themselves collide with other keys returned by `merge`, or
-    *       found in `this` or `that`, it is not defined which value will be chosen. For example:
-    *
-    *       Colliding multiple results of merging:
-    *       {{{
-    *         // key `3` collides between a result of merging keys `1` and `2`
-    *         val left = HashMap(1 -> 1, 2 -> 2)
-    *         val right = HashMap(1 -> 1, 2 -> 2)
-    *
-    *         val merged = left.merged(right){ case (_, (_, v1)) => 3 -> v1 }
-    *           // HashMap(3 -> 2) is returned, but it could also have returned HashMap(3 -> 1)
-    *       }}}
-    *       Colliding results of merging with other keys:
-    *       {{{
-    *         // key `2` collides between a result of merging `1`, and existing key `2`
-    *         val left = HashMap(1 -> 1, 2 -> 1)
-    *         val right = HashMap(1 -> 2)
-    *
-    *         val merged = left.merged(right)((_,_) => 2 -> 3)
-    *           // HashMap(2 -> 1) is returned, but it could also have returned HashMap(2 -> 3)
-    *       }}}
-    *
-    */
+   *  function to resolve any key collisions between the two HashMaps.
+   *
+   *  @example ```
+   *   val left = HashMap(1 -> 1, 2 -> 1)
+   *   val right = HashMap(2 -> 2, 3 -> 2)
+   *
+   *   val merged = left.merged(right){ case ((k0, v0), (k1, v1)) => (k0 + k1) -> (v0 + v1) }
+   *     // HashMap(1 -> 1, 3 -> 2, 4 -> 3)
+   *
+   *  ```
+   *
+   *  @param that the HashMap to merge this HashMap with
+   *  @param mergef the merge function which resolves collisions between the two HashMaps. If `mergef` is null, then
+   *               keys from `this` will overwrite keys from `that`, making the behaviour equivalent to
+   *               `that.concat(this)`
+   *
+   *  @note In cases where `mergef` returns keys which themselves collide with other keys returned by `merge`, or
+   *       found in `this` or `that`, it is not defined which value will be chosen. For example:
+   *
+   *       Colliding multiple results of merging:
+   *       ```
+   *         // key `3` collides between a result of merging keys `1` and `2`
+   *         val left = HashMap(1 -> 1, 2 -> 2)
+   *         val right = HashMap(1 -> 1, 2 -> 2)
+   *
+   *         val merged = left.merged(right){ case (_, (_, v1)) => 3 -> v1 }
+   *           // HashMap(3 -> 2) is returned, but it could also have returned HashMap(3 -> 1)
+   *       ```
+   *       Colliding results of merging with other keys:
+   *       ```
+   *         // key `2` collides between a result of merging `1`, and existing key `2`
+   *         val left = HashMap(1 -> 1, 2 -> 1)
+   *         val right = HashMap(1 -> 2)
+   *
+   *         val merged = left.merged(right)((_,_) => 2 -> 3)
+   *           // HashMap(2 -> 1) is returned, but it could also have returned HashMap(2 -> 3)
+   *       ```
+   *
+   */
   def merged[V1 >: V](that: HashMap[K, V1])(mergef: ((K, V), (K, V1)) => (K, V1)): HashMap[K, V1] =
     if (mergef == null) {
       that ++ this
@@ -554,18 +554,18 @@ private[immutable] sealed abstract class MapNode[K, +V] extends Node[MapNode[K, 
   def containsKey(key: K, originalHash: Int, hash: Int, shift: Int): Boolean
 
   /** Returns a MapNode with the passed key-value assignment added
-    *
-    * @param key the key to add to the MapNode
-    * @param value the value to associate with `key`
-    * @param originalHash the original hash of `key`
-    * @param hash the improved hash of `key`
-    * @param shift the shift of the node (distanceFromRoot * BitPartitionSize)
-    * @param replaceValue if true, then the value currently associated to `key` will be replaced with the passed value
-    *                     argument.
-    *                     if false, then the key will be inserted if not already present, however if the key is present
-    *                     then the passed value will not replace the current value. That is, if `false`, then this
-    *                     method has `update if not exists` semantics.
-    */
+   *
+   *  @param key the key to add to the MapNode
+   *  @param value the value to associate with `key`
+   *  @param originalHash the original hash of `key`
+   *  @param hash the improved hash of `key`
+   *  @param shift the shift of the node (distanceFromRoot * BitPartitionSize)
+   *  @param replaceValue if true, then the value currently associated to `key` will be replaced with the passed value
+   *                     argument.
+   *                     if false, then the key will be inserted if not already present, however if the key is present
+   *                     then the passed value will not replace the current value. That is, if `false`, then this
+   *                     method has `update if not exists` semantics.
+   */
   def updated[V1 >: V](key: K, value: V1, originalHash: Int, hash: Int, shift: Int, replaceValue: Boolean): MapNode[K, V1]
 
   def removed[V1 >: V](key: K, originalHash: Int, hash: Int, shift: Int): MapNode[K, V1]
@@ -603,17 +603,17 @@ private[immutable] sealed abstract class MapNode[K, +V] extends Node[MapNode[K, 
   def filterImpl(pred: ((K, V)) => Boolean, isFlipped: Boolean): MapNode[K, V]
 
   /** Merges this node with that node, adding each resulting tuple to `builder`
-    *
-    * `this` should be a node from `left` hashmap in `left.merged(right)(mergef)`
-    *
-    * @param that node from the "right" HashMap. Must also be at the same "path" or "position" within the right tree,
-    *             as `this` is, within the left tree
-    */
+   *
+   *  `this` should be a node from `left` hashmap in `left.merged(right)(mergef)`
+   *
+   *  @param that node from the "right" HashMap. Must also be at the same "path" or "position" within the right tree,
+   *             as `this` is, within the left tree
+   */
   def mergeInto[V1 >: V](that: MapNode[K, V1], builder: HashMapBuilder[K, V1], shift: Int)(mergef: ((K, V), (K, V1)) => (K, V1)): Unit
 
   /** Returns the exact (equal by reference) key, and value, associated to a given key.
-    * If the key is not bound to a value, then an exception is thrown
-    */
+   *  If the key is not bound to a value, then an exception is thrown
+   */
   def getTuple(key: K, originalHash: Int, hash: Int, shift: Int): (K, V)
 
   /** Adds all key-value pairs to a builder. */
@@ -775,25 +775,25 @@ private final class BitmapIndexedMapNode[K, +V](
   }
 
   /** A variant of `updated` which performs shallow mutations on the root (`this`), and if possible, on immediately
-    * descendant child nodes (only one level beneath `this`)
-    *
-    * The caller should pass a bitmap of child nodes of this node, which this method may mutate.
-    * If this method may mutate a child node, then if the updated key-value belongs in that child node, it will
-    * be shallowly mutated (its children will not be mutated).
-    *
-    * If instead this method may not mutate the child node in which the to-be-updated key-value pair belongs, then
-    * that child will be updated immutably, but the result will be mutably re-inserted as a child of this node.
-    *
-    * @param key the key to update
-    * @param value the value to set `key` to
-    * @param originalHash key.##
-    * @param keyHash the improved hash
-    * @param shallowlyMutableNodeMap bitmap of child nodes of this node, which can be shallowly mutated
-    *                                during the call to this method
-    *
-    * @return Int which is the bitwise OR of shallowlyMutableNodeMap and any freshly created nodes, which will be
-    *         available for mutations in subsequent calls.
-    */
+   *  descendant child nodes (only one level beneath `this`)
+   *
+   *  The caller should pass a bitmap of child nodes of this node, which this method may mutate.
+   *  If this method may mutate a child node, then if the updated key-value belongs in that child node, it will
+   *  be shallowly mutated (its children will not be mutated).
+   *
+   *  If instead this method may not mutate the child node in which the to-be-updated key-value pair belongs, then
+   *  that child will be updated immutably, but the result will be mutably re-inserted as a child of this node.
+   *
+   *  @param key the key to update
+   *  @param value the value to set `key` to
+   *  @param originalHash key.##
+   *  @param keyHash the improved hash
+   *  @param shallowlyMutableNodeMap bitmap of child nodes of this node, which can be shallowly mutated
+   *                                during the call to this method
+   *
+   *  @return Int which is the bitwise OR of shallowlyMutableNodeMap and any freshly created nodes, which will be
+   *         available for mutations in subsequent calls.
+   */
   def updateWithShallowMutations[V1 >: V](key: K, value: V1, originalHash: Int, keyHash: Int, shift: Int, shallowlyMutableNodeMap: Int): Int = {
     val mask = maskFrom(keyHash, shift)
     val bitpos = bitposFrom(mask)
@@ -1022,11 +1022,11 @@ private final class BitmapIndexedMapNode[K, +V](
   }
 
   /** Variant of `copyAndMigrateFromInlineToNode` which mutates `this` rather than returning a new node.
-    *
-    * @param bitpos the bit position of the data to migrate to node
-    * @param keyHash the improved hash of the key currently at `bitpos`
-    * @param node the node to place at `bitpos` beneath `this`
-    */
+   *
+   *  @param bitpos the bit position of the data to migrate to node
+   *  @param keyHash the improved hash of the key currently at `bitpos`
+   *  @param node the node to place at `bitpos` beneath `this`
+   */
   def migrateFromInlineToNodeInPlace[V1 >: V](bitpos: Int, keyHash: Int, node: MapNode[K, V1]): this.type = {
     val dataIx = dataIndex(bitpos)
     val idxOld = TupleLength * dataIx
@@ -2192,12 +2192,11 @@ private final class MapNodeRemoveAllSetNodeIterator[K](rootSetNode: SetNode[K]) 
   override def next(): K = Iterator.empty.next()
 }
 
-/**
-  * $factoryInfo
-  *
-  * @define Coll `immutable.HashMap`
-  * @define coll immutable champ hash map
-  */
+/** $factoryInfo
+ *
+ *  @define Coll `immutable.HashMap`
+ *  @define coll immutable champ hash map
+ */
 @SerialVersionUID(3L)
 object HashMap extends MapFactory[HashMap] {
 
@@ -2214,15 +2213,15 @@ object HashMap extends MapFactory[HashMap] {
     }
 
   /** Creates a new Builder which can be reused after calling `result()` without an
-    * intermediate call to `clear()` in order to build multiple related results.
-    */
+   *  intermediate call to `clear()` in order to build multiple related results.
+   */
   def newBuilder[K, V]: ReusableBuilder[(K, V), HashMap[K, V]] = new HashMapBuilder[K, V]
 }
 
 
 /** A `Builder` for a `HashMap`.
-  * $multipleResults
-  */
+ *  $multipleResults
+ */
 private[immutable] final class HashMapBuilder[K, V] extends ReusableBuilder[(K, V), HashMap[K, V]] {
   import MapNode._
   import Node._
@@ -2230,8 +2229,9 @@ private[immutable] final class HashMapBuilder[K, V] extends ReusableBuilder[(K, 
   private def newEmptyRootNode = new BitmapIndexedMapNode[K, V](0, 0, Array.emptyObjectArray.asInstanceOf[Array[Any]], Array.emptyIntArray, 0, 0)
 
   /** The last given out HashMap as a return value of `result()`, if any, otherwise null.
-    * Indicates that on next add, the elements should be copied to an identical structure, before continuing
-    * mutations. */
+   *  Indicates that on next add, the elements should be copied to an identical structure, before continuing
+   *  mutations. 
+   */
   @annotation.stableNull
   private var aliased: HashMap[K, V] | Null = compiletime.uninitialized
 

--- a/library/src/scala/collection/immutable/HashSet.scala
+++ b/library/src/scala/collection/immutable/HashSet.scala
@@ -28,12 +28,12 @@ import scala.runtime.Statics.releaseFence
 import scala.util.hashing.MurmurHash3
 
 /** This class implements immutable sets using a Compressed Hash-Array Mapped Prefix-tree.
-  * See paper https://michael.steindorfer.name/publications/oopsla15.pdf for more details.
-  *
-  *  @tparam A      the type of the elements contained in this hash set.
-  *  @define Coll `immutable.HashSet`
-  *  @define coll immutable champ hash set
-  */
+ *  See paper https://michael.steindorfer.name/publications/oopsla15.pdf for more details.
+ *
+ *  @tparam A      the type of the elements contained in this hash set.
+ *  @define Coll `immutable.HashSet`
+ *  @define coll immutable champ hash set
+ */
 final class HashSet[A] private[immutable](private[immutable] val rootNode: BitmapIndexedSetNode[A])
   extends AbstractSet[A]
     with StrictOptimizedSetOps[A, HashSet, HashSet[A]]
@@ -190,7 +190,8 @@ final class HashSet[A] private[immutable](private[immutable] val rootNode: Bitma
   @`inline` private[collection] def foreachWithHash(f: (A, Int) => Unit): Unit = rootNode.foreachWithHash(f)
 
   /** Applies a function f to each element, and its corresponding **original** hash, in this Set
-    * Stops iterating the first time that f returns `false`.*/
+   *  Stops iterating the first time that f returns `false`.
+   */
   @`inline` private[collection] def foreachWithHashWhile(f: (A, Int) => Boolean): Unit = rootNode.foreachWithHashWhile(f)
 
   // For binary compatibility, the method used to have this signature by mistake.
@@ -274,11 +275,11 @@ final class HashSet[A] private[immutable](private[immutable] val rootNode: Bitma
   }
 
   /** Immutably removes all elements of `that` from this HashSet
-    *
-    * Mutation is used internally, but only on root SetNodes which this method itself creates.
-    *
-    * That is, this method is safe to call on published sets because it does not mutate `this`
-    */
+   *
+   *  Mutation is used internally, but only on root SetNodes which this method itself creates.
+   *
+   *  That is, this method is safe to call on published sets because it does not mutate `this`
+   */
   private def removedAllWithShallowMutations(that: IterableOnce[A]^): HashSet[A] = {
     val iter = that.iterator
     var curr = rootNode
@@ -521,24 +522,24 @@ private final class BitmapIndexedSetNode[A](
     copyAndInsertValue(bitpos, element, originalHash, elementHash)
   }
   /** A variant of `updated` which performs shallow mutations on the root (`this`), and if possible, on immediately
-    * descendant child nodes (only one level beneath `this`)
-    *
-    * The caller should pass a bitmap of child nodes of this node, which this method may mutate.
-    * If this method may mutate a child node, then if the updated value is located in that child node, it will
-    * be shallowly mutated (its children will not be mutated).
-    *
-    * If instead this method may not mutate the child node in which the to-be-updated value is located, then
-    * that child will be updated immutably, but the result will be mutably re-inserted as a child of this node.
-    *
-    * @param key the key to update
-    * @param originalHash key.##
-    * @param keyHash the improved hash
-    * @param shallowlyMutableNodeMap bitmap of child nodes of this node, which can be shallowly mutated
-    *                                during the call to this method
-    *
-    * @return Int which is the bitwise OR of shallowlyMutableNodeMap and any freshly created nodes, which will be
-    *         available for mutations in subsequent calls.
-    */
+   *  descendant child nodes (only one level beneath `this`)
+   *
+   *  The caller should pass a bitmap of child nodes of this node, which this method may mutate.
+   *  If this method may mutate a child node, then if the updated value is located in that child node, it will
+   *  be shallowly mutated (its children will not be mutated).
+   *
+   *  If instead this method may not mutate the child node in which the to-be-updated value is located, then
+   *  that child will be updated immutably, but the result will be mutably re-inserted as a child of this node.
+   *
+   *  @param key the key to update
+   *  @param originalHash key.##
+   *  @param keyHash the improved hash
+   *  @param shallowlyMutableNodeMap bitmap of child nodes of this node, which can be shallowly mutated
+   *                                during the call to this method
+   *
+   *  @return Int which is the bitwise OR of shallowlyMutableNodeMap and any freshly created nodes, which will be
+   *         available for mutations in subsequent calls.
+   */
   def updateWithShallowMutations(element: A, originalHash: Int, elementHash: Int, shift: Int, shallowlyMutableNodeMap: Int): Int = {
     val mask = maskFrom(elementHash, shift)
     val bitpos = bitposFrom(mask)
@@ -646,14 +647,14 @@ private final class BitmapIndexedSetNode[A](
     else this
   }
   /** Variant of `removed` which will perform mutation on only the top-level node (`this`), rather than return a new
-    * node
-    *
-    * Should only be called on root nodes, because shift is assumed to be 0
-    *
-    * @param element the element to remove
-    * @param originalHash the original hash of `element`
-    * @param elementHash the improved hash of `element`
-    */
+   *  node
+   *
+   *  Should only be called on root nodes, because shift is assumed to be 0
+   *
+   *  @param element the element to remove
+   *  @param originalHash the original hash of `element`
+   *  @param elementHash the improved hash of `element`
+   */
   def removeWithShallowMutations(element: A, originalHash: Int, elementHash: Int): this.type = {
     val mask = maskFrom(elementHash, 0)
     val bitpos = bitposFrom(mask)
@@ -865,17 +866,17 @@ private final class BitmapIndexedSetNode[A](
     )
   }
   /** Variant of `copyAndMigrateFromInlineToNode` which mutates `this` rather than returning a new node.
-    *
-    * Note: This method will mutate `this`, and will mutate `this.content`
-    *
-    * Mutation of `this.content` will occur as an optimization not possible in maps. Since TupleLength == 1 for sets,
-    * content array size does not change during inline <-> node migrations. Therefor, since we are updating in-place,
-    * we reuse this.content by shifting data/nodes around, rather than allocating a new array.
-    *
-    * @param bitpos the bit position of the data to migrate to node
-    * @param keyHash the improved hash of the element currently at `bitpos`
-    * @param node the node to place at `bitpos`
-    */
+   *
+   *  Note: This method will mutate `this`, and will mutate `this.content`
+   *
+   *  Mutation of `this.content` will occur as an optimization not possible in maps. Since TupleLength == 1 for sets,
+   *  content array size does not change during inline <-> node migrations. Therefor, since we are updating in-place,
+   *  we reuse this.content by shifting data/nodes around, rather than allocating a new array.
+   *
+   *  @param bitpos the bit position of the data to migrate to node
+   *  @param keyHash the improved hash of the element currently at `bitpos`
+   *  @param node the node to place at `bitpos`
+   */
   def migrateFromInlineToNodeInPlace(bitpos: Int, keyHash: Int, node: SetNode[A]): this.type = {
     val dataIx = dataIndex(bitpos)
     val idxOld = TupleLength * dataIx
@@ -920,17 +921,17 @@ private final class BitmapIndexedSetNode[A](
   }
 
   /** Variant of `copyAndMigrateFromNodeToInline` which mutates `this` rather than returning a new node.
-    *
-    * Note: This method will mutate `this`, and will mutate `this.content`
-    *
-    * Mutation of `this.content` will occur as an optimization not possible in maps. Since TupleLength == 1 for sets,
-    * content array size does not change during inline <-> node migrations. Therefor, since we are updating in-place,
-    * we reuse this.content by shifting data/nodes around, rather than allocating a new array.
-    *
-    * @param bitpos the bit position of the node to migrate inline
-    * @param oldNode the node currently stored at position `bitpos`
-    * @param node the node containing the single element to migrate inline
-    */
+   *
+   *  Note: This method will mutate `this`, and will mutate `this.content`
+   *
+   *  Mutation of `this.content` will occur as an optimization not possible in maps. Since TupleLength == 1 for sets,
+   *  content array size does not change during inline <-> node migrations. Therefor, since we are updating in-place,
+   *  we reuse this.content by shifting data/nodes around, rather than allocating a new array.
+   *
+   *  @param bitpos the bit position of the node to migrate inline
+   *  @param oldNode the node currently stored at position `bitpos`
+   *  @param node the node containing the single element to migrate inline
+   */
   def migrateFromNodeToInlineInPlace(bitpos: Int, originalHash: Int, elementHash: Int, oldNode: SetNode[A], node: SetNode[A]): Unit = {
     val idxOld = this.content.length - 1 - nodeIndex(bitpos)
     val dataIxNew = dataIndex(bitpos)
@@ -1302,23 +1303,23 @@ private final class BitmapIndexedSetNode[A](
   }
 
   /** Utility method only for use in `diff` and `filterImpl`
-    *
-    * @param newSize the size of the new SetNode
-    * @param newDataMap the dataMap of the new SetNode
-    * @param newNodeMap the nodeMap of the new SetNode
-    * @param minimumIndex the minimum index (in range of [0, 31]) for which there are sub-nodes or data beneath the new
-    *                     SetNode
-    * @param oldDataPassThrough bitmap representing all the data that are just passed from `this` to the new
-    *                           SetNode
-    * @param nodesToPassThroughMap bitmap representing all nodes that are just passed from `this` to the new SetNode
-    * @param nodeMigrateToDataTargetMap bitmap representing all positions which will now be data in the new SetNode,
-    *                                   but which were nodes in `this`
-    * @param nodesToMigrateToData a queue (in order of child position) of single-element nodes, which will be migrated
-    *                             to data, in positions in the `nodeMigrateToDataTargetMap`
-    * @param mapOfNewNodes bitmap of positions of new nodes to include in the new SetNode
-    * @param newNodes  queue in order of child position, of all new nodes to include in the new SetNode
-    * @param newCachedHashCode the cached java keyset hashcode of the new SetNode
-    */
+   *
+   *  @param newSize the size of the new SetNode
+   *  @param newDataMap the dataMap of the new SetNode
+   *  @param newNodeMap the nodeMap of the new SetNode
+   *  @param minimumIndex the minimum index (in range of [0, 31]) for which there are sub-nodes or data beneath the new
+   *                     SetNode
+   *  @param oldDataPassThrough bitmap representing all the data that are just passed from `this` to the new
+   *                           SetNode
+   *  @param nodesToPassThroughMap bitmap representing all nodes that are just passed from `this` to the new SetNode
+   *  @param nodeMigrateToDataTargetMap bitmap representing all positions which will now be data in the new SetNode,
+   *                                   but which were nodes in `this`
+   *  @param nodesToMigrateToData a queue (in order of child position) of single-element nodes, which will be migrated
+   *                             to data, in positions in the `nodeMigrateToDataTargetMap`
+   *  @param mapOfNewNodes bitmap of positions of new nodes to include in the new SetNode
+   *  @param newNodes  queue in order of child position, of all new nodes to include in the new SetNode
+   *  @param newCachedHashCode the cached java keyset hashcode of the new SetNode
+   */
   private def newNodeFrom(
     newSize: Int,
     newDataMap: Int,
@@ -1754,13 +1755,12 @@ private final class HashCollisionSetNode[A](val originalHash: Int, val hash: Int
       new HashCollisionSetNode[A](originalHash, hash, content.appended(element))
     }
 
-  /**
-    * Removes an element from the hash collision node.
-    *
-    * When after deletion only one element remains, we return a bit-mapped indexed node with a
-    * singleton element and a hash-prefix for trie level 0. This node will be then a) either become
-    * the new root, or b) unwrapped and inlined deeper in the trie.
-    */
+  /** Removes an element from the hash collision node.
+   *
+   *  When after deletion only one element remains, we return a bit-mapped indexed node with a
+   *  singleton element and a hash-prefix for trie level 0. This node will be then a) either become
+   *  the new root, or b) unwrapped and inlined deeper in the trie.
+   */
   def removed(element: A, originalHash: Int, hash: Int, shift: Int): SetNode[A] =
     if (!this.contains(element, originalHash, hash, shift)) {
       this
@@ -1924,12 +1924,11 @@ private final class SetHashIterator[A](rootNode: SetNode[A])
 }
 
 
-/**
-  * $factoryInfo
-  *
-  * @define Coll `immutable.HashSet`
-  * @define coll immutable champ hash set
-  */
+/** $factoryInfo
+ *
+ *  @define Coll `immutable.HashSet`
+ *  @define coll immutable champ hash set
+ */
 @SerialVersionUID(3L)
 object HashSet extends IterableFactory[HashSet] {
 
@@ -1947,14 +1946,14 @@ object HashSet extends IterableFactory[HashSet] {
     }
 
   /** Creates a new Builder which can be reused after calling `result()` without an
-    * intermediate call to `clear()` in order to build multiple related results.
-    */
+   *  intermediate call to `clear()` in order to build multiple related results.
+   */
   def newBuilder[A]: ReusableBuilder[A, HashSet[A]] = new HashSetBuilder
 }
 
 /** Builder for HashSet.
-  * $multipleResults
-  */
+ *  $multipleResults
+ */
 private[collection] final class HashSetBuilder[A] extends ReusableBuilder[A, HashSet[A]] {
   import Node._
   import SetNode._
@@ -1962,8 +1961,9 @@ private[collection] final class HashSetBuilder[A] extends ReusableBuilder[A, Has
   private def newEmptyRootNode = new BitmapIndexedSetNode[A](0, 0, Array.emptyObjectArray.asInstanceOf[Array[Any]], Array.emptyIntArray, 0, 0)
 
   /** The last given out HashSet as a return value of `result()`, if any, otherwise null.
-    * Indicates that on next add, the elements should be copied to an identical structure, before continuing
-    * mutations. */
+   *  Indicates that on next add, the elements should be copied to an identical structure, before continuing
+   *  mutations. 
+   */
   @annotation.stableNull
   private var aliased: HashSet[A] | Null = null
 

--- a/library/src/scala/collection/immutable/IntMap.scala
+++ b/library/src/scala/collection/immutable/IntMap.scala
@@ -22,8 +22,7 @@ import scala.annotation.tailrec
 import scala.annotation.unchecked.uncheckedVariance
 import scala.language.implicitConversions
 
-/** Utility class for integer maps.
-  */
+/** Utility class for integer maps. */
 private[immutable] object IntMapUtils extends BitOperations.Int {
   def branchMask(i: Int, j: Int) = highestOneBit(i ^ j)
 
@@ -44,9 +43,9 @@ private[immutable] object IntMapUtils extends BitOperations.Int {
 import IntMapUtils.{Int => _, _}
 
 /** A companion object for integer maps.
-  *
-  *  @define Coll  `IntMap`
-  */
+ *
+ *  @define Coll  `IntMap`
+ */
 object IntMap {
   def empty[T] : IntMap[T]  = IntMap.Nil
 
@@ -127,9 +126,7 @@ private[immutable] abstract class IntMapIterator[V, T](it: IntMap[V]) extends Ab
   }
   push(it)
 
-  /**
-    * What value do we assign to a tip?
-    */
+  /** What value do we assign to a tip? */
   def valueOf(tip: IntMap.Tip[V]): T
 
   def hasNext = index != 0
@@ -167,18 +164,18 @@ private[immutable] class IntMapKeyIterator[V](it: IntMap[V]) extends IntMapItera
 import IntMap._
 
 /** Specialised immutable map structure for integer keys, based on
-  *  [[https://ittc.ku.edu/~andygill/papers/IntMap98.pdf Fast Mergeable Integer Maps]]
-  *  by Okasaki and Gill. Essentially a trie based on binary digits of the integers.
-  *
-  *  '''Note:''' This class is as of 2.8 largely superseded by HashMap.
-  *
-  *  @tparam T    type of the values associated with integer keys.
-  *
-  *  @define Coll `immutable.IntMap`
-  *  @define coll immutable integer map
-  *  @define mayNotTerminateInf
-  *  @define willNotTerminateInf
-  */
+ *  [Fast Mergeable Integer Maps](https://ittc.ku.edu/~andygill/papers/IntMap98.pdf)
+ *  by Okasaki and Gill. Essentially a trie based on binary digits of the integers.
+ *
+ *  **Note:** This class is as of 2.8 largely superseded by HashMap.
+ *
+ *  @tparam T    type of the values associated with integer keys.
+ *
+ *  @define Coll `immutable.IntMap`
+ *  @define coll immutable integer map
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
 sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
   with StrictOptimizedMapOps[Int, T, Map, IntMap[T]]
   with Serializable {
@@ -204,19 +201,16 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     buffer.toList
   }
 
-  /**
-    * Iterator over key, value pairs of the map in unsigned order of the keys.
-    *
-    * @return an iterator over pairs of integer keys and corresponding values.
-    */
+  /** Iterator over key, value pairs of the map in unsigned order of the keys.
+   *
+   *  @return an iterator over pairs of integer keys and corresponding values.
+   */
   def iterator: Iterator[(Int, T)] = this match {
     case IntMap.Nil => Iterator.empty
     case _ => new IntMapEntryIterator(this)
   }
 
-  /**
-    * Loops over the key, value pairs of the map in unsigned order of the keys.
-    */
+  /** Loops over the key, value pairs of the map in unsigned order of the keys. */
   override final def foreach[U](f: ((Int, T)) => U): Unit = this match {
     case IntMap.Bin(_, _, left, right) => { left.foreach(f); right.foreach(f) }
     case IntMap.Tip(key, value) => f((key, value))
@@ -234,12 +228,11 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case _ => new IntMapKeyIterator(this)
   }
 
-  /**
-    * Loop over the keys of the map. The same as `keys.foreach(f)`, but may
-    * be more efficient.
-    *
-    * @param f The loop body
-    */
+  /** Loop over the keys of the map. The same as `keys.foreach(f)`, but may
+   *  be more efficient.
+   *
+   *  @param f The loop body
+   */
   final def foreachKey[U](f: Int => U): Unit = this match {
     case IntMap.Bin(_, _, left, right) => { left.foreachKey(f); right.foreachKey(f) }
     case IntMap.Tip(key, _) => f(key)
@@ -251,12 +244,11 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case _ => new IntMapValueIterator(this)
   }
 
-  /**
-    * Loop over the values of the map. The same as `values.foreach(f)`, but may
-    * be more efficient.
-    *
-    * @param f The loop body
-    */
+  /** Loop over the values of the map. The same as `values.foreach(f)`, but may
+   *  be more efficient.
+   *
+   *  @param f The loop body
+   */
   final def foreachValue[U](f: T => U): Unit = this match {
     case IntMap.Bin(_, _, left, right) => { left.foreachValue(f); right.foreachValue(f) }
     case IntMap.Tip(_, value) => f(value)
@@ -338,23 +330,22 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
   def collect[V2](pf: PartialFunction[(Int, T), (Int, V2)]): IntMap[V2] =
     strictOptimizedCollect(IntMap.newBuilder[V2], pf)
 
-  /**
-    * Updates the map, using the provided function to resolve conflicts if the key is already present.
-    *
-    * Equivalent to:
-    * {{{
-    *   this.get(key) match {
-    *     case None => this.update(key, value)
-    *     case Some(oldvalue) => this.update(key, f(oldvalue, value)
-    *   }
-    * }}}
-    *
-    * @tparam S     The supertype of values in this `LongMap`.
-    * @param key    The key to update
-    * @param value  The value to use if there is no conflict
-    * @param f      The function used to resolve conflicts.
-    * @return       The updated map.
-    */
+  /** Updates the map, using the provided function to resolve conflicts if the key is already present.
+   *
+   *  Equivalent to:
+   *  ```
+   *   this.get(key) match {
+   *     case None => this.update(key, value)
+   *     case Some(oldvalue) => this.update(key, f(oldvalue, value)
+   *   }
+   *  ```
+   *
+   *  @tparam S     The supertype of values in this `LongMap`.
+   *  @param key    The key to update
+   *  @param value  The value to use if there is no conflict
+   *  @param f      The function used to resolve conflicts.
+   *  @return       The updated map.
+   */
   def updateWith[S >: T](key: Int, value: S, f: (T, S) => S): IntMap[S] = this match {
     case IntMap.Bin(prefix, mask, left, right) =>
       if (!hasMatch(key, prefix, mask)) join(key, IntMap.Tip(key, value), prefix, this)
@@ -377,15 +368,14 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case IntMap.Nil => IntMap.Nil
   }
 
-  /**
-    * A combined transform and filter function. Returns an `IntMap` such that
-    * for each `(key, value)` mapping in this map, if `f(key, value) == None`
-    * the map contains no mapping for key, and if `f(key, value)`.
-    *
-    * @tparam S  The type of the values in the resulting `LongMap`.
-    * @param f   The transforming function.
-    * @return    The modified map.
-    */
+  /** A combined transform and filter function. Returns an `IntMap` such that
+   *  for each `(key, value)` mapping in this map, if `f(key, value) == None`
+   *  the map contains no mapping for key, and if `f(key, value)`.
+   *
+   *  @tparam S  The type of the values in the resulting `LongMap`.
+   *  @param f   The transforming function.
+   *  @return    The modified map.
+   */
   def modifyOrRemove[S](f: (Int, T) => Option[S]): IntMap[S] = this match {
     case IntMap.Bin(prefix, mask, left, right) =>
       val newleft = left.modifyOrRemove(f)
@@ -404,14 +394,13 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
       IntMap.Nil
   }
 
-  /**
-    * Forms a union map with that map, using the combining function to resolve conflicts.
-    *
-    * @tparam S      The type of values in `that`, a supertype of values in `this`.
-    * @param that    The map to form a union with.
-    * @param f       The function used to resolve conflicts between two mappings.
-    * @return        Union of `this` and `that`, with identical key conflicts resolved using the function `f`.
-    */
+  /** Forms a union map with that map, using the combining function to resolve conflicts.
+   *
+   *  @tparam S      The type of values in `that`, a supertype of values in `this`.
+   *  @param that    The map to form a union with.
+   *  @param f       The function used to resolve conflicts between two mappings.
+   *  @return        Union of `this` and `that`, with identical key conflicts resolved using the function `f`.
+   */
   def unionWith[S >: T](that: IntMap[S], f: (Int, S, S) => S): IntMap[S] = (this, that) match{
     case (IntMap.Bin(p1, m1, l1, r1), that@(IntMap.Bin(p2, m2, l2, r2))) =>
       if (shorter(m1, m2)) {
@@ -433,17 +422,16 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case (x, IntMap.Nil) => x
   }
 
-  /**
-    * Forms the intersection of these two maps with a combining function. The
-    * resulting map is a map that has only keys present in both maps and has
-    * values produced from the original mappings by combining them with `f`.
-    *
-    * @tparam S      The type of values in `that`.
-    * @tparam R      The type of values in the resulting `LongMap`.
-    * @param that    The map to intersect with.
-    * @param f       The combining function.
-    * @return        Intersection of `this` and `that`, with values for identical keys produced by function `f`.
-    */
+  /** Forms the intersection of these two maps with a combining function. The
+   *  resulting map is a map that has only keys present in both maps and has
+   *  values produced from the original mappings by combining them with `f`.
+   *
+   *  @tparam S      The type of values in `that`.
+   *  @tparam R      The type of values in the resulting `LongMap`.
+   *  @param that    The map to intersect with.
+   *  @param f       The combining function.
+   *  @return        Intersection of `this` and `that`, with values for identical keys produced by function `f`.
+   */
   def intersectionWith[S, R](that: IntMap[S], f: (Int, T, S) => R): IntMap[R] = (this, that) match {
     case (IntMap.Bin(p1, m1, l1, r1), that@IntMap.Bin(p2, m2, l2, r2)) =>
       if (shorter(m1, m2)) {
@@ -467,23 +455,20 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case (_, _) => IntMap.Nil
   }
 
-  /**
-    * Left biased intersection. Returns the map that has all the same mappings
-    * as this but only for keys which are present in the other map.
-    *
-    * @tparam R      The type of values in `that`.
-    * @param that    The map to intersect with.
-    * @return        A map with all the keys both in `this` and `that`, mapped to corresponding values from `this`.
-    */
+  /** Left biased intersection. Returns the map that has all the same mappings
+   *  as this but only for keys which are present in the other map.
+   *
+   *  @tparam R      The type of values in `that`.
+   *  @param that    The map to intersect with.
+   *  @return        A map with all the keys both in `this` and `that`, mapped to corresponding values from `this`.
+   */
   def intersection[R](that: IntMap[R]): IntMap[T] =
     this.intersectionWith(that, (key: Int, value: T, value2: R) => value)
 
   def ++[S >: T](that: IntMap[S]) =
     this.unionWith[S](that, (key, x, y) => y)
 
-  /**
-    * The entry with the lowest key value considered in unsigned order.
-    */
+  /** The entry with the lowest key value considered in unsigned order. */
   @tailrec
   final def firstKey: Int = this match {
     case Bin(_, _, l, r) => l.firstKey
@@ -491,9 +476,7 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case IntMap.Nil => throw new IllegalStateException("Empty set")
   }
 
-  /**
-    * The entry with the highest key value considered in unsigned order.
-    */
+  /** The entry with the highest key value considered in unsigned order. */
   @tailrec
   final def lastKey: Int = this match {
     case Bin(_, _, l, r) => r.lastKey

--- a/library/src/scala/collection/immutable/LazyList.scala
+++ b/library/src/scala/collection/immutable/LazyList.scala
@@ -24,244 +24,244 @@ import scala.collection.mutable.{Builder, ReusableBuilder, StringBuilder}
 import scala.language.implicitConversions
 import scala.runtime.Statics
 
-/**  This class implements an immutable linked list. We call it "lazy"
-  *  because it computes its elements only when they are needed.
-  *
-  *  Elements are memoized; that is, the value of each element is computed at most once.
-  *
-  *  Elements are computed in order and are never skipped.
-  *  As a consequence, accessing the tail causes the head to be computed first.
-  *
-  *  How lazy is a `LazyList`? When you have a value of type `LazyList`, you
-  *  don't know yet whether the list is empty.
-  *  We say that it is lazy in its head.
-  *  If you have tested that it is non-empty,
-  *  then you also know that the head has been computed.
-  *
-  *  It is also lazy in its tail, which is also a `LazyList`.
-  *  You don't know whether the tail is empty until it is "forced", which is to say,
-  *  until an element of the tail is computed.
-  *
-  *  These important properties of `LazyList` depend on its construction using `#::` (or `#:::`).
-  *  That operator is analogous to the "cons" of a strict `List`, `::`.
-  *  It is "right-associative", so that the collection goes on the "right",
-  *  and the element on the left of the operator is prepended to the collection.
-  *  However, unlike the cons of a strict `List`, `#::` is lazy in its parameter,
-  *  which is the element prepended to the left, and also lazy in its right-hand side,
-  *  which is the `LazyList` being prepended to.
-  *  (That is accomplished by implicitly wrapping the `LazyList`, as shown in the Scaladoc.)
-  *
-  *  Other combinators from the collections API do not preserve this laziness.
-  *  In particular, `++`, or `concat`, is "eager" or "strict" in its parameter
-  *  and should not be used to compose `LazyList`s.
-  *
-  *  A `LazyList` may be infinite. For example, `LazyList.from(0)` contains
-  *  all of the natural numbers `0`, `1`, `2`, ... For infinite sequences,
-  *  some methods (such as `count`, `sum`, `max` or `min`) will not terminate.
-  *
-  *  Here is an example showing the Fibonacci sequence,
-  *  which may be evaluated to an arbitrary number of elements:
-  *
-  *  {{{
-  *  import scala.math.BigInt
-  *  val fibs: LazyList[BigInt] =
-  *    BigInt(0) #:: BigInt(1) #:: fibs.zip(fibs.tail).map(n => n._1 + n._2)
-  *  println {
-  *    fibs.take(5).mkString(", ")
-  *  }
-  *  // prints: 0, 1, 1, 2, 3
-  *  }}}
-  *
-  *  To illustrate, let's add some output to the definition `fibs`, so we
-  *  see what's going on.
-  *
-  *  {{{
-  *  import scala.math.BigInt
-  *  import scala.util.chaining._
-  *  val fibs: LazyList[BigInt] =
-  *    BigInt(0) #:: BigInt(1) #::
-  *      fibs.zip(fibs.tail).map(n => (n._1 + n._2)
-  *      .tap(sum => println(s"Adding ${n._1} and ${n._2} => $sum")))
-  *  fibs.take(5).foreach(println)
-  *  fibs.take(6).foreach(println)
-  *
-  *  // prints
-  *  //
-  *  // 0
-  *  // 1
-  *  // Adding 0 and 1 => 1
-  *  // 1
-  *  // Adding 1 and 1 => 2
-  *  // 2
-  *  // Adding 1 and 2 => 3
-  *  // 3
-  *
-  *  // And then prints
-  *  //
-  *  // 0
-  *  // 1
-  *  // 1
-  *  // 2
-  *  // 3
-  *  // Adding 2 and 3 => 5
-  *  // 5
-  *  }}}
-  *
-  *  Note that the definition of `fibs` uses `val` not `def`.
-  *  Memoization of the `LazyList` requires us to retain a reference to the computed values.
-  *
-  *  `LazyList` is considered an immutable data structure, even though its elements are computed on demand.
-  *  Once the values are memoized they do not change.
-  *  Moreover, the `LazyList` itself is defined once and references to it are interchangeable.
-  *  Values that have yet to be memoized still "exist"; they simply haven't been computed yet.
-  *
-  *  Memoization can be a source of memory leaks and must be used with caution.
-  *  It avoids recomputing elements of the list, but if a reference to the head
-  *  is retained unintentionally, then all elements will be retained.
-  *
-  *  The caveat that all elements are computed in order means
-  *  that some operations, such as [[drop]], [[dropWhile]], [[flatMap]] or [[collect]],
-  *  may process a large number of intermediate elements before returning.
-  *
-  *  Here's an example that illustrates these behaviors.
-  *  Let's begin with an iteration of the natural numbers.
-  *
-  *  {{{
-  *  // We'll start with a silly iteration
-  *  def loop(s: String, i: Int, iter: Iterator[Int]): Unit = {
-  *    // Stop after 200,000
-  *    if (i < 200001) {
-  *      if (i % 50000 == 0) println(s + i)
-  *      loop(s, iter.next(), iter)
-  *    }
-  *  }
-  *
-  *  // Our first LazyList definition will be a val definition
-  *  val lazylist1: LazyList[Int] = {
-  *    def loop(v: Int): LazyList[Int] = v #:: loop(v + 1)
-  *    loop(0)
-  *  }
-  *
-  *  // Because lazylist1 is a val, everything that the iterator produces is held
-  *  // by virtue of the fact that the head of the LazyList is held in lazylist1
-  *  val it1 = lazylist1.iterator
-  *  loop("Iterator1: ", it1.next(), it1)
-  *
-  *  // We can redefine this LazyList such that we retain only a reference to its Iterator.
-  *  // That allows the LazyList to be garbage collected.
-  *  // Using `def` to produce the LazyList in a method ensures
-  *  // that no val is holding onto the head, as with lazylist1.
-  *  def lazylist2: LazyList[Int] = {
-  *    def loop(v: Int): LazyList[Int] = v #:: loop(v + 1)
-  *    loop(0)
-  *  }
-  *  val it2 = lazylist2.iterator
-  *  loop("Iterator2: ", it2.next(), it2)
-  *
-  *  // And, of course, we don't actually need a LazyList at all for such a simple
-  *  // problem.  There's no reason to use a LazyList if you don't actually need
-  *  // one.
-  *  val it3 = new Iterator[Int] {
-  *    var i = -1
-  *    def hasNext = true
-  *    def next(): Int = { i += 1; i }
-  *  }
-  *  loop("Iterator3: ", it3.next(), it3)
-  *  }}}
-  *
-  *  In the `fibs` example earlier, the fact that `tail` works at all is of interest.
-  *  `fibs` has an initial `(0, 1, LazyList(...))`, so `tail` is deterministic.
-  *  If we defined `fibs` such that only `0` were concretely known, then the act
-  *  of determining `tail` would require the evaluation of `tail`, so the
-  *  computation would be unable to progress, as in this code:
-  *  {{{
-  *  // The first time we try to access the tail we're going to need more
-  *  // information which will require us to recurse, which will require us to
-  *  // recurse, which...
-  *  lazy val sov: LazyList[Vector[Int]] = Vector(0) #:: sov.zip(sov.tail).map { n => n._1 ++ n._2 }
-  *  }}}
-  *
-  *  The definition of `fibs` above creates a larger number of objects than
-  *  necessary depending on how you might want to implement it.  The following
-  *  implementation provides a more "cost effective" implementation due to the
-  *  fact that it has a more direct route to the numbers themselves:
-  *
-  *  {{{
-  *  lazy val fib: LazyList[Int] = {
-  *    def loop(h: Int, n: Int): LazyList[Int] = h #:: loop(n, h + n)
-  *    loop(1, 1)
-  *  }
-  *  }}}
-  *
-  *  The head, the tail and whether the list is empty is initially unknown.
-  *  Once any of those are evaluated, they are all known, though if the tail is
-  *  built with `#::` or `#:::`, its content still isn't evaluated. Instead, evaluating
-  *  the tail's content is deferred until the tail's empty status, head or tail is
-  *  evaluated.
-  *
-  *  Delaying the evaluation of whether a LazyList is empty until it's needed
-  *  allows LazyList to not eagerly evaluate any elements on a call to `filter`.
-  *
-  *  Only when it's further evaluated (which may be never!) do any of the elements get forced.
-  *
-  *  For example:
-  *
-  *  {{{
-  *  def tailWithSideEffect: LazyList[Nothing] = {
-  *    println("getting empty LazyList")
-  *    LazyList.empty
-  *  }
-  *
-  *  val emptyTail = tailWithSideEffect // prints "getting empty LazyList"
-  *
-  *  val suspended = 1 #:: tailWithSideEffect // doesn't print anything
-  *  val tail = suspended.tail // although the tail is evaluated, *still* nothing is yet printed
-  *  val filtered = tail.filter(_ => false) // still nothing is printed
-  *  filtered.isEmpty // prints "getting empty LazyList"
-  *  }}}
-  *
-  *  ----
-  *
-  *  You may sometimes encounter an exception like the following:
-  *
-  *  {{{
-  *  java.lang.RuntimeException: "LazyList evaluation depends on its own result (self-reference); see docs for more info
-  *  }}}
-  *
-  *  This exception occurs when a `LazyList` is attempting to derive its next element
-  *  from itself, and is attempting to read the element currently being evaluated.
-  *  As a trivial example:
-  *
-  *  {{{
-  *  lazy val a: LazyList[Int] = 1 #:: 2 #:: a.filter(_ > 2)
-  *  }}}
-  *
-  *  When attempting to evaluate the third element of `a`, it will skip the first two
-  *  elements and read the third, but that element is already being evaluated. This is
-  *  often caused by a subtle logic error; in this case, using `>=` in the `filter`
-  *  would fix the error.
-  *
-  *  @tparam A    the type of the elements contained in this lazy list.
-  *
-  *  @see [[https://docs.scala-lang.org/overviews/collections-2.13/concrete-immutable-collection-classes.html#lazylists "Scala's Collection Library overview"]]
-  *  section on `LazyLists` for a summary.
-  *  @define Coll `LazyList`
-  *  @define coll lazy list
-  *  @define orderDependent
-  *  @define orderDependentFold
-  *  @define appendStackSafety Note: Repeated chaining of calls to append methods (`appended`,
-  *                            `appendedAll`, `lazyAppendedAll`) without forcing any of the
-  *                            intermediate resulting lazy lists may overflow the stack when
-  *                            the final result is forced.
-  *  @define preservesLaziness This method preserves laziness; elements are only evaluated
-  *                            individually as needed.
-  *  @define initiallyLazy This method does not evaluate anything until an operation is performed
-  *                        on the result (e.g. calling `head` or `tail`, or checking if it is empty).
-  *  @define evaluatesAllElements This method evaluates all elements of the collection.
-  *  @note Under Capture Checking, LazyList is unsound with regards to lazy/strict separation of collections.
-  *        LazyList as-is will not be capture checked and might be deprecated in the future.
-  *        Use LazyListIterable instead.
-  */
+/** This class implements an immutable linked list. We call it "lazy"
+ *  because it computes its elements only when they are needed.
+ *
+ *  Elements are memoized; that is, the value of each element is computed at most once.
+ *
+ *  Elements are computed in order and are never skipped.
+ *  As a consequence, accessing the tail causes the head to be computed first.
+ *
+ *  How lazy is a `LazyList`? When you have a value of type `LazyList`, you
+ *  don't know yet whether the list is empty.
+ *  We say that it is lazy in its head.
+ *  If you have tested that it is non-empty,
+ *  then you also know that the head has been computed.
+ *
+ *  It is also lazy in its tail, which is also a `LazyList`.
+ *  You don't know whether the tail is empty until it is "forced", which is to say,
+ *  until an element of the tail is computed.
+ *
+ *  These important properties of `LazyList` depend on its construction using `#::` (or `#:::`).
+ *  That operator is analogous to the "cons" of a strict `List`, `::`.
+ *  It is "right-associative", so that the collection goes on the "right",
+ *  and the element on the left of the operator is prepended to the collection.
+ *  However, unlike the cons of a strict `List`, `#::` is lazy in its parameter,
+ *  which is the element prepended to the left, and also lazy in its right-hand side,
+ *  which is the `LazyList` being prepended to.
+ *  (That is accomplished by implicitly wrapping the `LazyList`, as shown in the Scaladoc.)
+ *
+ *  Other combinators from the collections API do not preserve this laziness.
+ *  In particular, `++`, or `concat`, is "eager" or "strict" in its parameter
+ *  and should not be used to compose `LazyList`s.
+ *
+ *  A `LazyList` may be infinite. For example, `LazyList.from(0)` contains
+ *  all of the natural numbers `0`, `1`, `2`, ... For infinite sequences,
+ *  some methods (such as `count`, `sum`, `max` or `min`) will not terminate.
+ *
+ *  Here is an example showing the Fibonacci sequence,
+ *  which may be evaluated to an arbitrary number of elements:
+ *
+ *  ```
+ *  import scala.math.BigInt
+ *  val fibs: LazyList[BigInt] =
+ *    BigInt(0) #:: BigInt(1) #:: fibs.zip(fibs.tail).map(n => n._1 + n._2)
+ *  println {
+ *    fibs.take(5).mkString(", ")
+ *  }
+ *  // prints: 0, 1, 1, 2, 3
+ *  ```
+ *
+ *  To illustrate, let's add some output to the definition `fibs`, so we
+ *  see what's going on.
+ *
+ *  ```
+ *  import scala.math.BigInt
+ *  import scala.util.chaining._
+ *  val fibs: LazyList[BigInt] =
+ *    BigInt(0) #:: BigInt(1) #::
+ *      fibs.zip(fibs.tail).map(n => (n._1 + n._2)
+ *      .tap(sum => println(s"Adding ${n._1} and ${n._2} => $sum")))
+ *  fibs.take(5).foreach(println)
+ *  fibs.take(6).foreach(println)
+ *
+ *  // prints
+ *  //
+ *  // 0
+ *  // 1
+ *  // Adding 0 and 1 => 1
+ *  // 1
+ *  // Adding 1 and 1 => 2
+ *  // 2
+ *  // Adding 1 and 2 => 3
+ *  // 3
+ *
+ *  // And then prints
+ *  //
+ *  // 0
+ *  // 1
+ *  // 1
+ *  // 2
+ *  // 3
+ *  // Adding 2 and 3 => 5
+ *  // 5
+ *  ```
+ *
+ *  Note that the definition of `fibs` uses `val` not `def`.
+ *  Memoization of the `LazyList` requires us to retain a reference to the computed values.
+ *
+ *  `LazyList` is considered an immutable data structure, even though its elements are computed on demand.
+ *  Once the values are memoized they do not change.
+ *  Moreover, the `LazyList` itself is defined once and references to it are interchangeable.
+ *  Values that have yet to be memoized still "exist"; they simply haven't been computed yet.
+ *
+ *  Memoization can be a source of memory leaks and must be used with caution.
+ *  It avoids recomputing elements of the list, but if a reference to the head
+ *  is retained unintentionally, then all elements will be retained.
+ *
+ *  The caveat that all elements are computed in order means
+ *  that some operations, such as [[drop]], [[dropWhile]], [[flatMap]] or [[collect]],
+ *  may process a large number of intermediate elements before returning.
+ *
+ *  Here's an example that illustrates these behaviors.
+ *  Let's begin with an iteration of the natural numbers.
+ *
+ *  ```
+ *  // We'll start with a silly iteration
+ *  def loop(s: String, i: Int, iter: Iterator[Int]): Unit = {
+ *    // Stop after 200,000
+ *    if (i < 200001) {
+ *      if (i % 50000 == 0) println(s + i)
+ *      loop(s, iter.next(), iter)
+ *    }
+ *  }
+ *
+ *  // Our first LazyList definition will be a val definition
+ *  val lazylist1: LazyList[Int] = {
+ *    def loop(v: Int): LazyList[Int] = v #:: loop(v + 1)
+ *    loop(0)
+ *  }
+ *
+ *  // Because lazylist1 is a val, everything that the iterator produces is held
+ *  // by virtue of the fact that the head of the LazyList is held in lazylist1
+ *  val it1 = lazylist1.iterator
+ *  loop("Iterator1: ", it1.next(), it1)
+ *
+ *  // We can redefine this LazyList such that we retain only a reference to its Iterator.
+ *  // That allows the LazyList to be garbage collected.
+ *  // Using `def` to produce the LazyList in a method ensures
+ *  // that no val is holding onto the head, as with lazylist1.
+ *  def lazylist2: LazyList[Int] = {
+ *    def loop(v: Int): LazyList[Int] = v #:: loop(v + 1)
+ *    loop(0)
+ *  }
+ *  val it2 = lazylist2.iterator
+ *  loop("Iterator2: ", it2.next(), it2)
+ *
+ *  // And, of course, we don't actually need a LazyList at all for such a simple
+ *  // problem.  There's no reason to use a LazyList if you don't actually need
+ *  // one.
+ *  val it3 = new Iterator[Int] {
+ *    var i = -1
+ *    def hasNext = true
+ *    def next(): Int = { i += 1; i }
+ *  }
+ *  loop("Iterator3: ", it3.next(), it3)
+ *  ```
+ *
+ *  In the `fibs` example earlier, the fact that `tail` works at all is of interest.
+ *  `fibs` has an initial `(0, 1, LazyList(...))`, so `tail` is deterministic.
+ *  If we defined `fibs` such that only `0` were concretely known, then the act
+ *  of determining `tail` would require the evaluation of `tail`, so the
+ *  computation would be unable to progress, as in this code:
+ *  ```
+ *  // The first time we try to access the tail we're going to need more
+ *  // information which will require us to recurse, which will require us to
+ *  // recurse, which...
+ *  lazy val sov: LazyList[Vector[Int]] = Vector(0) #:: sov.zip(sov.tail).map { n => n._1 ++ n._2 }
+ *  ```
+ *
+ *  The definition of `fibs` above creates a larger number of objects than
+ *  necessary depending on how you might want to implement it.  The following
+ *  implementation provides a more "cost effective" implementation due to the
+ *  fact that it has a more direct route to the numbers themselves:
+ *
+ *  ```
+ *  lazy val fib: LazyList[Int] = {
+ *    def loop(h: Int, n: Int): LazyList[Int] = h #:: loop(n, h + n)
+ *    loop(1, 1)
+ *  }
+ *  ```
+ *
+ *  The head, the tail and whether the list is empty is initially unknown.
+ *  Once any of those are evaluated, they are all known, though if the tail is
+ *  built with `#::` or `#:::`, its content still isn't evaluated. Instead, evaluating
+ *  the tail's content is deferred until the tail's empty status, head or tail is
+ *  evaluated.
+ *
+ *  Delaying the evaluation of whether a LazyList is empty until it's needed
+ *  allows LazyList to not eagerly evaluate any elements on a call to `filter`.
+ *
+ *  Only when it's further evaluated (which may be never!) do any of the elements get forced.
+ *
+ *  For example:
+ *
+ *  ```
+ *  def tailWithSideEffect: LazyList[Nothing] = {
+ *    println("getting empty LazyList")
+ *    LazyList.empty
+ *  }
+ *
+ *  val emptyTail = tailWithSideEffect // prints "getting empty LazyList"
+ *
+ *  val suspended = 1 #:: tailWithSideEffect // doesn't print anything
+ *  val tail = suspended.tail // although the tail is evaluated, *still* nothing is yet printed
+ *  val filtered = tail.filter(_ => false) // still nothing is printed
+ *  filtered.isEmpty // prints "getting empty LazyList"
+ *  ```
+ *
+ *  ----
+ *
+ *  You may sometimes encounter an exception like the following:
+ *
+ *  ```
+ *  java.lang.RuntimeException: "LazyList evaluation depends on its own result (self-reference); see docs for more info
+ *  ```
+ *
+ *  This exception occurs when a `LazyList` is attempting to derive its next element
+ *  from itself, and is attempting to read the element currently being evaluated.
+ *  As a trivial example:
+ *
+ *  ```
+ *  lazy val a: LazyList[Int] = 1 #:: 2 #:: a.filter(_ > 2)
+ *  ```
+ *
+ *  When attempting to evaluate the third element of `a`, it will skip the first two
+ *  elements and read the third, but that element is already being evaluated. This is
+ *  often caused by a subtle logic error; in this case, using `>=` in the `filter`
+ *  would fix the error.
+ *
+ *  @tparam A    the type of the elements contained in this lazy list.
+ *
+ *  @see ["Scala's Collection Library overview"](https://docs.scala-lang.org/overviews/collections-2.13/concrete-immutable-collection-classes.html#lazylists)
+ *  section on `LazyLists` for a summary.
+ *  @define Coll `LazyList`
+ *  @define coll lazy list
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define appendStackSafety Note: Repeated chaining of calls to append methods (`appended`,
+ *                            `appendedAll`, `lazyAppendedAll`) without forcing any of the
+ *                            intermediate resulting lazy lists may overflow the stack when
+ *                            the final result is forced.
+ *  @define preservesLaziness This method preserves laziness; elements are only evaluated
+ *                            individually as needed.
+ *  @define initiallyLazy This method does not evaluate anything until an operation is performed
+ *                        on the result (e.g. calling `head` or `tail`, or checking if it is empty).
+ *  @define evaluatesAllElements This method evaluates all elements of the collection.
+ *  @note Under Capture Checking, LazyList is unsound with regards to lazy/strict separation of collections.
+ *        LazyList as-is will not be capture checked and might be deprecated in the future.
+ *        Use LazyListIterable instead.
+ */
 @SerialVersionUID(4L)
 final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => LazyList[A] */)
   extends AbstractSeq[A]
@@ -339,9 +339,9 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
   @inline override def isEmpty: Boolean = evaluated eq Empty
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   override def knownSize: Int = if (knownIsEmpty) 0 else -1
 
   override def head: A =
@@ -358,24 +358,24 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
   @inline private def knownNonEmpty: Boolean = isEvaluated && !isEmpty
 
   /** Evaluates all undefined elements of the lazy list.
-    *
-    * This method detects cycles in lazy lists, and terminates after all
-    * elements of the cycle are evaluated. For example:
-    *
-    * {{{
-    * val ring: LazyList[Int] = 1 #:: 2 #:: 3 #:: ring
-    * ring.force
-    * ring.toString
-    *
-    * // prints
-    * //
-    * // LazyList(1, 2, 3, ...)
-    * }}}
-    *
-    * This method will *not* terminate for non-cyclic infinite-sized collections.
-    *
-    * @return this
-    */
+   *
+   *  This method detects cycles in lazy lists, and terminates after all
+   *  elements of the cycle are evaluated. For example:
+   *
+   *  ```
+   *  val ring: LazyList[Int] = 1 #:: 2 #:: 3 #:: ring
+   *  ring.force
+   *  ring.toString
+   *
+   *  // prints
+   *  //
+   *  // LazyList(1, 2, 3, ...)
+   *  ```
+   *
+   *  This method will *not* terminate for non-cyclic infinite-sized collections.
+   *
+   *  @return this
+   */
   def force: this.type = {
     // Use standard 2x 1x iterator trick for cycle detection ("those" is slow one)
     var these, those: LazyList[A] = this
@@ -394,25 +394,25 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
   }
 
   /** @inheritdoc
-    *
-    * The iterator returned by this method preserves laziness; elements are
-    * only evaluated individually as needed.
-    */
+   *
+   *  The iterator returned by this method preserves laziness; elements are
+   *  only evaluated individually as needed.
+   */
   override def iterator: Iterator[A] =
     if (knownIsEmpty) Iterator.empty
     else new LazyIterator(this)
 
   /** Applies the given function `f` to each element of this linear sequence
-    * (while respecting the order of the elements).
-    *
-    *  @param f The treatment to apply to each element.
-    *  @note  Overridden here as final to trigger tail-call optimization, which
-    *  replaces 'this' with 'tail' at each iteration. This is absolutely
-    *  necessary for allowing the GC to collect the underlying LazyList as elements
-    *  are consumed.
-    *  @note  This function will force the realization of the entire LazyList
-    *  unless the `f` throws an exception.
-    */
+   *  (while respecting the order of the elements).
+   *
+   *  @param f The treatment to apply to each element.
+   *  @note  Overridden here as final to trigger tail-call optimization, which
+   *  replaces 'this' with 'tail' at each iteration. This is absolutely
+   *  necessary for allowing the GC to collect the underlying LazyList as elements
+   *  are consumed.
+   *  @note  This function will force the realization of the entire LazyList
+   *  unless the `f` throws an exception.
+   */
   @tailrec
   override def foreach[U](f: A => U): Unit = {
     if (!isEmpty) {
@@ -422,13 +422,13 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
   }
 
   /** LazyList specialization of foldLeft which allows GC to collect along the
-    * way.
-    *
-    * @tparam B The type of value being accumulated.
-    * @param z The initial value seeded into the function `op`.
-    * @param op The operation to perform on successive elements of the `LazyList`.
-    * @return The accumulated value from successive applications of `op`.
-    */
+   *  way.
+   *
+   *  @tparam B The type of value being accumulated.
+   *  @param z The initial value seeded into the function `op`.
+   *  @param op The operation to perform on successive elements of the `LazyList`.
+   *  @return The accumulated value from successive applications of `op`.
+   */
   @tailrec
   override def foldLeft[B](z: B)(op: (B, A) => B): B =
     if (isEmpty) z
@@ -441,14 +441,14 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
   override protected def className = "LazyList"
 
   /** The lazy list resulting from the concatenation of this lazy list with the argument lazy list.
-    *
-    * $preservesLaziness
-    *
-    * $appendStackSafety
-    *
-    * @param suffix The collection that gets appended to this lazy list
-    * @return The lazy list containing elements of this lazy list and the iterable object.
-    */
+   *
+   *  $preservesLaziness
+   *
+   *  $appendStackSafety
+   *
+   *  @param suffix The collection that gets appended to this lazy list
+   *  @return The lazy list containing elements of this lazy list and the iterable object.
+   */
   def lazyAppendedAll[B >: A](suffix: => collection.IterableOnce[B]): LazyList[B] =
     newLL {
       if (isEmpty) suffix match {
@@ -460,29 +460,29 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
     }
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    *
-    * $appendStackSafety
-    */
+   *
+   *  $preservesLaziness
+   *
+   *  $appendStackSafety
+   */
   override def appendedAll[B >: A](suffix: IterableOnce[B]): LazyList[B] =
     if (knownIsEmpty) LazyList.from(suffix)
     else lazyAppendedAll(suffix)
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    *
-    * $appendStackSafety
-    */
+   *
+   *  $preservesLaziness
+   *
+   *  $appendStackSafety
+   */
   override def appended[B >: A](elem: B): LazyList[B] =
     if (knownIsEmpty) eagerCons(elem, Empty)
     else lazyAppendedAll(Iterator.single(elem))
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   override def scanLeft[B](z: B)(op: (B, A) => B): LazyList[B] =
     if (knownIsEmpty) eagerCons(z, Empty)
     else scanLeftImpl(z)(op)
@@ -497,12 +497,12 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
     )
 
   /** LazyList specialization of reduceLeft which allows GC to collect
-    *  along the way.
-    *
-    * @tparam B The type of value being accumulated.
-    * @param f The operation to perform on successive elements of the `LazyList`.
-    * @return The accumulated value from successive applications of `f`.
-    */
+   *  along the way.
+   *
+   *  @tparam B The type of value being accumulated.
+   *  @param f The operation to perform on successive elements of the `LazyList`.
+   *  @return The accumulated value from successive applications of `f`.
+   */
   override def reduceLeft[B >: A](f: (B, A) => B): B = {
     if (isEmpty) throw new UnsupportedOperationException("empty.reduceLeft")
     else {
@@ -517,74 +517,74 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
   }
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   override def partition(p: A => Boolean): (LazyList[A], LazyList[A]) = (filter(p), filterNot(p))
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   override def partitionMap[A1, A2](f: A => Either[A1, A2]): (LazyList[A1], LazyList[A2]) = {
     val (left, right) = map(f).partition(_.isLeft)
     (left.map(_.asInstanceOf[Left[A1, ?]].value), right.map(_.asInstanceOf[Right[?, A2]].value))
   }
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   override def filter(pred: A => Boolean): LazyList[A] =
     if (knownIsEmpty) Empty
     else filterImpl(this, pred, isFlipped = false)
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   override def filterNot(pred: A => Boolean): LazyList[A] =
     if (knownIsEmpty) Empty
     else filterImpl(this, pred, isFlipped = true)
 
   /** A `collection.WithFilter` which allows GC of the head of lazy list during processing.
-    *
-    * This method is not particularly useful for a lazy list, as [[filter]] already preserves
-    * laziness.
-    *
-    * The `collection.WithFilter` returned by this method preserves laziness; elements are
-    * only evaluated individually as needed.
-    */
+   *
+   *  This method is not particularly useful for a lazy list, as [[filter]] already preserves
+   *  laziness.
+   *
+   *  The `collection.WithFilter` returned by this method preserves laziness; elements are
+   *  only evaluated individually as needed.
+   */
   override def withFilter(p: A => Boolean): collection.WithFilter[A, LazyList] =
     new LazyList.WithFilter(coll, p)
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   override def prepended[B >: A](elem: B): LazyList[B] = eagerCons(elem, this)
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   override def prependedAll[B >: A](prefix: collection.IterableOnce[B]): LazyList[B] =
     if (knownIsEmpty) LazyList.from(prefix)
     else if (prefix.knownSize == 0) this
     else newLL(eagerHeadPrependIterator(prefix.iterator)(this))
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   override def map[B](f: A => B): LazyList[B] =
     if (knownIsEmpty) Empty
     else mapImpl(f)
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   override def tapEach[U](f: A => U): LazyList[A] = map { a => f(a); a }
 
   private def mapImpl[B](f: A => B): LazyList[B] =
@@ -594,18 +594,18 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
     }
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   override def collect[B](pf: PartialFunction[A, B]): LazyList[B] =
     if (knownIsEmpty) Empty
     else collectImpl(this, pf)
 
   /** @inheritdoc
-    *
-    * This method does not evaluate any elements further than
-    * the first element for which the partial function is defined.
-    */
+   *
+   *  This method does not evaluate any elements further than
+   *  the first element for which the partial function is defined.
+   */
   @tailrec
   override def collectFirst[B](pf: PartialFunction[A, B]): Option[B] =
     if (isEmpty) None
@@ -616,10 +616,10 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
     }
 
   /** @inheritdoc
-    *
-    * This method does not evaluate any elements further than
-    * the first element matching the predicate.
-    */
+   *
+   *  This method does not evaluate any elements further than
+   *  the first element matching the predicate.
+   */
   @tailrec
   override def find(p: A => Boolean): Option[A] =
     if (isEmpty) None
@@ -630,9 +630,9 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
     }
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   // optimisations are not for speed, but for functionality
   // see tickets #153, #498, #2147, and corresponding tests in run/ (as well as run/stream_flatmap_odds.scala)
   override def flatMap[B](f: A => IterableOnce[B]): LazyList[B] =
@@ -640,15 +640,15 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
     else flatMapImpl(this, f)
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   override def flatten[B](implicit asIterable: A => IterableOnce[B]): LazyList[B] = flatMap(asIterable)
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   override def zip[B](that: collection.IterableOnce[B]): LazyList[(A, B)] =
     if (knownIsEmpty || that.knownSize == 0) Empty
     else newLL(eagerHeadZipImpl(that.iterator))
@@ -658,15 +658,15 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
     else eagerCons((head, it.next()), newLL { tail eagerHeadZipImpl it })
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   override def zipWithIndex: LazyList[(A, Int)] = this zip LazyList.from(0)
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   override def zipAll[A1 >: A, B](that: collection.Iterable[B], thisElem: A1, thatElem: B): LazyList[(A1, B)] = {
     if (knownIsEmpty) {
       if (that.knownSize == 0) Empty
@@ -688,54 +688,54 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
   }
 
   /** @inheritdoc
-    *
-    * This method is not particularly useful for a lazy list, as [[zip]] already preserves
-    * laziness.
-    *
-    * The `collection.LazyZip2` returned by this method preserves laziness; elements are
-    * only evaluated individually as needed.
-    */
+   *
+   *  This method is not particularly useful for a lazy list, as [[zip]] already preserves
+   *  laziness.
+   *
+   *  The `collection.LazyZip2` returned by this method preserves laziness; elements are
+   *  only evaluated individually as needed.
+   */
   // just in case it can be meaningfully overridden at some point
   override def lazyZip[B](that: collection.Iterable[B]): LazyZip2[A, B, this.type] =
     super.lazyZip(that)
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   override def unzip[A1, A2](implicit asPair: A => (A1, A2)): (LazyList[A1], LazyList[A2]) =
     (map(asPair(_)._1), map(asPair(_)._2))
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   override def unzip3[A1, A2, A3](implicit asTriple: A => (A1, A2, A3)): (LazyList[A1], LazyList[A2], LazyList[A3]) =
     (map(asTriple(_)._1), map(asTriple(_)._2), map(asTriple(_)._3))
 
   /** @inheritdoc
-    *
-    * $initiallyLazy
-    * Additionally, it preserves laziness for all except the first `n` elements.
-    */
+   *
+   *  $initiallyLazy
+   *  Additionally, it preserves laziness for all except the first `n` elements.
+   */
   override def drop(n: Int): LazyList[A] =
     if (n <= 0) this
     else if (knownIsEmpty) Empty
     else dropImpl(this, n)
 
   /** @inheritdoc
-    *
-    * $initiallyLazy
-    * Additionally, it preserves laziness for all elements after the predicate returns `false`.
-    */
+   *
+   *  $initiallyLazy
+   *  Additionally, it preserves laziness for all elements after the predicate returns `false`.
+   */
   override def dropWhile(p: A => Boolean): LazyList[A] =
     if (knownIsEmpty) Empty
     else dropWhileImpl(this, p)
 
   /** @inheritdoc
-    *
-    * $initiallyLazy
-    */
+   *
+   *  $initiallyLazy
+   */
   override def dropRight(n: Int): LazyList[A] = {
     if (n <= 0) this
     else if (knownIsEmpty) Empty
@@ -756,9 +756,9 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
     else eagerCons(head, newLL(tail.eagerHeadDropRightImpl(scout.tail)))
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   override def take(n: Int): LazyList[A] =
     if (knownIsEmpty) Empty
     else takeImpl(n)
@@ -772,9 +772,9 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
   }
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   override def takeWhile(p: A => Boolean): LazyList[A] =
     if (knownIsEmpty) Empty
     else takeWhileImpl(p)
@@ -786,24 +786,24 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
     }
 
   /** @inheritdoc
-    *
-    * $initiallyLazy
-    */
+   *
+   *  $initiallyLazy
+   */
   override def takeRight(n: Int): LazyList[A] =
     if (n <= 0 || knownIsEmpty) Empty
     else takeRightImpl(this, n)
 
   /** @inheritdoc
-    *
-    * $initiallyLazy
-    * Additionally, it preserves laziness for all but the first `from` elements.
-    */
+   *
+   *  $initiallyLazy
+   *  Additionally, it preserves laziness for all but the first `from` elements.
+   */
   override def slice(from: Int, until: Int): LazyList[A] = take(until).drop(from)
 
   /** @inheritdoc
-    *
-    * $evaluatesAllElements
-    */
+   *
+   *  $evaluatesAllElements
+   */
   override def reverse: LazyList[A] = reverseOnto(Empty)
 
   // need contravariant type B to make the compiler happy - still returns LazyList[A]
@@ -813,17 +813,17 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
     else tail.reverseOnto(newLL(eagerCons(head, tl)))
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   override def diff[B >: A](that: collection.Seq[B]): LazyList[A] =
     if (knownIsEmpty) Empty
     else super.diff(that)
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   override def intersect[B >: A](that: collection.Seq[B]): LazyList[A] =
     if (knownIsEmpty) Empty
     else super.intersect(that)
@@ -835,20 +835,20 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
     else tail.lengthGt(len - 1)
 
   /** @inheritdoc
-    *
-    * The iterator returned by this method mostly preserves laziness;
-    * a single element ahead of the iterator is evaluated.
-    */
+   *
+   *  The iterator returned by this method mostly preserves laziness;
+   *  a single element ahead of the iterator is evaluated.
+   */
   override def grouped(size: Int): Iterator[LazyList[A]] = {
     require(size > 0, "size must be positive, but was " + size)
     slidingImpl(size = size, step = size)
   }
 
   /** @inheritdoc
-    *
-    * The iterator returned by this method mostly preserves laziness;
-    * `size - step max 1` elements ahead of the iterator are evaluated.
-    */
+   *
+   *  The iterator returned by this method mostly preserves laziness;
+   *  `size - step max 1` elements ahead of the iterator are evaluated.
+   */
   override def sliding(size: Int, step: Int): Iterator[LazyList[A]] = {
     require(size > 0 && step > 0, s"size=$size and step=$step, but both must be positive")
     slidingImpl(size = size, step = step)
@@ -859,9 +859,9 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
     else new SlidingIterator[A](this, size = size, step = step)
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   override def padTo[B >: A](len: Int, elem: B): LazyList[B] =
     if (len <= 0) this
     else newLL {
@@ -870,9 +870,9 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
     }
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   override def patch[B >: A](from: Int, other: IterableOnce[B], replaced: Int): LazyList[B] =
     if (knownIsEmpty) LazyList from other
     else patchImpl(from, other, replaced)
@@ -885,16 +885,16 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
     }
 
   /** @inheritdoc
-    *
-    * $evaluatesAllElements
-    */
+   *
+   *  $evaluatesAllElements
+   */
   // overridden just in case a lazy implementation is developed at some point
   override def transpose[B](implicit asIterable: A => collection.Iterable[B]): LazyList[LazyList[B]] = super.transpose
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   override def updated[B >: A](index: Int, elem: B): LazyList[B] =
     if (index < 0) throw new IndexOutOfBoundsException(s"$index")
     else updatedImpl(index, elem, index)
@@ -907,20 +907,20 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
     }
 
   /** Appends all elements of this $coll to a string builder using start, end, and separator strings.
-    *  The written text begins with the string `start` and ends with the string `end`.
-    *  Inside, the string representations (w.r.t. the method `toString`)
-    *  of all elements of this $coll are separated by the string `sep`.
-    *
-    * An undefined state is represented with `"&lt;not computed&gt;"` and cycles are represented with `"&lt;cycle&gt;"`.
-    *
-    * $evaluatesAllElements
-    *
-    *  @param sb    the string builder to which elements are appended.
-    *  @param start the starting string.
-    *  @param sep   the separator string.
-    *  @param end   the ending string.
-    *  @return      the string builder `b` to which elements were appended.
-    */
+   *  The written text begins with the string `start` and ends with the string `end`.
+   *  Inside, the string representations (w.r.t. the method `toString`)
+   *  of all elements of this $coll are separated by the string `sep`.
+   *
+   *  An undefined state is represented with `"&lt;not computed&gt;"` and cycles are represented with `"&lt;cycle&gt;"`.
+   *
+   *  $evaluatesAllElements
+   *
+   *  @param sb    the string builder to which elements are appended.
+   *  @param start the starting string.
+   *  @param sep   the separator string.
+   *  @param end   the ending string.
+   *  @return      the string builder `b` to which elements were appended.
+   */
   override def addString(sb: StringBuilder, start: String, sep: String, end: String): sb.type = {
     force
     addStringNoForce(sb.underlying, start, sep, end)
@@ -994,23 +994,23 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
   }
 
   /** $preservesLaziness
-    *
-    * @return a string representation of this collection. An undefined state is
-    *         represented with `"&lt;not computed&gt;"` and cycles are represented with `"&lt;cycle&gt;"`
-    *
-    *         Examples:
-    *
-    *           - `"LazyList(4, &lt;not computed&gt;)"`, a non-empty lazy list ;
-    *           - `"LazyList(1, 2, 3, &lt;not computed&gt;)"`, a lazy list with at least three elements ;
-    *           - `"LazyList(1, 2, 3, &lt;cycle&gt;)"`, an infinite lazy list that contains
-    *             a cycle at the fourth element.
-    */
+   *
+   *  @return a string representation of this collection. An undefined state is
+   *         represented with `"&lt;not computed&gt;"` and cycles are represented with `"&lt;cycle&gt;"`
+   *
+   *         Examples:
+   *
+   *           - `"LazyList(4, &lt;not computed&gt;)"`, a non-empty lazy list ;
+   *           - `"LazyList(1, 2, 3, &lt;not computed&gt;)"`, a lazy list with at least three elements ;
+   *           - `"LazyList(1, 2, 3, &lt;cycle&gt;)"`, an infinite lazy list that contains
+   *             a cycle at the fourth element.
+   */
   override def toString(): String = addStringNoForce(new JStringBuilder(className), "(", ", ", ")").toString
 
   /** @inheritdoc
-    *
-    * $preservesLaziness
-    */
+   *
+   *  $preservesLaziness
+   */
   @deprecated("Check .knownSize instead of .hasDefiniteSize for more actionable information (see scaladoc for details)", "2.13.0")
   override def hasDefiniteSize: Boolean = {
     if (!isEvaluated) false
@@ -1034,11 +1034,10 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
   }
 }
 
-/**
-  * $factoryInfo
-  * @define coll lazy list
-  * @define Coll `LazyList`
-  */
+/** $factoryInfo
+ *  @define coll lazy list
+ *  @define Coll `LazyList`
+ */
 @SerialVersionUID(4L)
 object LazyList extends SeqFactory[LazyList] {
 
@@ -1186,13 +1185,12 @@ object LazyList extends SeqFactory[LazyList] {
     }
   }
 
-  /** An alternative way of building and matching lazy lists using LazyList.cons(hd, tl).
-    */
+  /** An alternative way of building and matching lazy lists using LazyList.cons(hd, tl). */
   object cons {
     /** A lazy list consisting of a given first element and remaining elements.
-      *  @param hd   The first element of the result lazy list
-      *  @param tl   The remaining elements of the result lazy list
-      */
+     *  @param hd   The first element of the result lazy list
+     *  @param tl   The remaining elements of the result lazy list
+     */
     def apply[A](hd: => A, tl: => LazyList[A]): LazyList[A] = newLL(eagerCons(hd, newLL(tl)))
 
     /** Maps a lazy list to its head and tail. */
@@ -1203,12 +1201,12 @@ object LazyList extends SeqFactory[LazyList] {
 
   final class Deferrer[A] private[LazyList] (private val l: () => LazyList[A]) extends AnyVal {
     /** Constructs a `LazyList` consisting of a given first element followed by elements
-      *  from another `LazyList`.
-      */
+     *  from another `LazyList`.
+     */
     def #:: [B >: A](elem: => B): LazyList[B] = newLL(eagerCons(elem, newLL(l())))
     /** Constructs a `LazyList` consisting of the concatenation of the given `LazyList` and
-      *  another `LazyList`.
-      */
+     *  another `LazyList`.
+     */
     def #:::[B >: A](prefix: LazyList[B]): LazyList[B] = prefix lazyAppendedAll l()
   }
 
@@ -1246,43 +1244,40 @@ object LazyList extends SeqFactory[LazyList] {
     else eagerHeadPrependIterator(it.next().iterator)(eagerHeadConcatIterators(it))
 
   /** An infinite LazyList that repeatedly applies a given function to a start value.
-    *
-    *  @param start the start value of the LazyList
-    *  @param f     the function that's repeatedly applied
-    *  @return      the LazyList returning the infinite sequence of values `start, f(start), f(f(start)), ...`
-    */
+   *
+   *  @param start the start value of the LazyList
+   *  @param f     the function that's repeatedly applied
+   *  @return      the LazyList returning the infinite sequence of values `start, f(start), f(f(start)), ...`
+   */
   def iterate[A](start: => A)(f: A => A): LazyList[A] =
     newLL {
       val head = start
       eagerCons(head, iterate(f(head))(f))
     }
 
-  /**
-    * Creates an infinite LazyList starting at `start` and incrementing by
-    * step `step`.
-    *
-    * @param start the start value of the LazyList
-    * @param step the increment value of the LazyList
-    * @return the LazyList starting at value `start`.
-    */
+  /** Creates an infinite LazyList starting at `start` and incrementing by
+   *  step `step`.
+   *
+   *  @param start the start value of the LazyList
+   *  @param step the increment value of the LazyList
+   *  @return the LazyList starting at value `start`.
+   */
   def from(start: Int, step: Int): LazyList[Int] =
     newLL(eagerCons(start, from(start + step, step)))
 
-  /**
-    * Creates an infinite LazyList starting at `start` and incrementing by `1`.
-    *
-    * @param start the start value of the LazyList
-    * @return the LazyList starting at value `start`.
-    */
+  /** Creates an infinite LazyList starting at `start` and incrementing by `1`.
+   *
+   *  @param start the start value of the LazyList
+   *  @return the LazyList starting at value `start`.
+   */
   def from(start: Int): LazyList[Int] = from(start, 1)
 
-  /**
-    * Creates an infinite LazyList containing the given element expression (which
-    * is computed for each occurrence).
-    *
-    * @param elem the element composing the resulting LazyList
-    * @return the LazyList containing an infinite number of elem
-    */
+  /** Creates an infinite LazyList containing the given element expression (which
+   *  is computed for each occurrence).
+   *
+   *  @param elem the element composing the resulting LazyList
+   *  @return the LazyList containing an infinite number of elem
+   */
   def continually[A](elem: => A): LazyList[A] = newLL(eagerCons(elem, continually(elem)))
 
   override def fill[A](n: Int)(elem: => A): LazyList[A] =
@@ -1305,11 +1300,11 @@ object LazyList extends SeqFactory[LazyList] {
     }
 
   /** The builder returned by this method only evaluates elements
-    * of collections added to it as needed.
-    *
-    * @tparam A the type of the ${coll}’s elements
-    * @return A builder for $Coll objects.
-    */
+   *  of collections added to it as needed.
+   *
+   *  @tparam A the type of the ${coll}’s elements
+   *  @return A builder for $Coll objects.
+   */
   def newBuilder[A]: Builder[A, LazyList[A]] = new LazyBuilder[A]
 
   private class LazyIterator[+A](private var lazyList: LazyList[A]) extends AbstractIterator[A] {
@@ -1409,10 +1404,10 @@ object LazyList extends SeqFactory[LazyList] {
   }
 
   /** This serialization proxy is used for LazyLists which start with a sequence of evaluated cons cells.
-    * The forced sequence is serialized in a compact, sequential format, followed by the unevaluated tail, which uses
-    * standard Java serialization to store the complete structure of unevaluated thunks. This allows the serialization
-    * of long evaluated lazy lists without exhausting the stack through recursive serialization of cons cells.
-    */
+   *  The forced sequence is serialized in a compact, sequential format, followed by the unevaluated tail, which uses
+   *  standard Java serialization to store the complete structure of unevaluated thunks. This allows the serialization
+   *  of long evaluated lazy lists without exhausting the stack through recursive serialization of cons cells.
+   */
   @SerialVersionUID(4L)
   final class SerializationProxy[A](@transient protected var coll: LazyList[A]) extends Serializable {
 

--- a/library/src/scala/collection/immutable/List.scala
+++ b/library/src/scala/collection/immutable/List.scala
@@ -34,20 +34,20 @@ import scala.runtime.Statics.releaseFence
  *  This class is optimal for last-in-first-out (LIFO), stack-like access patterns. If you need another access
  *  pattern, for example, random access or FIFO, consider using a collection more suited to this than `List`.
  *
- *  ==Performance==
- *  '''Time:''' `List` has `O(1)` prepend and head/tail access. Most other operations are `O(n)` on the number of elements in the list.
+ *  ## Performance
+ *  **Time:** `List` has `O(1)` prepend and head/tail access. Most other operations are `O(n)` on the number of elements in the list.
  *  This includes the index-based lookup of elements, `length`, `append` and `reverse`.
  *
- *  '''Space:''' `List` implements '''structural sharing''' of the tail list. This means that many operations are either
+ *  **Space:** `List` implements **structural sharing** of the tail list. This means that many operations are either
  *  zero- or constant-memory cost.
- *  {{{
+ *  ```
  *  val mainList = List(3, 2, 1)
  *  val with4 =    4 :: mainList  // re-uses mainList, costs one :: instance
  *  val with42 =   42 :: mainList // also re-uses mainList, cost one :: instance
  *  val shorter =  mainList.tail  // costs nothing as it uses the same 2::1::Nil instances as mainList
- *  }}}
+ *  ```
  *
- *  @example {{{
+ *  @example ```
  *  // Make a list via the companion object factory
  *  val days = List("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday")
  *
@@ -61,7 +61,7 @@ import scala.runtime.Statics.releaseFence
  *    case Nil =>
  *      println("There don't seem to be any week days.")
  *  }
- *  }}}
+ *  ```
  *
  *  @note The functional list is characterized by persistence and structural sharing, thus offering considerable
  *        performance and space consumption benefits in some scenarios if used correctly.
@@ -92,23 +92,23 @@ sealed abstract class List[+A]
   override def iterableFactory: SeqFactory[List] = List
 
   /** Adds an element at the beginning of this list.
-    *  @param elem the element to prepend.
-    *  @return  a list which contains `x` as first element and
-    *           which continues with this list.
-    *  Example:
-    *  {{{1 :: List(2, 3) = List(2, 3).::(1) = List(1, 2, 3)}}}
-    */
+   *  @param elem the element to prepend.
+   *  @return  a list which contains `x` as first element and
+   *           which continues with this list.
+   *  Example:
+   *  ```1 :: List(2, 3) = List(2, 3).::(1) = List(1, 2, 3) ```
+   */
   def :: [B >: A](elem: B): List[B] =  new ::(elem, this)
 
   /** Adds the elements of a given list in front of this list.
-    *
-    * Example:
-    * {{{List(1, 2) ::: List(3, 4) = List(3, 4).:::(List(1, 2)) = List(1, 2, 3, 4)}}}
-    *
-    *  @param prefix  The list elements to prepend.
-    *  @return a list resulting from the concatenation of the given
-    *    list `prefix` and this list.
-    */
+   *
+   *  Example:
+   *  ```List(1, 2) ::: List(3, 4) = List(3, 4).:::(List(1, 2)) = List(1, 2, 3, 4) ```
+   *
+   *  @param prefix  The list elements to prepend.
+   *  @return a list resulting from the concatenation of the given
+   *    list `prefix` and this list.
+   */
   def ::: [B >: A](prefix: List[B]): List[B] =
     if (isEmpty) prefix
     else if (prefix.isEmpty) this
@@ -127,12 +127,12 @@ sealed abstract class List[+A]
     }
 
   /** Adds the elements of a given list in reverse order in front of this list.
-    *  `xs reverse_::: ys` is equivalent to
-    *  `xs.reverse ::: ys` but is more efficient.
-    *
-    *  @param prefix the prefix to reverse and then prepend
-    *  @return       the concatenation of the reversed prefix and the current list.
-    */
+   *  `xs reverse_::: ys` is equivalent to
+   *  `xs.reverse ::: ys` but is more efficient.
+   *
+   *  @param prefix the prefix to reverse and then prepend
+   *  @return       the concatenation of the reversed prefix and the current list.
+   */
   def reverse_:::[B >: A](prefix: List[B]): List[B] = {
     var these: List[B] = this
     var pres = prefix
@@ -441,14 +441,14 @@ sealed abstract class List[+A]
   override protected def className = "List"
 
   /** Builds a new list by applying a function to all elements of this list.
-    *  Like `xs map f`, but returns `xs` unchanged if function
-    *  `f` maps all elements to themselves (as determined by `eq`).
-    *
-    *  @param f      the function to apply to each element.
-    *  @tparam B     the element type of the returned collection.
-    *  @return       a list resulting from applying the given function
-    *                `f` to each element of this list and collecting the results.
-    */
+   *  Like `xs map f`, but returns `xs` unchanged if function
+   *  `f` maps all elements to themselves (as determined by `eq`).
+   *
+   *  @tparam B     the element type of the returned collection.
+   *  @param f      the function to apply to each element.
+   *  @return       a list resulting from applying the given function
+   *                `f` to each element of this list and collecting the results.
+   */
   @`inline` final def mapConserve[B >: A <: AnyRef](f: A => B): List[B] = {
     // Note to developers: there exists a duplication between this function and `reflect.internal.util.Collections#map2Conserve`.
     // If any successful optimization attempts or other changes are made, please rehash them there too.
@@ -670,11 +670,10 @@ case object Nil extends List[Nothing] {
   private val EmptyUnzip = (Nil, Nil)
 }
 
-/**
-  * $factoryInfo
-  * @define coll list
-  * @define Coll `List`
-  */
+/** $factoryInfo
+ *  @define coll list
+ *  @define Coll `List`
+ */
 @SerialVersionUID(3L)
 object List extends StrictOptimizedSeqFactory[List] {
   private val TupleOfNil = (Nil, Nil)

--- a/library/src/scala/collection/immutable/ListMap.scala
+++ b/library/src/scala/collection/immutable/ListMap.scala
@@ -23,26 +23,25 @@ import scala.collection.generic.DefaultSerializable
 import scala.runtime.Statics.releaseFence
 import scala.util.hashing.MurmurHash3
 
-/**
-  * This class implements immutable maps using a list-based data structure. List map iterators and
-  * traversal methods visit key-value pairs in the order they were first inserted.
-  *
-  * Entries are stored internally in reversed insertion order, which means the newest key is at the
-  * head of the list. As such, methods such as `head` and `tail` are O(n), while `last` and `init`
-  * are O(1). Other operations, such as inserting or removing entries, are also O(n), which makes
-  * this collection suitable only for a small number of elements.
-  *
-  * Instances of `ListMap` represent empty maps; they can be either created by calling the
-  * constructor directly, or by applying the function `ListMap.empty`.
-  *
-  * @tparam K the type of the keys contained in this list map
-  * @tparam V the type of the values associated with the keys
-  *
-  * @define Coll ListMap
-  * @define coll list map
-  * @define mayNotTerminateInf
-  * @define willNotTerminateInf
-  */
+/** This class implements immutable maps using a list-based data structure. List map iterators and
+ *  traversal methods visit key-value pairs in the order they were first inserted.
+ *
+ *  Entries are stored internally in reversed insertion order, which means the newest key is at the
+ *  head of the list. As such, methods such as `head` and `tail` are O(n), while `last` and `init`
+ *  are O(1). Other operations, such as inserting or removing entries, are also O(n), which makes
+ *  this collection suitable only for a small number of elements.
+ *
+ *  Instances of `ListMap` represent empty maps; they can be either created by calling the
+ *  constructor directly, or by applying the function `ListMap.empty`.
+ *
+ *  @tparam K the type of the keys contained in this list map
+ *  @tparam V the type of the values associated with the keys
+ *
+ *  @define Coll ListMap
+ *  @define coll list map
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
 sealed class ListMap[K, +V]
   extends AbstractMap[K, V]
     with SeqMap[K, V]
@@ -116,23 +115,20 @@ sealed class ListMap[K, +V]
 
 }
 
-/**
-  * $factoryInfo
-  *
-  * Note that each element insertion takes O(n) time, which means that creating a list map with
-  * n elements will take O(n^2^) time. This makes the builder suitable only for a small number of
-  * elements.
-  *
-  * @see [[https://docs.scala-lang.org/overviews/collections-2.13/concrete-immutable-collection-classes.html#list-maps "Scala's Collection Library overview"]]
-  * section on `List Maps` for more information.
-  * @define Coll ListMap
-  * @define coll list map
-  */
+/** $factoryInfo
+ *
+ *  Note that each element insertion takes O(n) time, which means that creating a list map with
+ *  n elements will take O(n^2^) time. This makes the builder suitable only for a small number of
+ *  elements.
+ *
+ *  @see ["Scala's Collection Library overview"](https://docs.scala-lang.org/overviews/collections-2.13/concrete-immutable-collection-classes.html#list-maps)
+ *  section on `List Maps` for more information.
+ *  @define Coll ListMap
+ *  @define coll list map
+ */
 @SerialVersionUID(3L)
 object ListMap extends MapFactory[ListMap] {
-  /**
-    * Represents an entry in the `ListMap`.
-    */
+  /** Represents an entry in the `ListMap`. */
   private[immutable] final class Node[K, V](
     override private[immutable] val key: K,
     private[immutable] var _value: V,
@@ -270,12 +266,12 @@ object ListMap extends MapFactory[ListMap] {
     }
 
   /** Returns a new ListMap builder
-    *
-    * The implementation safely handles additions after `result()` without calling `clear()`
-    *
-    * @tparam K the map key type
-    * @tparam V the map value type
-    */
+   *
+   *  The implementation safely handles additions after `result()` without calling `clear()`
+   *
+   *  @tparam K the map key type
+   *  @tparam V the map value type
+   */
   def newBuilder[K, V]: ReusableBuilder[(K, V), ListMap[K, V]] = new ListMapBuilder[K, V]
 
   @tailrec private def foldRightInternal[K, V, Z](map: ListMap[K, V], prevValue: Z, op: ((K, V), Z) => Z): Z = {
@@ -285,8 +281,8 @@ object ListMap extends MapFactory[ListMap] {
 }
 
 /** Builder for ListMap.
-  * $multipleResults
-  */
+ *  $multipleResults
+ */
 private[immutable] final class ListMapBuilder[K, V] extends mutable.ReusableBuilder[(K, V), ListMap[K, V]] {
   private var isAliased: Boolean = false
   private var underlying: ListMap[K, V] = ListMap.empty

--- a/library/src/scala/collection/immutable/ListSet.scala
+++ b/library/src/scala/collection/immutable/ListSet.scala
@@ -21,25 +21,24 @@ import mutable.{Builder, ImmutableBuilder}
 import scala.annotation.tailrec
 import scala.collection.generic.DefaultSerializable
 
-/**
-  * This class implements immutable sets using a list-based data structure. List set iterators and
-  * traversal methods visit elements in the order they were first inserted.
-  *
-  * Elements are stored internally in reversed insertion order, which means the newest element is at
-  * the head of the list. As such, methods such as `head` and `tail` are O(n), while `last` and
-  * `init` are O(1). Other operations, such as inserting or removing entries, are also O(n), which
-  * makes this collection suitable only for a small number of elements.
-  *
-  * Instances of `ListSet` represent empty sets; they can be either created by calling the
-  * constructor directly, or by applying the function `ListSet.empty`.
-  *
-  * @tparam A the type of the elements contained in this list set
-  *
-  * @define Coll ListSet
-  * @define coll list set
-  * @define mayNotTerminateInf
-  * @define willNotTerminateInf
-  */
+/** This class implements immutable sets using a list-based data structure. List set iterators and
+ *  traversal methods visit elements in the order they were first inserted.
+ *
+ *  Elements are stored internally in reversed insertion order, which means the newest element is at
+ *  the head of the list. As such, methods such as `head` and `tail` are O(n), while `last` and
+ *  `init` are O(1). Other operations, such as inserting or removing entries, are also O(n), which
+ *  makes this collection suitable only for a small number of elements.
+ *
+ *  Instances of `ListSet` represent empty sets; they can be either created by calling the
+ *  constructor directly, or by applying the function `ListSet.empty`.
+ *
+ *  @tparam A the type of the elements contained in this list set
+ *
+ *  @define Coll ListSet
+ *  @define coll list set
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
 sealed class ListSet[A]
   extends AbstractSet[A]
     with StrictOptimizedSetOps[A, ListSet, ListSet[A]]
@@ -72,9 +71,7 @@ sealed class ListSet[A]
 
   override def iterableFactory: IterableFactory[ListSet] = ListSet
 
-  /**
-    * Represents an entry in the `ListSet`.
-    */
+  /** Represents an entry in the `ListSet`. */
   protected class Node(override protected val elem: A) extends ListSet[A] {
 
     override def size = sizeInternal(this, 0)
@@ -107,16 +104,15 @@ sealed class ListSet[A]
   }
 }
 
-/**
-  * $factoryInfo
-  *
-  * Note that each element insertion takes O(n) time, which means that creating a list set with
-  * n elements will take O(n^2^) time. This makes the builder suitable only for a small number of
-  * elements.
-  *
-  * @define Coll ListSet
-  * @define coll list set
-  */
+/** $factoryInfo
+ *
+ *  Note that each element insertion takes O(n) time, which means that creating a list set with
+ *  n elements will take O(n^2^) time. This makes the builder suitable only for a small number of
+ *  elements.
+ *
+ *  @define Coll ListSet
+ *  @define coll list set
+ */
 @SerialVersionUID(3L)
 object ListSet extends IterableFactory[ListSet] {
 

--- a/library/src/scala/collection/immutable/LongMap.scala
+++ b/library/src/scala/collection/immutable/LongMap.scala
@@ -24,8 +24,7 @@ import scala.annotation.tailrec
 import scala.annotation.unchecked.uncheckedVariance
 import scala.language.implicitConversions
 
-/** Utility class for long maps.
-  */
+/** Utility class for long maps. */
 private[immutable] object LongMapUtils extends BitOperations.Long {
   def branchMask(i: Long, j: Long) = highestOneBit(i ^ j)
 
@@ -46,9 +45,9 @@ private[immutable] object LongMapUtils extends BitOperations.Long {
 import LongMapUtils.{Long => _, _}
 
 /** A companion object for long maps.
-  *
-  *  @define Coll  `LongMap`
-  */
+ *
+ *  @define Coll  `LongMap`
+ */
 object LongMap {
   def empty[T]: LongMap[T]  = LongMap.Nil
   def singleton[T](key: Long, value: T): LongMap[T] = LongMap.Tip(key, value)
@@ -124,9 +123,7 @@ private[immutable] abstract class LongMapIterator[V, T](it: LongMap[V]) extends 
   }
   push(it)
 
-  /**
-    * What value do we assign to a tip?
-    */
+  /** What value do we assign to a tip? */
   def valueOf(tip: LongMap.Tip[V]): T
 
   def hasNext = index != 0
@@ -161,20 +158,19 @@ private[immutable] class LongMapKeyIterator[V](it: LongMap[V]) extends LongMapIt
   def valueOf(tip: LongMap.Tip[V]) = tip.key
 }
 
-/**
-  *  Specialised immutable map structure for long keys, based on
-  *  [[https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.37.5452 Fast Mergeable Long Maps]]
-  *  by Okasaki and Gill. Essentially a trie based on binary digits of the integers.
-  *
-  *  Note: This class is as of 2.8 largely superseded by HashMap.
-  *
-  *  @tparam T      type of the values associated with the long keys.
-  *
-  *  @define Coll `immutable.LongMap`
-  *  @define coll immutable long integer map
-  *  @define mayNotTerminateInf
-  *  @define willNotTerminateInf
-  */
+/** Specialised immutable map structure for long keys, based on
+ *  [Fast Mergeable Long Maps](https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.37.5452)
+ *  by Okasaki and Gill. Essentially a trie based on binary digits of the integers.
+ *
+ *  Note: This class is as of 2.8 largely superseded by HashMap.
+ *
+ *  @tparam T      type of the values associated with the long keys.
+ *
+ *  @define Coll `immutable.LongMap`
+ *  @define coll immutable long integer map
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
 sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
   with StrictOptimizedMapOps[Long, T, Map, LongMap[T]]
   with Serializable {
@@ -199,19 +195,16 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     buffer.toList
   }
 
-  /**
-    * Iterator over key, value pairs of the map in unsigned order of the keys.
-    *
-    * @return an iterator over pairs of long keys and corresponding values.
-    */
+  /** Iterator over key, value pairs of the map in unsigned order of the keys.
+   *
+   *  @return an iterator over pairs of long keys and corresponding values.
+   */
   def iterator: Iterator[(Long, T)] = this match {
     case LongMap.Nil => Iterator.empty
     case _ => new LongMapEntryIterator(this)
   }
 
-  /**
-    * Loops over the key, value pairs of the map in unsigned order of the keys.
-    */
+  /** Loops over the key, value pairs of the map in unsigned order of the keys. */
   override final def foreach[U](f: ((Long, T)) => U): Unit = this match {
     case LongMap.Bin(_, _, left, right) => { left.foreach(f); right.foreach(f) }
     case LongMap.Tip(key, value) => f((key, value))
@@ -229,12 +222,11 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     case _ => new LongMapKeyIterator(this)
   }
 
-  /**
-    * Loop over the keys of the map. The same as keys.foreach(f), but may
-    * be more efficient.
-    *
-    * @param f The loop body
-    */
+  /** Loop over the keys of the map. The same as keys.foreach(f), but may
+   *  be more efficient.
+   *
+   *  @param f The loop body
+   */
   final def foreachKey[U](f: Long => U): Unit = this match {
     case LongMap.Bin(_, _, left, right) => { left.foreachKey(f); right.foreachKey(f) }
     case LongMap.Tip(key, _) => f(key)
@@ -246,12 +238,11 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     case _ => new LongMapValueIterator(this)
   }
 
-  /**
-    * Loop over the values of the map. The same as values.foreach(f), but may
-    * be more efficient.
-    *
-    * @param f The loop body
-    */
+  /** Loop over the values of the map. The same as values.foreach(f), but may
+   *  be more efficient.
+   *
+   *  @param f The loop body
+   */
   final def foreachValue[U](f: T => U): Unit = this match {
     case LongMap.Bin(_, _, left, right) => { left.foreachValue(f); right.foreachValue(f) }
     case LongMap.Tip(_, value) => f(value)
@@ -321,23 +312,22 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     case LongMap.Nil => LongMap.Tip(key, value)
   }
 
-  /**
-    * Updates the map, using the provided function to resolve conflicts if the key is already present.
-    *
-    * Equivalent to
-    * {{{
-    *   this.get(key) match {
-    *     case None => this.update(key, value)
-    *     case Some(oldvalue) => this.update(key, f(oldvalue, value)
-    *   }
-    * }}}
-    *
-    * @tparam S     The supertype of values in this `LongMap`.
-    * @param key    The key to update.
-    * @param value  The value to use if there is no conflict.
-    * @param f      The function used to resolve conflicts.
-    * @return       The updated map.
-    */
+  /** Updates the map, using the provided function to resolve conflicts if the key is already present.
+   *
+   *  Equivalent to
+   *  ```
+   *   this.get(key) match {
+   *     case None => this.update(key, value)
+   *     case Some(oldvalue) => this.update(key, f(oldvalue, value)
+   *   }
+   *  ```
+   *
+   *  @tparam S     The supertype of values in this `LongMap`.
+   *  @param key    The key to update.
+   *  @param value  The value to use if there is no conflict.
+   *  @param f      The function used to resolve conflicts.
+   *  @return       The updated map.
+   */
   def updateWith[S >: T](key: Long, value: S, f: (T, S) => S): LongMap[S] = this match {
     case LongMap.Bin(prefix, mask, left, right) =>
       if (!hasMatch(key, prefix, mask)) join(key, LongMap.Tip(key, value), prefix, this)
@@ -360,15 +350,14 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     case LongMap.Nil => LongMap.Nil
   }
 
-  /**
-    * A combined transform and filter function. Returns an `LongMap` such that
-    * for each `(key, value)` mapping in this map, if `f(key, value) == None`
-    * the map contains no mapping for key, and if `f(key, value)`.
-    *
-    * @tparam S    The type of the values in the resulting `LongMap`.
-    * @param f     The transforming function.
-    * @return      The modified map.
-    */
+  /** A combined transform and filter function. Returns an `LongMap` such that
+   *  for each `(key, value)` mapping in this map, if `f(key, value) == None`
+   *  the map contains no mapping for key, and if `f(key, value)`.
+   *
+   *  @tparam S    The type of the values in the resulting `LongMap`.
+   *  @param f     The transforming function.
+   *  @return      The modified map.
+   */
   def modifyOrRemove[S](f: (Long, T) => Option[S]): LongMap[S] = this match {
     case LongMap.Bin(prefix, mask, left, right) => {
       val newleft = left.modifyOrRemove(f)
@@ -386,14 +375,13 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     case LongMap.Nil => LongMap.Nil
   }
 
-  /**
-    * Forms a union map with that map, using the combining function to resolve conflicts.
-    *
-    * @tparam S      The type of values in `that`, a supertype of values in `this`.
-    * @param that    The map to form a union with.
-    * @param f       The function used to resolve conflicts between two mappings.
-    * @return        Union of `this` and `that`, with identical key conflicts resolved using the function `f`.
-    */
+  /** Forms a union map with that map, using the combining function to resolve conflicts.
+   *
+   *  @tparam S      The type of values in `that`, a supertype of values in `this`.
+   *  @param that    The map to form a union with.
+   *  @param f       The function used to resolve conflicts between two mappings.
+   *  @return        Union of `this` and `that`, with identical key conflicts resolved using the function `f`.
+   */
   def unionWith[S >: T](that: LongMap[S], f: (Long, S, S) => S): LongMap[S] = (this, that) match{
     case (LongMap.Bin(p1, m1, l1, r1), that@(LongMap.Bin(p2, m2, l2, r2))) =>
       if (shorter(m1, m2)) {
@@ -415,17 +403,16 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     case (x, LongMap.Nil) => x
   }
 
-  /**
-    * Forms the intersection of these two maps with a combining function. The
-    * resulting map is a map that has only keys present in both maps and has
-    * values produced from the original mappings by combining them with `f`.
-    *
-    * @tparam S      The type of values in `that`.
-    * @tparam R      The type of values in the resulting `LongMap`.
-    * @param that    The map to intersect with.
-    * @param f       The combining function.
-    * @return        Intersection of `this` and `that`, with values for identical keys produced by function `f`.
-    */
+  /** Forms the intersection of these two maps with a combining function. The
+   *  resulting map is a map that has only keys present in both maps and has
+   *  values produced from the original mappings by combining them with `f`.
+   *
+   *  @tparam S      The type of values in `that`.
+   *  @tparam R      The type of values in the resulting `LongMap`.
+   *  @param that    The map to intersect with.
+   *  @param f       The combining function.
+   *  @return        Intersection of `this` and `that`, with values for identical keys produced by function `f`.
+   */
   def intersectionWith[S, R](that: LongMap[S], f: (Long, T, S) => R): LongMap[R] = (this, that) match {
     case (LongMap.Bin(p1, m1, l1, r1), that@LongMap.Bin(p2, m2, l2, r2)) =>
       if (shorter(m1, m2)) {
@@ -449,14 +436,13 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     case (_, _) => LongMap.Nil
   }
 
-  /**
-    * Left biased intersection. Returns the map that has all the same mappings as this but only for keys
-    * which are present in the other map.
-    *
-    * @tparam R      The type of values in `that`.
-    * @param that    The map to intersect with.
-    * @return        A map with all the keys both in `this` and `that`, mapped to corresponding values from `this`.
-    */
+  /** Left biased intersection. Returns the map that has all the same mappings as this but only for keys
+   *  which are present in the other map.
+   *
+   *  @tparam R      The type of values in `that`.
+   *  @param that    The map to intersect with.
+   *  @return        A map with all the keys both in `this` and `that`, mapped to corresponding values from `this`.
+   */
   def intersection[R](that: LongMap[R]): LongMap[T] =
     this.intersectionWith(that, (key: Long, value: T, value2: R) => value)
 

--- a/library/src/scala/collection/immutable/Map.scala
+++ b/library/src/scala/collection/immutable/Map.scala
@@ -35,33 +35,33 @@ trait Map[K, +V]
   override final def toMap[K2, V2](implicit ev: (K, V) <:< (K2, V2)): Map[K2, V2] = Map.from(this.asInstanceOf[Map[K2, V2]])
 
   /** The same map with a given default function.
-    *  Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
-    *  are not affected by `withDefault`.
-    *
-    *  Invoking transformer methods (e.g. `map`) will not preserve the default value.
-    *
-    *  @param d     the function mapping keys to values, used for non-present keys
-    *  @return      a wrapper of the map with a default value
-    */
+   *  Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
+   *  are not affected by `withDefault`.
+   *
+   *  Invoking transformer methods (e.g. `map`) will not preserve the default value.
+   *
+   *  @param d     the function mapping keys to values, used for non-present keys
+   *  @return      a wrapper of the map with a default value
+   */
   def withDefault[V1 >: V](d: K -> V1): Map[K, V1] = new Map.WithDefault[K, V1](this, d)
 
   /** The same map with a given default value.
-    *  Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
-    *  are not affected by `withDefaultValue`.
-    *
-    *  Invoking transformer methods (e.g. `map`) will not preserve the default value.
-    *
-    *  @param d     default value used for non-present keys
-    *  @return      a wrapper of the map with a default value
-    */
+   *  Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
+   *  are not affected by `withDefaultValue`.
+   *
+   *  Invoking transformer methods (e.g. `map`) will not preserve the default value.
+   *
+   *  @param d     default value used for non-present keys
+   *  @return      a wrapper of the map with a default value
+   */
   def withDefaultValue[V1 >: V](d: V1): Map[K, V1] = new Map.WithDefault[K, V1](this, _ => d)
 }
 
 /** Base trait of immutable Maps implementations
-  *
-  * @define coll immutable map
-  * @define Coll `immutable.Map`
-  */
+ *
+ *  @define coll immutable map
+ *  @define Coll `immutable.Map`
+ */
 transparent trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[K, V, CC, C]]
   extends IterableOps[(K, V), Iterable, C]
     with collection.MapOps[K, V, CC, C]
@@ -70,10 +70,10 @@ transparent trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[
   protected def coll: C & CC[K, V]
 
   /** Removes a key from this map, returning a new map.
-    *
-    * @param key the key to be removed
-    * @return a new map without a binding for ''key''
-    */
+   *
+   *  @param key the key to be removed
+   *  @return a new map without a binding for *key*
+   */
   def removed(key: K): C
 
   /** Alias for `removed`. */
@@ -83,38 +83,37 @@ transparent trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[
   def - (key1: K, key2: K, keys: K*): C = removed(key1).removed(key2).removedAll(keys)
 
   /** Creates a new $coll from this $coll by removing all elements of another
-    *  collection.
-    *
-    *  $willForceEvaluation
-    *
-    *  @param keys   the collection containing the removed elements.
-    *  @return a new $coll that contains all elements of the current $coll
-    *  except one less occurrence of each of the elements of `elems`.
-    */
+   *  collection.
+   *
+   *  $willForceEvaluation
+   *
+   *  @param keys   the collection containing the removed elements.
+   *  @return a new $coll that contains all elements of the current $coll
+   *  except one less occurrence of each of the elements of `elems`.
+   */
   def removedAll(keys: IterableOnce[K]^): C = keys.iterator.foldLeft[C](coll)(_ - _)
 
   /** Alias for `removedAll`. */
   @`inline` final override def -- (keys: IterableOnce[K]^): C = removedAll(keys)
 
   /** Creates a new map obtained by updating this map with a given key/value pair.
+   *  @tparam   V1 the type of the added value
    *  @param    key the key
    *  @param    value the value
-   *  @tparam   V1 the type of the added value
    *  @return   A new map with the new key/value mapping added to this map.
    */
   def updated[V1 >: V](key: K, value: V1): CC[K, V1]
 
-  /**
-   * Updates a mapping for the specified key and its current optionally mapped value
-   * (`Some` if there is current mapping, `None` if not).
+  /** Updates a mapping for the specified key and its current optionally mapped value
+   *  (`Some` if there is current mapping, `None` if not).
    *
-   * If the remapping function returns `Some(v)`, the mapping is updated with the new value `v`.
-   * If the remapping function returns `None`, the mapping is removed (or remains absent if initially absent).
-   * If the function itself throws an exception, the exception is rethrown, and the current mapping is left unchanged.
+   *  If the remapping function returns `Some(v)`, the mapping is updated with the new value `v`.
+   *  If the remapping function returns `None`, the mapping is removed (or remains absent if initially absent).
+   *  If the function itself throws an exception, the exception is rethrown, and the current mapping is left unchanged.
    *
-   * @param key the key value
-   * @param remappingFunction a function that receives current optionally mapped value and returns a new mapping
-   * @return A new map with the updated mapping with the key
+   *  @param key the key value
+   *  @param remappingFunction a function that receives current optionally mapped value and returns a new mapping
+   *  @return A new map with the updated mapping with the key
    */
   def updatedWith[V1 >: V](key: K)(remappingFunction: Option[V] => Option[V1]): CC[K,V1] = {
     val previousValue = this.get(key)
@@ -126,21 +125,20 @@ transparent trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[
     }
   }
 
-  /**
-    * Alias for `updated`
-    *
-    * @param kv the key/value pair.
-    * @tparam V1 the type of the value in the key/value pair.
-    * @return A new map with the new binding added to this map.
-    */
+  /** Alias for `updated`
+   *
+   *  @tparam V1 the type of the value in the key/value pair.
+   *  @param kv the key/value pair.
+   *  @return A new map with the new binding added to this map.
+   */
   override def + [V1 >: V](kv: (K, V1)): CC[K, V1] = updated(kv._1, kv._2)
 
   /** This function transforms all the values of mappings contained
-    *  in this map with function `f`.
-    *
-    *  @param f A function over keys and values
-    *  @return  the updated map
-    */
+   *  in this map with function `f`.
+   *
+   *  @param f A function over keys and values
+   *  @return  the updated map
+   */
   def transform[W](f: (K, V) => W): CC[K, W] = map { case (k, v) => (k, f(k, v)) }
 
   override def keySet: Set[K] = new LazyImmutableKeySet
@@ -175,11 +173,10 @@ transparent trait StrictOptimizedMapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?]
 }
 
 
-/**
-  * $factoryInfo
-  * @define coll immutable map
-  * @define Coll `immutable.Map`
-  */
+/** $factoryInfo
+ *  @define coll immutable map
+ *  @define Coll `immutable.Map`
+ */
 @SerialVersionUID(3L)
 object Map extends MapFactory[Map] {
 

--- a/library/src/scala/collection/immutable/NumericRange.scala
+++ b/library/src/scala/collection/immutable/NumericRange.scala
@@ -21,26 +21,26 @@ import scala.collection.generic.CommonErrors
 import scala.annotation.compileTimeOnly
 
 /** `NumericRange` is a more generic version of the
-  *  `Range` class which works with arbitrary types.
-  *  It must be supplied with an `Integral` implementation of the
-  *  range type.
-  *
-  *  Factories for likely types include `Range.BigInt`, `Range.Long`,
-  *  and `Range.BigDecimal`.  `Range.Int` exists for completeness, but
-  *  the `Int`-based `scala.Range` should be more performant.
-  *
-  *  {{{
-  *     val r1 = Range(0, 100, 1)
-  *     val veryBig = Int.MaxValue.toLong + 1
-  *     val r2 = Range.Long(veryBig, veryBig + 100, 1)
-  *     assert(r1 sameElements r2.map(_ - veryBig))
-  *  }}}
-  *
-  *  @define Coll `NumericRange`
-  *  @define coll numeric range
-  *  @define mayNotTerminateInf
-  *  @define willNotTerminateInf
-  */
+ *  `Range` class which works with arbitrary types.
+ *  It must be supplied with an `Integral` implementation of the
+ *  range type.
+ *
+ *  Factories for likely types include `Range.BigInt`, `Range.Long`,
+ *  and `Range.BigDecimal`.  `Range.Int` exists for completeness, but
+ *  the `Int`-based `scala.Range` should be more performant.
+ *
+ *  ```
+ *     val r1 = Range(0, 100, 1)
+ *     val veryBig = Int.MaxValue.toLong + 1
+ *     val r2 = Range.Long(veryBig, veryBig + 100, 1)
+ *     assert(r1 sameElements r2.map(_ - veryBig))
+ *  ```
+ *
+ *  @define Coll `NumericRange`
+ *  @define coll numeric range
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
 @SerialVersionUID(3L)
 sealed class NumericRange[T](
   val start: T,
@@ -72,8 +72,8 @@ sealed class NumericRange[T](
 
 
   /** Note that NumericRange must be invariant so that constructs
-    *  such as "1L to 10 by 5" do not infer the range type as AnyVal.
-    */
+   *  such as "1L to 10 by 5" do not infer the range type as AnyVal.
+   */
   import num._
 
   // See comment in Range for why this must be lazy.
@@ -97,13 +97,12 @@ sealed class NumericRange[T](
     else new NumericRange.Exclusive(start + step, end, step)
 
   /** Creates a new range with the start and end values of this range and
-    *  a new `step`.
-    */
+   *  a new `step`.
+   */
   def by(newStep: T): NumericRange[T] = copy(start, end, newStep)
 
 
-  /** Creates a copy of this range.
-    */
+  /** Creates a copy of this range. */
   def copy(start: T, end: T, step: T): NumericRange[T] =
     new NumericRange(start, end, step, isInclusive)
 
@@ -387,9 +386,9 @@ sealed class NumericRange[T](
 }
 
 /** A companion object for numeric ranges.
-  *  @define Coll `NumericRange`
-  *  @define coll numeric range
-  */
+ *  @define Coll `NumericRange`
+ *  @define coll numeric range
+ */
 object NumericRange {
   private def bigDecimalCheckUnderflow[T](start: T, end: T, step: T)(implicit num: Integral[T]): Unit = {
     def FAIL(boundary: T, step: T): Unit = {
@@ -406,9 +405,9 @@ object NumericRange {
   }
 
   /** Calculates the number of elements in a range given start, end, step, and
-    *  whether or not it is inclusive.  Throws an exception if step == 0 or
-    *  the number of elements exceeds the maximum Int.
-    */
+   *  whether or not it is inclusive.  Throws an exception if step == 0 or
+   *  the number of elements exceeds the maximum Int.
+   */
   def count[T](start: T, end: T, step: T, isInclusive: Boolean)(implicit num: Integral[T]): Int = {
     val zero    = num.zero
     val upward  = num.lt(start, end)

--- a/library/src/scala/collection/immutable/Queue.scala
+++ b/library/src/scala/collection/immutable/Queue.scala
@@ -20,24 +20,24 @@ import scala.collection.generic.DefaultSerializable
 import scala.collection.mutable.{Builder, ListBuffer}
 
 /** `Queue` objects implement data structures that allow to
-  *  insert and retrieve elements in a first-in-first-out (FIFO) manner.
-  *
-  *  `Queue` is implemented as a pair of `List`s, one containing the ''in'' elements and the other the ''out'' elements.
-  *  Elements are added to the ''in'' list and removed from the ''out'' list. When the ''out'' list runs dry, the
-  *  queue is pivoted by replacing the ''out'' list by ''in.reverse'', and ''in'' by ''Nil''.
-  *
-  *  Adding items to the queue always has cost `O(1)`. Removing items has cost `O(1)`, except in the case
-  *  where a pivot is required, in which case, a cost of `O(n)` is incurred, where `n` is the number of elements in the queue. When this happens,
-  *  `n` remove operations with `O(1)` cost are guaranteed. Removing an item is on average `O(1)`.
-  *
-  *  @see [[https://docs.scala-lang.org/overviews/collections-2.13/concrete-immutable-collection-classes.html#immutable-queues "Scala's Collection Library overview"]]
-  *  section on `Immutable Queues` for more information.
-  *
-  *  @define Coll `immutable.Queue`
-  *  @define coll immutable queue
-  *  @define mayNotTerminateInf
-  *  @define willNotTerminateInf
-  */
+ *  insert and retrieve elements in a first-in-first-out (FIFO) manner.
+ *
+ *  `Queue` is implemented as a pair of `List`s, one containing the *in* elements and the other the *out* elements.
+ *  Elements are added to the *in* list and removed from the *out* list. When the *out* list runs dry, the
+ *  queue is pivoted by replacing the *out* list by *in.reverse*, and *in* by *Nil*.
+ *
+ *  Adding items to the queue always has cost `O(1)`. Removing items has cost `O(1)`, except in the case
+ *  where a pivot is required, in which case, a cost of `O(n)` is incurred, where `n` is the number of elements in the queue. When this happens,
+ *  `n` remove operations with `O(1)` cost are guaranteed. Removing an item is on average `O(1)`.
+ *
+ *  @see ["Scala's Collection Library overview"](https://docs.scala-lang.org/overviews/collections-2.13/concrete-immutable-collection-classes.html#immutable-queues)
+ *  section on `Immutable Queues` for more information.
+ *
+ *  @define Coll `immutable.Queue`
+ *  @define coll immutable queue
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
 
 sealed class Queue[+A] protected(protected val in: List[A], protected val out: List[A])
   extends AbstractSeq[A]
@@ -51,12 +51,12 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
   override def iterableFactory: SeqFactory[Queue] = Queue
 
   /** Returns the `n`-th element of this queue.
-    *  The first element is at position `0`.
-    *
-    *  @param  n index of the element to return
-    *  @return   the element at position `n` in this queue.
-    *  @throws NoSuchElementException if the queue is too short.
-    */
+   *  The first element is at position `0`.
+   *
+   *  @param  n index of the element to return
+   *  @return   the element at position `n` in this queue.
+   *  @throws NoSuchElementException if the queue is too short.
+   */
   override def apply(n: Int): A = {
     def indexOutOfRange(): Nothing = throw new IndexOutOfBoundsException(n.toString)
 
@@ -80,14 +80,13 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
     }
   }
 
-  /** Returns the elements in the list as an iterator
-    */
+  /** Returns the elements in the list as an iterator */
   override def iterator: Iterator[A] = out.iterator.concat(in.reverse)
 
   /** Checks if the queue is empty.
-    *
-    *  @return true, iff there is no element in the queue.
-    */
+   *
+   *  @return true, iff there is no element in the queue.
+   */
   override def isEmpty: Boolean = in.isEmpty && out.isEmpty
 
   override def head: A =
@@ -138,31 +137,31 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
   }
 
   /** Creates a new queue with element added at the end
-    *  of the old queue.
-    *
-    *  @param  elem        the element to insert
-    */
+   *  of the old queue.
+   *
+   *  @param  elem        the element to insert
+   */
   def enqueue[B >: A](elem: B): Queue[B] = new Queue(elem :: in, out)
 
   /** Creates a new queue with all elements provided by an `Iterable` object
-    *  added at the end of the old queue.
-    *
-    *  The elements are appended in the order they are given out by the
-    *  iterator.
-    *
-    *  @param  iter        an iterable object
-    */
+   *  added at the end of the old queue.
+   *
+   *  The elements are appended in the order they are given out by the
+   *  iterator.
+   *
+   *  @param  iter        an iterable object
+   */
   @deprecated("Use `enqueueAll` instead of `enqueue` to enqueue a collection of elements", "2.13.0")
   @`inline` final def enqueue[B >: A](iter: scala.collection.Iterable[B]^) = enqueueAll(iter)
 
   /** Creates a new queue with all elements provided by an `Iterable` object
-    *  added at the end of the old queue.
-    *
-    *  The elements are appended in the order they are given out by the
-    *  iterator.
-    *
-    *  @param  iter        an iterable object
-    */
+   *  added at the end of the old queue.
+   *
+   *  The elements are appended in the order they are given out by the
+   *  iterator.
+   *
+   *  @param  iter        an iterable object
+   */
   def enqueueAll[B >: A](iter: scala.collection.Iterable[B]^): Queue[B] = appendedAll(iter)
 
   /** Returns a tuple with the first element in the queue,
@@ -178,29 +177,28 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
   }
 
   /** Optionally retrieves the first element and a queue of the remaining elements.
-    *
-    * @return A tuple of the first element of the queue, and a new queue with this element removed.
-    *         If the queue is empty, `None` is returned.
-    */
+   *
+   *  @return A tuple of the first element of the queue, and a new queue with this element removed.
+   *         If the queue is empty, `None` is returned.
+   */
   def dequeueOption: Option[(A, Queue[A])] = if(isEmpty) None else Some(dequeue)
 
   /** Returns the first element in the queue, or throws an error if there
    *  is no element contained in the queue.
    *
-   *  @throws NoSuchElementException if the queue is empty
    *  @return the first element.
+   *  @throws NoSuchElementException if the queue is empty
    */
   def front: A = head
 
-  /** Returns a string representation of this queue.
-    */
+  /** Returns a string representation of this queue. */
   override def toString(): String = mkString("Queue(", ", ", ")")
 }
 
 /** $factoryInfo
-  *  @define Coll `immutable.Queue`
-  *  @define coll immutable queue
-  */
+ *  @define Coll `immutable.Queue`
+ *  @define coll immutable queue
+ */
 @SerialVersionUID(3L)
 object Queue extends StrictOptimizedSeqFactory[Queue] {
   def newBuilder[A]: Builder[A, Queue[A]] = new ListBuffer[A] mapResult (x => new Queue[A](Nil, x))

--- a/library/src/scala/collection/immutable/Range.scala
+++ b/library/src/scala/collection/immutable/Range.scala
@@ -23,15 +23,15 @@ import scala.collection.{AbstractIterator, AnyStepper, IterableFactoryDefaults, 
 import scala.util.hashing.MurmurHash3
 
 /** The `Range` class represents integer values in range
- *  ''[start;end)'' with non-zero step value `step`.
+ *  *[start;end)* with non-zero step value `step`.
  *  It's a special case of an indexed sequence.
  *  For example:
  *
- *  {{{
+ *  ```
  *     val r1 = 0 until 10
  *     val r2 = r1.start until r1.end by r1.step + 1
  *     println(r2.length) // = 5
- *  }}}
+ *  ```
  *
  *  Ranges that contain more than `Int.MaxValue` elements can be created, but
  *  these overfull ranges have only limited capabilities. Any method that
@@ -57,7 +57,7 @@ import scala.util.hashing.MurmurHash3
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
  *  @define doesNotUseBuilders
- *    '''Note:''' this method does not use builders to construct a new range,
+ *    **Note:** this method does not use builders to construct a new range,
  *         and its complexity is O(1).
  */
 @SerialVersionUID(4L)
@@ -182,28 +182,28 @@ sealed abstract class Range(
   }
 
   /** The last element of this range.  This method will return the correct value
-    *  even if there are too many elements to iterate over.
-    */
+   *  even if there are too many elements to iterate over.
+   */
   final override def last: Int =
     if (isEmpty) throw Range.emptyRangeError("last") else lastElement
   final override def head: Int =
     if (isEmpty) throw Range.emptyRangeError("head") else start
 
   /** Creates a new range containing all the elements of this range except the last one.
-    *
-    *  $doesNotUseBuilders
-    *
-    *  @return  a new range consisting of all the elements of this range except the last one.
-    */
+   *
+   *  $doesNotUseBuilders
+   *
+   *  @return  a new range consisting of all the elements of this range except the last one.
+   */
   final override def init: Range =
     if (isEmpty) throw Range.emptyRangeError("init") else dropRight(1)
 
   /** Creates a new range containing all the elements of this range except the first one.
-    *
-    *  $doesNotUseBuilders
-    *
-    *  @return  a new range consisting of all the elements of this range except the first one.
-    */
+   *
+   *  $doesNotUseBuilders
+   *
+   *  @return  a new range consisting of all the elements of this range except the first one.
+   */
   final override def tail: Range = {
     if (isEmpty) throw Range.emptyRangeError("tail")
     if (numRangeElements == 1) newEmptyRange(end)
@@ -220,10 +220,10 @@ sealed abstract class Range(
     if(isInclusive) new Range.Inclusive(start, end, step) else new Range.Exclusive(start, end, step)
 
   /** Creates a new range with the `start` and `end` values of this range and
-    *  a new `step`.
-    *
-    *  @return a new range with a different step
-    */
+   *  a new `step`.
+   *
+   *  @return a new range with a different step
+   */
   final def by(step: Int): Range = copy(start, end, step)
 
   // Check cannot be evaluated eagerly because we have a pattern where
@@ -304,29 +304,29 @@ sealed abstract class Range(
     (n ^ Int.MinValue) > ((numRangeElements - 1) ^ Int.MinValue) // unsigned comparison
 
   /** Creates a new range containing the first `n` elements of this range.
-    *
-    *  @param n  the number of elements to take.
-    *  @return   a new range consisting of `n` first elements.
-    */
+   *
+   *  @param n  the number of elements to take.
+   *  @return   a new range consisting of `n` first elements.
+   */
   final override def take(n: Int): Range =
     if (n <= 0 || isEmpty) newEmptyRange(start)
     else if (greaterEqualNumRangeElements(n)) this
     else new Range.Inclusive(start, locationAfterN(n - 1), step)
 
   /** Creates a new range containing all the elements of this range except the first `n` elements.
-    *
-    *  @param n  the number of elements to drop.
-    *  @return   a new range consisting of all the elements of this range except `n` first elements.
-    */
+   *
+   *  @param n  the number of elements to drop.
+   *  @return   a new range consisting of all the elements of this range except `n` first elements.
+   */
   final override def drop(n: Int): Range =
     if (n <= 0 || isEmpty) this
     else if (greaterEqualNumRangeElements(n)) newEmptyRange(end)
     else copy(locationAfterN(n), end, step)
 
   /** Creates a new range consisting of the last `n` elements of the range.
-    *
-    *  $doesNotUseBuilders
-    */
+   *
+   *  $doesNotUseBuilders
+   */
   final override def takeRight(n: Int): Range = {
     if (n <= 0 || isEmpty) newEmptyRange(start)
     else if (greaterEqualNumRangeElements(n)) this
@@ -334,9 +334,9 @@ sealed abstract class Range(
   }
 
   /** Creates a new range consisting of the initial `length - n` elements of the range.
-    *
-    *  $doesNotUseBuilders
-    */
+   *
+   *  $doesNotUseBuilders
+   */
   final override def dropRight(n: Int): Range = {
     if (n <= 0 || isEmpty) this
     else if (greaterEqualNumRangeElements(n)) newEmptyRange(end)
@@ -386,13 +386,13 @@ sealed abstract class Range(
   }
 
   /** Creates a new range containing the elements starting at `from` up to but not including `until`.
-    *
-    *  $doesNotUseBuilders
-    *
-    *  @param from  the element at which to start
-    *  @param until  the element at which to end (not included in the range)
-    *  @return   a new range consisting of a contiguous interval of values in the old range
-    */
+   *
+   *  $doesNotUseBuilders
+   *
+   *  @param from  the element at which to start
+   *  @param until  the element at which to end (not included in the range)
+   *  @return   a new range consisting of a contiguous interval of values in the old range
+   */
   final override def slice(from: Int, until: Int): Range =
     if (isEmpty) this
     else if (from <= 0) take(until)
@@ -412,14 +412,12 @@ sealed abstract class Range(
   // based on the given value.
   private def newEmptyRange(value: Int) = new Range.Exclusive(value, value, step)
 
-  /** Returns the reverse of this range.
-    */
+  /** Returns the reverse of this range. */
   final override def reverse: Range =
     if (isEmpty) this
     else new Range.Inclusive(last, start, -step)
 
-  /** Makes range inclusive.
-    */
+  /** Makes range inclusive. */
   final def inclusive: Range =
     if (isInclusive) this
     else new Range.Inclusive(start, end, step)
@@ -584,10 +582,10 @@ sealed abstract class Range(
 object Range {
 
   /** Counts the number of range elements.
-    *  precondition:  step != 0
-    *  If the size of the range exceeds Int.MaxValue, the
-    *  result will be negative.
-    */
+   *  precondition:  step != 0
+   *  If the size of the range exceeds Int.MaxValue, the
+   *  result will be negative.
+   */
   def count(start: Int, end: Int, step: Int, isInclusive: Boolean): Int = {
     if (step == 0)
       throw new IllegalArgumentException("step cannot be 0.")
@@ -618,21 +616,19 @@ object Range {
     count(start, end, step, isInclusive = false)
 
   /** Makes a range from `start` until `end` (exclusive) with given step value.
-    * @note step != 0
-    */
+   *  @note step != 0
+   */
   def apply(start: Int, end: Int, step: Int): Range.Exclusive = new Range.Exclusive(start, end, step)
 
-  /** Makes a range from `start` until `end` (exclusive) with step value 1.
-    */
+  /** Makes a range from `start` until `end` (exclusive) with step value 1. */
   def apply(start: Int, end: Int): Range.Exclusive = new Range.Exclusive(start, end, 1)
 
   /** Makes an inclusive range from `start` to `end` with given step value.
-    * @note step != 0
-    */
+   *  @note step != 0
+   */
   def inclusive(start: Int, end: Int, step: Int): Range.Inclusive = new Range.Inclusive(start, end, step)
 
-  /** Makes an inclusive range from `start` to `end` with step value 1.
-    */
+  /** Makes an inclusive range from `start` to `end` with step value 1. */
   def inclusive(start: Int, end: Int): Range.Inclusive = new Range.Inclusive(start, end, 1)
 
   @SerialVersionUID(4L)
@@ -691,9 +687,9 @@ object Range {
 }
 
 /**
-  * @param lastElement The last element included in the Range
-  * @param initiallyEmpty Whether the Range was initially empty or not
-  */
+ *  @param lastElement The last element included in the Range
+ *  @param initiallyEmpty Whether the Range was initially empty or not
+ */
 @SerialVersionUID(4L)
 private class RangeIterator(
   start: Int,

--- a/library/src/scala/collection/immutable/RedBlackTree.scala
+++ b/library/src/scala/collection/immutable/RedBlackTree.scala
@@ -70,7 +70,8 @@ private[collection] object RedBlackTree {
       } else tree.black
     }
     /** Creates a new balanced tree where `newLeft` replaces `tree.left`.
-     * tree and newLeft are never null */
+     *  tree and newLeft are never null 
+     */
     protected final def mutableBalanceLeft[A1, B, B1 >: B](tree: Tree[A1, B], newLeft: Tree[A1, B1]): Tree[A1, B1] = {
       // Parameter trees
       //            tree              |                   newLeft
@@ -113,7 +114,8 @@ private[collection] object RedBlackTree {
       }
     }
     /** Creates a new balanced tree where `newRight` replaces `tree.right`.
-     * tree and newRight are never null */
+     *  tree and newRight are never null 
+     */
     protected final def mutableBalanceRight[A1, B, B1 >: B](tree: Tree[A1, B], newRight: Tree[A1, B1]): Tree[A1, B1] = {
       // Parameter trees
       //            tree                |                             newRight
@@ -244,9 +246,7 @@ private[collection] object RedBlackTree {
     blacken(_init(tree))
   }
 
-  /**
-    * Returns the smallest node with a key larger than or equal to `x`. Returns `null` if there is no such node.
-    */
+  /** Returns the smallest node with a key larger than or equal to `x`. Returns `null` if there is no such node. */
   def minAfter[A, B](tree: Tree[A, B] | Null, x: A)(implicit ordering: Ordering[A]): Tree[A, B] | Null = if (tree eq null) null else {
     val cmp = ordering.compare(x, tree.key)
     if (cmp == 0) tree
@@ -256,9 +256,7 @@ private[collection] object RedBlackTree {
     } else minAfter(tree.right, x)
   }
 
-  /**
-    * Returns the largest node with a key smaller than `x`. Returns `null` if there is no such node.
-    */
+  /** Returns the largest node with a key smaller than `x`. Returns `null` if there is no such node. */
   def maxBefore[A, B](tree: Tree[A, B] | Null, x: A)(implicit ordering: Ordering[A]): Tree[A, B] | Null = if (tree eq null) null else {
     val cmp = ordering.compare(x, tree.key)
     if (cmp <= 0) maxBefore(tree.left, x)
@@ -786,7 +784,7 @@ private[collection] object RedBlackTree {
   @`inline` private[RedBlackTree] def mutableBlackTree[A, B](key: A, value: B, left: Tree[A, B] | Null, right: Tree[A, B] | Null) = new Tree[A,B](key, value.asInstanceOf[AnyRef], left, right, initialBlackCount)
 
   /** Creates a new immutable red tree.
-   * left and right may be null.
+   *  left and right may be null.
    */
   private[immutable] def RedTree[A, B](key: A, value: B, left: Tree[A, B] | Null, right: Tree[A, B] | Null): Tree[A, B] = {
     //assertNotMutable(left)
@@ -855,12 +853,11 @@ private[collection] object RedBlackTree {
     private var index = 0
     protected var lookahead: Tree[A, B] | Null = if (start.isDefined) startFrom(start.get) else findLeftMostOrPopOnEmpty(root)
 
-    /**
-      * Finds the leftmost subtree whose key is equal to the given key, or if no such thing,
-      * the leftmost subtree with the key that would be "next" after it according
-      * to the ordering. Along the way build up the iterator's path stack so that "next"
-      * functionality works.
-      */
+    /** Finds the leftmost subtree whose key is equal to the given key, or if no such thing,
+     *  the leftmost subtree with the key that would be "next" after it according
+     *  to the ordering. Along the way build up the iterator's path stack so that "next"
+     *  functionality works.
+     */
     private def startFrom(key: A) : Tree[A,B] | Null = if (root eq null) null else {
       @tailrec def find(tree: Tree[A, B] | Null): Tree[A, B] | Null =
         if (tree eq null) popNext()

--- a/library/src/scala/collection/immutable/Seq.scala
+++ b/library/src/scala/collection/immutable/Seq.scala
@@ -28,16 +28,15 @@ trait Seq[+A] extends Iterable[A]
 }
 
 /**
-  * @define coll immutable sequence
-  * @define Coll `immutable.Seq`
-  */
+ *  @define coll immutable sequence
+ *  @define Coll `immutable.Seq`
+ */
 transparent trait SeqOps[+A, +CC[B] <: caps.Pure, +C] extends Any with collection.SeqOps[A, CC, C] with caps.Pure
 
-/**
-  * $factoryInfo
-  * @define coll immutable sequence
-  * @define Coll `immutable.Seq`
-  */
+/** $factoryInfo
+ *  @define coll immutable sequence
+ *  @define Coll `immutable.Seq`
+ */
 @SerialVersionUID(3L)
 object Seq extends SeqFactory.Delegate[Seq](List) {
   override def from[E](it: IterableOnce[E]^): Seq[E] = it match {
@@ -93,10 +92,10 @@ trait IndexedSeq[+A] extends Seq[A]
   }
 
   /** a hint to the runtime when scanning values
-    * [[apply]] is preferred for scan with a max index less than this value
-    * [[iterator]] is preferred for scans above this range
-    * @return a hint about when to use [[apply]] or [[iterator]]
-    */
+   *  [[apply]] is preferred for scan with a max index less than this value
+   *  [[iterator]] is preferred for scans above this range
+   *  @return a hint about when to use [[apply]] or [[iterator]]
+   */
   protected def applyPreferredMaxLength: Int = IndexedSeqDefaults.defaultApplyPreferredMaxLength
 
   override def iterableFactory: SeqFactory[IndexedSeq] = IndexedSeq

--- a/library/src/scala/collection/immutable/Set.scala
+++ b/library/src/scala/collection/immutable/Set.scala
@@ -29,31 +29,31 @@ trait Set[A] extends Iterable[A]
 }
 
 /** Base trait for immutable set operations
-  *
-  * @define coll immutable set
-  * @define Coll `immutable.Set`
-  */
+ *
+ *  @define coll immutable set
+ *  @define Coll `immutable.Set`
+ */
 transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   extends collection.SetOps[A, CC, C] {
 
   /** Creates a new set with an additional element, unless the element is
-    *  already present.
-    *
-    *  @param elem the element to be added
-    *  @return a new set that contains all elements of this set and that also
-    *          contains `elem`.
-    */
+   *  already present.
+   *
+   *  @param elem the element to be added
+   *  @return a new set that contains all elements of this set and that also
+   *          contains `elem`.
+   */
   def incl(elem: A): C
 
   /** Alias for `incl`. */
   override final def + (elem: A): C = incl(elem) // like in collection.Set but not deprecated
 
   /** Creates a new set with a given element removed from this set.
-    *
-    *  @param elem the element to be removed
-    *  @return a new set that contains all elements of this set but that does not
-    *          contain `elem`.
-    */
+   *
+   *  @param elem the element to be removed
+   *  @return a new set that contains all elements of this set but that does not
+   *          contain `elem`.
+   */
   def excl(elem: A): C
 
   /** Alias for `excl`. */
@@ -63,11 +63,11 @@ transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
     foldLeft(empty)((result, elem) => if (that contains elem) result else result + elem)
 
   /** Creates a new $coll from this $coll by removing all elements of another
-    *  collection.
-    *
-    *  @param that the collection containing the elements to remove.
-    *  @return a new $coll with the given elements removed, omitting duplicates.
-    */
+   *  collection.
+   *
+   *  @param that the collection containing the elements to remove.
+   *  @return a new $coll with the given elements removed, omitting duplicates.
+   */
   def removedAll(that: IterableOnce[A]^): C = that.iterator.foldLeft[C](coll)(_ - _)
 
   /** Alias for removedAll. */
@@ -87,11 +87,10 @@ transparent trait StrictOptimizedSetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   }
 }
 
-/**
-  * $factoryInfo
-  * @define coll immutable set
-  * @define Coll `immutable.Set`
-  */
+/** $factoryInfo
+ *  @define coll immutable set
+ *  @define Coll `immutable.Set`
+ */
 @SerialVersionUID(3L)
 object Set extends IterableFactory[Set] {
 
@@ -360,8 +359,8 @@ object Set extends IterableFactory[Set] {
 abstract class AbstractSet[A] extends scala.collection.AbstractSet[A] with Set[A]
 
 /** Builder for Set.
-  * $multipleResults
-  */
+ *  $multipleResults
+ */
 private final class SetBuilderImpl[A] extends ReusableBuilder[A, Set[A]] {
   private var elems: Set[A] = Set.empty
   private var switchedToHashSetBuilder: Boolean = false

--- a/library/src/scala/collection/immutable/SortedMap.scala
+++ b/library/src/scala/collection/immutable/SortedMap.scala
@@ -21,38 +21,38 @@ import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.mutable.Builder
 
 /** An immutable map whose key-value pairs are sorted according to an [[scala.math.Ordering]] on the keys.
-  *
-  * Allows for range queries to be performed on its keys, and implementations must guarantee that traversal happens in
-  * sorted order, according to the map's [[scala.math.Ordering]].
-  *
-  *  @example {{{
-  *  import scala.collection.immutable.SortedMap
-  *
-  *  // Make a SortedMap via the companion object factory
-  *  val weekdays = SortedMap(
-  *    2 -> "Monday",
-  *    3 -> "Tuesday",
-  *    4 -> "Wednesday",
-  *    5 -> "Thursday",
-  *    6 -> "Friday"
-  *  )
-  *  // TreeMap(2 -> Monday, 3 -> Tuesday, 4 -> Wednesday, 5 -> Thursday, 6 -> Friday)
-  *
-  *  val days = weekdays ++ List(1 -> "Sunday", 7 -> "Saturday")
-  *  // TreeMap(1 -> Sunday, 2 -> Monday, 3 -> Tuesday, 4 -> Wednesday, 5 -> Thursday, 6 -> Friday, 7 -> Saturday)
-  *
-  *  val day3 = days.get(3) // Some("Tuesday")
-  *
-  *  val rangeOfDays = days.range(2, 5) // TreeMap(2 -> Monday, 3 -> Tuesday, 4 -> Wednesday)
-  *
-  *  val daysUntil2 = days.rangeUntil(2) // TreeMap(1 -> Sunday)
-  *  val daysTo2 = days.rangeTo(2) // TreeMap(1 -> Sunday, 2 -> Monday)
-  *  val daysAfter5 = days.rangeFrom(5) //  TreeMap(5 -> Thursday, 6 -> Friday, 7 -> Saturday)
-  *  }}}
-  *
-  *  @tparam K the type of the keys contained in this tree map.
-  *  @tparam V the type of the values associated with the keys.
-  */
+ *
+ *  Allows for range queries to be performed on its keys, and implementations must guarantee that traversal happens in
+ *  sorted order, according to the map's [[scala.math.Ordering]].
+ *
+ *  @example ```
+ *  import scala.collection.immutable.SortedMap
+ *
+ *  // Make a SortedMap via the companion object factory
+ *  val weekdays = SortedMap(
+ *    2 -> "Monday",
+ *    3 -> "Tuesday",
+ *    4 -> "Wednesday",
+ *    5 -> "Thursday",
+ *    6 -> "Friday"
+ *  )
+ *  // TreeMap(2 -> Monday, 3 -> Tuesday, 4 -> Wednesday, 5 -> Thursday, 6 -> Friday)
+ *
+ *  val days = weekdays ++ List(1 -> "Sunday", 7 -> "Saturday")
+ *  // TreeMap(1 -> Sunday, 2 -> Monday, 3 -> Tuesday, 4 -> Wednesday, 5 -> Thursday, 6 -> Friday, 7 -> Saturday)
+ *
+ *  val day3 = days.get(3) // Some("Tuesday")
+ *
+ *  val rangeOfDays = days.range(2, 5) // TreeMap(2 -> Monday, 3 -> Tuesday, 4 -> Wednesday)
+ *
+ *  val daysUntil2 = days.rangeUntil(2) // TreeMap(1 -> Sunday)
+ *  val daysTo2 = days.rangeTo(2) // TreeMap(1 -> Sunday, 2 -> Monday)
+ *  val daysAfter5 = days.rangeFrom(5) //  TreeMap(5 -> Thursday, 6 -> Friday, 7 -> Saturday)
+ *  ```
+ *
+ *  @tparam K the type of the keys contained in this tree map.
+ *  @tparam V the type of the values associated with the keys.
+ */
 trait SortedMap[K, +V]
   extends Map[K, V]
     with collection.SortedMap[K, V]
@@ -64,25 +64,25 @@ trait SortedMap[K, +V]
   override def sortedMapFactory: SortedMapFactory[SortedMap] = SortedMap
 
   /** The same map with a given default function.
-    *  Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
-    *  are not affected by `withDefault`.
-    *
-    *  Invoking transformer methods (e.g. `map`) will not preserve the default value.
-    *
-    *  @param d     the function mapping keys to values, used for non-present keys
-    *  @return      a wrapper of the map with a default value
-    */
+   *  Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
+   *  are not affected by `withDefault`.
+   *
+   *  Invoking transformer methods (e.g. `map`) will not preserve the default value.
+   *
+   *  @param d     the function mapping keys to values, used for non-present keys
+   *  @return      a wrapper of the map with a default value
+   */
   override def withDefault[V1 >: V](d: K -> V1): SortedMap[K, V1] = new SortedMap.WithDefault[K, V1](this, d)
 
   /** The same map with a given default value.
-    *  Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
-    *  are not affected by `withDefaultValue`.
-    *
-    *  Invoking transformer methods (e.g. `map`) will not preserve the default value.
-    *
-    *  @param d     default value used for non-present keys
-    *  @return      a wrapper of the map with a default value
-    */
+   *  Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
+   *  are not affected by `withDefaultValue`.
+   *
+   *  Invoking transformer methods (e.g. `map`) will not preserve the default value.
+   *
+   *  @param d     default value used for non-present keys
+   *  @return      a wrapper of the map with a default value
+   */
   override def withDefaultValue[V1 >: V](d: V1): SortedMap[K, V1] = new SortedMap.WithDefault[K, V1](this, _ => d)
 }
 

--- a/library/src/scala/collection/immutable/SortedSet.scala
+++ b/library/src/scala/collection/immutable/SortedSet.scala
@@ -30,9 +30,9 @@ trait SortedSet[A]
 }
 
 /**
-  * @define coll immutable sorted set
-  * @define Coll `immutable.SortedSet`
-  */
+ *  @define coll immutable sorted set
+ *  @define Coll `immutable.SortedSet`
+ */
 transparent trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
   extends SetOps[A, Set, C]
      with collection.SortedSetOps[A, CC, C] {
@@ -46,11 +46,10 @@ transparent trait StrictOptimizedSortedSetOps[A, +CC[X] <: SortedSet[X], +C <: S
     with StrictOptimizedSetOps[A, Set, C] {
 }
 
-/**
-  * $factoryInfo
-  * @define coll immutable sorted set
-  * @define Coll `immutable.SortedSet`
-  */
+/** $factoryInfo
+ *  @define coll immutable sorted set
+ *  @define Coll `immutable.SortedSet`
+ */
 @SerialVersionUID(3L)
 object SortedSet extends SortedIterableFactory.Delegate[SortedSet](TreeSet) {
   override def from[E: Ordering](it: IterableOnce[E]^): SortedSet[E] = (it: @unchecked) match {

--- a/library/src/scala/collection/immutable/Stream.scala
+++ b/library/src/scala/collection/immutable/Stream.scala
@@ -35,14 +35,14 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
   def tail: Stream[A]
 
   /** Forces evaluation of the whole `Stream` and returns it.
-    *
-    * @note Often we use `Stream`s to represent an infinite set or series.  If
-    * that's the case for your particular `Stream` then this function will never
-    * return and will probably crash the VM with an `OutOfMemory` exception.
-    * This function will not hang on a finite cycle, however.
-    *
-    *  @return The fully realized `Stream`.
-    */
+   *
+   *  @note Often we use `Stream`s to represent an infinite set or series.  If
+   *  that's the case for your particular `Stream` then this function will never
+   *  return and will probably crash the VM with an `OutOfMemory` exception.
+   *  This function will not hang on a finite cycle, however.
+   *
+   *  @return The fully realized `Stream`.
+   */
   def force: this.type
 
   override def iterableFactory: SeqFactory[Stream] = Stream
@@ -50,16 +50,16 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
   override protected def className: String = "Stream"
 
   /** Applies the given function `f` to each element of this linear sequence
-    * (while respecting the order of the elements).
-    *
-    *  @param f The treatment to apply to each element.
-    *  @note  Overridden here as final to trigger tail-call optimization, which
-    *  replaces 'this' with 'tail' at each iteration. This is absolutely
-    *  necessary for allowing the GC to collect the underlying Stream as elements
-    *  are consumed.
-    *  @note  This function will force the realization of the entire Stream
-    *  unless the `f` throws an exception.
-    */
+   *  (while respecting the order of the elements).
+   *
+   *  @param f The treatment to apply to each element.
+   *  @note  Overridden here as final to trigger tail-call optimization, which
+   *  replaces 'this' with 'tail' at each iteration. This is absolutely
+   *  necessary for allowing the GC to collect the underlying Stream as elements
+   *  are consumed.
+   *  @note  This function will force the realization of the entire Stream
+   *  unless the `f` throws an exception.
+   */
   @tailrec
   override final def foreach[U](f: A => U): Unit = {
     if (!this.isEmpty) {
@@ -82,13 +82,13 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
   }
 
   /** Stream specialization of foldLeft which allows GC to collect along the
-    * way.
-    *
-    * @tparam B The type of value being accumulated.
-    * @param z The initial value seeded into the function `op`.
-    * @param op The operation to perform on successive elements of the `Stream`.
-    * @return The accumulated value from successive applications of `op`.
-    */
+   *  way.
+   *
+   *  @tparam B The type of value being accumulated.
+   *  @param z The initial value seeded into the function `op`.
+   *  @param op The operation to perform on successive elements of the `Stream`.
+   *  @return The accumulated value from successive applications of `op`.
+   */
   @tailrec
   override final def foldLeft[B](z: B)(op: (B, A) => B): B = {
     if (this.isEmpty) z
@@ -96,9 +96,9 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
   }
 
   /** The stream resulting from the concatenation of this stream with the argument stream.
-    *  @param rest   The collection that gets appended to this stream
-    *  @return       The stream containing elements of this stream and the iterable object.
-    */
+   *  @param rest   The collection that gets appended to this stream
+   *  @return       The stream containing elements of this stream and the iterable object.
+   */
   @deprecated("The `append` operation has been renamed `lazyAppendedAll`", "2.13.0")
   @inline final def append[B >: A](rest: => IterableOnce[B]): Stream[B] = lazyAppendedAll(rest)
 
@@ -110,16 +110,16 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
   @inline def print(): Unit = Console.print(this.force.mkString(", "))
 
   /** Prints elements of this stream one by one, separated by `sep`.
-    *  @param sep   The separator string printed between consecutive elements.
-    */
+   *  @param sep   The separator string printed between consecutive elements.
+   */
   @deprecated(message = "Use print(stream.force.mkString(sep)) instead", since = "2.13.0")
   @inline def print(sep: String): Unit = Console.print(this.force.mkString(sep))
 
   /** The stream resulting from the concatenation of this stream with the argument stream.
-    *
-    * @param suffix The collection that gets appended to this stream
-    * @return The stream containing elements of this stream and the iterable object.
-    */
+   *
+   *  @param suffix The collection that gets appended to this stream
+   *  @return The stream containing elements of this stream and the iterable object.
+   */
   def lazyAppendedAll[B >: A](suffix: => collection.IterableOnce[B]): Stream[B] =
     if (isEmpty) iterableFactory.from(suffix) else Stream.cons[B](head, tail.lazyAppendedAll(suffix))
 
@@ -128,12 +128,12 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
     else Stream.cons(z, tail.scanLeft(op(z, head))(op))
 
   /** Stream specialization of reduceLeft which allows GC to collect
-    *  along the way.
-    *
-    * @tparam B The type of value being accumulated.
-    * @param f The operation to perform on successive elements of the `Stream`.
-    * @return The accumulated value from successive applications of `f`.
-    */
+   *  along the way.
+   *
+   *  @tparam B The type of value being accumulated.
+   *  @param f The operation to perform on successive elements of the `Stream`.
+   *  @return The accumulated value from successive applications of `f`.
+   */
   override final def reduceLeft[B >: A](f: (B, A) => B): B = {
     if (this.isEmpty) throw new UnsupportedOperationException("empty.reduceLeft")
     else {
@@ -224,19 +224,19 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
   protected def tailDefined: Boolean
 
   /** Appends all elements of this $coll to a string builder using start, end, and separator strings.
-    *  The written text begins with the string `start` and ends with the string `end`.
-    *  Inside, the string representations (w.r.t. the method `toString`)
-    *  of all elements of this $coll are separated by the string `sep`.
-    *
-    * Undefined elements are represented with `"_"`, an undefined tail is represented with `"&lt;not computed&gt;"`,
-    * and cycles are represented with `"&lt;cycle&gt;"`.
-    *
-    *  @param sb    the string builder to which elements are appended.
-    *  @param start the starting string.
-    *  @param sep   the separator string.
-    *  @param end   the ending string.
-    *  @return      the string builder `b` to which elements were appended.
-    */
+   *  The written text begins with the string `start` and ends with the string `end`.
+   *  Inside, the string representations (w.r.t. the method `toString`)
+   *  of all elements of this $coll are separated by the string `sep`.
+   *
+   *  Undefined elements are represented with `"_"`, an undefined tail is represented with `"&lt;not computed&gt;"`,
+   *  and cycles are represented with `"&lt;cycle&gt;"`.
+   *
+   *  @param sb    the string builder to which elements are appended.
+   *  @param start the starting string.
+   *  @param sep   the separator string.
+   *  @param end   the ending string.
+   *  @return      the string builder `b` to which elements were appended.
+   */
   override def addString(sb: StringBuilder, start: String, sep: String, end: String): sb.type = {
     force
     addStringNoForce(sb.underlying, start, sep, end)
@@ -315,20 +315,19 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
     b
   }
 
-  /**
-    * @return a string representation of this collection. Undefined elements are
-    *         represented with `"_"`, an undefined tail is represented with `"&lt;not computed&gt;"`,
-    *         and cycles are represented with `"&lt;cycle&gt;"`
-    *
-    *         Examples:
-    *
-    *           - `"Stream(_, &lt;not computed&gt;)"`, a non-empty stream, whose head has not been
-    *             evaluated ;
-    *           - `"Stream(_, 1, _, &lt;not computed&gt;)"`, a stream with at least three elements,
-    *             the second one has been evaluated ;
-    *           - `"Stream(1, 2, 3, &lt;cycle&gt;)"`, an infinite stream that contains
-    *             a cycle at the fourth element.
-    */
+  /** Returns a string representation of this collection. Undefined elements are
+   *         represented with `"_"`, an undefined tail is represented with `"&lt;not computed&gt;"`,
+   *         and cycles are represented with `"&lt;cycle&gt;"`
+   *
+   *         Examples:
+   *
+   *           - `"Stream(_, &lt;not computed&gt;)"`, a non-empty stream, whose head has not been
+   *             evaluated ;
+   *           - `"Stream(_, 1, _, &lt;not computed&gt;)"`, a stream with at least three elements,
+   *             the second one has been evaluated ;
+   *           - `"Stream(1, 2, 3, &lt;cycle&gt;)"`, an infinite stream that contains
+   *             a cycle at the fourth element.
+   */
   override def toString() = addStringNoForce(new JStringBuilder(className), "(", ", ", ")").toString
 
   @deprecated("Check .knownSize instead of .hasDefiniteSize for more actionable information (see scaladoc for details)", "2.13.0")
@@ -360,13 +359,12 @@ object Stream extends SeqFactory[Stream] {
   /* !!! #11997 This `object cons` must be defined lexically *before* `class Cons` below.
    * Otherwise it prevents Scala.js from building on Windows.
    */
-  /** An alternative way of building and matching Streams using Stream.cons(hd, tl).
-    */
+  /** An alternative way of building and matching Streams using Stream.cons(hd, tl). */
   object cons {
     /** A stream consisting of a given first element and remaining elements.
-      *  @param hd   The first element of the result stream
-      *  @param tl   The remaining elements of the result stream
-      */
+     *  @param hd   The first element of the result stream
+     *  @param tl   The remaining elements of the result stream
+     */
     def apply[A](hd: A, tl: => Stream[A]): Stream[A] = new Cons(hd, tl)
 
     /** Maps a stream to its head and tail. */
@@ -379,14 +377,14 @@ object Stream extends SeqFactory[Stream] {
     override def head: Nothing = throw new NoSuchElementException("head of empty stream")
     override def tail: Stream[Nothing] = throw new UnsupportedOperationException("tail of empty stream")
     /** Forces evaluation of the whole `Stream` and returns it.
-      *
-      * @note Often we use `Stream`s to represent an infinite set or series.  If
-      * that's the case for your particular `Stream` then this function will never
-      * return and will probably crash the VM with an `OutOfMemory` exception.
-      * This function will not hang on a finite cycle, however.
-      *
-      *  @return The fully realized `Stream`.
-      */
+     *
+     *  @note Often we use `Stream`s to represent an infinite set or series.  If
+     *  that's the case for your particular `Stream` then this function will never
+     *  return and will probably crash the VM with an `OutOfMemory` exception.
+     *  This function will not hang on a finite cycle, however.
+     *
+     *  @return The fully realized `Stream`.
+     */
     def force: this.type = this
     override def knownSize: Int = 0
     protected def tailDefined: Boolean = false
@@ -410,14 +408,14 @@ object Stream extends SeqFactory[Stream] {
     }
 
     /** Forces evaluation of the whole `Stream` and returns it.
-      *
-      * @note Often we use `Stream`s to represent an infinite set or series.  If
-      * that's the case for your particular `Stream` then this function will never
-      * return and will probably crash the VM with an `OutOfMemory` exception.
-      * This function will not hang on a finite cycle, however.
-      *
-      *  @return The fully realized `Stream`.
-      */
+     *
+     *  @note Often we use `Stream`s to represent an infinite set or series.  If
+     *  that's the case for your particular `Stream` then this function will never
+     *  return and will probably crash the VM with an `OutOfMemory` exception.
+     *  This function will not hang on a finite cycle, however.
+     *
+     *  @return The fully realized `Stream`.
+     */
     def force: this.type = {
       // Use standard 2x 1x iterator trick for cycle detection ("those" is slow one)
       var these, those: Stream[A] = this
@@ -439,12 +437,12 @@ object Stream extends SeqFactory[Stream] {
 
   final class Deferrer[A] private[Stream] (private val l: () => Stream[A]) extends AnyVal {
     /** Constructs a `Stream` consisting of a given first element followed by elements
-      *  from another `Stream`.
-      */
+     *  from another `Stream`.
+     */
     def #:: [B >: A](elem: B): Stream[B] = new Cons(elem, l())
     /** Constructs a `Stream` consisting of the concatenation of the given `Stream` and
-      *  another `Stream`.
-      */
+     *  another `Stream`.
+     */
     def #:::[B >: A](prefix: Stream[B]): Stream[B] = prefix lazyAppendedAll l()
   }
 
@@ -459,11 +457,11 @@ object Stream extends SeqFactory[Stream] {
   }
 
   /**
-    * @return A `Stream[A]` that gets its elements from the given `Iterator`.
-    *
-    * @param it Source iterator
-    * @tparam A type of elements
-    */
+   *  @tparam A type of elements
+   *
+   *  @param it Source iterator
+   *  @return A `Stream[A]` that gets its elements from the given `Iterator`.
+   */
   // Note that the resulting `Stream` will be effectively iterable more than once because
   // `Stream` memoizes its elements
   def fromIterator[A](it: Iterator[A]): Stream[A] =
@@ -488,41 +486,38 @@ object Stream extends SeqFactory[Stream] {
   }
 
   /** An infinite Stream that repeatedly applies a given function to a start value.
-    *
-    *  @param start the start value of the Stream
-    *  @param f     the function that's repeatedly applied
-    *  @return      the Stream returning the infinite sequence of values `start, f(start), f(f(start)), ...`
-    */
+   *
+   *  @param start the start value of the Stream
+   *  @param f     the function that's repeatedly applied
+   *  @return      the Stream returning the infinite sequence of values `start, f(start), f(f(start)), ...`
+   */
   def iterate[A](start: A)(f: A => A): Stream[A] = {
     cons(start, iterate(f(start))(f))
   }
 
-  /**
-    * Creates an infinite Stream starting at `start` and incrementing by
-    * step `step`.
-    *
-    * @param start the start value of the Stream
-    * @param step the increment value of the Stream
-    * @return the Stream starting at value `start`.
-    */
+  /** Creates an infinite Stream starting at `start` and incrementing by
+   *  step `step`.
+   *
+   *  @param start the start value of the Stream
+   *  @param step the increment value of the Stream
+   *  @return the Stream starting at value `start`.
+   */
   def from(start: Int, step: Int): Stream[Int] =
     cons(start, from(start + step, step))
 
-  /**
-    * Creates an infinite Stream starting at `start` and incrementing by `1`.
-    *
-    * @param start the start value of the Stream
-    * @return the Stream starting at value `start`.
-    */
+  /** Creates an infinite Stream starting at `start` and incrementing by `1`.
+   *
+   *  @param start the start value of the Stream
+   *  @return the Stream starting at value `start`.
+   */
   def from(start: Int): Stream[Int] = from(start, 1)
 
-  /**
-    * Creates an infinite Stream containing the given element expression (which
-    * is computed for each occurrence).
-    *
-    * @param elem the element composing the resulting Stream
-    * @return the Stream containing an infinite number of elem
-    */
+  /** Creates an infinite Stream containing the given element expression (which
+   *  is computed for each occurrence).
+   *
+   *  @param elem the element composing the resulting Stream
+   *  @return the Stream containing an infinite number of elem
+   */
   def continually[A](elem: => A): Stream[A] = cons(elem, continually(elem))
 
 
@@ -535,10 +530,10 @@ object Stream extends SeqFactory[Stream] {
   }
 
   /** This serialization proxy is used for Streams which start with a sequence of evaluated cons cells.
-    * The forced sequence is serialized in a compact, sequential format, followed by the unevaluated tail, which uses
-    * standard Java serialization to store the complete structure of unevaluated thunks. This allows the serialization
-    * of long evaluated streams without exhausting the stack through recursive serialization of cons cells.
-    */
+   *  The forced sequence is serialized in a compact, sequential format, followed by the unevaluated tail, which uses
+   *  standard Java serialization to store the complete structure of unevaluated thunks. This allows the serialization
+   *  of long evaluated streams without exhausting the stack through recursive serialization of cons cells.
+   */
   @SerialVersionUID(3L)
   class SerializationProxy[A](@transient protected var coll: Stream[A]) extends Serializable {
 

--- a/library/src/scala/collection/immutable/StrictOptimizedSeqOps.scala
+++ b/library/src/scala/collection/immutable/StrictOptimizedSeqOps.scala
@@ -19,8 +19,7 @@ import language.experimental.captureChecking
 
 import scala.collection.generic.CommonErrors
 
-/** Trait that overrides operations to take advantage of strict builders.
- */
+/** Trait that overrides operations to take advantage of strict builders. */
 transparent trait StrictOptimizedSeqOps[+A, +CC[B] <: caps.Pure, +C]
   extends Any
     with SeqOps[A, CC, C]

--- a/library/src/scala/collection/immutable/TreeMap.scala
+++ b/library/src/scala/collection/immutable/TreeMap.scala
@@ -25,54 +25,54 @@ import scala.collection.mutable.ReusableBuilder
 import scala.runtime.AbstractFunction2
 
 /** An immutable SortedMap whose values are stored in a red-black tree.
-  *
-  * This class is optimal when range queries will be performed,
-  * or when traversal in order of an ordering is desired.
-  * If you only need key lookups, and don't care in which order key-values
-  * are traversed in, consider using * [[scala.collection.immutable.HashMap]],
-  * which will generally have better performance. If you need insertion order,
-  * consider a * [[scala.collection.immutable.SeqMap]], which does not need to
-  * have an ordering supplied.
-  *
-  *  @example {{{
-  *  import scala.collection.immutable.TreeMap
-  *
-  *  // Make a TreeMap via the companion object factory
-  *  val weekdays = TreeMap(
-  *    2 -> "Monday",
-  *    3 -> "Tuesday",
-  *    4 -> "Wednesday",
-  *    5 -> "Thursday",
-  *    6 -> "Friday"
-  *  )
-  *  // TreeMap(2 -> Monday, 3 -> Tuesday, 4 -> Wednesday, 5 -> Thursday, 6 -> Friday)
-  *
-  *  val days = weekdays ++ List(1 -> "Sunday", 7 -> "Saturday")
-  *  // TreeMap(1 -> Sunday, 2 -> Monday, 3 -> Tuesday, 4 -> Wednesday, 5 -> Thursday, 6 -> Friday, 7 -> Saturday)
-  *
-  *  val day3 = days.get(3) // Some("Tuesday")
-  *
-  *  val rangeOfDays = days.range(2, 5) // TreeMap(2 -> Monday, 3 -> Tuesday, 4 -> Wednesday)
-  *
-  *  val daysUntil2 = days.rangeUntil(2) // TreeMap(1 -> Sunday)
-  *  val daysTo2 = days.rangeTo(2) // TreeMap(1 -> Sunday, 2 -> Monday)
-  *  val daysAfter5 = days.rangeFrom(5) //  TreeMap(5 -> Thursday, 6 -> Friday, 7 -> Saturday)
-  *  }}}
-  *
-  *  @tparam K         the type of the keys contained in this tree map.
-  *  @tparam V         the type of the values associated with the keys.
-  *  @param ordering   the implicit ordering used to compare objects of type `A`.
-  *
-  *  @see [[https://docs.scala-lang.org/overviews/collections-2.13/concrete-immutable-collection-classes.html#red-black-trees "Scala's Collection Library overview"]]
-  *  section on `Red-Black Trees` for more information.
-  *
-  *  @define Coll immutable.TreeMap
-  *  @define coll immutable tree map
-  *  @define orderDependent
-  *  @define orderDependentFold
-  *  @define mayNotTerminateInf
-  *  @define willNotTerminateInf
-  */
+ *
+ *  This class is optimal when range queries will be performed,
+ *  or when traversal in order of an ordering is desired.
+ *  If you only need key lookups, and don't care in which order key-values
+ *  are traversed in, consider using * [[scala.collection.immutable.HashMap]],
+ *  which will generally have better performance. If you need insertion order,
+ *  consider a * [[scala.collection.immutable.SeqMap]], which does not need to
+ *  have an ordering supplied.
+ *
+ *  @example ```
+ *  import scala.collection.immutable.TreeMap
+ *
+ *  // Make a TreeMap via the companion object factory
+ *  val weekdays = TreeMap(
+ *    2 -> "Monday",
+ *    3 -> "Tuesday",
+ *    4 -> "Wednesday",
+ *    5 -> "Thursday",
+ *    6 -> "Friday"
+ *  )
+ *  // TreeMap(2 -> Monday, 3 -> Tuesday, 4 -> Wednesday, 5 -> Thursday, 6 -> Friday)
+ *
+ *  val days = weekdays ++ List(1 -> "Sunday", 7 -> "Saturday")
+ *  // TreeMap(1 -> Sunday, 2 -> Monday, 3 -> Tuesday, 4 -> Wednesday, 5 -> Thursday, 6 -> Friday, 7 -> Saturday)
+ *
+ *  val day3 = days.get(3) // Some("Tuesday")
+ *
+ *  val rangeOfDays = days.range(2, 5) // TreeMap(2 -> Monday, 3 -> Tuesday, 4 -> Wednesday)
+ *
+ *  val daysUntil2 = days.rangeUntil(2) // TreeMap(1 -> Sunday)
+ *  val daysTo2 = days.rangeTo(2) // TreeMap(1 -> Sunday, 2 -> Monday)
+ *  val daysAfter5 = days.rangeFrom(5) //  TreeMap(5 -> Thursday, 6 -> Friday, 7 -> Saturday)
+ *  ```
+ *
+ *  @tparam K         the type of the keys contained in this tree map.
+ *  @tparam V         the type of the values associated with the keys.
+ *  @param ordering   the implicit ordering used to compare objects of type `A`.
+ *
+ *  @see [[https://docs.scala-lang.org/overviews/collections-2.13/concrete-immutable-collection-classes.html#red-black-trees "Scala's Collection Library overview"]]
+ *  section on `Red-Black Trees` for more information.
+ *
+ *  @define Coll immutable.TreeMap
+ *  @define coll immutable tree map
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
 final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V] | Null)(implicit val ordering: Ordering[K])
   extends AbstractMap[K, V]
     with SortedMap[K, V]
@@ -304,9 +304,9 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V] | Null)(impl
 }
 
 /** $factoryInfo
-  *  @define Coll immutable.TreeMap
-  *  @define coll immutable tree map
-  */
+ *  @define Coll immutable.TreeMap
+ *  @define coll immutable tree map
+ */
 @SerialVersionUID(3L)
 object TreeMap extends SortedMapFactory[TreeMap] {
 

--- a/library/src/scala/collection/immutable/TreeSet.scala
+++ b/library/src/scala/collection/immutable/TreeSet.scala
@@ -25,20 +25,20 @@ import scala.runtime.AbstractFunction1
 
 
 /** This class implements immutable sorted sets using a tree.
-  *
-  *  @tparam A         the type of the elements contained in this tree set
-  *  @param ordering   the implicit ordering used to compare objects of type `A`
-  *
-  *  @see [[https://docs.scala-lang.org/overviews/collections-2.13/concrete-immutable-collection-classes.html#red-black-trees "Scala's Collection Library overview"]]
-  *  section on `Red-Black Trees` for more information.
-  *
-  *  @define Coll `immutable.TreeSet`
-  *  @define coll immutable tree set
-  *  @define orderDependent
-  *  @define orderDependentFold
-  *  @define mayNotTerminateInf
-  *  @define willNotTerminateInf
-  */
+ *
+ *  @tparam A         the type of the elements contained in this tree set
+ *  @param ordering   the implicit ordering used to compare objects of type `A`
+ *
+ *  @see ["Scala's Collection Library overview"](https://docs.scala-lang.org/overviews/collections-2.13/concrete-immutable-collection-classes.html#red-black-trees)
+ *  section on `Red-Black Trees` for more information.
+ *
+ *  @define Coll `immutable.TreeSet`
+ *  @define coll immutable tree set
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
 final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[A, Any] | Null)(implicit val ordering: Ordering[A])
   extends AbstractSet[A]
     with SortedSet[A]
@@ -147,10 +147,10 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
   }
 
   /** Checks if this set contains element `elem`.
-    *
-    *  @param  elem    the element to check for membership.
-    *  @return true, iff `elem` is contained in this set.
-    */
+   *
+   *  @param  elem    the element to check for membership.
+   *  @return true, iff `elem` is contained in this set.
+   */
   def contains(elem: A): Boolean = RB.contains(tree, elem)
 
   override def range(from: A, until: A): TreeSet[A] = newSetOrSelf(RB.range(tree, from, until))
@@ -158,18 +158,18 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
   def rangeImpl(from: Option[A], until: Option[A]): TreeSet[A] = newSetOrSelf(RB.rangeImpl(tree, from, until))
 
   /** Creates a new `TreeSet` with the entry added.
-    *
-    *  @param elem    a new element to add.
-    *  @return        a new $coll containing `elem` and all the elements of this $coll.
-    */
+   *
+   *  @param elem    a new element to add.
+   *  @return        a new $coll containing `elem` and all the elements of this $coll.
+   */
   def incl(elem: A): TreeSet[A] =
     newSetOrSelf(RB.update(tree, elem, null, overwrite = false))
 
   /** Creates a new `TreeSet` with the entry removed.
-    *
-    *  @param elem    a new element to add.
-    *  @return        a new $coll containing all the elements of this $coll except `elem`.
-    */
+   *
+   *  @param elem    a new element to add.
+   *  @return        a new $coll containing all the elements of this $coll except `elem`.
+   */
   def excl(elem: A): TreeSet[A] =
     newSetOrSelf(RB.delete(tree, elem))
 
@@ -231,12 +231,11 @@ final class TreeSet[A] private[immutable] (private[immutable] val tree: RB.Tree[
   override protected def className = "TreeSet"
 }
 
-/**
-  * $factoryInfo
-  *
-  *  @define Coll `immutable.TreeSet`
-  *  @define coll immutable tree set
-  */
+/** $factoryInfo
+ *
+ *  @define Coll `immutable.TreeSet`
+ *  @define coll immutable tree set
+ */
 @SerialVersionUID(3L)
 object TreeSet extends SortedIterableFactory[TreeSet] {
 

--- a/library/src/scala/collection/immutable/Vector.scala
+++ b/library/src/scala/collection/immutable/Vector.scala
@@ -30,9 +30,9 @@ import scala.collection.mutable.ReusableBuilder
 import scala.runtime.ScalaRunTime.nullForGC
 
 /** $factoryInfo
-  * @define Coll `Vector`
-  * @define coll vector
-  */
+ *  @define Coll `Vector`
+ *  @define coll vector
+ */
 @SerialVersionUID(3L)
 object Vector extends StrictOptimizedSeqFactory[Vector] {
 
@@ -68,11 +68,11 @@ object Vector extends StrictOptimizedSeqFactory[Vector] {
   def newBuilder[A]: ReusableBuilder[A, Vector[A]] = new VectorBuilder[A]
 
   /** Creates a Vector with the same element at each index.
-    *
-    * Unlike `fill`, which takes a by-name argument for the value and can thereby
-    * compute different values for each index, this method guarantees that all
-    * elements are identical. This allows sparse allocation in O(log n) time and space.
-    */
+   *
+   *  Unlike `fill`, which takes a by-name argument for the value and can thereby
+   *  compute different values for each index, this method guarantees that all
+   *  elements are identical. This allows sparse allocation in O(log n) time and space.
+   */
   private[collection] def fillSparse[A](n: Int)(elem: A): Vector[A] = {
     //TODO Make public; this method is private for now because it is not forward binary compatible
     if(n <= 0) Vector0
@@ -96,26 +96,26 @@ object Vector extends StrictOptimizedSeqFactory[Vector] {
 
 
 /** Vector is a general-purpose, immutable data structure.  It provides random access and updates
-  * in O(log n) time, as well as very fast append/prepend/tail/init (amortized O(1), worst case O(log n)).
-  * Because vectors strike a good balance between fast random selections and fast random functional updates,
-  * they are currently the default implementation of immutable indexed sequences.
-  *
-  * Vectors are implemented by radix-balanced finger trees of width 32. There is a separate subclass
-  * for each level (0 to 6, with 0 being the empty vector and 6 a tree with a maximum width of 64 at the
-  * top level).
-  *
-  * Tree balancing:
-  * - Only the first dimension of an array may have a size < WIDTH
-  * - In a `data` (central) array the first dimension may be up to WIDTH-2 long, in `prefix1` and `suffix1` up
-  *   to WIDTH, and in other `prefix` and `suffix` arrays up to WIDTH-1
-  * - `prefix1` and `suffix1` are never empty
-  * - Balancing does not cross the main data array (i.e. prepending never touches the suffix and appending never touches
-  *   the prefix). The level is increased/decreased when the affected side plus main data is already full/empty
-  * - All arrays are left-aligned and truncated
-  *
-  * In addition to the data slices (`prefix1`, `prefix2`, ..., `dataN`, ..., `suffix2`, `suffix1`) we store a running
-  * count of elements after each prefix for more efficient indexing without having to dereference all prefix arrays.
-  */
+ *  in O(log n) time, as well as very fast append/prepend/tail/init (amortized O(1), worst case O(log n)).
+ *  Because vectors strike a good balance between fast random selections and fast random functional updates,
+ *  they are currently the default implementation of immutable indexed sequences.
+ *
+ *  Vectors are implemented by radix-balanced finger trees of width 32. There is a separate subclass
+ *  for each level (0 to 6, with 0 being the empty vector and 6 a tree with a maximum width of 64 at the
+ *  top level).
+ *
+ *  Tree balancing:
+ *  - Only the first dimension of an array may have a size < WIDTH
+ *  - In a `data` (central) array the first dimension may be up to WIDTH-2 long, in `prefix1` and `suffix1` up
+ *   to WIDTH, and in other `prefix` and `suffix` arrays up to WIDTH-1
+ *  - `prefix1` and `suffix1` are never empty
+ *  - Balancing does not cross the main data array (i.e. prepending never touches the suffix and appending never touches
+ *   the prefix). The level is increased/decreased when the affected side plus main data is already full/empty
+ *  - All arrays are left-aligned and truncated
+ *
+ *  In addition to the data slices (`prefix1`, `prefix2`, ..., `dataN`, ..., `suffix2`, `suffix1`) we store a running
+ *  count of elements after each prefix for more efficient indexing without having to dereference all prefix arrays.
+ */
 sealed abstract class Vector[+A] private[immutable] (private[immutable] final val prefix1: Arr1)
   extends AbstractSeq[A]
     with IndexedSeq[A]
@@ -1162,11 +1162,11 @@ private final class Vector6[+A](_prefix1: Arr1, private[immutable] val len1: Int
 
 
 /** Helper class for vector slicing. It is initialized with the validated start and end index,
-  * then the vector slices are added in succession with `consider`. No matter what the dimension
-  * of the originating vector is or where the cut is performed, this always results in a
-  * structure with the highest-dimensional data in the middle and fingers of decreasing dimension
-  * at both ends, which can be turned into a new vector with very little rebalancing.
-  */
+ *  then the vector slices are added in succession with `consider`. No matter what the dimension
+ *  of the originating vector is or where the cut is performed, this always results in a
+ *  structure with the highest-dimensional data in the middle and fingers of decreasing dimension
+ *  at both ends, which can be turned into a new vector with very little rebalancing.
+ */
 private final class VectorSliceBuilder(lo: Int, hi: Int) {
   //println(s"***** VectorSliceBuilder($lo, $hi)")
 
@@ -1596,16 +1596,15 @@ final class VectorBuilder[A] extends ReusableBuilder[A, Vector[A]] {
     this
   }
 
-  /**
-   * Removes `offset` leading `null`s in the prefix.
-   * This is needed after calling `alignTo` and subsequent additions,
-   * directly before the result is used for creating a new Vector.
-   * Note that the outermost array keeps its length to keep the
-   * Builder re-usable.
+  /** Removes `offset` leading `null`s in the prefix.
+   *  This is needed after calling `alignTo` and subsequent additions,
+   *  directly before the result is used for creating a new Vector.
+   *  Note that the outermost array keeps its length to keep the
+   *  Builder re-usable.
    *
-   * example:
+   *  example:
    *     a2 = Array(null, ..., null, Array(null, .., null, 0, 1, .., x), Array(x+1, .., x+32), ...)
-   * becomes
+   *  becomes
    *     a2 = Array(Array(0, 1, .., x), Array(x+1, .., x+32), ..., ?, ..., ?)
    */
   private def leftAlignPrefix(): Unit = {

--- a/library/src/scala/collection/mutable/AnyRefMap.scala
+++ b/library/src/scala/collection/mutable/AnyRefMap.scala
@@ -42,7 +42,6 @@ import scala.language.implicitConversions
  *  This map is not intended to contain more than 2^29^ entries (approximately
  *  500 million).  The maximum capacity is 2^30^, but performance will degrade
  *  rapidly as 2^30^ is approached.
- *
  */
 @(deprecated @companionClass)("Use `scala.collection.mutable.HashMap` instead for better performance.", since = "2.13.16")
 class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initialBufferSize: Int, initBlank: Boolean)
@@ -463,8 +462,8 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initi
   }
 
   /** Applies a transformation function to all values stored in this map.
-    *  Note: the default, if any,  is not transformed.
-    */
+   *  Note: the default, if any,  is not transformed.
+   */
   @deprecated("Use transformValuesInPlace instead of transformValues", "2.13.0")
   @`inline` final def transformValues(f: V => V): this.type = transformValuesInPlace(f)
 
@@ -486,27 +485,24 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initi
 
   // The implicit dummy parameter is necessary to distinguish these methods from the base methods they overload (not override).
   // Previously, in Scala 2, f took `K with AnyRef` scala/bug#11035
-  /**
-   * An overload of `map` which produces an `AnyRefMap`.
+  /** An overload of `map` which produces an `AnyRefMap`.
    *
-   * @param f the mapping function must produce a key-value pair where the key is an `AnyRef`
-   * @param dummy an implicit placeholder for purposes of distinguishing the (erased) signature of this method
+   *  @param f the mapping function must produce a key-value pair where the key is an `AnyRef`
+   *  @param dummy an implicit placeholder for purposes of distinguishing the (erased) signature of this method
    */
   def map[K2 <: AnyRef, V2](f: ((K, V)) => (K2, V2))(implicit dummy: DummyImplicit): AnyRefMap[K2, V2] =
     AnyRefMap.from(new View.Map(this, f))
-  /**
-   * An overload of `flatMap` which produces an `AnyRefMap`.
+  /** An overload of `flatMap` which produces an `AnyRefMap`.
    *
-   * @param f the mapping function must produce key-value pairs where the key is an `AnyRef`
-   * @param dummy an implicit placeholder for purposes of distinguishing the (erased) signature of this method
+   *  @param f the mapping function must produce key-value pairs where the key is an `AnyRef`
+   *  @param dummy an implicit placeholder for purposes of distinguishing the (erased) signature of this method
    */
   def flatMap[K2 <: AnyRef, V2](f: ((K, V)) => IterableOnce[(K2, V2)]^)(implicit dummy: DummyImplicit): AnyRefMap[K2, V2] =
     AnyRefMap.from(new View.FlatMap(this, f))
-  /**
-   * An overload of `collect` which produces an `AnyRefMap`.
+  /** An overload of `collect` which produces an `AnyRefMap`.
    *
-   * @param pf the mapping function must produce a key-value pair where the key is an `AnyRef`
-   * @param dummy an implicit placeholder for purposes of distinguishing the (erased) signature of this method
+   *  @param pf the mapping function must produce a key-value pair where the key is an `AnyRef`
+   *  @param dummy an implicit placeholder for purposes of distinguishing the (erased) signature of this method
    */
   def collect[K2 <: AnyRef, V2](pf: PartialFunction[(K, V), (K2, V2)])(implicit dummy: DummyImplicit): AnyRefMap[K2, V2] =
     strictOptimizedCollect(AnyRefMap.newBuilder[K2, V2], pf)
@@ -574,13 +570,13 @@ object AnyRefMap {
   def withDefault[K <: AnyRef, V](default: K -> V): AnyRefMap[K, V] = new AnyRefMap[K, V](default)
 
   /** Creates a new `AnyRefMap` from an existing source collection. A source collection
-    * which is already an `AnyRefMap` gets cloned.
-    *
-    * @param source Source collection
-    * @tparam K the type of the keys
-    * @tparam V the type of the values
-    * @return a new `AnyRefMap` with the elements of `source`
-    */
+   *  which is already an `AnyRefMap` gets cloned.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @param source Source collection
+   *  @return a new `AnyRefMap` with the elements of `source`
+   */
   def from[K <: AnyRef, V](source: IterableOnce[(K, V)]^): AnyRefMap[K, V] = source match {
     case source: AnyRefMap[?, ?] => source.clone().asInstanceOf[AnyRefMap[K, V]]
     case _ => buildFromIterableOnce(source)

--- a/library/src/scala/collection/mutable/ArrayBuffer.scala
+++ b/library/src/scala/collection/mutable/ArrayBuffer.scala
@@ -27,7 +27,7 @@ import scala.runtime.PStatics.VM_MaxArraySize
  *  access take constant time (amortized time). Prepends and removes are
  *  linear in the buffer size.
  *
- *  @see [[https://docs.scala-lang.org/overviews/collections-2.13/concrete-mutable-collection-classes.html#array-buffers "Scala's Collection Library overview"]]
+ *  @see ["Scala's Collection Library overview"](https://docs.scala-lang.org/overviews/collections-2.13/concrete-mutable-collection-classes.html#array-buffers)
  *  section on `Array Buffers` for more information.
  *
  *  @tparam A    the type of this arraybuffer's elements.
@@ -123,15 +123,14 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
   override def iterableFactory: SeqFactory[ArrayBuffer] = ArrayBuffer
 
   /** Note: This does not actually resize the internal representation.
-    * See clearAndShrink if you want to also resize internally
-    */
+   *  See clearAndShrink if you want to also resize internally
+   */
   def clear(): Unit = reduceToSize(0)
 
-  /**
-    * Clears this buffer and shrinks to @param size (rounding up to the next
-    * natural size)
-    * @param size
-    */
+  /** Clears this buffer and shrinks to @param size (rounding up to the next
+   *  natural size)
+   *  @param size
+   */
   def clearAndShrink(size: Int = ArrayBuffer.DefaultInitialSize): this.type = {
     clear()
     resize(size)
@@ -203,8 +202,8 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
   }
 
   /** Note: This does not actually resize the internal representation.
-    * See trimToSize if you want to also resize internally
-    */
+   *  See trimToSize if you want to also resize internally
+   */
   def remove(@deprecatedName("n", "2.13.0") index: Int): A = {
     checkWithinBounds(index, index + 1)
     val res = this(index)
@@ -214,8 +213,8 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
   }
 
   /** Note: This does not actually resize the internal representation.
-    * See trimToSize if you want to also resize internally
-    */
+   *  See trimToSize if you want to also resize internally
+   */
   def remove(@deprecatedName("n", "2.13.0") index: Int, count: Int): Unit =
     if (count > 0) {
       checkWithinBounds(index, index + count)
@@ -245,11 +244,11 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
   }
 
   /** Sorts this $coll in place according to an Ordering.
-    *
-    * @see [[scala.collection.mutable.IndexedSeqOps.sortInPlace]]
-    * @param  ord the ordering to be used to compare elements.
-    * @return modified input $coll sorted according to the ordering `ord`.
-    */
+   *
+   *  @see [[scala.collection.mutable.IndexedSeqOps.sortInPlace]]
+   *  @param  ord the ordering to be used to compare elements.
+   *  @return modified input $coll sorted according to the ordering `ord`.
+   */
   override def sortInPlace[B >: A]()(implicit ord: Ordering[B]): this.type = {
     if (length > 1) {
       mutationCount += 1
@@ -282,14 +281,13 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
     new MutationTracker.CheckedIterator(super.sliding(size = size, step = step), mutationCount)
 }
 
-/**
-  * Factory object for the `ArrayBuffer` class.
-  *
-  * $factoryInfo
-  *
-  * @define coll array buffer
-  * @define Coll `mutable.ArrayBuffer`
-  */
+/** Factory object for the `ArrayBuffer` class.
+ *
+ *  $factoryInfo
+ *
+ *  @define coll array buffer
+ *  @define Coll `mutable.ArrayBuffer`
+ */
 @SerialVersionUID(3L)
 object ArrayBuffer extends StrictOptimizedSeqFactory[ArrayBuffer] {
   final val DefaultInitialSize = 16
@@ -313,12 +311,11 @@ object ArrayBuffer extends StrictOptimizedSeqFactory[ArrayBuffer] {
 
   def empty[A]: ArrayBuffer[A] = new ArrayBuffer[A]()
 
-  /**
-   * The increased size for an array-backed collection.
+  /** The increased size for an array-backed collection.
    *
-   * @param arrayLen  the length of the backing array
-   * @param targetLen the minimum length to resize up to
-   * @return
+   *  @param arrayLen  the length of the backing array
+   *  @param targetLen the minimum length to resize up to
+   *  @return
    *   - `-1` if no resizing is needed, else
    *   - `VM_MaxArraySize` if `arrayLen` is too large to be doubled, else
    *   - `max(targetLen, arrayLen * 2, DefaultInitialSize)`.
@@ -344,9 +341,9 @@ object ArrayBuffer extends StrictOptimizedSeqFactory[ArrayBuffer] {
   }
 
   /**
-   * @param arrayLen  the length of the backing array
-   * @param targetLen the length to resize down to, if smaller than `arrayLen`
-   * @return -1 if no resizing is needed, or the size for the new array otherwise
+   *  @param arrayLen  the length of the backing array
+   *  @param targetLen the length to resize down to, if smaller than `arrayLen`
+   *  @return -1 if no resizing is needed, or the size for the new array otherwise
    */
   private def resizeDown(arrayLen: Int, targetLen: Int): Int =
     if (targetLen >= arrayLen) -1 else math.max(targetLen, 0)

--- a/library/src/scala/collection/mutable/ArrayBuilder.scala
+++ b/library/src/scala/collection/mutable/ArrayBuilder.scala
@@ -79,8 +79,7 @@ sealed abstract class ArrayBuilder[T]
   }
 }
 
-/** A companion object for array builders.
- */
+/** A companion object for array builders. */
 object ArrayBuilder {
 
   /** Creates a new arraybuilder of type `T`.

--- a/library/src/scala/collection/mutable/ArrayDeque.scala
+++ b/library/src/scala/collection/mutable/ArrayDeque.scala
@@ -27,7 +27,7 @@ import scala.reflect.ClassTag
   *  take amortized constant time. In general, removals and insertions at i-th index are O(min(i, n-i))
   *  and thus insertions and removals from end/beginning are fast.
   *
-  *  @note Subclasses ''must'' override the `ofArray` protected method to return a more specific type.
+  *  @note Subclasses *must* override the `ofArray` protected method to return a more specific type.
   *
   *  @tparam A  the type of this ArrayDeque's elements.
   *

--- a/library/src/scala/collection/mutable/ArraySeq.scala
+++ b/library/src/scala/collection/mutable/ArraySeq.scala
@@ -21,19 +21,18 @@ import scala.collection.convert.impl._
 import scala.reflect.ClassTag
 import scala.util.hashing.MurmurHash3
 
-/**
-  *  A collection representing `Array[T]`. Unlike `ArrayBuffer` it is always backed by the same
-  *  underlying `Array`, therefore it is not growable or shrinkable.
-  *
-  *  @tparam T    type of the elements in this wrapped array.
-  *
-  *  @define Coll `ArraySeq`
-  *  @define coll wrapped array
-  *  @define orderDependent
-  *  @define orderDependentFold
-  *  @define mayNotTerminateInf
-  *  @define willNotTerminateInf
-  */
+/** A collection representing `Array[T]`. Unlike `ArrayBuffer` it is always backed by the same
+ *  underlying `Array`, therefore it is not growable or shrinkable.
+ *
+ *  @tparam T    type of the elements in this wrapped array.
+ *
+ *  @define Coll `ArraySeq`
+ *  @define coll wrapped array
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
 @SerialVersionUID(3L)
 sealed abstract class ArraySeq[T]
   extends AbstractSeq[T]
@@ -54,16 +53,18 @@ sealed abstract class ArraySeq[T]
   override def empty: ArraySeq[T] = ArraySeq.empty(using elemTag.asInstanceOf[ClassTag[T]])
 
   /** The tag of the element type. This does not have to be equal to the element type of this ArraySeq. A primitive
-    * ArraySeq can be backed by an array of boxed values and a reference ArraySeq can be backed by an array of a supertype
-    * or subtype of the element type. */
+   *  ArraySeq can be backed by an array of boxed values and a reference ArraySeq can be backed by an array of a supertype
+   *  or subtype of the element type. 
+   */
   def elemTag: ClassTag[?]
 
   /** Updates element at given index. */
   def update(@deprecatedName("idx", "2.13.0") index: Int, elem: T): Unit
 
   /** The underlying array. Its element type does not have to be equal to the element type of this ArraySeq. A primitive
-    * ArraySeq can be backed by an array of boxed values and a reference ArraySeq can be backed by an array of a supertype
-    * or subtype of the element type. */
+   *  ArraySeq can be backed by an array of boxed values and a reference ArraySeq can be backed by an array of a supertype
+   *  or subtype of the element type. 
+   */
   def array: Array[?]
 
   override def stepper[S <: Stepper[?]](implicit shape: StepperShape[T, S]): S & EfficientSplit
@@ -97,8 +98,7 @@ sealed abstract class ArraySeq[T]
   }
 }
 
-/** A companion object used to create instances of `ArraySeq`.
-  */
+/** A companion object used to create instances of `ArraySeq`. */
 @SerialVersionUID(3L)
 object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
   val untagged: SeqFactory[ArraySeq] = new ClassTagSeqFactory.AnySeqDelegate(self)
@@ -111,17 +111,16 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
 
   def newBuilder[A : ClassTag]: Builder[A, ArraySeq[A]] = ArrayBuilder.make[A].mapResult(make)
 
-  /**
-   * Wraps an existing `Array` into a `ArraySeq` of the proper primitive specialization type
-   * without copying.
+  /** Wraps an existing `Array` into a `ArraySeq` of the proper primitive specialization type
+   *  without copying.
    *
-   * Note that an array containing boxed primitives can be converted to a `ArraySeq` without
-   * copying. For example, `val a: Array[Any] = Array(1)` is an array of `Object` at runtime,
-   * containing `Integer`s. An `ArraySeq[Int]` can be obtained with a cast:
-   * `ArraySeq.make(a).asInstanceOf[ArraySeq[Int]]`. The values are still
-   * boxed, the resulting instance is an [[ArraySeq.ofRef]]. Writing
-   * `ArraySeq.make(a.asInstanceOf[Array[Int]])` does not work, it throws a `ClassCastException`
-   * at runtime.
+   *  Note that an array containing boxed primitives can be converted to a `ArraySeq` without
+   *  copying. For example, `val a: Array[Any] = Array(1)` is an array of `Object` at runtime,
+   *  containing `Integer`s. An `ArraySeq[Int]` can be obtained with a cast:
+   *  `ArraySeq.make(a).asInstanceOf[ArraySeq[Int]]`. The values are still
+   *  boxed, the resulting instance is an [[ArraySeq.ofRef]]. Writing
+   *  `ArraySeq.make(a.asInstanceOf[Array[Int]])` does not work, it throws a `ClassCastException`
+   *  at runtime.
    */
   def make[T](x: Array[T]): ArraySeq[T] = ((x: @unchecked) match {
     case null              => null

--- a/library/src/scala/collection/mutable/BitSet.scala
+++ b/library/src/scala/collection/mutable/BitSet.scala
@@ -21,21 +21,20 @@ import scala.collection.immutable.Range
 import BitSetOps.{LogWL, MaxSize}
 import scala.annotation.implicitNotFound
 
-/**
-  * A class for mutable bitsets.
-  *
-  * $bitsetinfo
-  *
-  * @see [[https://docs.scala-lang.org/overviews/collections-2.13/concrete-mutable-collection-classes.html#mutable-bitsets "Scala's Collection Library overview"]]
-  * section on `Mutable Bitsets` for more information.
-  *
-  * @define Coll `BitSet`
-  * @define coll bitset
-  * @define orderDependent
-  * @define orderDependentFold
-  * @define mayNotTerminateInf
-  * @define willNotTerminateInf
-  */
+/** A class for mutable bitsets.
+ *
+ *  $bitsetinfo
+ *
+ *  @see ["Scala's Collection Library overview"](https://docs.scala-lang.org/overviews/collections-2.13/concrete-mutable-collection-classes.html#mutable-bitsets)
+ *  section on `Mutable Bitsets` for more information.
+ *
+ *  @define Coll `BitSet`
+ *  @define coll bitset
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
 class BitSet(protected[collection] final var elems: Array[Long])
   extends AbstractSet[Int]
     with SortedSet[Int]
@@ -108,10 +107,10 @@ class BitSet(protected[collection] final var elems: Array[Long])
   def unconstrained: collection.Set[Int] = this
 
   /** Updates this bitset to the union with another bitset by performing a bitwise "or".
-    *
-    *  @param   other  the bitset to form the union with.
-    *  @return  the bitset itself.
-    */
+   *
+   *  @param   other  the bitset to form the union with.
+   *  @return  the bitset itself.
+   */
   def |= (other: collection.BitSet): this.type = {
     ensureCapacity(other.nwords - 1)
     var i = 0
@@ -123,10 +122,10 @@ class BitSet(protected[collection] final var elems: Array[Long])
     this
   }
   /** Updates this bitset to the intersection with another bitset by performing a bitwise "and".
-    *
-    *  @param   other  the bitset to form the intersection with.
-    *  @return  the bitset itself.
-    */
+   *
+   *  @param   other  the bitset to form the intersection with.
+   *  @return  the bitset itself.
+   */
   def &= (other: collection.BitSet): this.type = {
     // Different from other operations: no need to ensure capacity because
     // anything beyond the capacity is 0.  Since we use other.word which is 0
@@ -140,10 +139,10 @@ class BitSet(protected[collection] final var elems: Array[Long])
     this
   }
   /** Updates this bitset to the symmetric difference with another bitset by performing a bitwise "xor".
-    *
-    *  @param   other  the bitset to form the symmetric difference with.
-    *  @return  the bitset itself.
-    */
+   *
+   *  @param   other  the bitset to form the symmetric difference with.
+   *  @return  the bitset itself.
+   */
   def ^= (other: collection.BitSet): this.type = {
     ensureCapacity(other.nwords - 1)
     var i = 0
@@ -156,10 +155,10 @@ class BitSet(protected[collection] final var elems: Array[Long])
     this
   }
   /** Updates this bitset to the difference with another bitset by performing a bitwise "and-not".
-    *
-    *  @param   other  the bitset to form the difference with.
-    *  @return  the bitset itself.
-    */
+   *
+   *  @param   other  the bitset to form the difference with.
+   *  @return  the bitset itself.
+   */
   def &~= (other: collection.BitSet): this.type = {
     var i = 0
     val max = Math.min(nwords, other.nwords)
@@ -380,8 +379,8 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
   }
 
   /** A bitset containing all the bits in an array, wrapping the existing
-    *  array without copying.
-    */
+   *  array without copying.
+   */
   def fromBitMaskNoCopy(elems: Array[Long]): BitSet = {
     val len = elems.length
     if (len == 0) empty

--- a/library/src/scala/collection/mutable/Buffer.scala
+++ b/library/src/scala/collection/mutable/Buffer.scala
@@ -36,10 +36,10 @@ trait Buffer[A]
 
   //TODO Prepend is a logical choice for a readable name of `+=:` but it conflicts with the renaming of `append` to `add`
   /** Prepends a single element at the front of this $coll.
-    *
-    *  @param elem  the element to $add.
-    *  @return the $coll itself
-    */
+   *
+   *  @param elem  the element to $add.
+   *  @return the $coll itself
+   */
   def prepend(elem: A): this.type
 
   /** Appends the given elements to this buffer.
@@ -74,72 +74,72 @@ trait Buffer[A]
   @inline final def ++=:(elems: IterableOnce[A]^): this.type = prependAll(elems)
 
   /** Inserts a new element at a given index into this buffer.
-    *
-    *  @param idx    the index where the new elements is inserted.
-    *  @param elem   the element to insert.
-    *  @throws   IndexOutOfBoundsException if the index `idx` is not in the valid range
-    *            `0 <= idx <= length`.
-    */
+   *
+   *  @param idx    the index where the new elements is inserted.
+   *  @param elem   the element to insert.
+   *  @throws   IndexOutOfBoundsException if the index `idx` is not in the valid range
+   *            `0 <= idx <= length`.
+   */
   @throws[IndexOutOfBoundsException]
   def insert(idx: Int, elem: A): Unit
 
   /** Inserts new elements at the index `idx`. Opposed to method
-    *  `update`, this method will not replace an element with a new
-    *  one. Instead, it will insert a new element at index `idx`.
-    *
-    *  @param idx     the index where a new element will be inserted.
-    *  @param elems   the iterable object providing all elements to insert.
-    *  @throws IndexOutOfBoundsException if `idx` is out of bounds.
-    */
+   *  `update`, this method will not replace an element with a new
+   *  one. Instead, it will insert a new element at index `idx`.
+   *
+   *  @param idx     the index where a new element will be inserted.
+   *  @param elems   the iterable object providing all elements to insert.
+   *  @throws IndexOutOfBoundsException if `idx` is out of bounds.
+   */
   @throws[IndexOutOfBoundsException]
   def insertAll(idx: Int, elems: IterableOnce[A]^): Unit
 
   /** Removes the element at a given index position.
-    *
-    *  @param idx  the index which refers to the element to delete.
-    *  @return   the element that was formerly at index `idx`.
-    */
+   *
+   *  @param idx  the index which refers to the element to delete.
+   *  @return   the element that was formerly at index `idx`.
+   */
   @throws[IndexOutOfBoundsException]
   def remove(idx: Int): A
 
   /** Removes the element on a given index position. It takes time linear in
-    *  the buffer size.
-    *
-    *  @param idx       the index which refers to the first element to remove.
-    *  @param count   the number of elements to remove.
-    *  @throws   IndexOutOfBoundsException if the index `idx` is not in the valid range
-    *            `0 <= idx <= length - count` (with `count > 0`).
-    *  @throws   IllegalArgumentException if `count < 0`.
-    */
+   *  the buffer size.
+   *
+   *  @param idx       the index which refers to the first element to remove.
+   *  @param count   the number of elements to remove.
+   *  @throws   IndexOutOfBoundsException if the index `idx` is not in the valid range
+   *            `0 <= idx <= length - count` (with `count > 0`).
+   *  @throws   IllegalArgumentException if `count < 0`.
+   */
   @throws[IndexOutOfBoundsException]
   @throws[IllegalArgumentException]
   def remove(idx: Int, count: Int): Unit
   
   /** Removes a single element from this buffer, at its first occurrence.
-    *  If the buffer does not contain that element, it is unchanged.
-    *
-    *  @param x  the element to remove.
-    *  @return   the buffer itself
-    */
+   *  If the buffer does not contain that element, it is unchanged.
+   *
+   *  @param x  the element to remove.
+   *  @return   the buffer itself
+   */
   def subtractOne (x: A): this.type = {
     val i = indexOf(x)
     if (i != -1) remove(i)
     this
   }
 
-  /** Removes the first ''n'' elements of this buffer.
-    *
-    *  @param n  the number of elements to remove from the beginning
-    *            of this buffer.
-    */
+  /** Removes the first *n* elements of this buffer.
+   *
+   *  @param n  the number of elements to remove from the beginning
+   *            of this buffer.
+   */
   @deprecated("use dropInPlace instead", since = "2.13.4")
   def trimStart(n: Int): Unit = dropInPlace(n)
 
-  /** Removes the last ''n'' elements of this buffer.
-    *
-    *  @param n  the number of elements to remove from the end
-    *            of this buffer.
-    */
+  /** Removes the last *n* elements of this buffer.
+   *
+   *  @param n  the number of elements to remove from the end
+   *            of this buffer.
+   */
   @deprecated("use dropRightInPlace instead", since = "2.13.4")
   def trimEnd(n: Int): Unit = dropRightInPlace(n)
 
@@ -167,7 +167,6 @@ trait Buffer[A]
    *
    *  @param  n the number of elements to remove
    *  @return this $coll
-   *
    */
   def dropInPlace(n: Int): this.type = { remove(0, normalized(n)); this }
 
@@ -175,7 +174,6 @@ trait Buffer[A]
    *
    *  @param  n the number of elements to remove
    *  @return this $coll
-   *
    */
   def dropRightInPlace(n: Int): this.type = {
     val norm = normalized(n)
@@ -187,7 +185,6 @@ trait Buffer[A]
    *
    *  @param  n the number of elements to retain
    *  @return this $coll
-   *
    */
   def takeInPlace(n: Int): this.type = {
     val norm = normalized(n)
@@ -199,7 +196,6 @@ trait Buffer[A]
    *
    *  @param  n the number of elements to retain
    *  @return this $coll
-   *
    */
   def takeRightInPlace(n: Int): this.type = { remove(0, length - normalized(n)); this }
 
@@ -208,7 +204,6 @@ trait Buffer[A]
    *  @param  start the lowest index to include
    *  @param  end   the lowest index to exclude
    *  @return this $coll
-   *
    */
   def sliceInPlace(start: Int, end: Int): this.type = takeInPlace(end).dropInPlace(start)
 

--- a/library/src/scala/collection/mutable/Builder.scala
+++ b/library/src/scala/collection/mutable/Builder.scala
@@ -16,13 +16,13 @@ import scala.language.`2.13`
 import language.experimental.captureChecking
 
 /** Base trait for collection builders.
-  *
-  * After calling `result()` the behavior of a Builder (which is not also a [[scala.collection.mutable.ReusableBuilder]])
-  * is undefined. No further methods should be called. It is common for mutable collections to be their own non-reusable
-  * Builder, in which case `result()` simply returns `this`.
-  *
-  * @see [[scala.collection.mutable.ReusableBuilder]] for Builders which can be reused after calling `result()`
-  */
+ *
+ *  After calling `result()` the behavior of a Builder (which is not also a [[scala.collection.mutable.ReusableBuilder]])
+ *  is undefined. No further methods should be called. It is common for mutable collections to be their own non-reusable
+ *  Builder, in which case `result()` simply returns `this`.
+ *
+ *  @see [[scala.collection.mutable.ReusableBuilder]] for Builders which can be reused after calling `result()`
+ */
 trait Builder[-A, +To] extends Growable[A] { self: Builder[A, To]^ =>
 
   /** Clears the contents of this builder.
@@ -52,11 +52,11 @@ trait Builder[-A, +To] extends Growable[A] { self: Builder[A, To]^ =>
    *  This method provides a hint only if the collection has a known size,
    *  as specified by the following pseudocode:
    *
-   *  {{{
+   *  ```
    *    if (coll.knownSize != -1)
    *      if (coll.knownSize + delta <= 0) sizeHint(0)
    *      else sizeHint(coll.knownSize + delta)
-   *  }}}
+   *  ```
    *
    *  If the delta is negative and the result size is known to be negative,
    *  then the size hint is issued at zero.
@@ -75,17 +75,17 @@ trait Builder[-A, +To] extends Growable[A] { self: Builder[A, To]^ =>
     }
 
   /** Gives a hint how many elements are expected to be added
-    *  when the next `result` is called, together with an upper bound
-    *  given by the size of some other collection. Some builder classes
-    *  will optimize their representation based on the hint. However,
-    *  builder implementations are still required to work correctly even if the hint is
-    *  wrong, i.e. a different number of elements is added.
-    *
-    *  @param size  the hint how many elements will be added.
-    *  @param boundingColl  the bounding collection. If it is
-    *                       an IndexedSeqLike, then sizes larger
-    *                       than collection's size are reduced.
-    */
+   *  when the next `result` is called, together with an upper bound
+   *  given by the size of some other collection. Some builder classes
+   *  will optimize their representation based on the hint. However,
+   *  builder implementations are still required to work correctly even if the hint is
+   *  wrong, i.e. a different number of elements is added.
+   *
+   *  @param size  the hint how many elements will be added.
+   *  @param boundingColl  the bounding collection. If it is
+   *                       an IndexedSeqLike, then sizes larger
+   *                       than collection's size are reduced.
+   */
   // should probably be `boundingColl: IterableOnce[_]`, but binary compatibility
   final def sizeHintBounded(size: Int, boundingColl: scala.collection.Iterable[?]^): Unit = {
     val s = boundingColl.knownSize

--- a/library/src/scala/collection/mutable/CollisionProofHashMap.scala
+++ b/library/src/scala/collection/mutable/CollisionProofHashMap.scala
@@ -23,18 +23,18 @@ import scala.collection.generic.DefaultSerializationProxy
 import scala.runtime.Statics
 
 /** This class implements mutable maps using a hashtable with red-black trees in the buckets for good
-  * worst-case performance on hash collisions. An `Ordering` is required for the element type. Equality
-  * as determined by the `Ordering` has to be consistent with `equals` and `hashCode`. Universal equality
-  * of numeric types is not supported (similar to `AnyRefMap`).
-  *
-  * @see [[https://docs.scala-lang.org/overviews/collections-2.13/concrete-mutable-collection-classes.html#hash-tables "Scala's Collection Library overview"]]
-  * section on `Hash Tables` for more information.
-  *
-  * @define Coll `mutable.CollisionProofHashMap`
-  * @define coll mutable collision-proof hash map
-  * @define mayNotTerminateInf
-  * @define willNotTerminateInf
-  */
+ *  worst-case performance on hash collisions. An `Ordering` is required for the element type. Equality
+ *  as determined by the `Ordering` has to be consistent with `equals` and `hashCode`. Universal equality
+ *  of numeric types is not supported (similar to `AnyRefMap`).
+ *
+ *  @see ["Scala's Collection Library overview"](https://docs.scala-lang.org/overviews/collections-2.13/concrete-mutable-collection-classes.html#hash-tables)
+ *  section on `Hash Tables` for more information.
+ *
+ *  @define Coll `mutable.CollisionProofHashMap`
+ *  @define coll mutable collision-proof hash map
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
 final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double)(implicit ordering: Ordering[K])
   extends AbstractMap[K, V]
     with MapOps[K, V, Map, CollisionProofHashMap[K, V]] //--
@@ -413,34 +413,34 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
   ///////////////////// Overrides code from SortedMapOps
 
   /** Builds a new `CollisionProofHashMap` by applying a function to all elements of this $coll.
-    *
-    *  @param f      the function to apply to each element.
-    *  @return       a new $coll resulting from applying the given function
-    *                `f` to each element of this $coll and collecting the results.
-    */
+   *
+   *  @param f      the function to apply to each element.
+   *  @return       a new $coll resulting from applying the given function
+   *                `f` to each element of this $coll and collecting the results.
+   */
   def map[K2, V2](f: ((K, V)) => (K2, V2))
       (implicit @implicitNotFound(CollisionProofHashMap.ordMsg) ordering: Ordering[K2]): CollisionProofHashMap[K2, V2] =
     sortedMapFactory.from(new View.Map[(K, V), (K2, V2)](this, f))
 
   /** Builds a new `CollisionProofHashMap` by applying a function to all elements of this $coll
-    *  and using the elements of the resulting collections.
-    *
-    *  @param f      the function to apply to each element.
-    *  @return       a new $coll resulting from applying the given collection-valued function
-    *                `f` to each element of this $coll and concatenating the results.
-    */
+   *  and using the elements of the resulting collections.
+   *
+   *  @param f      the function to apply to each element.
+   *  @return       a new $coll resulting from applying the given collection-valued function
+   *                `f` to each element of this $coll and concatenating the results.
+   */
   def flatMap[K2, V2](f: ((K, V)) => IterableOnce[(K2, V2)]^)
       (implicit @implicitNotFound(CollisionProofHashMap.ordMsg) ordering: Ordering[K2]): CollisionProofHashMap[K2, V2] =
     sortedMapFactory.from(new View.FlatMap(this, f))
 
   /** Builds a new sorted map by applying a partial function to all elements of this $coll
-    *  on which the function is defined.
-    *
-    *  @param pf     the partial function which filters and maps the $coll.
-    *  @return       a new $coll resulting from applying the given partial function
-    *                `pf` to each element on which it is defined and collecting the results.
-    *                The order of the elements is preserved.
-    */
+   *  on which the function is defined.
+   *
+   *  @param pf     the partial function which filters and maps the $coll.
+   *  @return       a new $coll resulting from applying the given partial function
+   *                `pf` to each element on which it is defined and collecting the results.
+   *                The order of the elements is preserved.
+   */
   def collect[K2, V2](pf: PartialFunction[(K, V), (K2, V2)])
       (implicit @implicitNotFound(CollisionProofHashMap.ordMsg) ordering: Ordering[K2]): CollisionProofHashMap[K2, V2] =
     sortedMapFactory.from(new View.Collect(this, pf))
@@ -693,10 +693,9 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
     root
   }
 
-  /**
-    * Transplant the node `from` to the place of node `to`. This is done by setting `from` as a child of `to`'s previous
-    * parent and setting `from`'s parent to the `to`'s previous parent. The children of `from` are left unchanged.
-    */
+  /** Transplant the node `from` to the place of node `to`. This is done by setting `from` as a child of `to`'s previous
+   *  parent and setting `from`'s parent to the `to`'s previous parent. The children of `from` are left unchanged.
+   */
   private def transplant(_root: RBNode, to: RBNode, from: RBNode): RBNode = {
     var root = _root
     if (to.parent eq null) root = from
@@ -737,11 +736,10 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
   }
 }
 
-/**
-  * $factoryInfo
-  * @define Coll `mutable.CollisionProofHashMap`
-  * @define coll mutable collision-proof hash map
-  */
+/** $factoryInfo
+ *  @define Coll `mutable.CollisionProofHashMap`
+ *  @define coll mutable collision-proof hash map
+ */
 @SerialVersionUID(3L)
 object CollisionProofHashMap extends SortedMapFactory[CollisionProofHashMap] {
   private[collection] final val ordMsg = "No implicit Ordering[${K2}] found to build a CollisionProofHashMap[${K2}, ${V2}]. You may want to upcast to a Map[${K}, ${V}] first by calling `unsorted`."
@@ -836,10 +834,9 @@ object CollisionProofHashMap extends SortedMapFactory[CollisionProofHashMap] {
   @tailrec private def minNodeNonNull[A, B](node: RBNode[A, B]): RBNode[A, B] =
     if (node.left eq null) node else minNodeNonNull(node.left)
 
-  /**
-    * Returns the node that follows `node` in an in-order tree traversal. If `node` has the maximum key (and is,
-    * therefore, the last node), this method returns `null`.
-    */
+  /** Returns the node that follows `node` in an in-order tree traversal. If `node` has the maximum key (and is,
+   *  therefore, the last node), this method returns `null`.
+   */
   private def successor[A, B](node: RBNode[A, B]): RBNode[A, B] | Null = {
     if (node.right ne null) minNodeNonNull(node.right)
     else {

--- a/library/src/scala/collection/mutable/Growable.scala
+++ b/library/src/scala/collection/mutable/Growable.scala
@@ -18,14 +18,14 @@ import scala.language.`2.13`
 import language.experimental.captureChecking
 
 /** This trait forms part of collections that can be augmented
-  * using a `+=` operator and that can be cleared of all elements using
-  * a `clear` method.
-  *
-  * @define coll growable collection
-  * @define Coll `Growable`
-  * @define add add
-  * @define Add Add
-  */
+ *  using a `+=` operator and that can be cleared of all elements using
+ *  a `clear` method.
+ *
+ *  @define coll growable collection
+ *  @define Coll `Growable`
+ *  @define add add
+ *  @define Add Add
+ */
 trait Growable[-A] extends Clearable {
 
   /** ${Add}s a single element to this $coll.
@@ -80,25 +80,24 @@ trait Growable[-A] extends Clearable {
 
 object Growable {
 
-  /**
-    * Fills a `Growable` instance with the elements of a given iterable.
-    * @param empty Instance to fill
-    * @param it Elements to add
-    * @tparam A Element type
-    * @return The filled instance
-    */
+  /** Fills a `Growable` instance with the elements of a given iterable.
+   *  @tparam A Element type
+   *  @param empty Instance to fill
+   *  @param it Elements to add
+   *  @return The filled instance
+   */
   def from[A](empty: Growable[A], it: collection.IterableOnce[A]^): empty.type = empty ++= it
 
 }
 
 /** This trait forms part of collections that can be cleared
-  *  with a clear() call.
-  *
-  *  @define coll collection
-  */
+ *  with a clear() call.
+ *
+ *  @define coll collection
+ */
 trait Clearable {
   /** Clears the $coll's contents. After this operation, the
-    *  $coll is empty.
-    */
+   *  $coll is empty.
+   */
   def clear(): Unit
 }

--- a/library/src/scala/collection/mutable/GrowableBuilder.scala
+++ b/library/src/scala/collection/mutable/GrowableBuilder.scala
@@ -17,13 +17,13 @@ import scala.language.`2.13`
 import language.experimental.captureChecking
 
 /** The canonical builder for collections that are growable, i.e. that support an
-  * efficient `+=` method which adds an element to the collection.
-  *
-  * GrowableBuilders can produce only a single instance of the collection they are growing.
-  *
-  * @define Coll `GrowingBuilder`
-  * @define coll growing builder
-  */
+ *  efficient `+=` method which adds an element to the collection.
+ *
+ *  GrowableBuilders can produce only a single instance of the collection they are growing.
+ *
+ *  @define Coll `GrowingBuilder`
+ *  @define coll growing builder
+ */
 class GrowableBuilder[Elem, To <: Growable[Elem]](protected val elems: To)
   extends Builder[Elem, To] {
 

--- a/library/src/scala/collection/mutable/HashMap.scala
+++ b/library/src/scala/collection/mutable/HashMap.scala
@@ -22,18 +22,18 @@ import scala.collection.generic.DefaultSerializationProxy
 import scala.util.hashing.MurmurHash3
 
 /** This class implements mutable maps using a hashtable.
-  *
-  *  @see [[https://docs.scala-lang.org/overviews/collections-2.13/concrete-mutable-collection-classes.html#hash-tables "Scala's Collection Library overview"]]
-  *  section on `Hash Tables` for more information.
-  *
-  *  @tparam K    the type of the keys contained in this hash map.
-  *  @tparam V    the type of the values assigned to keys in this hash map.
-  *
-  *  @define Coll `mutable.HashMap`
-  *  @define coll mutable hash map
-  *  @define mayNotTerminateInf
-  *  @define willNotTerminateInf
-  */
+ *
+ *  @see ["Scala's Collection Library overview"](https://docs.scala-lang.org/overviews/collections-2.13/concrete-mutable-collection-classes.html#hash-tables)
+ *  section on `Hash Tables` for more information.
+ *
+ *  @tparam K    the type of the keys contained in this hash map.
+ *  @tparam V    the type of the values assigned to keys in this hash map.
+ *
+ *  @define Coll `mutable.HashMap`
+ *  @define coll mutable hash map
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
 @deprecatedInheritance("HashMap will be made final; use .withDefault for the common use case of computing a default value", "2.13.0")
 class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
   extends AbstractMap[K, V]
@@ -221,12 +221,12 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
   }
 
   /** Adds a key-value pair to this map
-    *
-    * @param key the key to add
-    * @param value the value to add
-    * @param hash the **improved** hashcode of `key` (see computeHash)
-    * @param getOld if true, then the previous value for `key` will be returned, otherwise, false
-    */
+   *
+   *  @param key the key to add
+   *  @param value the value to add
+   *  @param hash the **improved** hashcode of `key` (see computeHash)
+   *  @param getOld if true, then the previous value for `key` will be returned, otherwise, false
+   */
   private def put0(key: K, value: V, hash: Int, getOld: Boolean): Some[V] | Null = {
     if(contentSize + 1 >= threshold) growTable(table.length * 2)
     val idx = index(hash)
@@ -267,11 +267,11 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
   private def remove0(elem: K) : Node[K, V] | Null = remove0(elem, computeHash(elem))
 
   /** Removes a key from this map if it exists
-    *
-    * @param elem the element to remove
-    * @param hash the **improved** hashcode of `element` (see computeHash)
-    * @return the node that contained element if it was present, otherwise null
-    */
+   *
+   *  @param elem the element to remove
+   *  @param hash the **improved** hashcode of `element` (see computeHash)
+   *  @return the node that contained element if it was present, otherwise null
+   */
   private def remove0(elem: K, hash: Int) : Node[K, V] | Null = {
     val idx = index(hash)
     table(idx) match {
@@ -594,11 +594,10 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
   }
 }
 
-/**
-  * $factoryInfo
-  *  @define Coll `mutable.HashMap`
-  *  @define coll mutable hash map
-  */
+/** $factoryInfo
+ *  @define Coll `mutable.HashMap`
+ *  @define coll mutable hash map
+ */
 @SerialVersionUID(3L)
 object HashMap extends MapFactory[HashMap] {
 

--- a/library/src/scala/collection/mutable/HashSet.scala
+++ b/library/src/scala/collection/mutable/HashSet.scala
@@ -22,15 +22,15 @@ import scala.collection.generic.DefaultSerializationProxy
 import scala.util.hashing.MurmurHash3
 
 /** This class implements mutable sets using a hashtable.
-  *
-  * @see [[https://docs.scala-lang.org/overviews/collections-2.13/concrete-mutable-collection-classes.html#hash-tables "Scala's Collection Library overview"]]
-  * section on `Hash Tables` for more information.
-  *
-  * @define Coll `mutable.HashSet`
-  * @define coll mutable hash set
-  * @define mayNotTerminateInf
-  * @define willNotTerminateInf
-  */
+ *
+ *  @see ["Scala's Collection Library overview"](https://docs.scala-lang.org/overviews/collections-2.13/concrete-mutable-collection-classes.html#hash-tables)
+ *  section on `Hash Tables` for more information.
+ *
+ *  @define Coll `mutable.HashSet`
+ *  @define coll mutable hash set
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
 final class HashSet[A](initialCapacity: Int, loadFactor: Double)
   extends AbstractSet[A]
     with SetOps[A, HashSet, HashSet[A]]
@@ -150,9 +150,9 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
   }
 
   /** Adds an element to this set.
-    * @param elem element to add
-    * @param hash the **improved** hash of `elem` (see computeHash)
-    */
+   *  @param elem element to add
+   *  @param hash the **improved** hash of `elem` (see computeHash)
+   */
   private def addElem(elem: A, hash: Int) : Boolean = {
     val idx = index(hash)
     table(idx) match {
@@ -401,11 +401,10 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
   }
 }
 
-/**
-  * $factoryInfo
-  * @define Coll `mutable.HashSet`
-  * @define coll mutable hash set
-  */
+/** $factoryInfo
+ *  @define Coll `mutable.HashSet`
+ *  @define coll mutable hash set
+ */
 @SerialVersionUID(3L)
 object HashSet extends IterableFactory[HashSet] {
 

--- a/library/src/scala/collection/mutable/ImmutableBuilder.scala
+++ b/library/src/scala/collection/mutable/ImmutableBuilder.scala
@@ -17,9 +17,7 @@ package mutable
 import scala.language.`2.13`
 import language.experimental.captureChecking
 
-/**
-  * Reusable builder for immutable collections
-  */
+/** Reusable builder for immutable collections */
 abstract class ImmutableBuilder[-A, C <: IterableOnce[?]](empty: C)
   extends ReusableBuilder[A, C] {
 

--- a/library/src/scala/collection/mutable/IndexedSeq.scala
+++ b/library/src/scala/collection/mutable/IndexedSeq.scala
@@ -32,12 +32,12 @@ transparent trait IndexedSeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
     with SeqOps[A, CC, C] {
 
   /** Modifies this $coll by applying a function to all elements of this $coll.
-    *
-    *  @param f      the function to apply to each element.
-    *  @return       this $coll modified by replacing all elements with the
-    *                result of applying the given function `f` to each element
-    *                of this $coll.
-    */
+   *
+   *  @param f      the function to apply to each element.
+   *  @return       this $coll modified by replacing all elements with the
+   *                result of applying the given function `f` to each element
+   *                of this $coll.
+   */
   def mapInPlace(f: A => A): this.type = {
     var i = 0
     val siz = size
@@ -46,11 +46,11 @@ transparent trait IndexedSeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
   }
 
   /** Sorts this $coll in place according to an Ordering.
-    *
-    * @see [[scala.collection.SeqOps.sorted]]
-    * @param  ord the ordering to be used to compare elements.
-    * @return modified input $coll sorted according to the ordering `ord`.
-    */
+   *
+   *  @see [[scala.collection.SeqOps.sorted]]
+   *  @param  ord the ordering to be used to compare elements.
+   *  @return modified input $coll sorted according to the ordering `ord`.
+   */
   def sortInPlace[B >: A]()(implicit ord: Ordering[B]): this.type = {
     val len = this.length
     if (len > 1) {
@@ -71,16 +71,16 @@ transparent trait IndexedSeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
   }
 
   /** Sorts this $coll in place according to a comparison function.
-    *
-    * @see [[scala.collection.SeqOps.sortWith]]
-    */
+   *
+   *  @see [[scala.collection.SeqOps.sortWith]]
+   */
   def sortInPlaceWith(lt: (A, A) => Boolean): this.type = sortInPlace()(using Ordering.fromLessThan(lt))
 
   /** Sorts this $coll in place according to the Ordering which results from transforming
-    * an implicitly given Ordering with a transformation function.
-    *
-    * @see [[scala.collection.SeqOps.sortBy]]
-    */
+   *  an implicitly given Ordering with a transformation function.
+   *
+   *  @see [[scala.collection.SeqOps.sortBy]]
+   */
   def sortInPlaceBy[B](f: A => B)(implicit ord: Ordering[B]): this.type = sortInPlace()(using ord.on(f))
 
 }

--- a/library/src/scala/collection/mutable/Iterable.scala
+++ b/library/src/scala/collection/mutable/Iterable.scala
@@ -24,11 +24,10 @@ trait Iterable[A]
   override def iterableFactory: IterableFactory[Iterable] = Iterable
 }
 
-/**
-  * $factoryInfo
-  * @define coll mutable collection
-  * @define Coll `mutable.Iterable`
-  */
+/** $factoryInfo
+ *  @define coll mutable collection
+ *  @define Coll `mutable.Iterable`
+ */
 @SerialVersionUID(3L)
 object Iterable extends IterableFactory.Delegate[Iterable](ArrayBuffer)
 

--- a/library/src/scala/collection/mutable/LinkedHashMap.scala
+++ b/library/src/scala/collection/mutable/LinkedHashMap.scala
@@ -158,9 +158,9 @@ class LinkedHashMap[K, V]
 
   /** Removes a key from this map if it exists
    *
-   * @param elem the element to remove
-   * @param hash the **improved** hashcode of `element` (see computeHash)
-   * @return the node that contained element if it was present, otherwise null
+   *  @param elem the element to remove
+   *  @param hash the **improved** hashcode of `element` (see computeHash)
+   *  @return the node that contained element if it was present, otherwise null
    */
   private def removeEntry0(elem: K, hash: Int): Entry | Null = {
     val idx = index(hash)
@@ -495,8 +495,7 @@ object LinkedHashMap extends MapFactory[LinkedHashMap] {
 
   def newBuilder[K, V]: GrowableBuilder[(K, V), LinkedHashMap[K, V]] = new GrowableBuilder(empty[K, V])
 
-  /** Class for the linked hash map entry, used internally.
-    */
+  /** Class for the linked hash map entry, used internally. */
   private[mutable] final class LinkedEntry[K, V](val key: K, val hash: Int, var value: V) {
     var earlier: LinkedEntry[K, V] | Null = null
     var later: LinkedEntry[K, V] | Null = null

--- a/library/src/scala/collection/mutable/LinkedHashSet.scala
+++ b/library/src/scala/collection/mutable/LinkedHashSet.scala
@@ -329,8 +329,7 @@ object LinkedHashSet extends IterableFactory[LinkedHashSet] {
 
   def newBuilder[A]: GrowableBuilder[A, LinkedHashSet[A]] = new GrowableBuilder(empty[A])
 
-  /** Class for the linked hash set entry, used internally.
-   */
+  /** Class for the linked hash set entry, used internally. */
   private[mutable] final class Entry[A](val key: A, val hash: Int) {
     @annotation.stableNull var earlier: Entry[A] | Null = null
     @annotation.stableNull var later: Entry[A] | Null = null

--- a/library/src/scala/collection/mutable/ListBuffer.scala
+++ b/library/src/scala/collection/mutable/ListBuffer.scala
@@ -24,20 +24,20 @@ import scala.collection.generic.DefaultSerializable
 import scala.runtime.Statics.releaseFence
 
 /** A `Buffer` implementation backed by a list. It provides constant time
-  *  prepend and append. Most other operations are linear.
-  *
-  *  @see [[https://docs.scala-lang.org/overviews/collections-2.13/concrete-mutable-collection-classes.html#list-buffers "Scala's Collection Library overview"]]
-  *  section on `List Buffers` for more information.
-  *
-  *  @tparam A    the type of this list buffer's elements.
-  *
-  *  @define Coll `ListBuffer`
-  *  @define coll list buffer
-  *  @define orderDependent
-  *  @define orderDependentFold
-  *  @define mayNotTerminateInf
-  *  @define willNotTerminateInf
-  */
+ *  prepend and append. Most other operations are linear.
+ *
+ *  @see ["Scala's Collection Library overview"](https://docs.scala-lang.org/overviews/collections-2.13/concrete-mutable-collection-classes.html#list-buffers)
+ *  section on `List Buffers` for more information.
+ *
+ *  @tparam A    the type of this list buffer's elements.
+ *
+ *  @define Coll `ListBuffer`
+ *  @define coll list buffer
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
 @SerialVersionUID(-8428291952499836345L)
 class ListBuffer[A]
   extends AbstractBuffer[A]
@@ -95,9 +95,9 @@ class ListBuffer[A]
   def result(): immutable.List[A] = toList
 
   /** Prepends the elements of this buffer to a given list
-    *
-    *  @param xs   the list to which elements are prepended
-    */
+   *
+   *  @param xs   the list to which elements are prepended
+   */
   def prependToList(xs: List[A]): List[A] = {
     if (isEmpty) xs
     else {
@@ -181,8 +181,8 @@ class ListBuffer[A]
   }
 
   /** Reduces the length of the buffer, and nulls out last0
-    *  if this reduces the length to 0.
-    */
+   *  if this reduces the length to 0.
+   */
   private def reduceLengthBy(num: Int): Unit = {
     len -= num
     if (len <= 0)   // obviously shouldn't be < 0, but still better not to leak
@@ -389,22 +389,20 @@ class ListBuffer[A]
     this
   }
 
-  /**
-   * Selects the last element.
+  /** Selects the last element.
    *
-   * Runs in constant time.
+   *  Runs in constant time.
    *
-   * @return The last element of this $coll.
-   * @throws NoSuchElementException If the $coll is empty.
+   *  @return The last element of this $coll.
+   *  @throws NoSuchElementException If the $coll is empty.
    */
   override def last: A = if (last0 eq null) throw new NoSuchElementException("last of empty ListBuffer") else last0.head
 
-  /**
-   * Optionally selects the last element.
+  /** Optionally selects the last element.
    *
-   * Runs in constant time.
+   *  Runs in constant time.
    *
-   * @return the last element of this $coll$ if it is nonempty, `None` if it is empty.
+   *  @return the last element of this $coll$ if it is nonempty, `None` if it is empty.
    */
   override def lastOption: Option[A] = if (last0 eq null) None else Some(last0.head)
 

--- a/library/src/scala/collection/mutable/LongMap.scala
+++ b/library/src/scala/collection/mutable/LongMap.scala
@@ -19,25 +19,24 @@ import scala.collection.generic.DefaultSerializationProxy
 import scala.language.implicitConversions
 
 /** This class implements mutable maps with `Long` keys based on a hash table with open addressing.
-  *
-  *  Basic map operations on single entries, including `contains` and `get`,
-  *  are typically substantially faster with `LongMap` than [[HashMap]].  Methods
-  *  that act on the whole map,  including `foreach` and `map` are not in
-  *  general expected to be faster than with a generic map, save for those
-  *  that take particular advantage of the internal structure of the map:
-  *  `foreachKey`, `foreachValue`, `mapValuesNow`, and `transformValues`.
-  *
-  *  Maps with open addressing may become less efficient at lookup after
-  *  repeated addition/removal of elements.  Although `LongMap` makes a
-  *  decent attempt to remain efficient regardless,  calling `repack`
-  *  on a map that will no longer have elements removed but will be
-  *  used heavily may save both time and storage space.
-  *
-  *  This map is not intended to contain more than 2^29 entries (approximately
-  *  500 million).  The maximum capacity is 2^30, but performance will degrade
-  *  rapidly as 2^30 is approached.
-  *
-  */
+ *
+ *  Basic map operations on single entries, including `contains` and `get`,
+ *  are typically substantially faster with `LongMap` than [[HashMap]].  Methods
+ *  that act on the whole map,  including `foreach` and `map` are not in
+ *  general expected to be faster than with a generic map, save for those
+ *  that take particular advantage of the internal structure of the map:
+ *  `foreachKey`, `foreachValue`, `mapValuesNow`, and `transformValues`.
+ *
+ *  Maps with open addressing may become less efficient at lookup after
+ *  repeated addition/removal of elements.  Although `LongMap` makes a
+ *  decent attempt to remain efficient regardless,  calling `repack`
+ *  on a map that will no longer have elements removed but will be
+ *  used heavily may save both time and storage space.
+ *
+ *  This map is not intended to contain more than 2^29 entries (approximately
+ *  500 million).  The maximum capacity is 2^30, but performance will degrade
+ *  rapidly as 2^30 is approached.
+ */
 final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBufferSize: Int, initBlank: Boolean)
   extends AbstractMap[Long, V]
     with MapOps[Long, V, Map, LongMap[V]]
@@ -61,10 +60,10 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
   def this(defaultEntry: Long -> V) = this(defaultEntry, 16, initBlank = true)
 
   /** Creates a new `LongMap` with an initial buffer of specified size.
-    *
-    *  A LongMap can typically contain half as many elements as its buffer size
-    *  before it requires resizing.
-    */
+   *
+   *  A LongMap can typically contain half as many elements as its buffer size
+   *  before it requires resizing.
+   */
   def this(initialBufferSize: Int) = this(LongMap.exceptionDefault, initialBufferSize, initBlank = true)
 
   /** Creates a new `LongMap` with specified default values and initial buffer size. */
@@ -216,12 +215,12 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
   }
 
   /** Retrieves the value associated with a key, or the default for that type if none exists
-    *  (null for AnyRef, 0 for floats and integers).
-    *
-    *  Note: this is the fastest way to retrieve a value that may or
-    *  may not exist, if the default null/zero is acceptable.  For key/value
-    *  pairs that do exist,  `apply` (i.e. `map(key)`) is equally fast.
-    */
+   *  (null for AnyRef, 0 for floats and integers).
+   *
+   *  Note: this is the fastest way to retrieve a value that may or
+   *  may not exist, if the default null/zero is acceptable.  For key/value
+   *  pairs that do exist,  `apply` (i.e. `map(key)`) is equally fast.
+   */
   def getOrNull(key: Long): V | Null = {
     if (key == -key) {
       if ((((key>>>63).toInt+1) & extraKeys) == 0) null
@@ -235,9 +234,9 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
   }
 
   /** Retrieves the value associated with a key.
-    *  If the key does not exist in the map, the `defaultEntry` for that key
-    *  will be returned instead.
-    */
+   *  If the key does not exist in the map, the `defaultEntry` for that key
+   *  will be returned instead.
+   */
   override def apply(key: Long): V = {
     if (key == -key) {
       if ((((key>>>63).toInt+1) & extraKeys) == 0) defaultEntry(key)
@@ -251,8 +250,8 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
   }
 
   /** The user-supplied default value for the key.  Throws an exception
-    *  if no other default behavior was specified.
-    */
+   *  if no other default behavior was specified.
+   */
   override def default(key: Long) = defaultEntry(key)
 
   private def repack(newMask: Int): Unit = {
@@ -320,9 +319,9 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
   }
 
   /** Updates the map to include a new key-value pair.
-    *
-    *  This is the fastest way to add an entry to a `LongMap`.
-    */
+   *
+   *  This is the fastest way to add an entry to a `LongMap`.
+   */
   override def update(key: Long, value: V): Unit = {
     if (key == -key) {
       if (key == 0) {
@@ -518,9 +517,9 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
   }
 
   /** Creates a new `LongMap` with different values.
-    *  Unlike `mapValues`, this method generates a new
-    *  collection immediately.
-    */
+   *  Unlike `mapValues`, this method generates a new
+   *  collection immediately.
+   */
   def mapValuesNow[V1](f: V => V1): LongMap[V1] = {
     val zv = if ((extraKeys & 1) == 1) f(zeroValue.asInstanceOf[V]).asInstanceOf[AnyRef | Null] else null
     val mv = if ((extraKeys & 2) == 2) f(minValue.asInstanceOf[V]).asInstanceOf[AnyRef | Null] else null
@@ -541,14 +540,14 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
   }
 
   /** Applies a transformation function to all values stored in this map.
-    *  Note: the default, if any,  is not transformed.
-    */
+   *  Note: the default, if any,  is not transformed.
+   */
   @deprecated("Use transformValuesInPlace instead of transformValues", "2.13.0")
   @`inline` final def transformValues(f: V => V): this.type = transformValuesInPlace(f)
 
   /** Applies a transformation function to all values stored in this map.
-    *  Note: the default, if any,  is not transformed.
-    */
+   *  Note: the default, if any,  is not transformed.
+   */
   def transformValuesInPlace(f: V => V): this.type = {
     if ((extraKeys & 1) == 1) zeroValue = f(zeroValue.asInstanceOf[V]).asInstanceOf[AnyRef | Null]
     if ((extraKeys & 2) == 2) minValue = f(minValue.asInstanceOf[V]).asInstanceOf[AnyRef | Null]
@@ -597,9 +596,9 @@ object LongMap {
   private val exceptionDefault: Long -> Nothing = (k: Long) => throw new NoSuchElementException(k.toString)
 
   /** A builder for instances of `LongMap`.
-    *
-    *  This builder can be reused to create multiple instances.
-    */
+   *
+   *  This builder can be reused to create multiple instances.
+   */
   final class LongMapBuilder[V] extends ReusableBuilder[(Long, V), LongMap[V]] {
     private[collection] var elems: LongMap[V] = new LongMap[V]
     override def addOne(entry: (Long, V)): this.type = {
@@ -630,12 +629,12 @@ object LongMap {
   def withDefault[V](default: Long -> V): LongMap[V] = new LongMap[V](default)
 
   /** Creates a new `LongMap` from an existing source collection. A source collection
-    * which is already a `LongMap` gets cloned.
-    *
-    * @param source Source collection
-    * @tparam V the type of the collection’s elements
-    * @return a new `LongMap` with the elements of `source`
-    */
+   *  which is already a `LongMap` gets cloned.
+   *
+   *  @tparam V the type of the collection’s elements
+   *  @param source Source collection
+   *  @return a new `LongMap` with the elements of `source`
+   */
   def from[V](source: IterableOnce[(Long, V)]^): LongMap[V] = source match {
     case source: LongMap[?] => source.clone().asInstanceOf[LongMap[V]]
     case _ => buildFromIterableOnce(source)
@@ -644,8 +643,8 @@ object LongMap {
   def newBuilder[V]: ReusableBuilder[(Long, V), LongMap[V]] = new LongMapBuilder[V]
 
   /** Creates a new `LongMap` from arrays of keys and values.
-    *  Equivalent to but more efficient than `LongMap((keys zip values): _*)`.
-    */
+   *  Equivalent to but more efficient than `LongMap((keys zip values): _*)`.
+   */
   def fromZip[V](keys: Array[Long], values: Array[V]): LongMap[V] = {
     val sz = math.min(keys.length, values.length)
     val lm = new LongMap[V](sz * 2)
@@ -656,8 +655,8 @@ object LongMap {
   }
 
   /** Creates a new `LongMap` from keys and values.
-    *  Equivalent to but more efficient than `LongMap((keys zip values): _*)`.
-    */
+   *  Equivalent to but more efficient than `LongMap((keys zip values): _*)`.
+   */
   def fromZip[V](keys: scala.collection.Iterable[Long], values: scala.collection.Iterable[V]): LongMap[V] = {
     val sz = math.min(keys.size, values.size)
     val lm = new LongMap[V](sz * 2)

--- a/library/src/scala/collection/mutable/Map.scala
+++ b/library/src/scala/collection/mutable/Map.scala
@@ -40,32 +40,32 @@ trait Map[K, V]
   */
 
   /** The same map with a given default function.
-    *  Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
-    *  are not affected by `withDefaultValue`.
-    *
-    *  Invoking transformer methods (e.g. `map`) will not preserve the default value.
-    *
-    *  @param d     the function mapping keys to values, used for non-present keys
-    *  @return      a wrapper of the map with a default value
-    */
+   *  Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
+   *  are not affected by `withDefaultValue`.
+   *
+   *  Invoking transformer methods (e.g. `map`) will not preserve the default value.
+   *
+   *  @param d     the function mapping keys to values, used for non-present keys
+   *  @return      a wrapper of the map with a default value
+   */
   def withDefault(d: K -> V): Map[K, V] = new Map.WithDefault[K, V](this, d)
 
   /** The same map with a given default value.
-    *  Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
-    *  are not affected by `withDefaultValue`.
-    *
-    *  Invoking transformer methods (e.g. `map`) will not preserve the default value.
-    *
-    *  @param d     default value used for non-present keys
-    *  @return      a wrapper of the map with a default value
-    */
+   *  Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
+   *  are not affected by `withDefaultValue`.
+   *
+   *  Invoking transformer methods (e.g. `map`) will not preserve the default value.
+   *
+   *  @param d     default value used for non-present keys
+   *  @return      a wrapper of the map with a default value
+   */
   def withDefaultValue(d: V): Map[K, V] = new Map.WithDefault[K, V](this, x => d)
 }
 
 /**
-  * @define coll mutable map
-  * @define Coll `mutable.Map`
-  */
+ *  @define coll mutable map
+ *  @define Coll `mutable.Map`
+ */
 transparent trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[K, V, CC, C]]
   extends IterableOps[(K, V), Iterable, C]
     with collection.MapOps[K, V, CC, C]
@@ -84,15 +84,15 @@ transparent trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[K,
   final def - (key1: K, key2: K, keys: K*): C = clone() -= key1 -= key2 --= keys
 
   /** Adds a new key/value pair to this map and optionally returns previously bound value.
-    *  If the map already contains a
-    *  mapping for the key, it will be overridden by the new value.
-    *
-    * @param key    the key to update
-    * @param value  the new value
-    * @return an option value containing the value associated with the key
-    *         before the `put` operation was executed, or `None` if `key`
-    *         was not defined in the map before.
-    */
+   *  If the map already contains a
+   *  mapping for the key, it will be overridden by the new value.
+   *
+   *  @param key    the key to update
+   *  @param value  the new value
+   *  @return an option value containing the value associated with the key
+   *         before the `put` operation was executed, or `None` if `key`
+   *         was not defined in the map before.
+   */
   def put(key: K, value: V): Option[V] = {
     val r = get(key)
     update(key, value)
@@ -100,25 +100,24 @@ transparent trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[K,
   }
 
   /** Adds a new key/value pair to this map.
-    *  If the map already contains a
-    *  mapping for the key, it will be overridden by the new value.
-    *
-    *  @param key    The key to update
-    *  @param value  The new value
-    */
+   *  If the map already contains a
+   *  mapping for the key, it will be overridden by the new value.
+   *
+   *  @param key    The key to update
+   *  @param value  The new value
+   */
   def update(key: K, value: V): Unit = { coll += ((key, value)) }
 
-  /**
-   * Updates a mapping for the specified key and its current optionally mapped value
-   * (`Some` if there is current mapping, `None` if not).
+  /** Updates a mapping for the specified key and its current optionally mapped value
+   *  (`Some` if there is current mapping, `None` if not).
    *
-   * If the remapping function returns `Some(v)`, the mapping is updated with the new value `v`.
-   * If the remapping function returns `None`, the mapping is removed (or remains absent if initially absent).
-   * If the function itself throws an exception, the exception is rethrown, and the current mapping is left unchanged.
+   *  If the remapping function returns `Some(v)`, the mapping is updated with the new value `v`.
+   *  If the remapping function returns `None`, the mapping is removed (or remains absent if initially absent).
+   *  If the function itself throws an exception, the exception is rethrown, and the current mapping is left unchanged.
    *
-   * @param key the key value
-   * @param remappingFunction a function that receives current optionally mapped value and returns a new mapping
-   * @return the new value associated with the specified key
+   *  @param key the key value
+   *  @param remappingFunction a function that receives current optionally mapped value and returns a new mapping
+   *  @return the new value associated with the specified key
    */
   def updateWith(key: K)(remappingFunction: Option[V] => Option[V]): Option[V] = {
     val previousValue = this.get(key)
@@ -152,11 +151,11 @@ transparent trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[K,
     }
 
   /** Removes a key from this map, returning the value associated previously
-    *  with that key as an option.
-    *  @param    key the key to be removed
-    *  @return   an option value containing the value associated previously with `key`,
-    *            or `None` if `key` was not defined in the map before.
-    */
+   *  with that key as an option.
+   *  @param    key the key to be removed
+   *  @return   an option value containing the value associated previously with `key`,
+   *            or `None` if `key` was not defined in the map before.
+   */
   def remove(key: K): Option[V] = {
     val r = get(key)
     if (r.isDefined) this -= key
@@ -171,10 +170,10 @@ transparent trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[K,
   @inline final def retain(p: (K, V) => Boolean): this.type = filterInPlace(p)
 
   /** Retains only those mappings for which the predicate
-    *  `p` returns `true`.
-    *
-    * @param p  The test predicate
-    */
+   *  `p` returns `true`.
+   *
+   *  @param p  The test predicate
+   */
   def filterInPlace(p: (K, V) => Boolean): this.type = {
     if (!isEmpty) this match {
       case tm: concurrent.Map[?, ?] => tm.asInstanceOf[concurrent.Map[K, V]].filterInPlaceImpl(p)
@@ -197,12 +196,12 @@ transparent trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[K,
   @inline final def transform(f: (K, V) => V): this.type = mapValuesInPlace(f)
 
   /** Applies a transformation function to all values contained in this map.
-    * The transformation function produces new values from existing keys
-    * associated values.
-    *
-    * @param f  the transformation to apply
-    * @return   the map itself.
-    */
+   *  The transformation function produces new values from existing keys
+   *  associated values.
+   *
+   *  @param f  the transformation to apply
+   *  @return   the map itself.
+   */
   def mapValuesInPlace(f: (K, V) => V): this.type = {
     if (!isEmpty) this match {
       case hm: mutable.HashMap[?, ?] => hm.asInstanceOf[mutable.HashMap[K, V]].mapValuesInPlaceImpl(f)
@@ -227,11 +226,10 @@ transparent trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[K,
   override def knownSize: Int = super[IterableOps].knownSize
 }
 
-/**
-  * $factoryInfo
-  * @define coll mutable map
-  * @define Coll `mutable.Map`
-  */
+/** $factoryInfo
+ *  @define coll mutable map
+ *  @define Coll `mutable.Map`
+ */
 @SerialVersionUID(3L)
 object Map extends MapFactory.Delegate[Map](HashMap) {
 

--- a/library/src/scala/collection/mutable/MultiMap.scala
+++ b/library/src/scala/collection/mutable/MultiMap.scala
@@ -20,7 +20,7 @@ import language.experimental.captureChecking
   *  This class is typically used as a mixin. It turns maps which map `K`
   *  to `Set[V]` objects into multimaps that map `K` to `V` objects.
   *
-  *  @example {{{
+  *  @example ```
   *  // first import all necessary types from package `collection.mutable`
   *  import collection.mutable.{ HashMap, MultiMap, Set }
   *
@@ -47,7 +47,7 @@ import language.experimental.captureChecking
   *  // to remove a previous added value there is the method `removeBinding`
   *  mm.removeBinding(1, "a")
   *  mm.entryExists(1, _ == "a") == false
-  *  }}}
+  *  ```
   *
   *  @define coll multimap
   *  @define Coll `MultiMap`

--- a/library/src/scala/collection/mutable/OpenHashMap.scala
+++ b/library/src/scala/collection/mutable/OpenHashMap.scala
@@ -22,9 +22,9 @@ import java.util.ConcurrentModificationException
 import scala.collection.generic.DefaultSerializable
 
 /**
-  *  @define Coll `OpenHashMap`
-  *  @define coll open hash map
-  */
+ *  @define Coll `OpenHashMap`
+ *  @define coll open hash map
+ */
 @deprecated("Use HashMap or one of the specialized versions (LongMap, AnyRefMap) instead of OpenHashMap", "2.13.0")
 @SerialVersionUID(3L)
 object OpenHashMap extends MapFactory[OpenHashMap] {
@@ -36,12 +36,12 @@ object OpenHashMap extends MapFactory[OpenHashMap] {
     new GrowableBuilder[(K, V), OpenHashMap[K, V]](empty)
 
   /** A hash table entry.
-    *
-    * The entry is occupied if and only if its `value` is a `Some`;
-    * deleted if and only if its `value` is `None`.
-    * If its `key` is not the default value of type `Key`, the entry is occupied.
-    * If the entry is occupied, `hash` contains the hash value of `key`.
-    */
+   *
+   *  The entry is occupied if and only if its `value` is a `Some`;
+   *  deleted if and only if its `value` is `None`.
+   *  If its `key` is not the default value of type `Key`, the entry is occupied.
+   *  If the entry is occupied, `hash` contains the hash value of `key`.
+   */
   final private class OpenEntry[Key, Value](var key: Key,
                                             var hash: Int,
                                             var value: Option[Value])
@@ -50,20 +50,20 @@ object OpenHashMap extends MapFactory[OpenHashMap] {
 }
 
 /** A mutable hash map based on an open addressing method. The precise scheme is
-  *  undefined, but it should make a reasonable effort to ensure that an insert
-  *  with consecutive hash codes is not unnecessarily penalised. In particular,
-  *  mappings of consecutive integer keys should work without significant
-  *  performance loss.
-  *
-  *  @tparam Key          type of the keys in this map.
-  *  @tparam Value        type of the values in this map.
-  *  @param initialSize   the initial size of the internal hash table.
-  *
-  *  @define Coll `OpenHashMap`
-  *  @define coll open hash map
-  *  @define mayNotTerminateInf
-  *  @define willNotTerminateInf
-  */
+ *  undefined, but it should make a reasonable effort to ensure that an insert
+ *  with consecutive hash codes is not unnecessarily penalised. In particular,
+ *  mappings of consecutive integer keys should work without significant
+ *  performance loss.
+ *
+ *  @tparam Key          type of the keys in this map.
+ *  @tparam Value        type of the values in this map.
+ *  @param initialSize   the initial size of the internal hash table.
+ *
+ *  @define Coll `OpenHashMap`
+ *  @define coll open hash map
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
 @deprecated("Use HashMap or one of the specialized versions (LongMap, AnyRefMap) instead of OpenHashMap", "2.13.0")
 class OpenHashMap[Key, Value](initialSize : Int)
   extends AbstractMap[Key, Value]
@@ -75,8 +75,7 @@ class OpenHashMap[Key, Value](initialSize : Int)
   import OpenHashMap.OpenEntry
   private type Entry = OpenEntry[Key, Value]
 
-  /** A default constructor creates a hashmap with initial size `8`.
-    */
+  /** A default constructor creates a hashmap with initial size `8`. */
   def this() = this(8)
 
   override def mapFactory: MapFactory[OpenHashMap] = OpenHashMap
@@ -86,10 +85,10 @@ class OpenHashMap[Key, Value](initialSize : Int)
   private var mask = actualInitialSize - 1
 
   /** The hash table.
-    *
-    * The table's entries are initialized to `null`, indication of an empty slot.
-    * A slot is either deleted or occupied if and only if the entry is non-`null`.
-    */
+   *
+   *  The table's entries are initialized to `null`, indication of an empty slot.
+   *  A slot is either deleted or occupied if and only if the entry is non-`null`.
+   */
   private var table = new Array[Entry](actualInitialSize)
 
   private var _size = 0
@@ -110,8 +109,8 @@ class OpenHashMap[Key, Value](initialSize : Int)
   }
 
   /** Increases the size of the table.
-    * Copies only the occupied slots, effectively eliminating the deleted slots.
-    */
+   *  Copies only the occupied slots, effectively eliminating the deleted slots.
+   */
   private def growTable() = {
     val oldSize = mask + 1
     val newSize = 4 * oldSize
@@ -125,10 +124,10 @@ class OpenHashMap[Key, Value](initialSize : Int)
   }
 
   /** Returns the index of the first slot in the hash table (in probe order)
-    * that is, in order of preference, either occupied by the given key, deleted, or empty.
-    *
-    * @param hash hash value for `key`
-    */
+   *  that is, in order of preference, either occupied by the given key, deleted, or empty.
+   *
+   *  @param hash hash value for `key`
+   */
   private def findIndex(key: Key, hash: Int): Int = {
     var index = hash & mask
     var j = 0
@@ -226,10 +225,10 @@ class OpenHashMap[Key, Value](initialSize : Int)
   }
 
   /** An iterator over the elements of this map. Use of this iterator follows
-    *  the same contract for concurrent modification as the foreach method.
-    *
-    *  @return   the iterator
-    */
+   *  the same contract for concurrent modification as the foreach method.
+   *
+   *  @return   the iterator
+   */
   def iterator: Iterator[(Key, Value)] = new OpenHashMapIterator[(Key, Value)] {
     override protected def nextResult(node: Entry): (Key, Value) = (node.key, node.value.get)
   }
@@ -268,15 +267,15 @@ class OpenHashMap[Key, Value](initialSize : Int)
   }
 
   /** Loops over the key, value mappings of this map.
-    *
-    *  The behaviour of modifying the map during an iteration is as follows:
-    *  - Deleting a mapping is always permitted.
-    *  - Changing the value of mapping which is already present is permitted.
-    *  - Anything else is not permitted. It will usually, but not always, throw an exception.
-    *
-    *  @tparam U  The return type of the specified function `f`, return result of which is ignored.
-    *  @param f   The function to apply to each key, value mapping.
-    */
+   *
+   *  The behaviour of modifying the map during an iteration is as follows:
+   *  - Deleting a mapping is always permitted.
+   *  - Changing the value of mapping which is already present is permitted.
+   *  - Anything else is not permitted. It will usually, but not always, throw an exception.
+   *
+   *  @tparam U  The return type of the specified function `f`, return result of which is ignored.
+   *  @param f   The function to apply to each key, value mapping.
+   */
   override def foreach[U](f : ((Key, Value)) => U): Unit = {
     val startModCount = modCount
     foreachUndeletedEntry(entry => {

--- a/library/src/scala/collection/mutable/PriorityQueue.scala
+++ b/library/src/scala/collection/mutable/PriorityQueue.scala
@@ -47,7 +47,7 @@ import scala.math.Ordering
  *  the invariant of the underlying heap-ordered tree. Note that [[clone]]
  *  does not rebuild the underlying tree.
  *
- *  {{{
+ *  ```
  *  scala> val pq = collection.mutable.PriorityQueue(1, 2, 5, 3, 7)
  *  val pq: scala.collection.mutable.PriorityQueue[Int] = PriorityQueue(7, 3, 5, 1, 2)
  *
@@ -56,7 +56,7 @@ import scala.math.Ordering
  *
  *  scala> pq.clone.dequeueAll
  *  val res1: Seq[Int] = ArraySeq(7, 5, 3, 2, 1)
- *  }}}
+ *  ```
  *
  *  @tparam A    type of the elements in this priority queue.
  *  @param ord   implicit ordering used to compare the elements of type `A`.
@@ -161,10 +161,10 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
   }
 
   /** Inserts a single element into the priority queue.
-    *
-    *  @param  elem        the element to insert.
-    *  @return             this $coll.
-    */
+   *
+   *  @param  elem        the element to insert.
+   *  @return             this $coll.
+   */
   def addOne(elem: A): this.type = {
     resarr.p_ensureAdditionalSize(1)
     resarr.p_array(resarr.p_size0) = elem.asInstanceOf[AnyRef]
@@ -234,17 +234,17 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
   }
 
   /** Adds all elements provided by a `IterableOnce` object
-    *  into the priority queue.
-    *
-    *  @param  xs    a iterable object.
-    *  @return       a new priority queue containing elements of both `xs` and `this`.
-    */
+   *  into the priority queue.
+   *
+   *  @param  xs    a iterable object.
+   *  @return       a new priority queue containing elements of both `xs` and `this`.
+   */
   def ++(xs: IterableOnce[A]^): PriorityQueue[A] = { this.clone() ++= xs }
 
   /** Adds all elements to the queue.
-    *
-    *  @param  elems       the elements to add.
-    */
+   *
+   *  @param  elems       the elements to add.
+   */
   def enqueue(elems: A*): Unit = { this ++= elems }
 
   /** Returns the element with the highest priority in the queue,
@@ -275,41 +275,41 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
   }
 
   /** Returns the element with the highest priority in the queue,
-    *  or throws an error if there is no element contained in the queue.
-    *
-    *  @return   the element with the highest priority.
-    */
+   *  or throws an error if there is no element contained in the queue.
+   *
+   *  @return   the element with the highest priority.
+   */
   override def head: A = if (resarr.p_size0 > 1) toA(resarr.p_array(1)) else throw new NoSuchElementException("queue is empty")
 
   /** Removes all elements from the queue. After this operation is completed,
-    *  the queue will be empty.
-    */
+   *  the queue will be empty.
+   */
   def clear(): Unit = {
     resarr.clear()
     resarr.p_size0 = 1
   }
 
   /** Returns an iterator which yields all the elements.
-    *
-    *  Note: The order of elements returned is undefined.
-    *  If you want to traverse the elements in priority queue
-    *  order, use `clone().dequeueAll.iterator`.
-    *
-    *  @return  an iterator over all the elements.
-    */
+   *
+   *  Note: The order of elements returned is undefined.
+   *  If you want to traverse the elements in priority queue
+   *  order, use `clone().dequeueAll.iterator`.
+   *
+   *  @return  an iterator over all the elements.
+   */
   override def iterator: Iterator[A] = resarr.iterator.drop(1)
 
   /** Returns the reverse of this priority queue. The new priority queue has
-    *  the same elements as the original, but the opposite ordering.
-    *
-    *  For example, the element with the highest priority in `pq` has the lowest
-    *  priority in `pq.reverse`, and vice versa.
-    *
-    *  Ties are handled arbitrarily.  Elements with equal priority may or
-    *  may not be reversed with respect to each other.
-    *
-    *  @return   the reversed priority queue.
-    */
+   *  the same elements as the original, but the opposite ordering.
+   *
+   *  For example, the element with the highest priority in `pq` has the lowest
+   *  priority in `pq.reverse`, and vice versa.
+   *
+   *  Ties are handled arbitrarily.  Elements with equal priority may or
+   *  may not be reversed with respect to each other.
+   *
+   *  @return   the reversed priority queue.
+   */
   def reverse: PriorityQueue[A] = {
     val revq = new PriorityQueue[A]()(using ord.reverse)
     // copy the existing data into the new array backwards
@@ -328,12 +328,12 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
 
 
   /** Returns an iterator which yields all the elements in the reverse order
-    *  than that returned by the method `iterator`.
-    *
-    *  Note: The order of elements returned is undefined.
-    *
-    *  @return  an iterator over all elements sorted in descending order.
-    */
+   *  than that returned by the method `iterator`.
+   *
+   *  Note: The order of elements returned is undefined.
+   *
+   *  @return  an iterator over all elements sorted in descending order.
+   */
   def reverseIterator: Iterator[A] = new AbstractIterator[A] {
     private var i = resarr.p_size0 - 1
     def hasNext: Boolean = i >= 1
@@ -345,29 +345,29 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
   }
 
   /** Returns a regular queue containing the same elements.
-    *
-    *  Note: the order of elements is undefined.
-    */
+   *
+   *  Note: the order of elements is undefined.
+   */
   def toQueue: Queue[A] = new Queue[A] ++= this.iterator
 
   /** Returns a textual representation of a queue as a string.
-    *
-    *  @return the string representation of this queue.
-    */
+   *
+   *  @return the string representation of this queue.
+   */
   override def toString() = toList.mkString("PriorityQueue(", ", ", ")")
 
   /** Converts this $coll to a list.
-    *
-    *  Note: the order of elements is undefined.
-    *
-    *  @return a list containing all elements of this $coll.
-    */
+   *
+   *  Note: the order of elements is undefined.
+   *
+   *  @return a list containing all elements of this $coll.
+   */
   override def toList: immutable.List[A] = immutable.List.from(this.iterator)
 
   /** This method clones the priority queue.
-    *
-    *  @return  a priority queue with the same elements.
-    */
+   *
+   *  @return  a priority queue with the same elements.
+   */
   override def clone(): PriorityQueue[A] = {
     val pq = new PriorityQueue[A]
     val n = resarr.p_size0

--- a/library/src/scala/collection/mutable/Queue.scala
+++ b/library/src/scala/collection/mutable/Queue.scala
@@ -20,15 +20,15 @@ import scala.collection.generic.DefaultSerializable
 
 
 /** `Queue` objects implement data structures that allow to
-  *  insert and retrieve elements in a first-in-first-out (FIFO) manner.
-  *
-  *  @define Coll `mutable.Queue`
-  *  @define coll mutable queue
-  *  @define orderDependent
-  *  @define orderDependentFold
-  *  @define mayNotTerminateInf
-  *  @define willNotTerminateInf
-  */
+ *  insert and retrieve elements in a first-in-first-out (FIFO) manner.
+ *
+ *  @define Coll `mutable.Queue`
+ *  @define coll mutable queue
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
 class Queue[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
   extends ArrayDeque[A](array, start, end)
     with IndexedSeqOps[A, Queue, Queue[A]]
@@ -46,70 +46,67 @@ class Queue[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix = "Queue"
 
-  /**
-    * Adds elements to the end of this queue
-    *
-    * @param elem
-    * @return this
-    */
+  /** Adds elements to the end of this queue
+   *
+   *  @param elem
+   *  @return this
+   */
   def enqueue(elem: A): this.type = this += elem
 
   /** Enqueue two or more elements at the end of the queue. The last element
-    *  of the sequence will be on end of the queue.
-    *
-    *  @param   elems      the element sequence.
-    *  @return this
-    */
+   *  of the sequence will be on end of the queue.
+   *
+   *  @param   elems      the element sequence.
+   *  @return this
+   */
   def enqueue(elem1: A, elem2: A, elems: A*): this.type = enqueue(elem1).enqueue(elem2).enqueueAll(elems)
 
   /** Enqueues all elements in the given iterable object into the queue. The
-    *  last element in the iterable object will be on front of the new queue.
-    *
-    *  @param elems the iterable object.
-    *  @return this
-    */
+   *  last element in the iterable object will be on front of the new queue.
+   *
+   *  @param elems the iterable object.
+   *  @return this
+   */
   def enqueueAll(elems: scala.collection.IterableOnce[A]^): this.type = this ++= elems
 
-  /**
-    * Removes the first element from this queue and returns it.
-    *
-    * @return
-    * @throws NoSuchElementException when queue is empty
-    */
+  /** Removes the first element from this queue and returns it.
+   *
+   *  @return
+   *  @throws NoSuchElementException when queue is empty
+   */
   def dequeue(): A = removeHead()
 
   /** Returns the first element in the queue which satisfies the
-    *  given predicate, and removes this element from the queue.
-    *
-    *  @param p   the predicate used for choosing the first element
-    *  @return the first element of the queue for which p yields true
-    */
+   *  given predicate, and removes this element from the queue.
+   *
+   *  @param p   the predicate used for choosing the first element
+   *  @return the first element of the queue for which p yields true
+   */
   def dequeueFirst(p: A => Boolean): Option[A] =
     removeFirst(p)
 
   /** Returns all elements in the queue which satisfy the
-    *  given predicate, and removes those elements from the queue.
-    *
-    *  @param p   the predicate used for choosing elements
-    *  @return    a sequence of all elements in the queue for which
-    *             p yields true.
-    */
+   *  given predicate, and removes those elements from the queue.
+   *
+   *  @param p   the predicate used for choosing elements
+   *  @return    a sequence of all elements in the queue for which
+   *             p yields true.
+   */
   def dequeueAll(p: A => Boolean): scala.collection.immutable.Seq[A] =
     removeAll(p)
 
-  /**
-    * Returns and dequeues all elements from the queue which satisfy the given predicate.
-    *
-    *  @param f   the predicate used for choosing elements
-    *  @return The removed elements
-    */
+  /** Returns and dequeues all elements from the queue which satisfy the given predicate.
+   *
+   *  @param f   the predicate used for choosing elements
+   *  @return The removed elements
+   */
   def dequeueWhile(f: A => Boolean): scala.collection.Seq[A] = removeHeadWhile(f)
 
   /** Returns the first element in the queue, or throws an error if there
-    *  is no element contained in the queue.
-    *
-    *  @return the first element.
-    */
+   *  is no element contained in the queue.
+   *
+   *  @return the first element.
+   */
   @`inline` final def front: A = head
 
   override protected def klone(): Queue[A] = {
@@ -123,11 +120,10 @@ class Queue[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
 
 }
 
-/**
-  * $factoryInfo
-  * @define coll queue
-  * @define Coll `Queue`
-  */
+/** $factoryInfo
+ *  @define coll queue
+ *  @define Coll `Queue`
+ */
 @SerialVersionUID(3L)
 object Queue extends StrictOptimizedSeqFactory[Queue] {
 

--- a/library/src/scala/collection/mutable/RedBlackTree.scala
+++ b/library/src/scala/collection/mutable/RedBlackTree.scala
@@ -19,10 +19,9 @@ import scala.annotation.tailrec
 import collection.{AbstractIterator, Iterator}
 import java.lang.String
 
-/**
- * An object containing the red-black tree implementation used by mutable `TreeMaps`.
+/** An object containing the red-black tree implementation used by mutable `TreeMaps`.
  *
- * The trees implemented in this object are *not* thread safe.
+ *  The trees implemented in this object are *not* thread safe.
  */
 private[collection] object RedBlackTree {
 
@@ -127,9 +126,8 @@ private[collection] object RedBlackTree {
   @tailrec def maxNodeNonNull[A, B](node: Node[A, B]): Node[A, B] =
     if (node.right eq null) node else maxNodeNonNull(node.right)
 
-  /**
-   * Returns the first (lowest) map entry with a key equal or greater than `key`. Returns `None` if there is no such
-   * node.
+  /** Returns the first (lowest) map entry with a key equal or greater than `key`. Returns `None` if there is no such
+   *  node.
    */
   def minAfter[A, B](tree: Tree[A, B], key: A)(implicit ord: Ordering[A]): Option[(A, B)] =
     minNodeAfter(tree.root, key) match {
@@ -159,9 +157,7 @@ private[collection] object RedBlackTree {
     }
   }
 
-  /**
-   * Returns the last (highest) map entry with a key smaller than `key`. Returns `None` if there is no such node.
-   */
+  /** Returns the last (highest) map entry with a key smaller than `key`. Returns `None` if there is no such node. */
   def maxBefore[A, B](tree: Tree[A, B], key: A)(implicit ord: Ordering[A]): Option[(A, B)] =
     maxNodeBefore(tree.root, key) match {
       case null => None
@@ -362,9 +358,8 @@ private[collection] object RedBlackTree {
 
   // ---- helpers ----
 
-  /**
-   * Returns the node that follows `node` in an in-order tree traversal. If `node` has the maximum key (and is,
-   * therefore, the last node), this method returns `null`.
+  /** Returns the node that follows `node` in an in-order tree traversal. If `node` has the maximum key (and is,
+   *  therefore, the last node), this method returns `null`.
    */
   private def successor[A, B](node: Node[A, B]): Node[A, B] | Null = {
     if (node.right ne null) minNodeNonNull(node.right)
@@ -379,9 +374,8 @@ private[collection] object RedBlackTree {
     }
   }
 
-  /**
-   * Returns the node that precedes `node` in an in-order tree traversal. If `node` has the minimum key (and is,
-   * therefore, the first node), this method returns `null`.
+  /** Returns the node that precedes `node` in an in-order tree traversal. If `node` has the minimum key (and is,
+   *  therefore, the first node), this method returns `null`.
    */
   private def predecessor[A, B](node: Node[A, B]): Node[A, B] | Null = {
     if (node.left ne null) maxNodeNonNull(node.left)
@@ -428,9 +422,8 @@ private[collection] object RedBlackTree {
     x.parent = y
   }
 
-  /**
-   * Transplant the node `from` to the place of node `to`. This is done by setting `from` as a child of `to`'s previous
-   * parent and setting `from`'s parent to the `to`'s previous parent. The children of `from` are left unchanged.
+  /** Transplant the node `from` to the place of node `to`. This is done by setting `from` as a child of `to`'s previous
+   *  parent and setting `from`'s parent to the `to`'s previous parent. The children of `from` are left unchanged.
    */
   private def transplant[A, B](tree: Tree[A, B], to: Node[A, B], from: Node[A, B] | Null): Unit = {
     if (to.parent eq null) tree.root = from
@@ -544,19 +537,16 @@ private[collection] object RedBlackTree {
 
   // ---- debugging ----
 
-  /**
-   * Checks if the tree is in a valid state. That happens if:
-   * - It is a valid binary search tree;
-   * - All red-black properties are satisfied;
-   * - All non-null nodes have their `parent` reference correct;
-   * - The size variable in `tree` corresponds to the actual size of the tree.
+  /** Checks if the tree is in a valid state. That happens if:
+   *  - It is a valid binary search tree;
+   *  - All red-black properties are satisfied;
+   *  - All non-null nodes have their `parent` reference correct;
+   *  - The size variable in `tree` corresponds to the actual size of the tree.
    */
   def isValid[A: Ordering, B](tree: Tree[A, B]): Boolean =
     isValidBST(tree.root) && hasProperParentRefs(tree) && isValidRedBlackTree(tree) && size(tree.root) == tree.size
 
-  /**
-   * Returns true if all non-null nodes have their `parent` reference correct.
-   */
+  /** Returns true if all non-null nodes have their `parent` reference correct. */
   private def hasProperParentRefs[A, B](tree: Tree[A, B]): Boolean = {
 
     def hasProperParentRefs(node: Node[A, B] | Null): Boolean = {
@@ -572,9 +562,7 @@ private[collection] object RedBlackTree {
     else (tree.root.nn.parent eq null) && hasProperParentRefs(tree.root)
   }
 
-  /**
-   * Returns true if this node follows the properties of a binary search tree.
-   */
+  /** Returns true if this node follows the properties of a binary search tree. */
   private def isValidBST[A, B](node: Node[A, B] | Null)(implicit ord: Ordering[A]): Boolean = {
     if (node eq null) true
     else {
@@ -584,9 +572,8 @@ private[collection] object RedBlackTree {
     }
   }
 
-  /**
-   * Returns true if the tree has all the red-black tree properties: if the root node is black, if all children of red
-   * nodes are black and if the path from any node to any of its null children has the same number of black nodes.
+  /** Returns true if the tree has all the red-black tree properties: if the root node is black, if all children of red
+   *  nodes are black and if the path from any node to any of its null children has the same number of black nodes.
    */
   private def isValidRedBlackTree[A, B](tree: Tree[A, B]): Boolean = {
 

--- a/library/src/scala/collection/mutable/Seq.scala
+++ b/library/src/scala/collection/mutable/Seq.scala
@@ -25,18 +25,17 @@ trait Seq[A]
   override def iterableFactory: SeqFactory[Seq] = Seq
 }
 
-/**
-  * $factoryInfo
-  * @define coll mutable sequence
-  * @define Coll `mutable.Seq`
-  */
+/** $factoryInfo
+ *  @define coll mutable sequence
+ *  @define Coll `mutable.Seq`
+ */
 @SerialVersionUID(3L)
 object Seq extends SeqFactory.Delegate[Seq](ArrayBuffer)
 
 /**
-  * @define coll mutable sequence
-  * @define Coll `mutable.Seq`
-  */
+ *  @define coll mutable sequence
+ *  @define Coll `mutable.Seq`
+ */
 transparent trait SeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
   extends collection.SeqOps[A, CC, C]
     with Cloneable[C]
@@ -49,11 +48,11 @@ transparent trait SeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
   }
 
   /** Replaces element at given index with a new value.
-    *
-    *  @param idx      the index of the element to replace.
-    *  @param elem     the new value.
-    *  @throws   IndexOutOfBoundsException if the index is not valid.
-    */
+   *
+   *  @param idx      the index of the element to replace.
+   *  @param elem     the new value.
+   *  @throws   IndexOutOfBoundsException if the index is not valid.
+   */
   @throws[IndexOutOfBoundsException]
   def update(idx: Int, elem: A): Unit
 

--- a/library/src/scala/collection/mutable/Set.scala
+++ b/library/src/scala/collection/mutable/Set.scala
@@ -27,9 +27,9 @@ trait Set[A]
 }
 
 /**
-  * @define coll mutable set
-  * @define Coll `mutable.Set`
-  */
+ *  @define coll mutable set
+ *  @define Coll `mutable.Set`
+ */
 transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   extends collection.SetOps[A, CC, C]
     with IterableOps[A, CC, C] // only needed so we can use super[IterableOps] below
@@ -51,18 +51,18 @@ transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
     }
 
   /** Updates the presence of a single element in this set.
-    *
-    * This method allows one to add or remove an element `elem`
-    *  from this set depending on the value of parameter `included`.
-    *  Typically, one would use the following syntax:
-    *  {{{
-    *     set(elem) = true  // adds element
-    *     set(elem) = false // removes element
-    *  }}}
-    *
-    *  @param elem     the element to be added or removed
-    *  @param included a flag indicating whether element should be included or excluded.
-    */
+   *
+   *  This method allows one to add or remove an element `elem`
+   *  from this set depending on the value of parameter `included`.
+   *  Typically, one would use the following syntax:
+   *  ```
+   *     set(elem) = true  // adds element
+   *     set(elem) = false // removes element
+   *  ```
+   *
+   *  @param elem     the element to be added or removed
+   *  @param included a flag indicating whether element should be included or excluded.
+   */
   def update(elem: A, included: Boolean): Unit = {
     if (included) add(elem)
     else remove(elem)
@@ -86,10 +86,10 @@ transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   @inline final def retain(p: A => Boolean): Unit = filterInPlace(p)
 
   /** Removes all elements from the set for which do not satisfy a predicate.
-    *  @param  p  the predicate used to test elements. Only elements for
-    *             which `p` returns `true` are retained in the set; all others
-    *             are removed.
-    */
+   *  @param  p  the predicate used to test elements. Only elements for
+   *             which `p` returns `true` are retained in the set; all others
+   *             are removed.
+   */
   def filterInPlace(p: A => Boolean): this.type = {
     if (nonEmpty) {
       val array = this.toArray[Any] // scala/bug#7269 toArray avoids ConcurrentModificationException
@@ -111,11 +111,10 @@ transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   override def knownSize: Int = super[IterableOps].knownSize
 }
 
-/**
-  * $factoryInfo
-  * @define coll mutable set
-  * @define Coll `mutable.Set`
-  */
+/** $factoryInfo
+ *  @define coll mutable set
+ *  @define Coll `mutable.Set`
+ */
 @SerialVersionUID(3L)
 object Set extends IterableFactory.Delegate[Set](HashSet)
 

--- a/library/src/scala/collection/mutable/SortedMap.scala
+++ b/library/src/scala/collection/mutable/SortedMap.scala
@@ -17,9 +17,7 @@ import scala.language.`2.13`
 import language.experimental.captureChecking
 import scala.collection.{SortedMapFactory, SortedMapFactoryDefaults}
 
-/**
-  * Base type for mutable sorted map collections
-  */
+/** Base type for mutable sorted map collections */
 trait SortedMap[K, V]
   extends collection.SortedMap[K, V]
     with Map[K, V]
@@ -31,25 +29,25 @@ trait SortedMap[K, V]
   override def sortedMapFactory: SortedMapFactory[SortedMap] = SortedMap
 
   /** The same sorted map with a given default function.
-    *  Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
-    *  are not affected by `withDefault`.
-    *
-    *  Invoking transformer methods (e.g. `map`) will not preserve the default value.
-    *
-    *  @param d     the function mapping keys to values, used for non-present keys
-    *  @return      a wrapper of the map with a default value
-    */
+   *  Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
+   *  are not affected by `withDefault`.
+   *
+   *  Invoking transformer methods (e.g. `map`) will not preserve the default value.
+   *
+   *  @param d     the function mapping keys to values, used for non-present keys
+   *  @return      a wrapper of the map with a default value
+   */
   override def withDefault(d: K -> V): SortedMap[K, V] = new SortedMap.WithDefault[K, V](this, d)
 
   /** The same map with a given default value.
-    * Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
-    * are not affected by `withDefaultValue`.
-    *
-    * Invoking transformer methods (e.g. `map`) will not preserve the default value.
-    *
-    * @param d default value used for non-present keys
-    * @return a wrapper of the map with a default value
-    */
+   *  Note: The default is only used for `apply`. Other methods like `get`, `contains`, `iterator`, `keys`, etc.
+   *  are not affected by `withDefaultValue`.
+   *
+   *  Invoking transformer methods (e.g. `map`) will not preserve the default value.
+   *
+   *  @param d default value used for non-present keys
+   *  @return a wrapper of the map with a default value
+   */
   override def withDefaultValue(d: V): SortedMap[K, V] = new SortedMap.WithDefault[K, V](this, _ => d)
 }
 

--- a/library/src/scala/collection/mutable/SortedSet.scala
+++ b/library/src/scala/collection/mutable/SortedSet.scala
@@ -17,8 +17,7 @@ package mutable
 import scala.language.`2.13`
 import language.experimental.captureChecking
 
-/** Base type for mutable sorted set collections
- */
+/** Base type for mutable sorted set collections */
 trait SortedSet[A]
   extends Set[A]
     with collection.SortedSet[A]
@@ -31,9 +30,9 @@ trait SortedSet[A]
 }
 
 /**
-  * @define coll mutable sorted set
-  * @define Coll `mutable.SortedSet`
-  */
+ *  @define coll mutable sorted set
+ *  @define Coll `mutable.SortedSet`
+ */
 transparent trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
   extends SetOps[A, Set, C]
     with collection.SortedSetOps[A, CC, C] {
@@ -41,8 +40,6 @@ transparent trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, 
   def unsorted: Set[A]
 }
 
-/**
- *  $factoryInfo
- */
+/** $factoryInfo */
 @SerialVersionUID(3L)
 object SortedSet extends SortedIterableFactory.Delegate[SortedSet](TreeSet)

--- a/library/src/scala/collection/mutable/Stack.scala
+++ b/library/src/scala/collection/mutable/Stack.scala
@@ -52,20 +52,19 @@ class Stack[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix = "Stack"
 
-  /**
-    * Adds elements to the top of this stack
-    *
-    * @param elem
-    * @return
-    */
+  /** Adds elements to the top of this stack
+   *
+   *  @param elem
+   *  @return
+   */
   def push(elem: A): this.type = prepend(elem)
 
   /** Pushes two or more elements onto the stack. The last element
-    *  of the sequence will be on top of the new stack.
-    *
-    *  @param   elems      the element sequence.
-    *  @return the stack with the new elements on top.
-    */
+   *  of the sequence will be on top of the new stack.
+   *
+   *  @param   elems      the element sequence.
+   *  @return the stack with the new elements on top.
+   */
   def push(elem1: A, elem2: A, elems: A*): this.type = {
     val k = elems.knownSize
     ensureSize(length + (if(k >= 0) k + 2 else 3))
@@ -73,46 +72,43 @@ class Stack[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
   }
 
   /** Pushes all elements in the given iterable object onto the stack. The
-    *  last element in the iterable object will be on top of the new stack.
-    *
-    *  @param elems the iterable object.
-    *  @return the stack with the new elements on top.
-    */
+   *  last element in the iterable object will be on top of the new stack.
+   *
+   *  @param elems the iterable object.
+   *  @return the stack with the new elements on top.
+   */
   def pushAll(elems: scala.collection.IterableOnce[A]^): this.type =
     prependAll(elems match {
       case it: scala.collection.Seq[A] => it.view.reverse
       case it => IndexedSeq.from(it).view.reverse
     })
 
-  /**
-    * Removes the top element from this stack and returns it
-    *
-    * @return
-    * @throws NoSuchElementException when stack is empty
-    */
+  /** Removes the top element from this stack and returns it
+   *
+   *  @return
+   *  @throws NoSuchElementException when stack is empty
+   */
   def pop(): A = removeHead()
 
-  /**
-    * Pop all elements from this stack and return it
-    *
-    * @return The removed elements
-    */
+  /** Pop all elements from this stack and return it
+   *
+   *  @return The removed elements
+   */
   def popAll(): scala.collection.Seq[A] = removeAll()
 
-  /**
-    * Returns and removes all elements from the top of this stack which satisfy the given predicate.
-    *
-    *  @param f   the predicate used for choosing elements
-    *  @return The removed elements
-    */
+  /** Returns and removes all elements from the top of this stack which satisfy the given predicate.
+   *
+   *  @param f   the predicate used for choosing elements
+   *  @return The removed elements
+   */
   def popWhile(f: A => Boolean): scala.collection.Seq[A] = removeHeadWhile(f)
 
   /** Returns the top element of the stack. This method will not remove
    *  the element from the stack. An error is signaled if there is no
    *  element on the stack.
    *
-   *  @throws NoSuchElementException if the stack is empty
    *  @return the top element
+   *  @throws NoSuchElementException if the stack is empty
    */
   @`inline` final def top: A = head
 
@@ -127,11 +123,10 @@ class Stack[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
 
 }
 
-/**
-  * $factoryInfo
-  * @define coll stack
-  * @define Coll `Stack`
-  */
+/** $factoryInfo
+ *  @define coll stack
+ *  @define Coll `Stack`
+ */
 @SerialVersionUID(3L)
 object Stack extends StrictOptimizedSeqFactory[Stack] {
 

--- a/library/src/scala/collection/mutable/StringBuilder.scala
+++ b/library/src/scala/collection/mutable/StringBuilder.scala
@@ -44,7 +44,7 @@ import scala.Predef.{ // unimport char-related implicit conversions to avoid tri
  *
  *  $multipleResults
  *
- *  @see [[https://docs.scala-lang.org/overviews/collections-2.13/concrete-mutable-collection-classes.html#stringbuilders "Scala's Collection Library overview"]]
+ *  @see ["Scala's Collection Library overview"](https://docs.scala-lang.org/overviews/collections-2.13/concrete-mutable-collection-classes.html#stringbuilders)
  *  section on `StringBuilders` for more information.
  *
  *  @define Coll `mutable.IndexedSeq`
@@ -62,21 +62,21 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
   def this() = this(new java.lang.StringBuilder)
 
   /** Constructs a string builder with no characters in it and an
-    *  initial capacity specified by the `capacity` argument.
-    *
-    *  @param  capacity  the initial capacity.
-    *  @throws java.lang.NegativeArraySizeException  if capacity < 0.
-    */
+   *  initial capacity specified by the `capacity` argument.
+   *
+   *  @param  capacity  the initial capacity.
+   *  @throws java.lang.NegativeArraySizeException  if capacity < 0.
+   */
   def this(capacity: Int) = this(new java.lang.StringBuilder(capacity))
 
   /** Constructs a string builder with initial characters
-    *  equal to characters of `str`.
-    */
+   *  equal to characters of `str`.
+   */
   def this(str: String) = this(new java.lang.StringBuilder(str))
 
   /** Constructs a string builder initialized with string value `initValue`
-    *  and with additional character capacity `initCapacity`.
-    */
+   *  and with additional character capacity `initCapacity`.
+   */
   def this(initCapacity: Int, initValue: String) =
     this(new java.lang.StringBuilder(initValue.length + initCapacity).append(initValue))
 
@@ -136,31 +136,31 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
   }
 
   /** Appends the string representation of the given argument,
-    *  which is converted to a String with `String.valueOf`.
-    *
-    *  @param  x   an `Any` object.
-    *  @return     this StringBuilder.
-    */
+   *  which is converted to a String with `String.valueOf`.
+   *
+   *  @param  x   an `Any` object.
+   *  @return     this StringBuilder.
+   */
   def append(x: Any): this.type = {
     underlying.append(String.valueOf(x))
     this
   }
 
   /** Appends the given String to this sequence.
-    *
-    *  @param  s   a String.
-    *  @return     this StringBuilder.
-    */
+   *
+   *  @param  s   a String.
+   *  @return     this StringBuilder.
+   */
   def append(s: String): this.type = {
     underlying.append(s)
     this
   }
 
   /** Appends the given CharSequence to this sequence.
-    *
-    *  @param  cs   a CharSequence.
-    *  @return     this StringBuilder.
-    */
+   *
+   *  @param  cs   a CharSequence.
+   *  @return     this StringBuilder.
+   */
   def append(cs: java.lang.CharSequence): this.type = {
     underlying.append(cs match {
       // Both cases call into append(<CharSequence>), but java SB
@@ -172,20 +172,20 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
   }
 
   /** Appends the specified string builder to this sequence.
-    *
-    *  @param s
-    *  @return
-    */
+   *
+   *  @param s
+   *  @return
+   */
   def append(s: StringBuilder): this.type = {
     underlying.append(s.underlying)
     this
   }
 
   /** Appends all the Chars in the given IterableOnce[Char] to this sequence.
-    *
-    *  @param  xs  the characters to be appended.
-    *  @return     this StringBuilder.
-    */
+   *
+   *  @param  xs  the characters to be appended.
+   *  @return     this StringBuilder.
+   */
   def appendAll(xs: IterableOnce[Char]^): this.type = {
     xs match {
       case x: WrappedString => underlying.append(x.unwrap)
@@ -204,34 +204,34 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
   }
 
   /** Appends all the Chars in the given Array[Char] to this sequence.
-    *
-    *  @param  xs  the characters to be appended.
-    *  @return     a reference to this object.
-    */
+   *
+   *  @param  xs  the characters to be appended.
+   *  @return     a reference to this object.
+   */
   def appendAll(xs: Array[Char]): this.type = {
     underlying.append(xs)
     this
   }
 
   /** Appends a portion of the given Array[Char] to this sequence.
-    *
-    *  @param  xs      the Array containing Chars to be appended.
-    *  @param  offset  the index of the first Char to append.
-    *  @param  len     the numbers of Chars to append.
-    *  @return         this StringBuilder.
-    */
+   *
+   *  @param  xs      the Array containing Chars to be appended.
+   *  @param  offset  the index of the first Char to append.
+   *  @param  len     the numbers of Chars to append.
+   *  @return         this StringBuilder.
+   */
   def appendAll(xs: Array[Char], offset: Int, len: Int): this.type = {
     underlying.append(xs, offset, len)
     this
   }
 
   /** Appends the String representation of the given primitive type
-    *  to this sequence.  The argument is converted to a String with
-    *  String.valueOf.
-    *
-    *  @param   x  a primitive value
-    *  @return     This StringBuilder.
-    */
+   *  to this sequence.  The argument is converted to a String with
+   *  String.valueOf.
+   *
+   *  @param   x  a primitive value
+   *  @return     This StringBuilder.
+   */
   def append(x: Boolean): this.type = { underlying.append(x) ; this }
   def append(x: Byte): this.type = append(x.toInt)
   def append(x: Short): this.type = append(x.toInt)
@@ -242,101 +242,101 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
   def append(x: Char): this.type = { underlying.append(x) ; this }
 
   /** Removes a subsequence of Chars from this sequence, starting at the
-    *  given start index (inclusive) and extending to the end index (exclusive)
-    *  or to the end of the String, whichever comes first.
-    *
-    *  @param  start  The beginning index, inclusive.
-    *  @param  end    The ending index, exclusive.
-    *  @return        This StringBuilder.
-    *  @throws StringIndexOutOfBoundsException   if start < 0 || start > end
-    */
+   *  given start index (inclusive) and extending to the end index (exclusive)
+   *  or to the end of the String, whichever comes first.
+   *
+   *  @param  start  The beginning index, inclusive.
+   *  @param  end    The ending index, exclusive.
+   *  @return        This StringBuilder.
+   *  @throws StringIndexOutOfBoundsException   if start < 0 || start > end
+   */
   def delete(start: Int, end: Int): this.type = {
     underlying.delete(start, end)
     this
   }
 
   /** Replaces a subsequence of Chars with the given String.  The semantics
-    *  are as in delete, with the String argument then inserted at index 'start'.
-    *
-    *  @param  start  The beginning index, inclusive.
-    *  @param  end    The ending index, exclusive.
-    *  @param  str    The String to be inserted at the start index.
-    *  @return        This StringBuilder.
-    *  @throws StringIndexOutOfBoundsException if start < 0, start > length, or start > end
-    */
+   *  are as in delete, with the String argument then inserted at index 'start'.
+   *
+   *  @param  start  The beginning index, inclusive.
+   *  @param  end    The ending index, exclusive.
+   *  @param  str    The String to be inserted at the start index.
+   *  @return        This StringBuilder.
+   *  @throws StringIndexOutOfBoundsException if start < 0, start > length, or start > end
+   */
   def replace(start: Int, end: Int, str: String): this.type = {
     underlying.replace(start, end, str)
     this
   }
 
   /** Inserts a subarray of the given Array[Char] at the given index
-    *  of this sequence.
-    *
-    * @param  index   index at which to insert the subarray.
-    * @param  str     the Array from which Chars will be taken.
-    * @param  offset  the index of the first Char to insert.
-    * @param  len     the number of Chars from 'str' to insert.
-    * @return         This StringBuilder.
-    *
-    * @throws StringIndexOutOfBoundsException  if index < 0, index > length,
-    *         offset < 0, len < 0, or (offset + len) > str.length.
-    */
+   *  of this sequence.
+   *
+   *  @param  index   index at which to insert the subarray.
+   *  @param  str     the Array from which Chars will be taken.
+   *  @param  offset  the index of the first Char to insert.
+   *  @param  len     the number of Chars from 'str' to insert.
+   *  @return         This StringBuilder.
+   *
+   *  @throws StringIndexOutOfBoundsException  if index < 0, index > length,
+   *         offset < 0, len < 0, or (offset + len) > str.length.
+   */
   def insertAll(index: Int, str: Array[Char], offset: Int, len: Int): this.type = {
     underlying.insert(index, str, offset, len)
     this
   }
 
   /** Inserts the String representation (via String.valueOf) of the given
-    *  argument into this sequence at the given index.
-    *
-    *  @param  index   the index at which to insert.
-    *  @param  x       a value.
-    *  @return         this StringBuilder.
-    *  @throws StringIndexOutOfBoundsException  if the index is out of bounds.
-    */
+   *  argument into this sequence at the given index.
+   *
+   *  @param  index   the index at which to insert.
+   *  @param  x       a value.
+   *  @return         this StringBuilder.
+   *  @throws StringIndexOutOfBoundsException  if the index is out of bounds.
+   */
   def insert(index: Int, x: Any): this.type = insert(index, String.valueOf(x))
 
   /** Inserts the String into this character sequence.
-    *
-    *  @param  index the index at which to insert.
-    *  @param  x     a String.
-    *  @return       this StringBuilder.
-    *  @throws StringIndexOutOfBoundsException  if the index is out of bounds.
-    */
+   *
+   *  @param  index the index at which to insert.
+   *  @param  x     a String.
+   *  @return       this StringBuilder.
+   *  @throws StringIndexOutOfBoundsException  if the index is out of bounds.
+   */
   def insert(index: Int, x: String): this.type = {
     underlying.insert(index, x)
     this
   }
 
   /** Inserts the given `Seq[Char]` into this sequence at the given index.
-    *
-    *  @param  index the index at which to insert.
-    *  @param  xs    the `Seq[Char]`.
-    *  @return       this `StringBuilder`.
-    *  @throws StringIndexOutOfBoundsException  if the index is out of bounds.
-    */
+   *
+   *  @param  index the index at which to insert.
+   *  @param  xs    the `Seq[Char]`.
+   *  @return       this `StringBuilder`.
+   *  @throws StringIndexOutOfBoundsException  if the index is out of bounds.
+   */
   def insertAll(index: Int, xs: IterableOnce[Char]^): this.type =
     insertAll(index, (ArrayBuilder.make[Char] ++= xs).result())
 
   /** Inserts the given `Array[Char]` into this sequence at the given index.
-    *
-    *  @param  index the index at which to insert.
-    *  @param  xs    the `Array[Char]`.
-    *  @return       this `StringBuilder`.
-    *  @throws StringIndexOutOfBoundsException  if the index is out of bounds.
-    */
+   *
+   *  @param  index the index at which to insert.
+   *  @param  xs    the `Array[Char]`.
+   *  @return       this `StringBuilder`.
+   *  @throws StringIndexOutOfBoundsException  if the index is out of bounds.
+   */
   def insertAll(index: Int, xs: Array[Char]): this.type = {
     underlying.insert(index, xs)
     this
   }
 
   /** Calls String.valueOf on the given primitive value, and inserts the
-    *  String at the given index.
-    *
-    *  @param  index the offset position.
-    *  @param  x     a primitive value.
-    *  @return       this StringBuilder.
-    */
+   *  String at the given index.
+   *
+   *  @param  index the offset position.
+   *  @param  x     a primitive value.
+   *  @return       this StringBuilder.
+   */
   def insert(index: Int, x: Boolean): this.type = insert(index, String.valueOf(x))
   def insert(index: Int, x: Byte): this.type    = insert(index, x.toInt)
   def insert(index: Int, x: Short): this.type   = insert(index, x.toInt)
@@ -347,12 +347,12 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
   def insert(index: Int, x: Char): this.type    = insert(index, String.valueOf(x))
 
   /** Sets the length of the character sequence.  If the current sequence
-    *  is shorter than the given length, it is padded with nulls; if it is
-    *  longer, it is truncated.
-    *
-    *  @param  len  the new length
-    *  @throws IndexOutOfBoundsException if the argument is negative.
-    */
+   *  is shorter than the given length, it is padded with nulls; if it is
+   *  longer, it is truncated.
+   *
+   *  @param  len  the new length
+   *  @throws IndexOutOfBoundsException if the argument is negative.
+   */
   def setLength(len: Int): Unit = underlying.setLength(len)
 
   def update(idx: Int, elem: Char): Unit = underlying.setCharAt(idx, elem)
@@ -447,8 +447,7 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
    */
   def substring(start: Int, end: Int): String = underlying.substring(start, end)
 
-  /** For implementing CharSequence.
-   */
+  /** For implementing CharSequence. */
   def subSequence(start: Int, end: Int): java.lang.CharSequence =
     underlying.substring(start, end)
 

--- a/library/src/scala/collection/mutable/TreeMap.scala
+++ b/library/src/scala/collection/mutable/TreeMap.scala
@@ -20,16 +20,15 @@ import scala.collection.Stepper.EfficientSplit
 import scala.collection.generic.DefaultSerializable
 import scala.collection.mutable.{RedBlackTree => RB}
 
-/**
-  * A mutable sorted map implemented using a mutable red-black tree as underlying data structure.
-  *
-  * @param ordering the implicit ordering used to compare objects of type `A`.
-  * @tparam K the type of the keys contained in this tree map.
-  * @tparam V the type of the values associated with the keys.
-  *
-  * @define Coll mutable.TreeMap
-  * @define coll mutable tree map
-  */
+/** A mutable sorted map implemented using a mutable red-black tree as underlying data structure.
+ *
+ *  @tparam K the type of the keys contained in this tree map.
+ *  @tparam V the type of the values associated with the keys.
+ *  @param ordering the implicit ordering used to compare objects of type `A`.
+ *
+ *  @define Coll mutable.TreeMap
+ *  @define coll mutable tree map
+ */
 sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: Ordering[K])
   extends AbstractMap[K, V]
     with SortedMap[K, V]
@@ -42,11 +41,10 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
 
   override def sortedMapFactory: TreeMap.type = TreeMap
 
-  /**
-    * Creates an empty `TreeMap`.
-    * @param ord the implicit ordering used to compare objects of type `K`.
-    * @return an empty `TreeMap`.
-    */
+  /** Creates an empty `TreeMap`.
+   *  @param ord the implicit ordering used to compare objects of type `K`.
+   *  @return an empty `TreeMap`.
+   */
   def this()(implicit ord: Ordering[K]) = this(RB.Tree.empty)(using ord)
 
   def iterator: Iterator[(K, V)] = {
@@ -118,20 +116,19 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
 
   def get(key: K): Option[V] = RB.get(tree, key)
 
-  /**
-    * Creates a ranged projection of this map. Any mutations in the ranged projection will update the original map and
-    * vice versa.
-    *
-    * Only entries with keys between this projection's key range will ever appear as elements of this map, independently
-    * of whether the entries are added through the original map or through this view. That means that if one inserts a
-    * key-value in a view whose key is outside the view's bounds, calls to `get` or `contains` will _not_ consider the
-    * newly added entry. Mutations are always reflected in the original map, though.
-    *
-    * @param from the lower bound (inclusive) of this projection wrapped in a `Some`, or `None` if there is no lower
-    *             bound.
-    * @param until the upper bound (exclusive) of this projection wrapped in a `Some`, or `None` if there is no upper
-    *              bound.
-    */
+  /** Creates a ranged projection of this map. Any mutations in the ranged projection will update the original map and
+   *  vice versa.
+   *
+   *  Only entries with keys between this projection's key range will ever appear as elements of this map, independently
+   *  of whether the entries are added through the original map or through this view. That means that if one inserts a
+   *  key-value in a view whose key is outside the view's bounds, calls to `get` or `contains` will _not_ consider the
+   *  newly added entry. Mutations are always reflected in the original map, though.
+   *
+   *  @param from the lower bound (inclusive) of this projection wrapped in a `Some`, or `None` if there is no lower
+   *             bound.
+   *  @param until the upper bound (exclusive) of this projection wrapped in a `Some`, or `None` if there is no upper
+   *              bound.
+   */
   def rangeImpl(from: Option[K], until: Option[K]): TreeMap[K, V] = new TreeMapProjection(from, until)
 
   override def foreach[U](f: ((K, V)) => U): Unit = RB.foreach(tree, f)
@@ -154,42 +151,35 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
   override protected def className: String = "TreeMap"
 
 
-  /**
-    * A ranged projection of a [[TreeMap]]. Mutations on this map affect the original map and vice versa.
-    *
-    * Only entries with keys between this projection's key range will ever appear as elements of this map, independently
-    * of whether the entries are added through the original map or through this view. That means that if one inserts a
-    * key-value in a view whose key is outside the view's bounds, calls to `get` or `contains` will _not_ consider the
-    * newly added entry. Mutations are always reflected in the original map, though.
-    *
-    * @param from the lower bound (inclusive) of this projection wrapped in a `Some`, or `None` if there is no lower
-    *             bound.
-    * @param until the upper bound (exclusive) of this projection wrapped in a `Some`, or `None` if there is no upper
-    *              bound.
-    */
+  /** A ranged projection of a [[TreeMap]]. Mutations on this map affect the original map and vice versa.
+   *
+   *  Only entries with keys between this projection's key range will ever appear as elements of this map, independently
+   *  of whether the entries are added through the original map or through this view. That means that if one inserts a
+   *  key-value in a view whose key is outside the view's bounds, calls to `get` or `contains` will _not_ consider the
+   *  newly added entry. Mutations are always reflected in the original map, though.
+   *
+   *  @param from the lower bound (inclusive) of this projection wrapped in a `Some`, or `None` if there is no lower
+   *             bound.
+   *  @param until the upper bound (exclusive) of this projection wrapped in a `Some`, or `None` if there is no upper
+   *              bound.
+   */
   private final class TreeMapProjection(from: Option[K], until: Option[K]) extends TreeMap[K, V](tree) {
 
-    /**
-      * Given a possible new lower bound, chooses and returns the most constraining one (the maximum).
-      */
+    /** Given a possible new lower bound, chooses and returns the most constraining one (the maximum). */
     private def pickLowerBound(newFrom: Option[K]): Option[K] = (from, newFrom) match {
       case (Some(fr), Some(newFr)) => Some(ordering.max(fr, newFr))
       case (None, _) => newFrom
       case _ => from
     }
 
-    /**
-      * Given a possible new upper bound, chooses and returns the most constraining one (the minimum).
-      */
+    /** Given a possible new upper bound, chooses and returns the most constraining one (the minimum). */
     private def pickUpperBound(newUntil: Option[K]): Option[K] = (until, newUntil) match {
       case (Some(unt), Some(newUnt)) => Some(ordering.min(unt, newUnt))
       case (None, _) => newUntil
       case _ => until
     }
 
-    /**
-      * Returns true if the argument is inside the view bounds (between `from` and `until`).
-      */
+    /** Returns true if the argument is inside the view bounds (between `from` and `until`). */
     private def isInsideViewBounds(key: K): Boolean = {
       val afterFrom = from.isEmpty || ordering.compare(from.get, key) <= 0
       val beforeUntil = until.isEmpty || ordering.compare(key, until.get) < 0
@@ -240,12 +230,11 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
 
 }
 
-/**
-  * $factoryInfo
-  *
-  * @define Coll mutable.TreeMap
-  * @define coll mutable tree map
-  */
+/** $factoryInfo
+ *
+ *  @define Coll mutable.TreeMap
+ *  @define coll mutable tree map
+ */
 @SerialVersionUID(3L)
 object TreeMap extends SortedMapFactory[TreeMap] {
 

--- a/library/src/scala/collection/mutable/TreeSet.scala
+++ b/library/src/scala/collection/mutable/TreeSet.scala
@@ -20,15 +20,14 @@ import scala.collection.generic.DefaultSerializable
 import scala.collection.mutable.{RedBlackTree => RB}
 import scala.collection.{SortedIterableFactory, SortedSetFactoryDefaults, Stepper, StepperShape, StrictOptimizedIterableOps, StrictOptimizedSortedSetOps, mutable}
 
-/**
-  * A mutable sorted set implemented using a mutable red-black tree as underlying data structure.
-  *
-  * @param ordering the implicit ordering used to compare objects of type `A`.
-  * @tparam A the type of the keys contained in this tree set.
-  *
-  * @define Coll mutable.TreeSet
-  * @define coll mutable tree set
-  */
+/** A mutable sorted set implemented using a mutable red-black tree as underlying data structure.
+ *
+ *  @tparam A the type of the keys contained in this tree set.
+ *  @param ordering the implicit ordering used to compare objects of type `A`.
+ *
+ *  @define Coll mutable.TreeSet
+ *  @define coll mutable tree set
+ */
 // Original API designed in part by Lucien Pereira
 sealed class TreeSet[A] private (private val tree: RB.Tree[A, Null])(implicit val ordering: Ordering[A])
   extends AbstractSet[A]
@@ -42,11 +41,10 @@ sealed class TreeSet[A] private (private val tree: RB.Tree[A, Null])(implicit va
   if (ordering eq null)
     throw new NullPointerException("ordering must not be null")
 
-  /**
-    * Creates an empty `TreeSet`.
-    * @param ord the implicit ordering used to compare objects of type `A`.
-    * @return an empty `TreeSet`.
-    */
+  /** Creates an empty `TreeSet`.
+   *  @param ord the implicit ordering used to compare objects of type `A`.
+   *  @return an empty `TreeSet`.
+   */
   def this()(implicit ord: Ordering[A]) = this(RB.Tree.empty)(using ord)
 
   override def sortedIterableFactory: SortedIterableFactory[TreeSet] = TreeSet
@@ -102,43 +100,36 @@ sealed class TreeSet[A] private (private val tree: RB.Tree[A, Null])(implicit va
   override def foreach[U](f: A => U): Unit = RB.foreachKey(tree, f)
 
 
-  /**
-    * A ranged projection of a [[TreeSet]]. Mutations on this set affect the original set and vice versa.
-    *
-    * Only keys between this projection's key range will ever appear as elements of this set, independently of whether
-    * the elements are added through the original set or through this view. That means that if one inserts an element in
-    * a view whose key is outside the view's bounds, calls to `contains` will _not_ consider the newly added element.
-    * Mutations are always reflected in the original set, though.
-    *
-    * @param from the lower bound (inclusive) of this projection wrapped in a `Some`, or `None` if there is no lower
-    *             bound.
-    * @param until the upper bound (exclusive) of this projection wrapped in a `Some`, or `None` if there is no upper
-    *              bound.
-    */
+  /** A ranged projection of a [[TreeSet]]. Mutations on this set affect the original set and vice versa.
+   *
+   *  Only keys between this projection's key range will ever appear as elements of this set, independently of whether
+   *  the elements are added through the original set or through this view. That means that if one inserts an element in
+   *  a view whose key is outside the view's bounds, calls to `contains` will _not_ consider the newly added element.
+   *  Mutations are always reflected in the original set, though.
+   *
+   *  @param from the lower bound (inclusive) of this projection wrapped in a `Some`, or `None` if there is no lower
+   *             bound.
+   *  @param until the upper bound (exclusive) of this projection wrapped in a `Some`, or `None` if there is no upper
+   *              bound.
+   */
   private final class TreeSetProjection(from: Option[A], until: Option[A]) extends TreeSet[A](tree) {
     self: TreeSetProjection^{} =>
 
-    /**
-      * Given a possible new lower bound, chooses and returns the most constraining one (the maximum).
-      */
+    /** Given a possible new lower bound, chooses and returns the most constraining one (the maximum). */
     private def pickLowerBound(newFrom: Option[A]): Option[A] = (from, newFrom) match {
       case (Some(fr), Some(newFr)) => Some(ordering.max(fr, newFr))
       case (None, _) => newFrom
       case _ => from
     }
 
-    /**
-      * Given a possible new upper bound, chooses and returns the most constraining one (the minimum).
-      */
+    /** Given a possible new upper bound, chooses and returns the most constraining one (the minimum). */
     private def pickUpperBound(newUntil: Option[A]): Option[A] = (until, newUntil) match {
       case (Some(unt), Some(newUnt)) => Some(ordering.min(unt, newUnt))
       case (None, _) => newUntil
       case _ => until
     }
 
-    /**
-      * Returns true if the argument is inside the view bounds (between `from` and `until`).
-      */
+    /** Returns true if the argument is inside the view bounds (between `from` and `until`). */
     private def isInsideViewBounds(key: A): Boolean = {
       val afterFrom = from.isEmpty || ordering.compare(from.get, key) <= 0
       val beforeUntil = until.isEmpty || ordering.compare(key, until.get) < 0
@@ -186,11 +177,10 @@ sealed class TreeSet[A] private (private val tree: RB.Tree[A, Null])(implicit va
 
 }
 
-/**
-  * $factoryInfo
-  * @define Coll `mutable.TreeSet`
-  * @define coll mutable tree set
-  */
+/** $factoryInfo
+ *  @define Coll `mutable.TreeSet`
+ *  @define coll mutable tree set
+ */
 @SerialVersionUID(3L)
 object TreeSet extends SortedIterableFactory[TreeSet] {
 

--- a/library/src/scala/collection/mutable/UnrolledBuffer.scala
+++ b/library/src/scala/collection/mutable/UnrolledBuffer.scala
@@ -21,31 +21,30 @@ import scala.reflect.ClassTag
 import scala.collection.immutable.Nil
 
 /** A buffer that stores elements in an unrolled linked list.
-  *
-  *  Unrolled linked lists store elements in linked fixed size
-  *  arrays.
-  *
-  *  Unrolled buffers retain locality and low memory overhead
-  *  properties of array buffers, but offer much more efficient
-  *  element addition, since they never reallocate and copy the
-  *  internal array.
-  *
-  *  However, they provide `O(n/m)` complexity random access,
-  *  where `n` is the number of elements, and `m` the size of
-  *  internal array chunks.
-  *
-  *  Ideal to use when:
-  *  - elements are added to the buffer and then all of the
-  *    elements are traversed sequentially
-  *  - two unrolled buffers need to be concatenated (see `concat`)
-  *
-  *  Better than singly linked lists for random access, but
-  *  should still be avoided for such a purpose.
-  *
-  *  @define coll unrolled buffer
-  *  @define Coll `UnrolledBuffer`
-  *
-  */
+ *
+ *  Unrolled linked lists store elements in linked fixed size
+ *  arrays.
+ *
+ *  Unrolled buffers retain locality and low memory overhead
+ *  properties of array buffers, but offer much more efficient
+ *  element addition, since they never reallocate and copy the
+ *  internal array.
+ *
+ *  However, they provide `O(n/m)` complexity random access,
+ *  where `n` is the number of elements, and `m` the size of
+ *  internal array chunks.
+ *
+ *  Ideal to use when:
+ *  - elements are added to the buffer and then all of the
+ *    elements are traversed sequentially
+ *  - two unrolled buffers need to be concatenated (see `concat`)
+ *
+ *  Better than singly linked lists for random access, but
+ *  should still be avoided for such a purpose.
+ *
+ *  @define coll unrolled buffer
+ *  @define Coll `UnrolledBuffer`
+ */
 @SerialVersionUID(3L)
 sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
   extends AbstractBuffer[T]
@@ -94,12 +93,12 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
   def classTagCompanion: UnrolledBuffer.type = UnrolledBuffer
 
   /** Concatenates the target unrolled buffer to this unrolled buffer.
-    *
-    *  The specified buffer `that` is cleared after this operation. This is
-    *  an O(1) operation.
-    *
-    *  @param that    the unrolled buffer whose elements are added to this buffer
-    */
+   *
+   *  The specified buffer `that` is cleared after this operation. This is
+   *  an O(1) operation.
+   *
+   *  @param that    the unrolled buffer whose elements are added to this buffer
+   */
   def concat(that: UnrolledBuffer[T]) = {
     // bind the two together
     if (!lastptr.bind(that.headptr)) lastptr = that.lastPtr
@@ -262,8 +261,7 @@ object UnrolledBuffer extends StrictOptimizedClassTagSeqFactory[UnrolledBuffer] 
 
   private[collection] val unrolledlength = 32
 
-  /** Unrolled buffer node.
-    */
+  /** Unrolled buffer node. */
   class Unrolled[T: ClassTag] private[collection] (var size: Int, var array: Array[T], var next: Unrolled[T] | Null, val buff: UnrolledBuffer[T] | Null = null) {
     this: Unrolled[T]^{} =>
     private[collection] def this() = this(0, new Array[T](unrolledlength), null, null)

--- a/library/src/scala/collection/mutable/WeakHashMap.scala
+++ b/library/src/scala/collection/mutable/WeakHashMap.scala
@@ -26,7 +26,7 @@ import scala.collection.convert.JavaCollectionWrappers.{JMapWrapper, JMapWrapper
  *  @tparam K      type of keys contained in this map
  *  @tparam V      type of values associated with the keys
  *
- *  @see [[https://docs.scala-lang.org/overviews/collections-2.13/concrete-mutable-collection-classes.html#weak-hash-maps "Scala's Collection Library overview"]]
+ *  @see ["Scala's Collection Library overview"](https://docs.scala-lang.org/overviews/collections-2.13/concrete-mutable-collection-classes.html#weak-hash-maps)
  *  section on `Weak Hash Maps` for more information.
  *
  *  @define Coll `WeakHashMap`

--- a/library/src/scala/collection/package.scala
+++ b/library/src/scala/collection/package.scala
@@ -64,8 +64,8 @@ package object collection {
   /** An extractor used to head/tail deconstruct sequences. */
   object +: {
     /** Splits a sequence into head +: tail.
-      * @return Some((head, tail)) if sequence is non-empty. None otherwise.
-      */
+     *  @return Some((head, tail)) if sequence is non-empty. None otherwise.
+     */
     def unapply[A, CC[_] <: Seq[?], C <: SeqOps[A, CC, C]](t: (C & SeqOps[A, CC, C])^): Option[(A, C^{t})] =
       if(t.isEmpty) None
       else Some(t.head -> t.tail)
@@ -74,8 +74,8 @@ package object collection {
   /** An extractor used to init/last deconstruct sequences. */
   object :+ {
     /** Splits a sequence into init :+ last.
-      * @return Some((init, last)) if sequence is non-empty. None otherwise.
-      */
+     *  @return Some((init, last)) if sequence is non-empty. None otherwise.
+     */
     def unapply[A, CC[_] <: Seq[?], C <: SeqOps[A, CC, C]](t: (C & SeqOps[A, CC, C])^): Option[(C^{t}, A)] =
       if(t.isEmpty) None
       else Some(t.init -> t.last)

--- a/library/src/scala/compat/Platform.scala
+++ b/library/src/scala/compat/Platform.scala
@@ -64,16 +64,16 @@ object Platform {
    *  Note that if `elemClass` is a subclass of [[scala.AnyVal]] then the returned value is an Array of the corresponding java primitive type.
    *  For example, the following code `scala.compat.Platform.createArray(classOf[Int], 4)` returns an array of the java primitive type `int`.
    *
-   *  For a [[scala.AnyVal]] array, the values of the array are set to 0 for ''numeric value types'' ([[scala.Double]], [[scala.Float]], [[scala.Long]], [[scala.Int]], [[scala.Char]],
+   *  For a [[scala.AnyVal]] array, the values of the array are set to 0 for *numeric value types* ([[scala.Double]], [[scala.Float]], [[scala.Long]], [[scala.Int]], [[scala.Char]],
    *  [[scala.Short]], and [[scala.Byte]]), and `false` for [[scala.Boolean]]. Creation of an array of type [[scala.Unit]] is not possible.
    *
    *  For subclasses of [[scala.AnyRef]], the values of the array are set to `null`.
    *
    *  The caller must cast the returned value to the correct type.
    *
-   *  @example {{{
+   *  @example ```
    *  val a = scala.compat.Platform.createArray(classOf[Int], 4).asInstanceOf[Array[Int]] // returns Array[Int](0, 0, 0, 0)
-   *  }}}
+   *  ```
    *
    *  @param elemClass the `Class` object of the component type of the array
    *  @param length    the length of the new array.
@@ -105,9 +105,9 @@ object Platform {
    * @throws java.lang.LinkageError if the linkage fails
    * @throws java.lang.ExceptionInInitializerError if the initialization provoked by this method fails
    * @throws java.lang.ClassNotFoundException if the class cannot be located
-   *  @example {{{
+   *  @example ```
    *  val a = scala.compat.Platform.getClassForName("java.lang.Integer")  // returns the Class[_] for java.lang.Integer
-   *  }}}
+   *  ```
    */
   @inline
   @deprecated("Use `java.lang.Class#forName` instead.", since = "2.13.0")

--- a/library/src/scala/compiletime/package.scala
+++ b/library/src/scala/compiletime/package.scala
@@ -185,11 +185,11 @@ inline def summonAll[T <: Tuple]: T =
 def byName[T](x: => T): T = x
 
 /** Casts a value to be `Matchable`. This is needed if the value's type is an unconstrained
-  *  type parameter and the value is the scrutinee of a match expression.
-  *  This is normally disallowed since it violates parametricity and allows
-  *  to uncover implementation details that were intended to be hidden.
-  *  The `asMatchable` escape hatch should be used sparingly. It's usually
-  *  better to constrain the scrutinee type to be `Matchable` in the first place.
-  */
+ *  type parameter and the value is the scrutinee of a match expression.
+ *  This is normally disallowed since it violates parametricity and allows
+ *  to uncover implementation details that were intended to be hidden.
+ *  The `asMatchable` escape hatch should be used sparingly. It's usually
+ *  better to constrain the scrutinee type to be `Matchable` in the first place.
+ */
 extension [T](x: T)
   transparent inline def asMatchable: x.type & Matchable = x.asInstanceOf[x.type & Matchable]

--- a/library/src/scala/concurrent/Awaitable.scala
+++ b/library/src/scala/concurrent/Awaitable.scala
@@ -18,47 +18,44 @@ import scala.concurrent.duration.Duration
 
 
 
-/**
- * An object that may eventually be completed with a result value of type `T` which may be
- * awaited using blocking methods.
+/** An object that may eventually be completed with a result value of type `T` which may be
+ *  awaited using blocking methods.
  *
- * The [[Await]] object provides methods that allow accessing the result of an `Awaitable`
- * by blocking the current thread until the `Awaitable` has been completed or a timeout has
- * occurred.
+ *  The [[Await]] object provides methods that allow accessing the result of an `Awaitable`
+ *  by blocking the current thread until the `Awaitable` has been completed or a timeout has
+ *  occurred.
  */
 trait Awaitable[+T] {
 
-  /**
-   * Await the "completed" state of this `Awaitable`.
+  /** Await the "completed" state of this `Awaitable`.
    *
-   * '''''This method should not be called directly; use [[Await.ready]] instead.'''''
+   *  ***This method should not be called directly; use [[Await.ready]] instead.***
    *
-   * @param  atMost
+   *  @param  atMost
    *         maximum wait time, which may be negative (no waiting is done),
    *         [[scala.concurrent.duration.Duration.Inf Duration.Inf]] for unbounded waiting, or a finite positive
    *         duration
-   * @return this `Awaitable`
-   * @throws InterruptedException     if the current thread is interrupted while waiting
-   * @throws TimeoutException         if after waiting for the specified time this `Awaitable` is still not ready
-   * @throws IllegalArgumentException if `atMost` is [[scala.concurrent.duration.Duration.Undefined Duration.Undefined]]
+   *  @return this `Awaitable`
+   *  @throws InterruptedException     if the current thread is interrupted while waiting
+   *  @throws TimeoutException         if after waiting for the specified time this `Awaitable` is still not ready
+   *  @throws IllegalArgumentException if `atMost` is [[scala.concurrent.duration.Duration.Undefined Duration.Undefined]]
    */
   @throws(classOf[TimeoutException])
   @throws(classOf[InterruptedException])
   def ready(atMost: Duration)(implicit permit: CanAwait): this.type
 
-  /**
-   * Await and return the result (of type `T`) of this `Awaitable`.
+  /** Await and return the result (of type `T`) of this `Awaitable`.
    *
-   * '''''This method should not be called directly; use [[Await.result]] instead.'''''
+   *  ***This method should not be called directly; use [[Await.result]] instead.***
    *
-   * @param  atMost
+   *  @param  atMost
    *         maximum wait time, which may be negative (no waiting is done),
    *         [[scala.concurrent.duration.Duration.Inf Duration.Inf]] for unbounded waiting, or a finite positive
    *         duration
-   * @return the result value if the `Awaitable` is completed within the specific maximum wait time
-   * @throws InterruptedException     if the current thread is interrupted while waiting
-   * @throws TimeoutException         if after waiting for the specified time this `Awaitable` is still not ready
-   * @throws IllegalArgumentException if `atMost` is [[scala.concurrent.duration.Duration.Undefined Duration.Undefined]]
+   *  @return the result value if the `Awaitable` is completed within the specific maximum wait time
+   *  @throws InterruptedException     if the current thread is interrupted while waiting
+   *  @throws TimeoutException         if after waiting for the specified time this `Awaitable` is still not ready
+   *  @throws IllegalArgumentException if `atMost` is [[scala.concurrent.duration.Duration.Undefined Duration.Undefined]]
    */
   @throws(classOf[TimeoutException])
   @throws(classOf[InterruptedException])

--- a/library/src/scala/concurrent/BlockContext.scala
+++ b/library/src/scala/concurrent/BlockContext.scala
@@ -14,21 +14,20 @@ package scala.concurrent
 
 import scala.language.`2.13`
 
-/**
- * A context to be notified by [[scala.concurrent.blocking]] when
- * a thread is about to block. In effect this trait provides
- * the implementation for [[scala.concurrent.Await]].
- * [[scala.concurrent.Await.result]] and [[scala.concurrent.Await.ready]]
- * locates an instance of `BlockContext` by first looking for one
- * provided through [[BlockContext.withBlockContext]] and failing that,
- * checking whether `Thread.currentThread` is an instance of `BlockContext`.
- * So a thread pool can have its `java.lang.Thread` instances implement
- * `BlockContext`. There's a default `BlockContext` used if the thread
- * doesn't implement `BlockContext`.
+/** A context to be notified by [[scala.concurrent.blocking]] when
+ *  a thread is about to block. In effect this trait provides
+ *  the implementation for [[scala.concurrent.Await]].
+ *  [[scala.concurrent.Await.result]] and [[scala.concurrent.Await.ready]]
+ *  locates an instance of `BlockContext` by first looking for one
+ *  provided through [[BlockContext.withBlockContext]] and failing that,
+ *  checking whether `Thread.currentThread` is an instance of `BlockContext`.
+ *  So a thread pool can have its `java.lang.Thread` instances implement
+ *  `BlockContext`. There's a default `BlockContext` used if the thread
+ *  doesn't implement `BlockContext`.
  *
- * Typically, you'll want to chain to the previous `BlockContext`,
- * like this:
- * {{{
+ *  Typically, you'll want to chain to the previous `BlockContext`,
+ *  like this:
+ *  ```
  *  val oldContext = BlockContext.current
  *  val myContext = new BlockContext {
  *    override def blockOn[T](thunk: => T)(implicit permission: CanAwait): T = {
@@ -42,20 +41,20 @@ import scala.language.`2.13`
  *    // then this block runs with myContext as the handler
  *    // for scala.concurrent.blocking
  *  }
- *  }}}
+ *  ```
  */
 trait BlockContext {
 
   /** Used internally by the framework;
-    * Designates (and eventually executes) a thunk which potentially blocks the calling `java.lang.Thread`.
-    *
-    * Clients must use `scala.concurrent.blocking` or `scala.concurrent.Await` instead.
-    *
-    * In implementations of this method it is RECOMMENDED to first check if `permission` is `null` and
-    * if it is, throw an `IllegalArgumentException`.
-    *
-    * @throws IllegalArgumentException if the `permission` is `null`
-    */
+   *  Designates (and eventually executes) a thunk which potentially blocks the calling `java.lang.Thread`.
+   *
+   *  Clients must use `scala.concurrent.blocking` or `scala.concurrent.Await` instead.
+   *
+   *  In implementations of this method it is RECOMMENDED to first check if `permission` is `null` and
+   *  if it is, throw an `IllegalArgumentException`.
+   *
+   *  @throws IllegalArgumentException if the `permission` is `null`
+   */
   def blockOn[T](thunk: => T)(implicit permission: CanAwait): T
 }
 
@@ -64,10 +63,9 @@ object BlockContext {
     override final def blockOn[T](thunk: => T)(implicit permission: CanAwait): T = thunk
   }
 
-  /**
-    * The default block context will execute the supplied thunk immediately.
-    * @return the `BlockContext` that will be used if no other is found.
-    **/
+  /** The default block context will execute the supplied thunk immediately.
+   *  @return the `BlockContext` that will be used if no other is found.
+   */
   final def defaultBlockContext: BlockContext = DefaultBlockContext
 
   private final val contextLocal = new ThreadLocal[BlockContext]()
@@ -81,13 +79,11 @@ object BlockContext {
     }
 
   /**
-   * @return the `BlockContext` that would be used for the current `java.lang.Thread` at this point
-   **/
+   *  @return the `BlockContext` that would be used for the current `java.lang.Thread` at this point
+   */
   final def current: BlockContext = prefer(contextLocal.get)
 
-  /**
-   * Installs a current `BlockContext` around executing `body`.
-   **/
+  /** Installs a current `BlockContext` around executing `body`. */
   final def withBlockContext[T](blockContext: BlockContext)(body: => T): T = {
     val old = contextLocal.get // can be null
     if (old eq blockContext) body
@@ -97,10 +93,9 @@ object BlockContext {
     }
   }
 
-  /**
-   * Installs the BlockContext `blockContext` around the invocation to `f` and passes in the previously installed BlockContext to `f`.
-   * @return the value produced by applying `f`
-   **/
+  /** Installs the BlockContext `blockContext` around the invocation to `f` and passes in the previously installed BlockContext to `f`.
+   *  @return the value produced by applying `f`
+   */
   final def usingBlockContext[I, T](blockContext: BlockContext)(f: BlockContext => T): T = {
     val old = contextLocal.get // can be null
     if (old eq blockContext) f(prefer(old))

--- a/library/src/scala/concurrent/ExecutionContext.scala
+++ b/library/src/scala/concurrent/ExecutionContext.scala
@@ -16,46 +16,45 @@ import scala.language.`2.13`
 import java.util.concurrent.{ ExecutorService, Executor }
 import scala.annotation.implicitNotFound
 
-/**
- * An `ExecutionContext` can execute program logic asynchronously,
- * typically but not necessarily on a thread pool.
+/** An `ExecutionContext` can execute program logic asynchronously,
+ *  typically but not necessarily on a thread pool.
  *
- * A general purpose `ExecutionContext` must be asynchronous in executing
- * any `Runnable` that is passed into its `execute`-method. A special purpose
- * `ExecutionContext` may be synchronous but must only be passed to code that
- * is explicitly safe to be run using a synchronously executing `ExecutionContext`.
+ *  A general purpose `ExecutionContext` must be asynchronous in executing
+ *  any `Runnable` that is passed into its `execute`-method. A special purpose
+ *  `ExecutionContext` may be synchronous but must only be passed to code that
+ *  is explicitly safe to be run using a synchronously executing `ExecutionContext`.
  *
- * APIs such as `Future.onComplete` require you to provide a callback
- * and an implicit `ExecutionContext`. The implicit `ExecutionContext`
- * will be used to execute the callback.
+ *  APIs such as `Future.onComplete` require you to provide a callback
+ *  and an implicit `ExecutionContext`. The implicit `ExecutionContext`
+ *  will be used to execute the callback.
  *
- * While it is possible to simply import
- * `scala.concurrent.ExecutionContext.Implicits.global` to obtain an
- * implicit `ExecutionContext`, application developers should carefully
- * consider where they want to define the execution policy;
- * ideally, one place per application — or per logically related section of code —
- * will make a decision about which `ExecutionContext` to use.
- * That is, you will mostly want to avoid hardcoding, especially via an import,
- * `scala.concurrent.ExecutionContext.Implicits.global`.
- * The recommended approach is to add `(implicit ec: ExecutionContext)` to methods,
- * or class constructor parameters, which need an `ExecutionContext`.
+ *  While it is possible to simply import
+ *  `scala.concurrent.ExecutionContext.Implicits.global` to obtain an
+ *  implicit `ExecutionContext`, application developers should carefully
+ *  consider where they want to define the execution policy;
+ *  ideally, one place per application — or per logically related section of code —
+ *  will make a decision about which `ExecutionContext` to use.
+ *  That is, you will mostly want to avoid hardcoding, especially via an import,
+ *  `scala.concurrent.ExecutionContext.Implicits.global`.
+ *  The recommended approach is to add `(implicit ec: ExecutionContext)` to methods,
+ *  or class constructor parameters, which need an `ExecutionContext`.
  *
- * Then locally import a specific `ExecutionContext` in one place for the entire
- * application or module, passing it implicitly to individual methods.
- * Alternatively define a local implicit val with the required `ExecutionContext`.
+ *  Then locally import a specific `ExecutionContext` in one place for the entire
+ *  application or module, passing it implicitly to individual methods.
+ *  Alternatively define a local implicit val with the required `ExecutionContext`.
  *
- * A custom `ExecutionContext` may be appropriate to execute code
- * which blocks on IO or performs long-running computations.
- * `ExecutionContext.fromExecutorService` and `ExecutionContext.fromExecutor`
- * are good ways to create a custom `ExecutionContext`.
+ *  A custom `ExecutionContext` may be appropriate to execute code
+ *  which blocks on IO or performs long-running computations.
+ *  `ExecutionContext.fromExecutorService` and `ExecutionContext.fromExecutor`
+ *  are good ways to create a custom `ExecutionContext`.
  *
- * The intent of `ExecutionContext` is to lexically scope code execution.
- * That is, each method, class, file, package, or application determines
- * how to run its own code. This avoids issues such as running
- * application callbacks on a thread pool belonging to a networking library.
- * The size of a networking library's thread pool can be safely configured,
- * knowing that only that library's network operations will be affected.
- * Application callback execution can be configured separately.
+ *  The intent of `ExecutionContext` is to lexically scope code execution.
+ *  That is, each method, class, file, package, or application determines
+ *  how to run its own code. This avoids issues such as running
+ *  application callbacks on a thread pool belonging to a networking library.
+ *  The size of a networking library's thread pool can be safely configured,
+ *  knowing that only that library's network operations will be affected.
+ *  Application callback execution can be configured separately.
  */
 @implicitNotFound("""Cannot find an implicit ExecutionContext. You might add
 an (implicit ec: ExecutionContext) parameter to your method.
@@ -84,139 +83,134 @@ trait ExecutionContext {
   def reportFailure(@deprecatedName("t") cause: Throwable): Unit
 
   /** Prepares for the execution of a task. Returns the prepared
-     *  execution context. The recommended implementation of
-     *  `prepare` is to return `this`.
-     *
-     *  This method should no longer be overridden or called. It was
-     *  originally expected that `prepare` would be called by
-     *  all libraries that consume ExecutionContexts, in order to
-     *  capture thread local context. However, this usage has proven
-     *  difficult to implement in practice and instead it is
-     *  now better to avoid using `prepare` entirely.
-     *
-     *  Instead, if an `ExecutionContext` needs to capture thread
-     *  local context, it should capture that context when it is
-     *  constructed, so that it doesn't need any additional
-     *  preparation later.
-     */
+   *  execution context. The recommended implementation of
+   *  `prepare` is to return `this`.
+   *
+   *  This method should no longer be overridden or called. It was
+   *  originally expected that `prepare` would be called by
+   *  all libraries that consume ExecutionContexts, in order to
+   *  capture thread local context. However, this usage has proven
+   *  difficult to implement in practice and instead it is
+   *  now better to avoid using `prepare` entirely.
+   *
+   *  Instead, if an `ExecutionContext` needs to capture thread
+   *  local context, it should capture that context when it is
+   *  constructed, so that it doesn't need any additional
+   *  preparation later.
+   */
   @deprecated("preparation of ExecutionContexts will be removed", "2.12.0")
   // This cannot be removed until there is a suitable replacement
   def prepare(): ExecutionContext = this
 }
 
-/**
- * An [[ExecutionContext]] that is also a
- * Java [[java.util.concurrent.Executor Executor]].
+/** An [[ExecutionContext]] that is also a
+ *  Java [[java.util.concurrent.Executor Executor]].
  */
 trait ExecutionContextExecutor extends ExecutionContext with Executor
 
-/**
- * An [[ExecutionContext]] that is also a
- * Java [[java.util.concurrent.ExecutorService ExecutorService]].
+/** An [[ExecutionContext]] that is also a
+ *  Java [[java.util.concurrent.ExecutorService ExecutorService]].
  */
 trait ExecutionContextExecutorService extends ExecutionContextExecutor with ExecutorService
 
 
-/** Contains factory methods for creating execution contexts.
- */
+/** Contains factory methods for creating execution contexts. */
 object ExecutionContext {
-  /**
-   * The global [[ExecutionContext]]. This default `ExecutionContext` implementation is backed by a work-stealing thread
-   * pool. It can be configured via the following system properties:
+  /** The global [[ExecutionContext]]. This default `ExecutionContext` implementation is backed by a work-stealing thread
+   *  pool. It can be configured via the following system properties:
    *
    *   - `scala.concurrent.context.minThreads` = defaults to "1"
    *   - `scala.concurrent.context.numThreads` = defaults to "x1" (i.e. the current number of available processors * 1)
    *   - `scala.concurrent.context.maxThreads` = defaults to "x1" (i.e. the current number of available processors * 1)
    *   - `scala.concurrent.context.maxExtraThreads` = defaults to "256"
    *
-   * The pool size of threads is then `numThreads` bounded by `minThreads` on the lower end and `maxThreads` on the high end.
+   *  The pool size of threads is then `numThreads` bounded by `minThreads` on the lower end and `maxThreads` on the high end.
    *
-   * The `maxExtraThreads` is the maximum number of extra threads to have at any given time to evade deadlock,
-   * see [[scala.concurrent.blocking]].
+   *  The `maxExtraThreads` is the maximum number of extra threads to have at any given time to evade deadlock,
+   *  see [[scala.concurrent.blocking]].
    *
-   * The `global` execution context can be used explicitly, by defining an
-   * `implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global`, or by importing
-   * [[ExecutionContext.Implicits.global]].
+   *  The `global` execution context can be used explicitly, by defining an
+   *  `implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global`, or by importing
+   *  [[ExecutionContext.Implicits.global]].
    *
-   * == Batching short-lived nested tasks ==
+   *  ## Batching short-lived nested tasks
    *
-   * Asynchronous code with short-lived nested tasks is executed more efficiently when using
-   * `ExecutionContext.opportunistic` (continue reading to learn why it is `private[scala]` and how to access it).
+   *  Asynchronous code with short-lived nested tasks is executed more efficiently when using
+   *  `ExecutionContext.opportunistic` (continue reading to learn why it is `private[scala]` and how to access it).
    *
-   * `ExecutionContext.opportunistic` uses the same thread pool as `ExecutionContext.global`. It attempts to batch
-   * nested task and execute them on the same thread as the enclosing task. This is ideally suited to execute
-   * short-lived tasks as it reduces the overhead of context switching.
+   *  `ExecutionContext.opportunistic` uses the same thread pool as `ExecutionContext.global`. It attempts to batch
+   *  nested task and execute them on the same thread as the enclosing task. This is ideally suited to execute
+   *  short-lived tasks as it reduces the overhead of context switching.
    *
-   * WARNING: long-running and/or blocking tasks should be demarcated within [[scala.concurrent.blocking]]-blocks
+   *  WARNING: long-running and/or blocking tasks should be demarcated within [[scala.concurrent.blocking]]-blocks
    *          to ensure that any pending tasks in the current batch can be executed by another thread on `global`.
    *
-   * === How to use ===
+   *  ### How to use
    *
-   * This field is `private[scala]` to maintain binary compatibility. It was added in 2.13.4, code that references it
-   * directly fails to run with a 2.13.0-3 Scala library.
+   *  This field is `private[scala]` to maintain binary compatibility. It was added in 2.13.4, code that references it
+   *  directly fails to run with a 2.13.0-3 Scala library.
    *
-   * Libraries should not reference this field directly because users of the library might be using an earlier Scala
-   * version. In order to use the batching `ExecutionContext` in a library, the code needs to fall back to `global`
-   * in case the `opportunistic` field is missing (example below). The resulting `ExecutionContext` has batching
-   * behavior in all Scala 2.13 versions (`global` is batching in 2.13.0-3).
+   *  Libraries should not reference this field directly because users of the library might be using an earlier Scala
+   *  version. In order to use the batching `ExecutionContext` in a library, the code needs to fall back to `global`
+   *  in case the `opportunistic` field is missing (example below). The resulting `ExecutionContext` has batching
+   *  behavior in all Scala 2.13 versions (`global` is batching in 2.13.0-3).
    *
-   * {{{
-   * implicit val ec: scala.concurrent.ExecutionContext = try {
+   *  ```
+   *  implicit val ec: scala.concurrent.ExecutionContext = try {
    *   scala.concurrent.ExecutionContext.getClass
    *     .getDeclaredMethod("opportunistic")
    *     .invoke(scala.concurrent.ExecutionContext)
    *     .asInstanceOf[scala.concurrent.ExecutionContext]
-   * } catch {
+   *  } catch {
    *   case _: NoSuchMethodException =>
    *     scala.concurrent.ExecutionContext.global
-   * }
-   * }}}
+   *  }
+   *  ```
    *
-   * Application authors can safely use the field because the Scala version at run time is the same as at compile time.
-   * Options to bypass the access restriction include:
+   *  Application authors can safely use the field because the Scala version at run time is the same as at compile time.
+   *  Options to bypass the access restriction include:
    *
    *   1. Using a structural type (example below). This uses reflection at run time.
    *   1. Writing a Scala `object` in the `scala` package (example below).
    *   1. Writing a Java source file. This works because `private[scala]` is emitted as `public` in Java bytecode.
    *
-   * {{{
-   * // Option 1
-   * implicit val ec: scala.concurrent.ExecutionContext =
+   *  ```
+   *  // Option 1
+   *  implicit val ec: scala.concurrent.ExecutionContext =
    *   (scala.concurrent.ExecutionContext:
    *     {def opportunistic: scala.concurrent.ExecutionContextExecutor}
    *   ).opportunistic
    *
-   * // Option 2
-   * package scala {
+   *  // Option 2
+   *  package scala {
    *   object OpportunisticEC {
    *     implicit val ec: scala.concurrent.ExecutionContext =
    *       scala.concurrent.ExecutionContext.opportunistic
    *   }
-   * }
-   * }}}
+   *  }
+   *  ```
    *
-   * @return the global [[ExecutionContext]]
+   *  @return the global [[ExecutionContext]]
    */
   final lazy val global: ExecutionContextExecutor = impl.ExecutionContextImpl.fromExecutor(null: Executor | Null)
 
-  /**
-   * WARNING: Only ever execute logic which will quickly return control to the caller.
+  /** WARNING: Only ever execute logic which will quickly return control to the caller.
    *
-   * This `ExecutionContext` steals execution time from other threads by having its
-   * `Runnable`s run on the `Thread` which calls `execute` and then yielding back control
-   * to the caller after *all* its `Runnable`s have been executed.
-   * Nested invocations of `execute` will be trampolined to prevent uncontrolled stack space growth.
+   *  This `ExecutionContext` steals execution time from other threads by having its
+   *  `Runnable`s run on the `Thread` which calls `execute` and then yielding back control
+   *  to the caller after *all* its `Runnable`s have been executed.
+   *  Nested invocations of `execute` will be trampolined to prevent uncontrolled stack space growth.
    *
-   * When using `parasitic` with abstractions such as `Future` it will in many cases be non-deterministic
-   * as to which `Thread` will be executing the logic, as it depends on when/if that `Future` is completed.
+   *  When using `parasitic` with abstractions such as `Future` it will in many cases be non-deterministic
+   *  as to which `Thread` will be executing the logic, as it depends on when/if that `Future` is completed.
    *
-   * Do *not* call any blocking code in the `Runnable`s submitted to this `ExecutionContext`
-   * as it will prevent progress by other enqueued `Runnable`s and the calling `Thread`.
+   *  Do *not* call any blocking code in the `Runnable`s submitted to this `ExecutionContext`
+   *  as it will prevent progress by other enqueued `Runnable`s and the calling `Thread`.
    *
-   * Symptoms of misuse of this `ExecutionContext` include, but are not limited to, deadlocks
-   * and severe performance problems.
+   *  Symptoms of misuse of this `ExecutionContext` include, but are not limited to, deadlocks
+   *  and severe performance problems.
    *
-   * Any `NonFatal` or `InterruptedException`s will be reported to the `defaultReporter`.
+   *  Any `NonFatal` or `InterruptedException`s will be reported to the `defaultReporter`.
    */
   object parasitic extends ExecutionContextExecutor with BatchingExecutor {
     override final def submitForExecution(runnable: Runnable): Unit = runnable.run()
@@ -224,9 +218,7 @@ object ExecutionContext {
     override final def reportFailure(t: Throwable): Unit = defaultReporter(t)
   }
 
-  /**
-   * See [[ExecutionContext.global]].
-   */
+  /** See [[ExecutionContext.global]]. */
   private[scala] lazy val opportunistic: ExecutionContextExecutor = new ExecutionContextExecutor with BatchingExecutor {
     final override def submitForExecution(runnable: Runnable): Unit = global.execute(runnable)
 
@@ -240,9 +232,8 @@ object ExecutionContext {
   }
 
   object Implicits {
-    /**
-     * An accessor that can be used to import the global `ExecutionContext` into the implicit scope,
-     * see [[ExecutionContext.global]].
+    /** An accessor that can be used to import the global `ExecutionContext` into the implicit scope,
+     *  see [[ExecutionContext.global]].
      */
     implicit final def global: ExecutionContext = ExecutionContext.global
   }
@@ -261,10 +252,10 @@ object ExecutionContext {
    *  If it is guaranteed that none of the executed tasks are blocking, a single-threaded `ExecutorService`
    *  can be used to create an `ExecutionContext` as follows:
    *
-   *  {{{
+   *  ```
    *  import java.util.concurrent.Executors
    *  val ec = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
-   *  }}}
+   *  ```
    *
    *  @param e the `ExecutorService` to use. If `null`, a new `ExecutorService` is created with [[scala.concurrent.ExecutionContext$.global default configuration]].
    *  @return  the `ExecutionContext` using the given `ExecutorService`

--- a/library/src/scala/concurrent/Future.scala
+++ b/library/src/scala/concurrent/Future.scala
@@ -31,7 +31,7 @@ import scala.concurrent.impl.Promise.DefaultPromise
  *  Computations are executed using an `ExecutionContext`, which is usually supplied implicitly,
  *  and which is commonly backed by a thread pool.
  *
- *  {{{
+ *  ```
  *  import ExecutionContext.Implicits.global
  *  val s = "Hello"
  *  val f: Future[String] = Future {
@@ -40,18 +40,18 @@ import scala.concurrent.impl.Promise.DefaultPromise
  *  f foreach {
  *    msg => println(msg)
  *  }
- *  }}}
+ *  ```
  *
  *  Note that the `global` context is convenient but restricted:
  *  "fatal" exceptions are reported only by printing a stack trace,
  *  and the underlying thread pool may be shared by a mix of jobs.
  *  For any nontrivial application, see the caveats explained at [[ExecutionContext]]
  *  and also the overview linked below, which explains
- *  [[https://docs.scala-lang.org/overviews/core/futures.html#exceptions exception handling]]
+ *  [exception handling](https://docs.scala-lang.org/overviews/core/futures.html#exceptions)
  *  in depth.
  *
  *
- *  @see [[https://docs.scala-lang.org/overviews/core/futures.html Futures and Promises]]
+ *  @see [Futures and Promises](https://docs.scala-lang.org/overviews/core/futures.html)
  *
  *  @define multipleCallbacks
  *  Multiple callbacks may be registered; there is no guarantee that they will be
@@ -79,30 +79,30 @@ import scala.concurrent.impl.Promise.DefaultPromise
  *  @define forComprehensionExamples
  *  Example:
  *
- *  {{{
+ *  ```
  *  val f = Future { 5 }
  *  val g = Future { 3 }
  *  val h = for {
  *    x: Int <- f // returns Future(5)
  *    y: Int <- g // returns Future(3)
  *  } yield x + y
- *  }}}
+ *  ```
  *
  *  is translated to:
  *
- *  {{{
+ *  ```
  *  f flatMap { (x: Int) => g map { (y: Int) => x + y } }
- *  }}}
+ *  ```
  *
- * @define callbackInContext
- * The provided callback always runs in the provided implicit
- *`ExecutionContext`, though there is no guarantee that the
- * `execute()` method on the `ExecutionContext` will be called once
- * per callback or that `execute()` will be called in the current
- * thread. That is, the implementation may run multiple callbacks
- * in a batch within a single `execute()` and it may run
- * `execute()` either immediately or asynchronously.
- * Completion of the `Future` must *happen-before* the invocation of the callback.
+ *  @define callbackInContext
+ *  The provided callback always runs in the provided implicit
+ *  `ExecutionContext`, though there is no guarantee that the
+ *  `execute()` method on the `ExecutionContext` will be called once
+ *  per callback or that `execute()` will be called in the current
+ *  thread. That is, the implementation may run multiple callbacks
+ *  in a batch within a single `execute()` and it may run
+ *  `execute()` either immediately or asynchronously.
+ *  Completion of the `Future` must *happen-before* the invocation of the callback.
  */
 trait Future[+T] extends Awaitable[T] {
 
@@ -120,9 +120,9 @@ trait Future[+T] extends Awaitable[T] {
    *  $multipleCallbacks
    *  $callbackInContext
    *
-   * @tparam U    only used to accept any return type of the given callback function
-   * @param f     the function to be executed when this `Future` completes
-   * @group Callbacks
+   *  @tparam U    only used to accept any return type of the given callback function
+   *  @param f     the function to be executed when this `Future` completes
+   *  @group Callbacks
    */
   def onComplete[U](f: Try[T] => U)(implicit executor: ExecutionContext): Unit
 
@@ -134,7 +134,7 @@ trait Future[+T] extends Awaitable[T] {
    *  $nonDeterministic
    *
    *  @return    `true` if the future was completed, `false` otherwise
-   * @group Polling
+   *  @group Polling
    */
   def isCompleted: Boolean
 
@@ -147,8 +147,8 @@ trait Future[+T] extends Awaitable[T] {
    *  if it contained a valid result, or `Some(Failure(error))` if it contained
    *  an exception.
    *
-   * @return    `None` if the `Future` wasn't completed, `Some` if it was.
-   * @group Polling
+   *  @return    `None` if the `Future` wasn't completed, `Some` if it was.
+   *  @group Polling
    */
   def value: Option[Try[T]]
 
@@ -162,8 +162,8 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  $caughtThrowables
    *
-   * @return a failed projection of this `Future`.
-   * @group Transformations
+   *  @return a failed projection of this `Future`.
+   *  @group Transformations
    */
   def failed: Future[Throwable] = transform(Future.failedFun)(using parasitic)
 
@@ -176,10 +176,10 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  $swallowsExceptions
    *
-   * @tparam U     only used to accept any return type of the given callback function
-   * @param f      the function which will be executed if this `Future` completes with a result,
+   *  @tparam U     only used to accept any return type of the given callback function
+   *  @param f      the function which will be executed if this `Future` completes with a result,
    *               the return value of `f` will be discarded.
-   * @group Callbacks
+   *  @group Callbacks
    */
   def foreach[U](f: T => U)(implicit executor: ExecutionContext): Unit = onComplete { _ foreach f }
 
@@ -188,11 +188,11 @@ trait Future[+T] extends Awaitable[T] {
    *  exception thrown when 's' or 'f' is applied, that exception will be propagated
    *  to the resulting future.
    *
-   * @tparam S  the type of the returned `Future`
-   * @param  s  function that transforms a successful result of the receiver into a successful result of the returned future
-   * @param  f  function that transforms a failure of the receiver into a failure of the returned future
-   * @return    a `Future` that will be completed with the transformed value
-   * @group Transformations
+   *  @tparam S  the type of the returned `Future`
+   *  @param  s  function that transforms a successful result of the receiver into a successful result of the returned future
+   *  @param  f  function that transforms a failure of the receiver into a failure of the returned future
+   *  @return    a `Future` that will be completed with the transformed value
+   *  @group Transformations
    */
   def transform[S](s: T => S, f: Throwable => Throwable)(implicit executor: ExecutionContext): Future[S] =
     transform {
@@ -202,24 +202,24 @@ trait Future[+T] extends Awaitable[T] {
     }
 
   /** Creates a new Future by applying the specified function to the result
-   * of this Future. If there is any non-fatal exception thrown when 'f'
-   * is applied then that exception will be propagated to the resulting future.
+   *  of this Future. If there is any non-fatal exception thrown when 'f'
+   *  is applied then that exception will be propagated to the resulting future.
    *
-   * @tparam S  the type of the returned `Future`
-   * @param  f  function that transforms the result of this future
-   * @return    a `Future` that will be completed with the transformed value
-   * @group Transformations
+   *  @tparam S  the type of the returned `Future`
+   *  @param  f  function that transforms the result of this future
+   *  @return    a `Future` that will be completed with the transformed value
+   *  @group Transformations
    */
   def transform[S](f: Try[T] => Try[S])(implicit executor: ExecutionContext): Future[S]
 
   /** Creates a new Future by applying the specified function, which produces a Future, to the result
-   * of this Future. If there is any non-fatal exception thrown when 'f'
-   * is applied then that exception will be propagated to the resulting future.
+   *  of this Future. If there is any non-fatal exception thrown when 'f'
+   *  is applied then that exception will be propagated to the resulting future.
    *
-   * @tparam S  the type of the returned `Future`
-   * @param  f  function that transforms the result of this future
-   * @return    a `Future` that will be completed with the transformed value
-   * @group Transformations
+   *  @tparam S  the type of the returned `Future`
+   *  @param  f  function that transforms the result of this future
+   *  @return    a `Future` that will be completed with the transformed value
+   *  @group Transformations
    */
   def transformWith[S](f: Try[T] => Future[S])(implicit executor: ExecutionContext): Future[S]
 
@@ -230,20 +230,20 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  Example:
    *
-   *  {{{
+   *  ```
    *  val f = Future { "The future" }
    *  val g = f map { x: String => x + " is now!" }
-   *  }}}
+   *  ```
    *
    *  Note that a for comprehension involving a `Future`
    *  may expand to include a call to `map` and or `flatMap`
    *  and `withFilter`.  See [[scala.concurrent.Future#flatMap]] for an example of such a comprehension.
    *
    *
-   * @tparam S  the type of the returned `Future`
-   * @param f   the function which will be applied to the successful result of this `Future`
-   * @return    a `Future` which will be completed with the result of the application of the function
-   * @group Transformations
+   *  @tparam S  the type of the returned `Future`
+   *  @param f   the function which will be applied to the successful result of this `Future`
+   *  @return    a `Future` which will be completed with the result of the application of the function
+   *  @group Transformations
    */
   def map[S](f: T => S)(implicit executor: ExecutionContext): Future[S] = transform(_ map f)
 
@@ -254,10 +254,10 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  $forComprehensionExamples
    *
-   * @tparam S  the type of the returned `Future`
-   * @param f   the function which will be applied to the successful result of this `Future`
-   * @return    a `Future` which will be completed with the result of the application of the function
-   * @group Transformations
+   *  @tparam S  the type of the returned `Future`
+   *  @param f   the function which will be applied to the successful result of this `Future`
+   *  @return    a `Future` which will be completed with the result of the application of the function
+   *  @group Transformations
    */
   def flatMap[S](f: T => Future[S])(implicit executor: ExecutionContext): Future[S] = transformWith {
     t =>
@@ -268,8 +268,8 @@ trait Future[+T] extends Awaitable[T] {
   /** Creates a new future with one level of nesting flattened, this method is equivalent
    *  to `flatMap(identity)`.
    *
-   * @tparam S  the type of the returned `Future`
-   * @group Transformations
+   *  @tparam S  the type of the returned `Future`
+   *  @group Transformations
    */
   def flatten[S](implicit ev: T <:< Future[S]): Future[S] = flatMap(ev)(using parasitic)
 
@@ -281,17 +281,17 @@ trait Future[+T] extends Awaitable[T] {
    *  If the current future fails, then the resulting future also fails.
    *
    *  Example:
-   *  {{{
+   *  ```
    *  val f = Future { 5 }
    *  val g = f filter { _ % 2 == 1 }
    *  val h = f filter { _ % 2 == 0 }
    *  g foreach println // Eventually prints 5
    *  Await.result(h, Duration.Zero) // throw a NoSuchElementException
-   *  }}}
+   *  ```
    *
-   * @param p   the predicate to apply to the successful result of this `Future`
-   * @return    a `Future` which will hold the successful result of this `Future` if it matches the predicate or a `NoSuchElementException`
-   * @group Transformations
+   *  @param p   the predicate to apply to the successful result of this `Future`
+   *  @return    a `Future` which will hold the successful result of this `Future` if it matches the predicate or a `NoSuchElementException`
+   *  @group Transformations
    */
   def filter(p: T => Boolean)(implicit executor: ExecutionContext): Future[T] =
     transform {
@@ -303,7 +303,7 @@ trait Future[+T] extends Awaitable[T] {
     }
 
   /** Used by for-comprehensions.
-   * @group Transformations
+   *  @group Transformations
    */
   final def withFilter(p: T => Boolean)(implicit executor: ExecutionContext): Future[T] = filter(p)(using executor)
 
@@ -315,7 +315,7 @@ trait Future[+T] extends Awaitable[T] {
    *  If the current future fails, then the resulting future also fails.
    *
    *  Example:
-   *  {{{
+   *  ```
    *  val f = Future { -5 }
    *  val g = f collect {
    *    case x if x < 0 => -x
@@ -325,12 +325,12 @@ trait Future[+T] extends Awaitable[T] {
    *  }
    *  g foreach println // Eventually prints 5
    *  Await.result(h, Duration.Zero) // throw a NoSuchElementException
-   *  }}}
+   *  ```
    *
-   * @tparam S    the type of the returned `Future`
-   * @param pf    the `PartialFunction` to apply to the successful result of this `Future`
-   * @return      a `Future` holding the result of application of the `PartialFunction` or a `NoSuchElementException`
-   * @group Transformations
+   *  @tparam S    the type of the returned `Future`
+   *  @param pf    the `PartialFunction` to apply to the successful result of this `Future`
+   *  @return      a `Future` holding the result of application of the `PartialFunction` or a `NoSuchElementException`
+   *  @group Transformations
    */
   def collect[S](pf: PartialFunction[T, S])(implicit executor: ExecutionContext): Future[S] =
     transform {
@@ -346,16 +346,16 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  Example:
    *
-   *  {{{
+   *  ```
    *  Future (6 / 0) recover { case e: ArithmeticException => 0 } // result: 0
    *  Future (6 / 0) recover { case e: NotFoundException   => 0 } // result: exception
    *  Future (6 / 2) recover { case e: ArithmeticException => 0 } // result: 3
-   *  }}}
+   *  ```
    *
-   * @tparam U    the type of the returned `Future`
-   * @param pf    the `PartialFunction` to apply if this `Future` fails
-   * @return      a `Future` with the successful value of this `Future` or the result of the `PartialFunction`
-   * @group Transformations
+   *  @tparam U    the type of the returned `Future`
+   *  @param pf    the `PartialFunction` to apply if this `Future` fails
+   *  @return      a `Future` with the successful value of this `Future` or the result of the `PartialFunction`
+   *  @group Transformations
    */
   def recover[U >: T](pf: PartialFunction[Throwable, U])(implicit executor: ExecutionContext): Future[U] =
     transform { _ recover pf }
@@ -368,15 +368,15 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  Example:
    *
-   *  {{{
+   *  ```
    *  val f = Future { Int.MaxValue }
    *  Future (6 / 0) recoverWith { case e: ArithmeticException => f } // result: Int.MaxValue
-   *  }}}
+   *  ```
    *
-   * @tparam U    the type of the returned `Future`
-   * @param pf    the `PartialFunction` to apply if this `Future` fails
-   * @return      a `Future` with the successful value of this `Future` or the outcome of the `Future` returned by the `PartialFunction`
-   * @group Transformations
+   *  @tparam U    the type of the returned `Future`
+   *  @param pf    the `PartialFunction` to apply if this `Future` fails
+   *  @return      a `Future` with the successful value of this `Future` or the outcome of the `Future` returned by the `PartialFunction`
+   *  @group Transformations
    */
   def recoverWith[U >: T](pf: PartialFunction[Throwable, Future[U]])(implicit executor: ExecutionContext): Future[U] =
     transformWith {
@@ -397,10 +397,10 @@ trait Future[+T] extends Awaitable[T] {
    *  If the application of `f` throws a non-fatal throwable, the resulting future
    *  is failed with that throwable.
    *
-   * @tparam U      the type of the other `Future`
-   * @param that    the other `Future`
-   * @return        a `Future` with the results of both futures or the failure of the first of them that failed
-   * @group Transformations
+   *  @tparam U      the type of the other `Future`
+   *  @param that    the other `Future`
+   *  @return        a `Future` with the results of both futures or the failure of the first of them that failed
+   *  @group Transformations
    */
   def zip[U](that: Future[U]): Future[(T, U)] =
     zipWith(that)(Future.zipWithTuple2Fun)(using parasitic)
@@ -414,12 +414,12 @@ trait Future[+T] extends Awaitable[T] {
    *  If the application of `f` throws a non-fatal throwable, the resulting future
    *  is failed with that throwable.
    *
-   * @tparam U      the type of the other `Future`
-   * @tparam R      the type of the resulting `Future`
-   * @param that    the other `Future`
-   * @param f       the function to apply to the results of `this` and `that`
-   * @return        a `Future` with the result of the application of `f` to the results of `this` and `that`
-   * @group Transformations
+   *  @tparam U      the type of the other `Future`
+   *  @tparam R      the type of the resulting `Future`
+   *  @param that    the other `Future`
+   *  @param f       the function to apply to the results of `this` and `that`
+   *  @return        a `Future` with the result of the application of `f` to the results of `this` and `that`
+   *  @group Transformations
    */
   def zipWith[U, R](that: Future[U])(f: (T, U) => R)(implicit executor: ExecutionContext): Future[R] = {
     // This is typically overriden by the implementation in DefaultPromise, which provides
@@ -437,17 +437,17 @@ trait Future[+T] extends Awaitable[T] {
    *  Using this method will not cause concurrent programs to become nondeterministic.
    *
    *  Example:
-   *  {{{
+   *  ```
    *  val f = Future { throw new RuntimeException("failed") }
    *  val g = Future { 5 }
    *  val h = f fallbackTo g
    *  h foreach println // Eventually prints 5
-   *  }}}
+   *  ```
    *
-   * @tparam U     the type of the other `Future` and the resulting `Future`
-   * @param that   the `Future` whose result we want to use if this `Future` fails.
-   * @return       a `Future` with the successful result of this or that `Future` or the failure of this `Future` if both fail
-   * @group Transformations
+   *  @tparam U     the type of the other `Future` and the resulting `Future`
+   *  @param that   the `Future` whose result we want to use if this `Future` fails.
+   *  @return       a `Future` with the successful result of this or that `Future` or the failure of this `Future` if both fail
+   *  @group Transformations
    */
   def fallbackTo[U >: T](that: Future[U]): Future[U] =
     if (this eq that) this
@@ -463,10 +463,10 @@ trait Future[+T] extends Awaitable[T] {
   /** Creates a new `Future[S]` which is completed with this `Future`'s result if
    *  that conforms to `S`'s erased type or a `ClassCastException` otherwise.
    *
-   * @tparam S     the type of the returned `Future`
-   * @param tag    the `ClassTag` which will be used to cast the result of this `Future`
-   * @return       a `Future` holding the casted result of this `Future` or a `ClassCastException` otherwise
-   * @group Transformations
+   *  @tparam S     the type of the returned `Future`
+   *  @param tag    the `ClassTag` which will be used to cast the result of this `Future`
+   *  @return       a `Future` holding the casted result of this `Future` or a `ClassCastException` otherwise
+   *  @group Transformations
    */
   def mapTo[S](implicit tag: ClassTag[S]): Future[S] = {
     implicit val ec = parasitic
@@ -491,7 +491,7 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  The following example prints out `5`:
    *
-   *  {{{
+   *  ```
    *  val f = Future { 5 }
    *  f andThen {
    *    case r => throw new RuntimeException("runtime exception")
@@ -499,14 +499,14 @@ trait Future[+T] extends Awaitable[T] {
    *    case Failure(t) => println(t)
    *    case Success(v) => println(v)
    *  }
-   *  }}}
+   *  ```
    *
-   * $swallowsExceptions
+   *  $swallowsExceptions
    *
-   * @tparam U     only used to accept any return type of the given `PartialFunction`
-   * @param pf     a `PartialFunction` which will be conditionally applied to the outcome of this `Future`
-   * @return       a `Future` which will be completed with the exact same outcome as this `Future` but after the `PartialFunction` has been executed.
-   * @group Callbacks
+   *  @tparam U     only used to accept any return type of the given `PartialFunction`
+   *  @param pf     a `PartialFunction` which will be conditionally applied to the outcome of this `Future`
+   *  @return       a `Future` which will be completed with the exact same outcome as this `Future` but after the `PartialFunction` has been executed.
+   *  @group Callbacks
    */
   def andThen[U](pf: PartialFunction[Try[T], U])(implicit executor: ExecutionContext): Future[T] =
     transform {
@@ -527,9 +527,7 @@ trait Future[+T] extends Awaitable[T] {
  */
 object Future {
 
-  /**
-   * Utilities, hoisted functions, etc.
-   */
+  /** Utilities, hoisted functions, etc. */
 
   private[concurrent] final val toBoxed = Map[Class[?], Class[?]](
     classOf[Boolean] -> classOf[java.lang.Boolean],
@@ -581,8 +579,7 @@ object Future {
   private[concurrent] def timeoutError(delay: Duration): Nothing =
     throw new TimeoutException(s"Future timed out after [$delay]")
 
-  /** A Future which is never completed.
-   */
+  /** A Future which is never completed. */
   object never extends Future[Nothing] {
 
     @throws[TimeoutException]
@@ -643,8 +640,7 @@ object Future {
     override final def toString(): String = "Future(<never>)"
   }
 
-  /** A Future which is completed with the Unit value.
-   */
+  /** A Future which is completed with the Unit value. */
   final val unit: Future[Unit] = fromTry(Success(()))
 
   /** Creates an already completed Future with the specified exception.
@@ -672,53 +668,53 @@ object Future {
   final def fromTry[T](result: Try[T]): Future[T] = Promise.fromTry(result).future
 
   /** Starts an asynchronous computation and returns a `Future` instance with the result of that computation.
-  *
-  *  The following expressions are equivalent:
-  *
-  *  {{{
-  *  val f1 = Future(expr)
-  *  val f2 = Future.unit.map(_ => expr)
-  *  val f3 = Future.unit.transform(_ => Success(expr))
-  *  }}}
-  *
-  *  The result becomes available once the asynchronous computation is completed.
-  *
-  *  @tparam T        the type of the result
-  *  @param body      the asynchronous computation
-  *  @param executor  the execution context on which the future is run
-  *  @return          the `Future` holding the result of the computation
-  */
+   *
+   *  The following expressions are equivalent:
+   *
+   *  ```
+   *  val f1 = Future(expr)
+   *  val f2 = Future.unit.map(_ => expr)
+   *  val f3 = Future.unit.transform(_ => Success(expr))
+   *  ```
+   *
+   *  The result becomes available once the asynchronous computation is completed.
+   *
+   *  @tparam T        the type of the result
+   *  @param body      the asynchronous computation
+   *  @param executor  the execution context on which the future is run
+   *  @return          the `Future` holding the result of the computation
+   */
   final def apply[T](body: => T)(implicit executor: ExecutionContext): Future[T] =
     unit.map(_ => body)
 
   /** Starts an asynchronous computation and returns a `Future` instance with the result of that computation once it completes.
-  *
-  *  The following expressions are semantically equivalent:
-  *
-  *  {{{
-  *  val f1 = Future(expr).flatten
-  *  val f2 = Future.delegate(expr)
-  *  val f3 = Future.unit.flatMap(_ => expr)
-  *  }}}
-  *
-  *  The result becomes available once the resulting Future of the asynchronous computation is completed.
-  *
-  *  @tparam T        the type of the result
-  *  @param body      the asynchronous computation, returning a Future
-  *  @param executor  the execution context on which the `body` is evaluated in
-  *  @return          the `Future` holding the result of the computation
-  */
+   *
+   *  The following expressions are semantically equivalent:
+   *
+   *  ```
+   *  val f1 = Future(expr).flatten
+   *  val f2 = Future.delegate(expr)
+   *  val f3 = Future.unit.flatMap(_ => expr)
+   *  ```
+   *
+   *  The result becomes available once the resulting Future of the asynchronous computation is completed.
+   *
+   *  @tparam T        the type of the result
+   *  @param body      the asynchronous computation, returning a Future
+   *  @param executor  the execution context on which the `body` is evaluated in
+   *  @return          the `Future` holding the result of the computation
+   */
   final def delegate[T](body: => Future[T])(implicit executor: ExecutionContext): Future[T] =
     unit.flatMap(_ => body)
 
   /** Simple version of `Future.traverse`. Asynchronously and non-blockingly transforms, in essence, a `IterableOnce[Future[A]]`
    *  into a `Future[IterableOnce[A]]`. Useful for reducing many `Future`s into a single `Future`.
    *
-   * @tparam A        the type of the value inside the Futures
-   * @tparam CC       the type of the `IterableOnce` of Futures
-   * @tparam To       the type of the resulting collection
-   * @param in        the `IterableOnce` of Futures which will be sequenced
-   * @return          the `Future` of the resulting collection
+   *  @tparam A        the type of the value inside the Futures
+   *  @tparam CC       the type of the `IterableOnce` of Futures
+   *  @tparam To       the type of the resulting collection
+   *  @param in        the `IterableOnce` of Futures which will be sequenced
+   *  @return          the `Future` of the resulting collection
    */
   final def sequence[A, CC[X] <: IterableOnce[X], To](in: CC[Future[A]])(implicit bf: BuildFrom[CC[Future[A]], A, To], executor: ExecutionContext): Future[To] =
     in.iterator.foldLeft(successful(bf.newBuilder(in))) {
@@ -728,9 +724,9 @@ object Future {
   /** Asynchronously and non-blockingly returns a new `Future` to the result of the first future
    *  in the list that is completed. This means no matter if it is completed as a success or as a failure.
    *
-   * @tparam T        the type of the value in the future
-   * @param futures   the `IterableOnce` of Futures in which to find the first completed
-   * @return          the `Future` holding the result of the future that is first to be completed
+   *  @tparam T        the type of the value in the future
+   *  @param futures   the `IterableOnce` of Futures in which to find the first completed
+   *  @return          the `Future` holding the result of the future that is first to be completed
    */
   final def firstCompletedOf[T](futures: IterableOnce[Future[T]])(implicit executor: ExecutionContext): Future[T] = {
     val i = futures.iterator
@@ -766,10 +762,10 @@ object Future {
   /** Asynchronously and non-blockingly returns a `Future` that will hold the optional result
    *  of the first `Future` with a result that matches the predicate, failed `Future`s will be ignored.
    *
-   * @tparam T        the type of the value in the future
-   * @param futures   the `scala.collection.immutable.Iterable` of Futures to search
-   * @param p         the predicate which indicates if it's a match
-   * @return          the `Future` holding the optional result of the search
+   *  @tparam T        the type of the value in the future
+   *  @param futures   the `scala.collection.immutable.Iterable` of Futures to search
+   *  @param p         the predicate which indicates if it's a match
+   *  @return          the `Future` holding the optional result of the search
    */
   final def find[T](futures: scala.collection.immutable.Iterable[Future[T]])(p: T => Boolean)(implicit executor: ExecutionContext): Future[Option[T]] = {
     def searchNext(i: Iterator[Future[T]]): Future[Option[T]] =
@@ -789,16 +785,16 @@ object Future {
    *  or the result of the fold.
    *
    *  Example:
-   *  {{{
+   *  ```
    *    val futureSum = Future.foldLeft(futures)(0)(_ + _)
-   *  }}}
+   *  ```
    *
-   * @tparam T       the type of the value of the input Futures
-   * @tparam R       the type of the value of the returned `Future`
-   * @param futures  the `scala.collection.immutable.Iterable` of Futures to be folded
-   * @param zero     the start value of the fold
-   * @param op       the fold operation to be applied to the zero and futures
-   * @return         the `Future` holding the result of the fold
+   *  @tparam T       the type of the value of the input Futures
+   *  @tparam R       the type of the value of the returned `Future`
+   *  @param futures  the `scala.collection.immutable.Iterable` of Futures to be folded
+   *  @param zero     the start value of the fold
+   *  @param op       the fold operation to be applied to the zero and futures
+   *  @return         the `Future` holding the result of the fold
    */
   final def foldLeft[T, R](futures: scala.collection.immutable.Iterable[Future[T]])(zero: R)(op: (R, T) => R)(implicit executor: ExecutionContext): Future[R] =
     foldNext(futures.iterator, zero, op)
@@ -813,16 +809,16 @@ object Future {
    *  or the result of the fold.
    *
    *  Example:
-   *  {{{
+   *  ```
    *    val futureSum = Future.fold(futures)(0)(_ + _)
-   *  }}}
+   *  ```
    *
-   * @tparam T       the type of the value of the input Futures
-   * @tparam R       the type of the value of the returned `Future`
-   * @param futures  the `IterableOnce` of Futures to be folded
-   * @param zero     the start value of the fold
-   * @param op       the fold operation to be applied to the zero and futures
-   * @return         the `Future` holding the result of the fold
+   *  @tparam T       the type of the value of the input Futures
+   *  @tparam R       the type of the value of the returned `Future`
+   *  @param futures  the `IterableOnce` of Futures to be folded
+   *  @param zero     the start value of the fold
+   *  @param op       the fold operation to be applied to the zero and futures
+   *  @return         the `Future` holding the result of the fold
    */
   @deprecated("use Future.foldLeft instead", "2.12.0")
   // not removed in 2.13, to facilitate 2.11/2.12/2.13 cross-building; remove further down the line (see scala/scala#6319)
@@ -834,14 +830,14 @@ object Future {
    *  where the fold-zero is the result value of the first `Future` in the collection.
    *
    *  Example:
-   *  {{{
+   *  ```
    *    val futureSum = Future.reduce(futures)(_ + _)
-   *  }}}
-   * @tparam T       the type of the value of the input Futures
-   * @tparam R       the type of the value of the returned `Future`
-   * @param futures  the `IterableOnce` of Futures to be reduced
-   * @param op       the reduce operation which is applied to the results of the futures
-   * @return         the `Future` holding the result of the reduce
+   *  ```
+   *  @tparam T       the type of the value of the input Futures
+   *  @tparam R       the type of the value of the returned `Future`
+   *  @param futures  the `IterableOnce` of Futures to be reduced
+   *  @param op       the reduce operation which is applied to the results of the futures
+   *  @return         the `Future` holding the result of the reduce
    */
   @deprecated("use Future.reduceLeft instead", "2.12.0")
   // not removed in 2.13, to facilitate 2.11/2.12/2.13 cross-building; remove further down the line (see scala/scala#6319)
@@ -853,14 +849,14 @@ object Future {
    *  where the zero is the result value of the first `Future`.
    *
    *  Example:
-   *  {{{
+   *  ```
    *    val futureSum = Future.reduceLeft(futures)(_ + _)
-   *  }}}
-   * @tparam T       the type of the value of the input Futures
-   * @tparam R       the type of the value of the returned `Future`
-   * @param futures  the `scala.collection.immutable.Iterable` of Futures to be reduced
-   * @param op       the reduce operation which is applied to the results of the futures
-   * @return         the `Future` holding the result of the reduce
+   *  ```
+   *  @tparam T       the type of the value of the input Futures
+   *  @tparam R       the type of the value of the returned `Future`
+   *  @param futures  the `scala.collection.immutable.Iterable` of Futures to be reduced
+   *  @param op       the reduce operation which is applied to the results of the futures
+   *  @return         the `Future` holding the result of the reduce
    */
   final def reduceLeft[T, R >: T](futures: scala.collection.immutable.Iterable[Future[T]])(op: (R, T) => R)(implicit executor: ExecutionContext): Future[R] = {
     val i = futures.iterator
@@ -873,15 +869,15 @@ object Future {
    *  This is useful for performing a parallel map. For example, to apply a function to all items of a list
    *  in parallel:
    *
-   *  {{{
+   *  ```
    *    val myFutureList = Future.traverse(myList)(x => Future(myFunc(x)))
-   *  }}}
-   * @tparam A        the type of the value inside the Futures in the collection
-   * @tparam B        the type of the value of the returned `Future`
-   * @tparam M        the type of the collection of Futures
-   * @param in        the collection to be mapped over with the provided function to produce a collection of Futures that is then sequenced into a Future collection
-   * @param fn        the function to be mapped over the collection to produce a collection of Futures
-   * @return          the `Future` of the collection of results
+   *  ```
+   *  @tparam A        the type of the value inside the Futures in the collection
+   *  @tparam B        the type of the value of the returned `Future`
+   *  @tparam M        the type of the collection of Futures
+   *  @param in        the collection to be mapped over with the provided function to produce a collection of Futures that is then sequenced into a Future collection
+   *  @param fn        the function to be mapped over the collection to produce a collection of Futures
+   *  @return          the `Future` of the collection of results
    */
   final def traverse[A, B, M[X] <: IterableOnce[X]](in: M[A])(fn: A => Future[B])(implicit bf: BuildFrom[M[A], B, M[B]], executor: ExecutionContext): Future[M[B]] =
     in.iterator.foldLeft(successful(bf.newBuilder(in))) {

--- a/library/src/scala/concurrent/Promise.scala
+++ b/library/src/scala/concurrent/Promise.scala
@@ -35,8 +35,7 @@ import scala.util.{ Try, Success, Failure }
  *  Note: Using this method may result in non-deterministic concurrent programs.
  */
 trait Promise[T] {
-  /** Future containing the value of this promise.
-   */
+  /** Future containing the value of this promise. */
   def future: Future[T]
 
   /** Returns whether the promise has already been completed with

--- a/library/src/scala/concurrent/SyncVar.scala
+++ b/library/src/scala/concurrent/SyncVar.scala
@@ -25,11 +25,10 @@ class SyncVar[A] {
   private var isDefined: Boolean = false
   private var value: A = compiletime.uninitialized
 
-  /**
-   * Wait for this SyncVar to become defined and then get
-   * the stored value without modifying it.
+  /** Wait for this SyncVar to become defined and then get
+   *  the stored value without modifying it.
    *
-   * @return value that is held in this container
+   *  @return value that is held in this container
    */
   def get: A = synchronized {
     while (!isDefined) wait()
@@ -37,8 +36,8 @@ class SyncVar[A] {
   }
 
   /** Waits `timeout` millis. If `timeout <= 0` just returns 0.
-    * It never returns negative results.
-    */
+   *  It never returns negative results.
+   */
   private def waitMeasuringElapsed(timeout: Long): Long = if (timeout <= 0) 0 else {
     val start = System.nanoTime()
     wait(timeout)
@@ -67,11 +66,10 @@ class SyncVar[A] {
     if (isDefined) Some(value) else None
   }
 
-  /**
-   * Wait for this SyncVar to become defined and then get
-   * the stored value, unsetting it as a side effect.
+  /** Wait for this SyncVar to become defined and then get
+   *  the stored value, unsetting it as a side effect.
    *
-   * @return value that was held in this container
+   *  @return value that was held in this container
    */
   def take(): A = synchronized {
     try get
@@ -92,7 +90,8 @@ class SyncVar[A] {
   }
 
   /** Place a value in the SyncVar. If the SyncVar already has a stored value,
-   * wait until another thread takes it. */
+   *  wait until another thread takes it. 
+   */
   def put(x: A): Unit = synchronized {
     while (isDefined) wait()
     setVal(x)

--- a/library/src/scala/concurrent/duration/Deadline.scala
+++ b/library/src/scala/concurrent/duration/Deadline.scala
@@ -14,72 +14,57 @@ package scala.concurrent.duration
 
 import scala.language.`2.13`
 
-/**
- * This class stores a deadline, as obtained via `Deadline.now` or the
- * duration DSL:
+/** This class stores a deadline, as obtained via `Deadline.now` or the
+ *  duration DSL:
  *
- * {{{
- * import scala.concurrent.duration._
- * 3.seconds.fromNow
- * }}}
+ *  ```
+ *  import scala.concurrent.duration._
+ *  3.seconds.fromNow
+ *  ```
  *
- * Its main purpose is to manage repeated attempts to achieve something (like
- * awaiting a condition) by offering the methods `hasTimeLeft` and `timeLeft`.  All
- * durations are measured according to `System.nanoTime`; this
- * does not take into account changes to the system clock (such as leap
- * seconds).
+ *  Its main purpose is to manage repeated attempts to achieve something (like
+ *  awaiting a condition) by offering the methods `hasTimeLeft` and `timeLeft`.  All
+ *  durations are measured according to `System.nanoTime`; this
+ *  does not take into account changes to the system clock (such as leap
+ *  seconds).
  */
 case class Deadline private (time: FiniteDuration) extends Ordered[Deadline] {
-  /**
-   * Returns a deadline advanced (i.e., moved into the future) by the given duration.
-   */
+  /** Returns a deadline advanced (i.e., moved into the future) by the given duration. */
   def +(other: FiniteDuration): Deadline = copy(time = time + other)
-  /**
-   * Returns a deadline moved backwards (i.e., towards the past) by the given duration.
-   */
+  /** Returns a deadline moved backwards (i.e., towards the past) by the given duration. */
   def -(other: FiniteDuration): Deadline = copy(time = time - other)
-  /**
-   * Calculates time difference between this and the other deadline, where the result is directed (i.e., may be negative).
-   */
+  /** Calculates time difference between this and the other deadline, where the result is directed (i.e., may be negative). */
   def -(other: Deadline): FiniteDuration = time - other.time
-  /**
-   * Calculates time difference between this duration and now; the result is negative if the deadline has passed.
+  /** Calculates time difference between this duration and now; the result is negative if the deadline has passed.
    *
-   * '''''Note that on some systems this operation is costly because it entails a system call.'''''
-   * Checks `System.nanoTime` for your platform.
+   *  ***Note that on some systems this operation is costly because it entails a system call.***
+   *  Checks `System.nanoTime` for your platform.
    */
   def timeLeft: FiniteDuration = this - Deadline.now
-  /**
-   * Determine whether the deadline still lies in the future at the point where this method is called.
+  /** Determine whether the deadline still lies in the future at the point where this method is called.
    *
-   * '''''Note that on some systems this operation is costly because it entails a system call.'''''
-   * Checks `System.nanoTime` for your platform.
+   *  ***Note that on some systems this operation is costly because it entails a system call.***
+   *  Checks `System.nanoTime` for your platform.
    */
   def hasTimeLeft(): Boolean = !isOverdue()
-  /**
-   * Determine whether the deadline lies in the past at the point where this method is called.
+  /** Determine whether the deadline lies in the past at the point where this method is called.
    *
-   * '''''Note that on some systems this operation is costly because it entails a system call.'''''
-   * Checks `System.nanoTime` for your platform.
+   *  ***Note that on some systems this operation is costly because it entails a system call.***
+   *  Checks `System.nanoTime` for your platform.
    */
   def isOverdue(): Boolean = (time.toNanos - System.nanoTime()) < 0
-  /**
-   * The natural ordering for deadline is determined by the natural order of the underlying (finite) duration.
-   */
+  /** The natural ordering for deadline is determined by the natural order of the underlying (finite) duration. */
   def compare(other: Deadline): Int = time compare other.time
 }
 
 object Deadline {
-  /**
-   * Constructs a deadline due exactly at the point where this method is called. Useful for then
-   * advancing it to obtain a future deadline, or for sampling the current time exactly once and
-   * then comparing it to multiple deadlines (using subtraction).
+  /** Constructs a deadline due exactly at the point where this method is called. Useful for then
+   *  advancing it to obtain a future deadline, or for sampling the current time exactly once and
+   *  then comparing it to multiple deadlines (using subtraction).
    */
   def now: Deadline = Deadline(Duration(System.nanoTime, NANOSECONDS))
 
-  /**
-   * The natural ordering for deadline is determined by the natural order of the underlying (finite) duration.
-   */
+  /** The natural ordering for deadline is determined by the natural order of the underlying (finite) duration. */
   implicit object DeadlineIsOrdered extends Ordering[Deadline] {
     def compare(a: Deadline, b: Deadline): Int = a compare b
   }

--- a/library/src/scala/concurrent/duration/Duration.scala
+++ b/library/src/scala/concurrent/duration/Duration.scala
@@ -18,43 +18,39 @@ import scala.collection.StringParsers
 
 object Duration {
 
-  /**
-   * Constructs a Duration from the given length and unit. Observe that nanosecond precision may be lost if
+  /** Constructs a Duration from the given length and unit. Observe that nanosecond precision may be lost if
    *
    *  - the unit is NANOSECONDS
    *  - and the length has an absolute value greater than `2^53`
    *
-   * Infinite inputs (and NaN) are converted into [[Duration.Inf]], [[Duration.MinusInf]] and [[Duration.Undefined]], respectively.
+   *  Infinite inputs (and NaN) are converted into [[Duration.Inf]], [[Duration.MinusInf]] and [[Duration.Undefined]], respectively.
    *
-   * @throws IllegalArgumentException if the length was finite but the resulting duration cannot be expressed as a [[FiniteDuration]]
+   *  @throws IllegalArgumentException if the length was finite but the resulting duration cannot be expressed as a [[FiniteDuration]]
    */
   def apply(length: Double, unit: TimeUnit): Duration     = fromNanos(unit.toNanos(1) * length)
 
-  /**
-   * Constructs a finite duration from the given length and time unit. The unit given is retained
-   * throughout calculations as long as possible, so that it can be retrieved later.
+  /** Constructs a finite duration from the given length and time unit. The unit given is retained
+   *  throughout calculations as long as possible, so that it can be retrieved later.
    */
   def apply(length: Long, unit: TimeUnit): FiniteDuration = new FiniteDuration(length, unit)
 
-  /**
-   * Constructs a finite duration from the given length and time unit, where the latter is
-   * looked up in a list of string representation. Valid choices are:
+  /** Constructs a finite duration from the given length and time unit, where the latter is
+   *  looked up in a list of string representation. Valid choices are:
    *
-   * `d, day, h, hr, hour, m, min, minute, s, sec, second, ms, milli, millisecond, µs, micro, microsecond, ns, nano, nanosecond`
-   * and their pluralized forms (for every but the first mentioned form of each unit, i.e. no "ds", but "days").
+   *  `d, day, h, hr, hour, m, min, minute, s, sec, second, ms, milli, millisecond, µs, micro, microsecond, ns, nano, nanosecond`
+   *  and their pluralized forms (for every but the first mentioned form of each unit, i.e. no "ds", but "days").
    */
   def apply(length: Long, unit: String): FiniteDuration   = new FiniteDuration(length,  Duration.timeUnit(unit))
 
   // Double stores 52 bits mantissa, but there is an implied '1' in front, making the limit 2^53
   // private final val maxPreciseDouble = 9007199254740992d // not used after https://github.com/scala/scala/pull/9233
 
-  /**
-   * Parses String into Duration.  Format is `"<length><unit>"`, where
-   * whitespace is allowed before, between and after the parts. Infinities are
-   * designated by `"Inf"`, `"PlusInf"`, `"+Inf"`, `"Duration.Inf"` and `"-Inf"`, `"MinusInf"` or `"Duration.MinusInf"`.
-   * Undefined is designated by `"Duration.Undefined"`.
+  /** Parses String into Duration.  Format is `"<length><unit>"`, where
+   *  whitespace is allowed before, between and after the parts. Infinities are
+   *  designated by `"Inf"`, `"PlusInf"`, `"+Inf"`, `"Duration.Inf"` and `"-Inf"`, `"MinusInf"` or `"Duration.MinusInf"`.
+   *  Undefined is designated by `"Duration.Undefined"`.
    *
-   * @throws NumberFormatException if format is not parsable
+   *  @throws NumberFormatException if format is not parsable
    */
   def apply(s: String): Duration = {
     val s1: String = s filterNot (_.isWhitespace)
@@ -98,31 +94,27 @@ object Duration {
   protected[duration] val timeUnit: Map[String, TimeUnit] =
     timeUnitLabels.flatMap{ case (unit, names) => expandLabels(names) map (_ -> unit) }.toMap
 
-  /**
-   * Extracts length and time unit out of a string, where the format must match the description for [[Duration$.apply(s:String)* apply(String)]].
-   * The extractor will not match for malformed strings or non-finite durations.
+  /** Extracts length and time unit out of a string, where the format must match the description for [[Duration$.apply(s:String)* apply(String)]].
+   *  The extractor will not match for malformed strings or non-finite durations.
    */
   def unapply(s: String): Option[(Long, TimeUnit)] =
     ( try Some(apply(s)) catch { case _: RuntimeException => None } ) flatMap unapply
 
-  /**
-   * Extracts length and time unit out of a duration, if it is finite.
-   */
+  /** Extracts length and time unit out of a duration, if it is finite. */
   def unapply(d: Duration): Option[(Long, TimeUnit)] =
     if (d.isFinite) Some((d.length, d.unit)) else None
 
-  /**
-   * Constructs a possibly infinite or undefined Duration from the given number of nanoseconds.
+  /** Constructs a possibly infinite or undefined Duration from the given number of nanoseconds.
    *
    *  - `Double.PositiveInfinity` is mapped to [[Duration.Inf]]
    *  - `Double.NegativeInfinity` is mapped to [[Duration.MinusInf]]
    *  - `Double.NaN` is mapped to [[Duration.Undefined]]
    *  - `-0d` is mapped to [[Duration.Zero]] (exactly like `0d`)
    *
-   * The semantics of the resulting Duration objects matches the semantics of their Double
-   * counterparts with respect to arithmetic operations.
+   *  The semantics of the resulting Duration objects matches the semantics of their Double
+   *  counterparts with respect to arithmetic operations.
    *
-   * @throws IllegalArgumentException if the length was finite but the resulting duration cannot be expressed as a [[FiniteDuration]]
+   *  @throws IllegalArgumentException if the length was finite but the resulting duration cannot be expressed as a [[FiniteDuration]]
    */
   def fromNanos(nanos: Double): Duration = {
     if (nanos.isInfinite)
@@ -142,12 +134,11 @@ object Duration {
   private final val ns_per_h   = ns_per_min * 60
   private final val ns_per_d   = ns_per_h   * 24
 
-  /**
-   * Constructs a finite duration from the given number of nanoseconds. The
-   * result will have the coarsest possible time unit which can exactly express
-   * this duration.
+  /** Constructs a finite duration from the given number of nanoseconds. The
+   *  result will have the coarsest possible time unit which can exactly express
+   *  this duration.
    *
-   * @throws IllegalArgumentException for `Long.MinValue` since that would lead to inconsistent behavior afterwards (cannot be negated)
+   *  @throws IllegalArgumentException for `Long.MinValue` since that would lead to inconsistent behavior afterwards (cannot be negated)
    */
   def fromNanos(nanos: Long): FiniteDuration = {
          if (nanos % ns_per_d   == 0) Duration(nanos / ns_per_d  , DAYS)
@@ -159,22 +150,19 @@ object Duration {
     else Duration(nanos, NANOSECONDS)
   }
 
-  /**
-   * Preconstructed value of `0.days`.
-   */
+  /** Preconstructed value of `0.days`. */
   // unit as coarse as possible to keep (_ + Zero) sane unit-wise
   val Zero: FiniteDuration = new FiniteDuration(0, DAYS)
 
-  /**
-   * The Undefined value corresponds closely to Double.NaN:
+  /** The Undefined value corresponds closely to Double.NaN:
    *
    *  - it is the result of otherwise invalid operations
    *  - it does not equal itself (according to `equals()`)
    *  - it compares greater than any other Duration apart from itself (for which `compare` returns 0)
    *
-   * The particular comparison semantics mirror those of Double.NaN.
+   *  The particular comparison semantics mirror those of Double.NaN.
    *
-   * '''''Use [[eq]] when checking an input of a method against this value.'''''
+   *  ***Use [[eq]] when checking an input of a method against this value.***
    */
   val Undefined: Infinite = new Infinite {
     override def toString() = "Duration.Undefined"
@@ -231,10 +219,9 @@ object Duration {
     final def toCoarsest: Duration = this
   }
 
-  /**
-   * Infinite duration: greater than any other (apart from Undefined) and not equal to any other
-   * but itself. This value closely corresponds to Double.PositiveInfinity,
-   * matching its semantics in arithmetic operations.
+  /** Infinite duration: greater than any other (apart from Undefined) and not equal to any other
+   *  but itself. This value closely corresponds to Double.PositiveInfinity,
+   *  matching its semantics in arithmetic operations.
    */
   val Inf: Infinite = new Infinite  {
     override def toString(): String      = "Duration.Inf"
@@ -248,10 +235,9 @@ object Duration {
     private def readResolve(): AnyRef  = Inf            // Instructs deserialization to use this same instance
   }
 
-  /**
-   * Infinite duration: less than any other and not equal to any other
-   * but itself. This value closely corresponds to Double.NegativeInfinity,
-   * matching its semantics in arithmetic operations.
+  /** Infinite duration: less than any other and not equal to any other
+   *  but itself. This value closely corresponds to Double.NegativeInfinity,
+   *  matching its semantics in arithmetic operations.
    */
   val MinusInf: Infinite = new Infinite {
     override def toString(): String      = "Duration.MinusInf"
@@ -263,283 +249,246 @@ object Duration {
 
   // Java Factories
 
-  /**
-   * Constructs a finite duration from the given length and time unit. The unit given is retained
-   * throughout calculations as long as possible, so that it can be retrieved later.
+  /** Constructs a finite duration from the given length and time unit. The unit given is retained
+   *  throughout calculations as long as possible, so that it can be retrieved later.
    */
   def create(length: Long, unit: TimeUnit): FiniteDuration = apply(length, unit)
-  /**
-   * Constructs a Duration from the given length and unit. Observe that nanosecond precision may be lost if
+  /** Constructs a Duration from the given length and unit. Observe that nanosecond precision may be lost if
    *
    *  - the unit is NANOSECONDS
    *  - and the length has an absolute value greater than `2^53`
    *
-   * Infinite inputs (and NaN) are converted into [[Duration.Inf]], [[Duration.MinusInf]] and [[Duration.Undefined]], respectively.
+   *  Infinite inputs (and NaN) are converted into [[Duration.Inf]], [[Duration.MinusInf]] and [[Duration.Undefined]], respectively.
    *
-   * @throws IllegalArgumentException if the length was finite but the resulting duration cannot be expressed as a [[FiniteDuration]]
+   *  @throws IllegalArgumentException if the length was finite but the resulting duration cannot be expressed as a [[FiniteDuration]]
    */
   def create(length: Double, unit: TimeUnit): Duration     = apply(length, unit)
-  /**
-   * Constructs a finite duration from the given length and time unit, where the latter is
-   * looked up in a list of string representation. Valid choices are:
+  /** Constructs a finite duration from the given length and time unit, where the latter is
+   *  looked up in a list of string representation. Valid choices are:
    *
-   * `d, day, h, hour, min, minute, s, sec, second, ms, milli, millisecond, µs, micro, microsecond, ns, nano, nanosecond`
-   * and their pluralized forms (for every but the first mentioned form of each unit, i.e. no "ds", but "days").
+   *  `d, day, h, hour, min, minute, s, sec, second, ms, milli, millisecond, µs, micro, microsecond, ns, nano, nanosecond`
+   *  and their pluralized forms (for every but the first mentioned form of each unit, i.e. no "ds", but "days").
    */
   def create(length: Long, unit: String): FiniteDuration   = apply(length, unit)
-  /**
-   * Parses String into Duration.  Format is `"<length><unit>"`, where
-   * whitespace is allowed before, between and after the parts. Infinities are
-   * designated by `"Inf"`, `"PlusInf"`, `"+Inf"` and `"-Inf"` or `"MinusInf"`.
+  /** Parses String into Duration.  Format is `"<length><unit>"`, where
+   *  whitespace is allowed before, between and after the parts. Infinities are
+   *  designated by `"Inf"`, `"PlusInf"`, `"+Inf"` and `"-Inf"` or `"MinusInf"`.
    *
-   * @throws NumberFormatException if format is not parsable
+   *  @throws NumberFormatException if format is not parsable
    */
   def create(s: String): Duration                          = apply(s)
 
-  /**
-   * The natural ordering of durations matches the natural ordering for Double, including non-finite values.
-   */
+  /** The natural ordering of durations matches the natural ordering for Double, including non-finite values. */
   implicit object DurationIsOrdered extends Ordering[Duration] {
     def compare(a: Duration, b: Duration): Int = a compare b
   }
 }
 
-/**
- * <h2>Utility for working with java.util.concurrent.TimeUnit durations.</h2>
+/** <h2>Utility for working with java.util.concurrent.TimeUnit durations.</h2>
  *
- * '''''This class is not meant as a general purpose representation of time, it is
- * optimized for the needs of `scala.concurrent`.'''''
+ *  ***This class is not meant as a general purpose representation of time, it is
+ *  optimized for the needs of `scala.concurrent`.***
  *
- * <h2>Basic Usage</h2>
+ *  <h2>Basic Usage</h2>
  *
- * <p/>
- * Examples:
- * {{{
- * import scala.concurrent.duration._
+ *  <p/>
+ *  Examples:
+ *  ```
+ *  import scala.concurrent.duration._
  *
- * val duration = Duration(100, MILLISECONDS)
- * val duration = Duration(100, "millis")
+ *  val duration = Duration(100, MILLISECONDS)
+ *  val duration = Duration(100, "millis")
  *
- * duration.toNanos
- * duration < 1.second
- * duration <= Duration.Inf
- * }}}
+ *  duration.toNanos
+ *  duration < 1.second
+ *  duration <= Duration.Inf
+ *  ```
  *
- * '''''Invoking inexpressible conversions (like calling `toSeconds` on an infinite duration) will throw an IllegalArgumentException.'''''
+ *  ***Invoking inexpressible conversions (like calling `toSeconds` on an infinite duration) will throw an IllegalArgumentException.***
  *
- * <p/>
- * Implicits are also provided for Int, Long and Double. Example usage:
- * {{{
- * import scala.concurrent.duration._
+ *  <p/>
+ *  Implicits are also provided for Int, Long and Double. Example usage:
+ *  ```
+ *  import scala.concurrent.duration._
  *
- * val duration = 100.millis
- * }}}
+ *  val duration = 100.millis
+ *  ```
  *
- * '''''The DSL provided by the implicit conversions always allows construction of finite durations, even for infinite Double inputs; use Duration.Inf instead.'''''
+ *  ***The DSL provided by the implicit conversions always allows construction of finite durations, even for infinite Double inputs; use Duration.Inf instead.***
  *
- * Extractors, parsing and arithmetic are also included:
- * {{{
- * val d = Duration("1.2 µs")
- * val Duration(length, unit) = 5 millis
- * val d2 = d * 2.5
- * val d3 = d2 + 1.millisecond
- * }}}
+ *  Extractors, parsing and arithmetic are also included:
+ *  ```
+ *  val d = Duration("1.2 µs")
+ *  val Duration(length, unit) = 5 millis
+ *  val d2 = d * 2.5
+ *  val d3 = d2 + 1.millisecond
+ *  ```
  *
- * <h2>Handling of Time Units</h2>
+ *  <h2>Handling of Time Units</h2>
  *
- * Calculations performed on finite durations always retain the more precise unit of either operand, no matter
- * whether a coarser unit would be able to exactly express the same duration. This means that Duration can be
- * used as a lossless container for a (length, unit) pair if it is constructed using the corresponding methods
- * and no arithmetic is performed on it; adding/subtracting durations should in that case be done with care.
+ *  Calculations performed on finite durations always retain the more precise unit of either operand, no matter
+ *  whether a coarser unit would be able to exactly express the same duration. This means that Duration can be
+ *  used as a lossless container for a (length, unit) pair if it is constructed using the corresponding methods
+ *  and no arithmetic is performed on it; adding/subtracting durations should in that case be done with care.
  *
- * <h2>Correspondence to Double Semantics</h2>
+ *  <h2>Correspondence to Double Semantics</h2>
  *
- * The semantics of arithmetic operations on Duration are two-fold:
+ *  The semantics of arithmetic operations on Duration are two-fold:
  *
  *  - exact addition/subtraction with nanosecond resolution for finite durations, independent of the summands' magnitude
  *  - isomorphic to `java.lang.Double` when it comes to infinite or undefined values
  *
- * The conversion between Duration and Double is done using [[Duration.toUnit]] (with unit NANOSECONDS)
- * and [[Duration$.fromNanos(nanos:Double)* Duration.fromNanos(Double)]]
+ *  The conversion between Duration and Double is done using [[Duration.toUnit]] (with unit NANOSECONDS)
+ *  and [[Duration$.fromNanos(nanos:Double)* Duration.fromNanos(Double)]]
  *
- * <h2>Ordering</h2>
+ *  <h2>Ordering</h2>
  *
- * The default ordering is consistent with the ordering of Double numbers, which means that Undefined is
- * considered greater than all other durations, including [[Duration.Inf]].
+ *  The default ordering is consistent with the ordering of Double numbers, which means that Undefined is
+ *  considered greater than all other durations, including [[Duration.Inf]].
  *
- * @define exc @throws IllegalArgumentException when invoked on a non-finite duration
+ *  @define exc @throws IllegalArgumentException when invoked on a non-finite duration
  *
- * @define ovf @throws IllegalArgumentException in case of a finite overflow: the range of a finite duration is `+-(2^63-1)`ns, and no conversion to infinite durations takes place.
+ *  @define ovf @throws IllegalArgumentException in case of a finite overflow: the range of a finite duration is `+-(2^63-1)`ns, and no conversion to infinite durations takes place.
  */
 sealed abstract class Duration extends Serializable with Ordered[Duration] {
-  /**
-   * Obtains the length of this Duration measured in the unit obtained by the `unit` method.
+  /** Obtains the length of this Duration measured in the unit obtained by the `unit` method.
    *
-   * $exc
+   *  $exc
    */
   def length: Long
-  /**
-   * Obtains the time unit in which the length of this duration is measured.
+  /** Obtains the time unit in which the length of this duration is measured.
    *
-   * $exc
+   *  $exc
    */
   def unit: TimeUnit
-  /**
-   * Returns the length of this duration measured in whole nanoseconds, rounding towards zero.
+  /** Returns the length of this duration measured in whole nanoseconds, rounding towards zero.
    *
-   * $exc
+   *  $exc
    */
   def toNanos: Long
-  /**
-   * Returns the length of this duration measured in whole microseconds, rounding towards zero.
+  /** Returns the length of this duration measured in whole microseconds, rounding towards zero.
    *
-   * $exc
+   *  $exc
    */
   def toMicros: Long
-  /**
-   * Returns the length of this duration measured in whole milliseconds, rounding towards zero.
+  /** Returns the length of this duration measured in whole milliseconds, rounding towards zero.
    *
-   * $exc
+   *  $exc
    */
   def toMillis: Long
-  /**
-   * Returns the length of this duration measured in whole seconds, rounding towards zero.
+  /** Returns the length of this duration measured in whole seconds, rounding towards zero.
    *
-   * $exc
+   *  $exc
    */
   def toSeconds: Long
-  /**
-   * Returns the length of this duration measured in whole minutes, rounding towards zero.
+  /** Returns the length of this duration measured in whole minutes, rounding towards zero.
    *
-   * $exc
+   *  $exc
    */
   def toMinutes: Long
-  /**
-   * Returns the length of this duration measured in whole hours, rounding towards zero.
+  /** Returns the length of this duration measured in whole hours, rounding towards zero.
    *
-   * $exc
+   *  $exc
    */
   def toHours: Long
-  /**
-   * Returns the length of this duration measured in whole days, rounding towards zero.
+  /** Returns the length of this duration measured in whole days, rounding towards zero.
    *
-   * $exc
+   *  $exc
    */
   def toDays: Long
-  /**
-   * Returns the number of nanoseconds as floating point number, scaled down to the given unit.
-   * The result may not precisely represent this duration due to the Double datatype's inherent
-   * limitations (mantissa size effectively 53 bits). Non-finite durations are represented as
+  /** Returns the number of nanoseconds as floating point number, scaled down to the given unit.
+   *  The result may not precisely represent this duration due to the Double datatype's inherent
+   *  limitations (mantissa size effectively 53 bits). Non-finite durations are represented as
    *  - [[Duration.Undefined]] is mapped to Double.NaN
    *  - [[Duration.Inf]] is mapped to Double.PositiveInfinity
    *  - [[Duration.MinusInf]] is mapped to Double.NegativeInfinity
    */
   def toUnit(unit: TimeUnit): Double
 
-  /**
-   * Returns the sum of that duration and this. When involving non-finite summands the semantics match those
-   * of Double.
+  /** Returns the sum of that duration and this. When involving non-finite summands the semantics match those
+   *  of Double.
    *
-   * $ovf
+   *  $ovf
    */
   def +(other: Duration): Duration
-  /**
-   * Returns the difference of that duration and this. When involving non-finite summands the semantics match those
-   * of Double.
+  /** Returns the difference of that duration and this. When involving non-finite summands the semantics match those
+   *  of Double.
    *
-   * $ovf
+   *  $ovf
    */
   def -(other: Duration): Duration
-  /**
-   * Returns this duration multiplied by the scalar factor. When involving non-finite factors the semantics match those
-   * of Double.
+  /** Returns this duration multiplied by the scalar factor. When involving non-finite factors the semantics match those
+   *  of Double.
    *
-   * $ovf
+   *  $ovf
    */
   def *(factor: Double): Duration
-  /**
-   * Returns this duration divided by the scalar factor. When involving non-finite factors the semantics match those
-   * of Double.
+  /** Returns this duration divided by the scalar factor. When involving non-finite factors the semantics match those
+   *  of Double.
    *
-   * $ovf
+   *  $ovf
    */
   def /(divisor: Double): Duration
-  /**
-   * Returns the quotient of this and that duration as floating-point number. The semantics are
-   * determined by Double as if calculating the quotient of the nanosecond lengths of both factors.
+  /** Returns the quotient of this and that duration as floating-point number. The semantics are
+   *  determined by Double as if calculating the quotient of the nanosecond lengths of both factors.
    */
   def /(divisor: Duration): Double
-  /**
-   * Negate this duration. The only two values which are mapped to themselves are [[Duration.Zero]] and [[Duration.Undefined]].
-   */
+  /** Negate this duration. The only two values which are mapped to themselves are [[Duration.Zero]] and [[Duration.Undefined]]. */
   def unary_- : Duration
-  /**
-   * This method returns whether this duration is finite, which is not the same as
-   * `!isInfinite` for Double because this method also returns `false` for [[Duration.Undefined]].
+  /** This method returns whether this duration is finite, which is not the same as
+   *  `!isInfinite` for Double because this method also returns `false` for [[Duration.Undefined]].
    */
   def isFinite: Boolean
-  /**
-   * Returns the smaller of this and that duration as determined by the natural ordering.
-   */
+  /** Returns the smaller of this and that duration as determined by the natural ordering. */
   def min(other: Duration): Duration = if (this < other) this else other
-  /**
-   * Returns the larger of this and that duration as determined by the natural ordering.
-   */
+  /** Returns the larger of this and that duration as determined by the natural ordering. */
   def max(other: Duration): Duration = if (this > other) this else other
 
   // Java API
 
-  /**
-   * Returns this duration divided by the scalar factor. When involving non-finite factors the semantics match those
-   * of Double.
+  /** Returns this duration divided by the scalar factor. When involving non-finite factors the semantics match those
+   *  of Double.
    *
-   * $ovf
+   *  $ovf
    */
   def div(divisor: Double): Duration = this / divisor
-  /**
-   * Returns the quotient of this and that duration as floating-point number. The semantics are
-   * determined by Double as if calculating the quotient of the nanosecond lengths of both factors.
+  /** Returns the quotient of this and that duration as floating-point number. The semantics are
+   *  determined by Double as if calculating the quotient of the nanosecond lengths of both factors.
    */
   def div(other: Duration): Double   = this / other
   def gt(other: Duration): Boolean   = this > other
   def gteq(other: Duration): Boolean = this >= other
   def lt(other: Duration): Boolean   = this < other
   def lteq(other: Duration): Boolean = this <= other
-  /**
-   * Returns the difference of that duration and this. When involving non-finite summands the semantics match those
-   * of Double.
+  /** Returns the difference of that duration and this. When involving non-finite summands the semantics match those
+   *  of Double.
    *
-   * $ovf
+   *  $ovf
    */
   def minus(other: Duration): Duration = this - other
-  /**
-   * Returns this duration multiplied by the scalar factor. When involving non-finite factors the semantics match those
-   * of Double.
+  /** Returns this duration multiplied by the scalar factor. When involving non-finite factors the semantics match those
+   *  of Double.
    *
-   * $ovf
+   *  $ovf
    */
   def mul(factor: Double): Duration    = this * factor
-  /**
-   * Negate this duration. The only two values which are mapped to themselves are [[Duration.Zero]] and [[Duration.Undefined]].
-   */
+  /** Negate this duration. The only two values which are mapped to themselves are [[Duration.Zero]] and [[Duration.Undefined]]. */
   def neg(): Duration                  = -this
-  /**
-   * Returns the sum of that duration and this. When involving non-finite summands the semantics match those
-   * of Double.
+  /** Returns the sum of that duration and this. When involving non-finite summands the semantics match those
+   *  of Double.
    *
-   * $ovf
+   *  $ovf
    */
   def plus(other: Duration): Duration  = this + other
-  /**
-   * Returns duration which is equal to this duration but with a coarsest Unit, or self in case it is already the coarsest Unit
-   * <p/>
-   * Examples:
-   * {{{
-   * Duration(60, MINUTES).toCoarsest // Duration(1, HOURS)
-   * Duration(1000, MILLISECONDS).toCoarsest // Duration(1, SECONDS)
-   * Duration(48, HOURS).toCoarsest // Duration(2, DAYS)
-   * Duration(5, SECONDS).toCoarsest // Duration(5, SECONDS)
-   * }}}
+  /** Returns duration which is equal to this duration but with a coarsest Unit, or self in case it is already the coarsest Unit
+   *  <p/>
+   *  Examples:
+   *  ```
+   *  Duration(60, MINUTES).toCoarsest // Duration(1, HOURS)
+   *  Duration(1000, MILLISECONDS).toCoarsest // Duration(1, SECONDS)
+   *  Duration(48, HOURS).toCoarsest // Duration(2, DAYS)
+   *  Duration(5, SECONDS).toCoarsest // Duration(5, SECONDS)
+   *  ```
    */
   def toCoarsest: Duration
 }
@@ -563,9 +512,8 @@ object FiniteDuration {
   private final val max_d  = max_h   / 24
 }
 
-/**
- * This class represents a finite duration. Its addition and subtraction operators are overloaded to retain
- * this guarantee statically. The range of this class is limited to `+-(2^63-1)`ns, which is roughly 292  years.
+/** This class represents a finite duration. Its addition and subtraction operators are overloaded to retain
+ *  this guarantee statically. The range of this class is limited to `+-(2^63-1)`ns, which is roughly 292  years.
  */
 final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duration {
   import FiniteDuration._
@@ -598,9 +546,7 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
   def toDays: Long                = unit.toDays(length)
   def toUnit(u: TimeUnit): Double = toNanos.toDouble / NANOSECONDS.convert(1, u)
 
-  /**
-   * Constructs a [[Deadline]] from this duration by adding it to the current instant `Deadline.now`.
-   */
+  /** Constructs a [[Deadline]] from this duration by adding it to the current instant `Deadline.now`. */
   def fromNow: Deadline = Deadline.now + this
 
   private def unitString  = timeUnitName(unit) + ( if (length == 1) "" else "s" )
@@ -661,17 +607,15 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
 
   // overloaded methods taking Long so that you can calculate while statically staying finite
 
-  /**
-   * Returns the quotient of this duration and the given integer factor.
+  /** Returns the quotient of this duration and the given integer factor.
    *
-   * @throws java.lang.ArithmeticException if the factor is 0
+   *  @throws java.lang.ArithmeticException if the factor is 0
    */
   def /(divisor: Long): FiniteDuration = fromNanos(toNanos / divisor)
 
-  /**
-   * Returns the product of this duration and the given integer factor.
+  /** Returns the product of this duration and the given integer factor.
    *
-   * @throws IllegalArgumentException if the result would overflow the range of FiniteDuration
+   *  @throws IllegalArgumentException if the result would overflow the range of FiniteDuration
    */
   def *(factor: Long): FiniteDuration  = new FiniteDuration(safeMul(length, factor), unit)
 
@@ -695,17 +639,15 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
     if (a == _a ^ b == _b) -product else product
   }
 
-  /**
-   * Returns the quotient of this duration and the given integer factor.
+  /** Returns the quotient of this duration and the given integer factor.
    *
-   * @throws java.lang.ArithmeticException if the factor is 0
+   *  @throws java.lang.ArithmeticException if the factor is 0
    */
   def div(divisor: Long): FiniteDuration = this / divisor
 
-  /**
-   * Returns the product of this duration and the given integer factor.
+  /** Returns the product of this duration and the given integer factor.
    *
-   * @throws IllegalArgumentException if the result would overflow the range of FiniteDuration
+   *  @throws IllegalArgumentException if the result would overflow the range of FiniteDuration
    */
   def mul(factor: Long): FiniteDuration  = this * factor
 

--- a/library/src/scala/concurrent/duration/package.scala
+++ b/library/src/scala/concurrent/duration/package.scala
@@ -20,11 +20,12 @@ package object duration {
    * This object can be used as closing token if you prefer dot-less style but do not want
    * to enable language.postfixOps:
    *
-   * {{{
+   * ```
    * import scala.concurrent.duration._
    *
    * val duration = 2 seconds span
-   * }}}
+   * ```
+   
    */
   object span
 
@@ -32,11 +33,12 @@ package object duration {
    * This object can be used as closing token for declaring a deadline at some future point
    * in time:
    *
-   * {{{
+   * ```
    * import scala.concurrent.duration._
    *
    * val deadline = 3 seconds fromNow
-   * }}}
+   * ```
+   
    */
   object fromNow
 

--- a/library/src/scala/concurrent/impl/Promise.scala
+++ b/library/src/scala/concurrent/impl/Promise.scala
@@ -25,14 +25,13 @@ import java.util.concurrent.atomic.AtomicReference
 import java.util.Objects.requireNonNull
 import java.io.{IOException, NotSerializableException, ObjectInputStream, ObjectOutputStream}
 
-/**
-  * Latch used to implement waiting on a DefaultPromise's result.
-  *
-  * Inspired by: http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/src/main/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
-  * Written by Doug Lea with assistance from members of JCP JSR-166
-  * Expert Group and released to the public domain, as explained at
-  * https://creativecommons.org/publicdomain/zero/1.0/
-  */
+/** Latch used to implement waiting on a DefaultPromise's result.
+ *
+ *  Inspired by: http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/src/main/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
+ *  Written by Doug Lea with assistance from members of JCP JSR-166
+ *  Expert Group and released to the public domain, as explained at
+ *  https://creativecommons.org/publicdomain/zero/1.0/
+ */
 private[impl] final class CompletionLatch[T] extends AbstractQueuedSynchronizer with (Try[T] => Unit) {
   //@volatie not needed since we use acquire/release
   /*@volatile*/ @annotation.stableNull private var _result: Try[T] | Null = null
@@ -49,30 +48,25 @@ private[impl] final class CompletionLatch[T] extends AbstractQueuedSynchronizer 
 }
 
 private[concurrent] object Promise {
-  /**
-   * Link represents a completion dependency between 2 DefaultPromises.
-   * As the DefaultPromise referred to by a Link can itself be linked to another promise
-   * `relink` traverses such chains and compresses them so that the link always points
-   * to the root of the dependency chain.
+  /** Link represents a completion dependency between 2 DefaultPromises.
+   *  As the DefaultPromise referred to by a Link can itself be linked to another promise
+   *  `relink` traverses such chains and compresses them so that the link always points
+   *  to the root of the dependency chain.
    *
-   * In order to conserve memory, the owner of a Link (a DefaultPromise) is not stored
-   * on the Link, but is instead passed in as a parameter to the operation(s).
+   *  In order to conserve memory, the owner of a Link (a DefaultPromise) is not stored
+   *  on the Link, but is instead passed in as a parameter to the operation(s).
    *
-   * If when compressing a chain of Links it is discovered that the root has been completed,
-   * the `owner`'s value is completed with that value, and the Link chain is discarded.
-   **/
+   *  If when compressing a chain of Links it is discovered that the root has been completed,
+   *  the `owner`'s value is completed with that value, and the Link chain is discarded.
+   */
   private[concurrent] final class Link[T](to: DefaultPromise[T]) extends AtomicReference[DefaultPromise[T]](to) {
-    /**
-     * Compresses this chain and returns the currently known root of this chain of Links.
-     **/
+    /** Compresses this chain and returns the currently known root of this chain of Links. */
     final def promise(owner: DefaultPromise[T]): DefaultPromise[T] = {
       val c = get()
       compressed(current = c, target = c, owner = owner)
     }
 
-    /**
-     * The combination of traversing and possibly unlinking of a given `target` DefaultPromise.
-     **/
+    /** The combination of traversing and possibly unlinking of a given `target` DefaultPromise. */
     @inline @tailrec private final def compressed(current: DefaultPromise[T], target: DefaultPromise[T], owner: DefaultPromise[T]): DefaultPromise[T] = {
       val value = target.get()
       if (value.isInstanceOf[Callbacks[?]]) {
@@ -86,10 +80,9 @@ private[concurrent] object Promise {
     }
   }
 
-  /**
-   * The process of "resolving" a Try is to validate that it only contains
-   * those values which makes sense in the context of Futures.
-   **/
+  /** The process of "resolving" a Try is to validate that it only contains
+   *  those values which makes sense in the context of Futures.
+   */
   // requireNonNull is paramount to guard against null completions
   private final def resolve[T](value: Try[T]): Try[T] =
     if (requireNonNull(value).isInstanceOf[Success[T]]) value
@@ -105,26 +98,19 @@ private[concurrent] object Promise {
 
   // Left non-final to enable addition of extra fields by Java/Scala converters in scala-java8-compat.
   class DefaultPromise[T] private (initial: AnyRef) extends AtomicReference[AnyRef](initial) with scala.concurrent.Promise[T] with scala.concurrent.Future[T] with (Try[T] => Unit) {
-    /**
-     * Constructs a new, completed, Promise.
-     */
+    /** Constructs a new, completed, Promise. */
     final def this(result: Try[T]) = this(resolve(result): AnyRef)
 
-    /**
-     * Constructs a new, un-completed, Promise.
-     */
+    /** Constructs a new, un-completed, Promise. */
     final def this() = this(Noop: AnyRef)
 
-    /**
-     * WARNING: the `resolved` value needs to have been pre-resolved using `resolve()`
-     * INTERNAL API
+    /** WARNING: the `resolved` value needs to have been pre-resolved using `resolve()`
+     *  INTERNAL API
      */
     override final def apply(resolved: Try[T]): Unit =
       tryComplete0(get(), resolved)
 
-    /**
-     * Returns the associated `Future` with this `Promise`
-     */
+    /** Returns the associated `Future` with this `Promise` */
     override final def future: Future[T] = this
 
     override final def transform[S](f: Try[T] => Try[S])(implicit executor: ExecutionContext): Future[S] =
@@ -374,8 +360,7 @@ private[concurrent] object Promise {
         callbacks.asInstanceOf[Transformation[T, ?]].submitWithValue(resolved)
       }
 
-    /** Link this promise to the root of another promise.
-     */
+    /** Link this promise to the root of another promise. */
     @tailrec private[concurrent] final def linkRootOf(target: DefaultPromise[T], link: Link[T] | Null): Unit =
       if (this ne target) {
         val state = get()
@@ -392,10 +377,9 @@ private[concurrent] object Promise {
           state.asInstanceOf[Link[T]].promise(this).linkRootOf(target, link)
       }
 
-    /**
-     * Unlinks (removes) the link chain if the root is discovered to be already completed,
-     * and completes the `owner` with that result.
-     **/
+    /** Unlinks (removes) the link chain if the root is discovered to be already completed,
+     *  and completes the `owner` with that result.
+     */
     @tailrec private[concurrent] final def unlink(resolved: Try[T]): Unit = {
       val state = get()
       if (state.isInstanceOf[Link[?]]) {
@@ -438,12 +422,11 @@ private[concurrent] object Promise {
 
   private final val Noop = new Transformation[Nothing, Nothing](Xform_noop, null: (Any => Any) | Null, ExecutionContext.parasitic)
 
-  /**
-   * A Transformation[F, T] receives an F (it is a Callback[F]) and applies a transformation function to that F,
-   * Producing a value of type T (it is a Promise[T]).
-   * In order to conserve allocations, indirections, and avoid introducing bi/mega-morphicity the transformation
-   * function's type parameters are erased, and the _xform tag will be used to reify them.
-   **/
+  /** A Transformation[F, T] receives an F (it is a Callback[F]) and applies a transformation function to that F,
+   *  Producing a value of type T (it is a Promise[T]).
+   *  In order to conserve allocations, indirections, and avoid introducing bi/mega-morphicity the transformation
+   *  function's type parameters are erased, and the _xform tag will be used to reify them.
+   */
   final class Transformation[-F, T] private (
     @annotation.stableNull private final var _fun: (Any => Any) | Null,
     @annotation.stableNull private final var _ec: ExecutionContext | Null,

--- a/library/src/scala/concurrent/package.scala
+++ b/library/src/scala/concurrent/package.scala
@@ -19,20 +19,20 @@ import scala.util.Try
 
 /** This package object contains primitives for concurrent and parallel programming.
  *
- * == Guide ==
+ * ## Guide
  *
  * A more detailed guide to Futures and Promises, including discussion and examples
  * can be found at
  * [[https://docs.scala-lang.org/overviews/core/futures.html]].
  *
- * == Common Imports ==
+ * ## Common Imports
  *
  * When working with Futures, you will often find that importing the whole concurrent
  * package is convenient:
  *
- * {{{
+ * ```
  * import scala.concurrent._
- * }}}
+ * ```
  *
  * When using things like `Future`s, it is often required to have an implicit `ExecutionContext`
  * in scope. The general advice for these implicits are as follows.
@@ -40,39 +40,39 @@ import scala.util.Try
  * If the code in question is a class or method definition, and no `ExecutionContext` is available,
  * request one from the caller by adding an implicit parameter list:
  *
- * {{{
+ * ```
  * def myMethod(myParam: MyType)(implicit ec: ExecutionContext) = …
  * //Or
  * class MyClass(myParam: MyType)(implicit ec: ExecutionContext) { … }
- * }}}
+ * ```
  *
  * This allows the caller of the method, or creator of the instance of the class, to decide which
  * `ExecutionContext` should be used.
  *
  * For typical REPL usage and experimentation, importing the global `ExecutionContext` is often desired.
  *
- * {{{
+ * ```
  * import scala.concurrent.ExecutionContext.Implicits.global
- * }}}
+ * ```
  *
- * == Specifying Durations ==
+ * ## Specifying Durations
  *
  * Operations often require a duration to be specified. A duration DSL is available
  * to make defining these easier:
  *
- * {{{
+ * ```
  * import scala.concurrent.duration._
  * val d: Duration = 10.seconds
- * }}}
+ * ```
  *
- * == Using Futures For Non-blocking Computation ==
+ * ## Using Futures For Non-blocking Computation
  *
  * Basic use of futures is easy with the factory method on Future, which executes a
  * provided function asynchronously, handing you back a future result of that function
  * without blocking the current thread. In order to create the Future you will need
  * either an implicit or explicit ExecutionContext to be provided:
  *
- * {{{
+ * ```
  * import scala.concurrent._
  * import ExecutionContext.Implicits.global  // implicit execution context
  *
@@ -80,23 +80,23 @@ import scala.util.Try
  *   val words = Files.readAllLines("/etc/dictionaries-common/words").asScala
  *   words.indexOfSlice("zebra")
  * }
- * }}}
+ * ```
  *
- * == Avoid Blocking ==
+ * ## Avoid Blocking
  *
  * Although blocking is possible in order to await results (with a mandatory timeout duration):
  *
- * {{{
+ * ```
  * import scala.concurrent.duration._
  * Await.result(firstZebra, 10.seconds)
- * }}}
+ * ```
  *
  * and although this is sometimes necessary to do, in particular for testing purposes, blocking
  * in general is discouraged when working with Futures and concurrency in order to avoid
  * potential deadlocks and improve performance. Instead, use callbacks or combinators to
  * remain in the future domain:
  *
- * {{{
+ * ```
  * val animalRange: Future[Int] = for {
  *   aardvark <- firstAardvark
  *   zebra <- firstZebra
@@ -105,7 +105,7 @@ import scala.util.Try
  * animalRange.onSuccess {
  *   case x if x > 500000 => println("It's a long way from Aardvark to Zebra")
  * }
- * }}}
+ * ```
  */
 package object concurrent {
   type ExecutionException =    java.util.concurrent.ExecutionException

--- a/library/src/scala/deprecated.scala
+++ b/library/src/scala/deprecated.scala
@@ -24,14 +24,14 @@ import scala.annotation.meta._
  *  Library authors should prepend the name of their library to the version number to help
  *  developers distinguish deprecations coming from different libraries:
  *
- *  {{{
+ *  ```
  *  @deprecated("this method will be removed", "FooLib 12.0")
  *  def oldMethod(x: Int) = ...
- *  }}}
+ *  ```
  *
  *  The compiler will emit deprecation warnings grouped by library and version:
  *
- *  {{{
+ *  ```
  *  oldMethod(1)
  *  oldMethod(2)
  *  aDeprecatedMethodFromLibraryBar(3, 4)
@@ -39,12 +39,12 @@ import scala.annotation.meta._
  *  // warning: there was one deprecation warning (since BarLib 3.2)
  *  // warning: there were two deprecation warnings (since FooLib 12.0)
  *  // warning: there were three deprecation warnings in total; re-run with -deprecation for details
- *  }}}
+ *  ```
  *
  *  The Scala compiler also warns about using definitions annotated with [[java.lang.Deprecated]]. However it is
  *  recommended to use the Scala `@deprecated` annotation in Scala code because it allows providing a deprecation message.
  *
- *  '''`@deprecated` in the Scala language and its standard library'''<br/>
+ *  **`@deprecated` in the Scala language and its standard library**<br/>
  *
  *  A deprecated element of the Scala language or a definition in the Scala standard library will
  *  be preserved at least for the current major version.
@@ -53,7 +53,7 @@ import scala.annotation.meta._
  *  all 2.13.x releases, but may be removed in the future. (A deprecated element
  *  might be kept longer to ease migration, but developers should not rely on this.)
  *
- *  @see    The official documentation on [[https://www.scala-lang.org/news/2.11.0/#binary-compatibility binary compatibility]].
+ *  @see    The official documentation on [binary compatibility](https://www.scala-lang.org/news/2.11.0/#binary-compatibility).
  *  @param  message the message to print during compilation if the definition is accessed
  *  @param  since   a string identifying the first version in which the definition was deprecated
  *  @see    [[scala.deprecatedInheritance]]

--- a/library/src/scala/deprecatedInheritance.scala
+++ b/library/src/scala/deprecatedInheritance.scala
@@ -28,18 +28,18 @@ import scala.annotation.meta._
  *  Library authors should prepend the name of their library to the version number to help
  *  developers distinguish deprecations coming from different libraries:
  *
- *  {{{
+ *  ```
  *  @deprecatedInheritance("this class will be made final", "FooLib 12.0")
  *  class Foo
- *  }}}
+ *  ```
  *
- *  {{{
+ *  ```
  *  val foo = new Foo     // no deprecation warning
  *  class Bar extends Foo
  *  // warning: inheritance from class Foo is deprecated (since FooLib 12.0): this class will be made final
  *  // class Bar extends Foo
  *  //                   ^
- *  }}}
+ *  ```
  *
  *  @param  message the message to print during compilation if the class was sub-classed
  *  @param  since   a string identifying the first version in which inheritance was deprecated

--- a/library/src/scala/deprecatedName.scala
+++ b/library/src/scala/deprecatedName.scala
@@ -29,16 +29,16 @@ import scala.annotation.meta._
  *  Library authors should prepend the name of their library to the version number to help
  *  developers distinguish deprecations coming from different libraries:
  *
- *  {{{
+ *  ```
  *  def inc(x: Int, @deprecatedName("y", "FooLib 12.0") n: Int): Int = x + n
  *  inc(1, y = 2)
- *  }}}
+ *  ```
  *  will produce the following warning:
- *  {{{
+ *  ```
  *  warning: the parameter name y is deprecated (since FooLib 12.0): use n instead
  *  inc(1, y = 2)
  *           ^
- *  }}}
+ *  ```
  *
  *  @see    [[scala.deprecated]]
  *  @see    [[scala.deprecatedInheritance]]

--- a/library/src/scala/deprecatedOverriding.scala
+++ b/library/src/scala/deprecatedOverriding.scala
@@ -25,14 +25,14 @@ import scala.annotation.meta._
  *  Library authors should prepend the name of their library to the version number to help
  *  developers distinguish deprecations coming from different libraries:
  *
- *  {{{
+ *  ```
  *  class Foo {
  *    @deprecatedOverriding("this method will be made final", "FooLib 12.0")
  *    def add(x: Int, y: Int) = x + y
  *  }
- *  }}}
+ *  ```
  *
- *  {{{
+ *  ```
  *  class Bar extends Foo // no deprecation warning
  *  class Baz extends Foo {
  *    override def add(x: Int, y: Int) = x - y
@@ -40,7 +40,7 @@ import scala.annotation.meta._
  *  // warning: overriding method add in class Foo is deprecated (since FooLib 12.0): this method will be made final
  *  // override def add(x: Int, y: Int) = x - y
  *  //              ^
- *  }}}
+ *  ```
  *
  *  @param  message the message to print during compilation if the member was overridden
  *  @param  since   a string identifying the first version in which overriding was deprecated

--- a/library/src/scala/deriving/Mirror.scala
+++ b/library/src/scala/deriving/Mirror.scala
@@ -2,8 +2,7 @@ package scala.deriving
 
 // import language.experimental.captureChecking
 
-/** Mirrors allows typelevel access to enums, case classes and objects, and their sealed parents.
- */
+/** Mirrors allows typelevel access to enums, case classes and objects, and their sealed parents. */
 sealed trait Mirror {
 
   /** The mirrored *-type. */

--- a/library/src/scala/inline.scala
+++ b/library/src/scala/inline.scala
@@ -18,7 +18,7 @@ import scala.language.`2.13`
  * An annotation for methods that the optimizer should inline.
  *
  * Note that by default, the Scala optimizer is disabled and no callsites are inlined. See
- * `-opt:help` and [[https://docs.scala-lang.org/overviews/compiler-options/optimizer.html the overview document]]
+ * `-opt:help` and [the overview document](https://docs.scala-lang.org/overviews/compiler-options/optimizer.html)
  * for information on how to enable the optimizer and inliner.
  *
  * When inlining is enabled, the inliner will always try to inline methods or callsites annotated
@@ -28,7 +28,7 @@ import scala.language.`2.13`
  *
  * Examples:
  *
- * {{{
+ * ```
  * @inline   final def f1(x: Int) = x
  * @noinline final def f2(x: Int) = x
  *           final def f3(x: Int) = x
@@ -41,14 +41,15 @@ import scala.language.`2.13`
  *  def t6 = f3(1): @inline     // inlined if possible
  *  def t7 = f3(1): @noinline   // not inlined
  * }
- * }}}
+ * ```
  *
  * Note: parentheses are required when annotating a callsite within a larger expression.
  *
- * {{{
+ * ```
  * def t1 = f1(1) + f1(1): @noinline   // equivalent to (f1(1) + f1(1)): @noinline
  * def t2 = f1(1) + (f1(1): @noinline) // the second call to f1 is not inlined
- * }}}
+ * ```
+ 
  */
 @deprecatedInheritance("Scheduled for being final in the future", "2.13.0")
 class inline extends scala.annotation.StaticAnnotation

--- a/library/src/scala/io/AnsiColor.scala
+++ b/library/src/scala/io/AnsiColor.scala
@@ -17,18 +17,18 @@ import scala.language.`2.13`
 
 /** ANSI escape codes providing control over text formatting and color on supporting text terminals.
   *
-  * ==ANSI Style and Control Codes==
+  * ## ANSI Style and Control Codes
   *
   * This group of escape codes provides control over text styling. For example, to turn on reverse video with bold and
   * then turn off all styling embed these codes,
   *
-  * {{{
+  * ```
   * import io.AnsiColor._
   *
   * println(s"\${REVERSED}\${BOLD}Hello 1979!\${RESET}")
-  * }}}
+  * ```
   *
-  * ==Foreground and Background Colors==
+  * ## Foreground and Background Colors
   *
   * Embedding ANSI color codes in text output will control the text foreground and background colors.
   *

--- a/library/src/scala/io/Codec.scala
+++ b/library/src/scala/io/Codec.scala
@@ -30,9 +30,7 @@ import scala.language.implicitConversions
 // MacRoman vs. UTF-8: see https://groups.google.com/d/msg/jruby-developers/-qtwRhoE1WM/whSPVpTNV28J
 // -Dfile.encoding: see https://bugs.java.com/view_bug.do?bug_id=4375816
 
-/** A class for character encoding/decoding preferences.
- *
- */
+/** A class for character encoding/decoding preferences. */
 class Codec(val charSet: Charset) {
   type Configure[T] = (T => T, Boolean)
   type Handler      = CharacterCodingException => Int

--- a/library/src/scala/io/Position.scala
+++ b/library/src/scala/io/Position.scala
@@ -31,18 +31,17 @@ import annotation.nowarn
  *  the undefined position is 0:   `encode(0,0) == 0`
  *  encodings are non-negative :   `encode(line,column) >= 0`
  *  position order is preserved:
- *  {{{
+ *  ```
  *  (line1 <= line2) || (line1 == line2 && column1 <= column2)
- *  }}}
+ *  ```
  *  implies
- *  {{{
+ *  ```
  *  encode(line1,column1) <= encode(line2,column2)
- *  }}}
+ *  ```
  */
 @deprecated("this class will be removed", "2.10.0")
 private[scala] abstract class Position {
-  /** Definable behavior for overflow conditions.
-   */
+  /** Definable behavior for overflow conditions. */
   def checkInput(line: Int, column: Int): Unit
 
   /** Number of bits used to encode the line number. */

--- a/library/src/scala/io/Source.scala
+++ b/library/src/scala/io/Source.scala
@@ -26,8 +26,7 @@ import scala.annotation.nowarn
 object Source {
   val DefaultBufSize = 2048
 
-  /** Creates a `Source` from System.in.
-   */
+  /** Creates a `Source` from System.in. */
   def stdin = fromInputStream(System.in)
 
   /** Creates a Source from an Iterable.
@@ -39,16 +38,13 @@ object Source {
     val iter = iterable.iterator
   } withReset(() => fromIterable(iterable))
 
-  /** Creates a Source instance from a single character.
-   */
+  /** Creates a Source instance from a single character. */
   def fromChar(c: Char): Source = fromIterable(Array(c))
 
-  /** creates Source from array of characters, with empty description.
-   */
+  /** creates Source from array of characters, with empty description. */
   def fromChars(chars: Array[Char]): Source = fromIterable(chars)
 
-  /** creates Source from a String, with no description.
-   */
+  /** creates Source from a String, with no description. */
   def fromString(s: String): Source = fromIterable(s)
 
   /** creates Source from file with given name, setting its description to
@@ -63,13 +59,11 @@ object Source {
   def fromFile(name: String, enc: String): BufferedSource =
     fromFile(name)(using Codec(enc))
 
-  /** creates `source` from file with given file `URI`.
-   */
+  /** creates `source` from file with given file `URI`. */
   def fromFile(uri: URI)(implicit codec: Codec): BufferedSource =
     fromFile(new JFile(uri))(using codec)
 
-  /** creates Source from file with given file: URI
-   */
+  /** creates Source from file with given file: URI */
   def fromFile(uri: URI, enc: String): BufferedSource =
     fromFile(uri)(using Codec(enc))
 
@@ -79,8 +73,7 @@ object Source {
   def fromFile(file: JFile)(implicit codec: Codec): BufferedSource =
     fromFile(file, Source.DefaultBufSize)(using codec)
 
-  /** same as fromFile(file, enc, Source.DefaultBufSize)
-   */
+  /** same as fromFile(file, enc, Source.DefaultBufSize) */
   def fromFile(file: JFile, enc: String): BufferedSource =
     fromFile(file)(using Codec(enc))
 
@@ -120,28 +113,23 @@ object Source {
   def fromRawBytes(bytes: Array[Byte]): Source =
     fromString(new String(bytes, Codec.ISO8859.charSet))
 
-  /** creates `Source` from file with given file: URI
-   */
+  /** creates `Source` from file with given file: URI */
   def fromURI(uri: URI)(implicit codec: Codec): BufferedSource =
     fromFile(new JFile(uri))(using codec)
 
-  /** same as fromURL(new URL(s))(Codec(enc))
-   */
+  /** same as fromURL(new URL(s))(Codec(enc)) */
   def fromURL(s: String, enc: String): BufferedSource =
     fromURL(s)(using Codec(enc))
 
-  /** same as fromURL(new URL(s))
-   */
+  /** same as fromURL(new URL(s)) */
   def fromURL(s: String)(implicit codec: Codec): BufferedSource =
     fromURL(new URI(s).toURL)(using codec)
 
-  /** same as fromInputStream(url.openStream())(Codec(enc))
-   */
+  /** same as fromInputStream(url.openStream())(Codec(enc)) */
   def fromURL(url: URL, enc: String): BufferedSource =
     fromURL(url)(using Codec(enc))
 
-  /** same as fromInputStream(url.openStream())(codec)
-   */
+  /** same as fromInputStream(url.openStream())(codec) */
   def fromURL(url: URL)(implicit codec: Codec): BufferedSource =
     fromInputStream(url.openStream())(using codec)
 
@@ -201,7 +189,6 @@ object Source {
  *  The default positioner encodes line and column numbers in the position passed to [[report]].
  *  This behavior can be changed by supplying a
  *  [[scala.io.Source.withPositioning(pos:* custom positioner]].
- *
  */
 abstract class Source extends Iterator[Char] with Closeable {
   /** The actual iterator. */
@@ -249,12 +236,10 @@ abstract class Source extends Iterator[Char] with Closeable {
    */
   def getLines(): Iterator[String] = new LineIterator()
 
-  /** Returns `'''true'''` if this source has more characters.
-   */
+  /** Returns `**true**` if this source has more characters. */
   def hasNext: Boolean = iter.hasNext
 
-  /** Returns next character.
-   */
+  /** Returns next character. */
   def next(): Char = positioner.next()
 
   @nowarn("cat=deprecation")

--- a/library/src/scala/jdk/Accumulator.scala
+++ b/library/src/scala/jdk/Accumulator.scala
@@ -20,78 +20,76 @@ import scala.collection.{Stepper, StepperShape, mutable}
 import scala.language.implicitConversions
 
 /** Accumulators are mutable sequences with two distinct features:
-  *   - An accumulator can be appended efficiently to another
-  *   - There are manually specialized Accumulators for `Int`, `Long` and `Double` that don't box
-  *     the elements
-  *
-  * These two features make Accumulators a good candidate to collect the results of a parallel Java
-  * stream pipeline into a Scala collection. The
-  * [[scala.collection.convert.StreamExtensions.StreamHasToScala.toScala]] extension method on Java
-  * streams (available by importing
-  * [[scala.jdk.StreamConverters `scala.jdk.StreamConverters._`]]) is specialized for
-  * Accumulators: they are built in parallel, the parts are merged efficiently.
-  *
-  * Building specialized Accumulators is handled transparently. As a user, using the
-  * [[Accumulator]] object as a factory automatically creates an [[IntAccumulator]],
-  * [[LongAccumulator]], [[DoubleAccumulator]] or [[AnyAccumulator]] depending on the element type.
-  *
-  * Note: to run the example, start the Scala REPL with `scala -Yrepl-class-based` to avoid
-  * deadlocks, see [[https://github.com/scala/bug/issues/9076]].
-  *
-  * {{{
-  *   scala> import scala.jdk.StreamConverters._
-  *   import scala.jdk.StreamConverters._
-  *
-  *   scala> def isPrime(n: Int): Boolean = !(2 +: (3 to Math.sqrt(n).toInt by 2) exists (n % _ == 0))
-  *   isPrime: (n: Int)Boolean
-  *
-  *   scala> val intAcc = (1 to 10000).asJavaParStream.filter(isPrime).toScala(scala.jdk.Accumulator)
-  *   intAcc: scala.jdk.IntAccumulator = IntAccumulator(1, 3, 5, 7, 11, 13, 17, 19, ...
-  *
-  *   scala> val stringAcc = (1 to 100).asJavaParStream.mapToObj("<>" * _).toScala(Accumulator)
-  *   stringAcc: scala.jdk.AnyAccumulator[String] = AnyAccumulator(<>, <><>, <><><>, ...
-  * }}}
-  *
-  * There are two possibilities to process elements of a primitive Accumulator without boxing:
-  * specialized operations of the Accumulator, or the Stepper interface. The most common collection
-  * operations are overloaded or overridden in the primitive Accumulator classes, for example
-  * [[IntAccumulator.map(f:Int=>Int)* IntAccumulator.map]] or [[IntAccumulator.exists]].
-  * Thanks to Scala's function specialization,
-  * `intAcc.exists(x => testOn(x))` does not incur boxing.
-  *
-  * The [[scala.collection.Stepper]] interface provides iterator-like `hasStep` and `nextStep` methods, and is
-  * specialized for `Int`, `Long` and `Double`. The `intAccumulator.stepper` method creates an
-  * [[scala.collection.IntStepper]] that yields the elements of the accumulator without boxing.
-  *
-  * Accumulators can hold more than `Int.MaxValue` elements. They have a [[sizeLong]] method that
-  * returns the size as a `Long`. Note that certain operations defined in [[scala.collection.Seq]]
-  * are implemented using [[length]], so they will not work correctly for large accumulators.
-  *
-  * The [[Accumulator]] class is a base class to share code between [[AnyAccumulator]] (for
-  * reference types) and the manual specializations [[IntAccumulator]], [[LongAccumulator]] and
-  * [[DoubleAccumulator]].
-  */
+ *   - An accumulator can be appended efficiently to another
+ *   - There are manually specialized Accumulators for `Int`, `Long` and `Double` that don't box
+ *     the elements
+ *
+ *  These two features make Accumulators a good candidate to collect the results of a parallel Java
+ *  stream pipeline into a Scala collection. The
+ *  [[scala.collection.convert.StreamExtensions.StreamHasToScala.toScala]] extension method on Java
+ *  streams (available by importing
+ *  [[scala.jdk.StreamConverters `scala.jdk.StreamConverters._`]]) is specialized for
+ *  Accumulators: they are built in parallel, the parts are merged efficiently.
+ *
+ *  Building specialized Accumulators is handled transparently. As a user, using the
+ *  [[Accumulator]] object as a factory automatically creates an [[IntAccumulator]],
+ *  [[LongAccumulator]], [[DoubleAccumulator]] or [[AnyAccumulator]] depending on the element type.
+ *
+ *  Note: to run the example, start the Scala REPL with `scala -Yrepl-class-based` to avoid
+ *  deadlocks, see [[https://github.com/scala/bug/issues/9076]].
+ *
+ *  ```
+ *   scala> import scala.jdk.StreamConverters._
+ *   import scala.jdk.StreamConverters._
+ *
+ *   scala> def isPrime(n: Int): Boolean = !(2 +: (3 to Math.sqrt(n).toInt by 2) exists (n % _ == 0))
+ *   isPrime: (n: Int)Boolean
+ *
+ *   scala> val intAcc = (1 to 10000).asJavaParStream.filter(isPrime).toScala(scala.jdk.Accumulator)
+ *   intAcc: scala.jdk.IntAccumulator = IntAccumulator(1, 3, 5, 7, 11, 13, 17, 19, ...
+ *
+ *   scala> val stringAcc = (1 to 100).asJavaParStream.mapToObj("<>" * _).toScala(Accumulator)
+ *   stringAcc: scala.jdk.AnyAccumulator[String] = AnyAccumulator(<>, <><>, <><><>, ...
+ *  ```
+ *
+ *  There are two possibilities to process elements of a primitive Accumulator without boxing:
+ *  specialized operations of the Accumulator, or the Stepper interface. The most common collection
+ *  operations are overloaded or overridden in the primitive Accumulator classes, for example
+ *  [[IntAccumulator.map(f:Int=>Int)* IntAccumulator.map]] or [[IntAccumulator.exists]].
+ *  Thanks to Scala's function specialization,
+ *  `intAcc.exists(x => testOn(x))` does not incur boxing.
+ *
+ *  The [[scala.collection.Stepper]] interface provides iterator-like `hasStep` and `nextStep` methods, and is
+ *  specialized for `Int`, `Long` and `Double`. The `intAccumulator.stepper` method creates an
+ *  [[scala.collection.IntStepper]] that yields the elements of the accumulator without boxing.
+ *
+ *  Accumulators can hold more than `Int.MaxValue` elements. They have a [[sizeLong]] method that
+ *  returns the size as a `Long`. Note that certain operations defined in [[scala.collection.Seq]]
+ *  are implemented using [[length]], so they will not work correctly for large accumulators.
+ *
+ *  The [[Accumulator]] class is a base class to share code between [[AnyAccumulator]] (for
+ *  reference types) and the manual specializations [[IntAccumulator]], [[LongAccumulator]] and
+ *  [[DoubleAccumulator]].
+ */
 abstract class Accumulator[@specialized(Double, Int, Long) A, +CC[X] <: mutable.Seq[X], +C <: mutable.Seq[A]]
   extends mutable.Seq[A]
     with mutable.Builder[A, C] {
 
-  /**
-   * Implementation Details
+  /** Implementation Details
    *
-   * Every subclass has two arrays
+   *  Every subclass has two arrays
    *   - `current: Array[A]`
    *   - `history: Array[Array[A]]`
    *
-   * Elements are added to `current` at [[index]] until it's full, then `current` is added to `history` at [[hIndex]].
-   * [[nextBlockSize]] defines the size of the next `current`. See also [[cumulative]].
+   *  Elements are added to `current` at [[index]] until it's full, then `current` is added to `history` at [[hIndex]].
+   *  [[nextBlockSize]] defines the size of the next `current`. See also [[cumulative]].
    */
   private[jdk] var index: Int = 0
   private[jdk] var hIndex: Int = 0
   private[jdk] var totalSize: Long = 0L
 
-  /**
-   * The total number of elements stored in the history up to `history(i)` (where `0 <= i < hIndex`).
-   * This method is constant-time, the cumulative lengths are stored.
+  /** The total number of elements stored in the history up to `history(i)` (where `0 <= i < hIndex`).
+   *  This method is constant-time, the cumulative lengths are stored.
    *   - [[AnyAccumulator]] keeps a separate array to store the cumulative lengths.
    *   - [[LongAccumulator]] and [[DoubleAccumulator]] store the cumulative length at the last slot in every
    *     array in the history. Every array is allocated with 1 extra slot for this purpose. [[DoubleAccumulator]]
@@ -145,210 +143,210 @@ abstract class Accumulator[@specialized(Double, Int, Long) A, +CC[X] <: mutable.
 }
 
 /** Contains factory methods to build Accumulators.
-  *
-  * Note that the `Accumulator` object itself is not a factory, but it is implicitly convert to
-  * a factory according to the element type, see [[Accumulator.toFactory]].
-  *
-  * This allows passing the `Accumulator` object as argument when a [[collection.Factory]], and
-  * the implicit [[Accumulator.AccumulatorFactoryShape]] instance is used to build a specialized
-  * Accumulator according to the element type:
-  *
-  * {{{
-  *   scala> val intAcc = Accumulator(1,2,3)
-  *   intAcc: scala.collection.convert.IntAccumulator = IntAccumulator(1, 2, 3)
-  *
-  *   scala> val anyAccc = Accumulator("K")
-  *   anyAccc: scala.collection.convert.AnyAccumulator[String] = AnyAccumulator(K)
-  *
-  *   scala> val intAcc2 = List(1,2,3).to(Accumulator)
-  *   intAcc2: scala.jdk.IntAccumulator = IntAccumulator(1, 2, 3)
-  *
-  *   scala> val anyAcc2 = List("K").to(Accumulator)
-  *   anyAcc2: scala.jdk.AnyAccumulator[String] = AnyAccumulator(K)
-  * }}}
-  *
-  * @define coll Accumulator
-  * @define Coll `Accumulator`
-  */
+ *
+ *  Note that the `Accumulator` object itself is not a factory, but it is implicitly convert to
+ *  a factory according to the element type, see [[Accumulator.toFactory]].
+ *
+ *  This allows passing the `Accumulator` object as argument when a [[collection.Factory]], and
+ *  the implicit [[Accumulator.AccumulatorFactoryShape]] instance is used to build a specialized
+ *  Accumulator according to the element type:
+ *
+ *  ```
+ *   scala> val intAcc = Accumulator(1,2,3)
+ *   intAcc: scala.collection.convert.IntAccumulator = IntAccumulator(1, 2, 3)
+ *
+ *   scala> val anyAccc = Accumulator("K")
+ *   anyAccc: scala.collection.convert.AnyAccumulator[String] = AnyAccumulator(K)
+ *
+ *   scala> val intAcc2 = List(1,2,3).to(Accumulator)
+ *   intAcc2: scala.jdk.IntAccumulator = IntAccumulator(1, 2, 3)
+ *
+ *   scala> val anyAcc2 = List("K").to(Accumulator)
+ *   anyAcc2: scala.jdk.AnyAccumulator[String] = AnyAccumulator(K)
+ *  ```
+ *
+ *  @define coll Accumulator
+ *  @define Coll `Accumulator`
+ */
 object Accumulator {
   implicit def toFactory[A, C](sa: Accumulator.type)(implicit canAccumulate: AccumulatorFactoryShape[A, C]): collection.Factory[A, C] = canAccumulate.factory
 
   /** Creates a target $coll from an existing source collection
-    *
-    * @param source Source collection
-    * @tparam A the type of the ${coll}’s elements
-    * @tparam C the (inferred) specific type of the $coll
-    * @return a new $coll with the elements of `source`
-    */
+   *
+   *  @tparam A the type of the ${coll}’s elements
+   *  @tparam C the (inferred) specific type of the $coll
+   *  @param source Source collection
+   *  @return a new $coll with the elements of `source`
+   */
   def from[A, C](source: IterableOnce[A])(implicit canAccumulate: AccumulatorFactoryShape[A, C]): C =
     source.iterator.to(canAccumulate.factory)
 
   /** An empty collection.
-    * @tparam A      the type of the ${coll}'s elements
-    */
+   *  @tparam A      the type of the ${coll}'s elements
+   */
   def empty[A, C](implicit canAccumulate: AccumulatorFactoryShape[A, C]): C =
     canAccumulate.empty
 
   /** Creates an $coll with the specified elements.
-    * @tparam A     the type of the ${coll}'s elements
-    * @tparam C     the (inferred) specific type of the $coll
-    * @param elems  the elements of the created $coll
-    * @return a new $coll with elements `elems`
-    */
+   *  @tparam A     the type of the ${coll}'s elements
+   *  @tparam C     the (inferred) specific type of the $coll
+   *  @param elems  the elements of the created $coll
+   *  @return a new $coll with elements `elems`
+   */
   def apply[A, C](elems: A*)(implicit canAccumulate: AccumulatorFactoryShape[A, C]): C =
     canAccumulate.factory.fromSpecific(elems)
 
   /** Produces an $coll containing repeated applications of a function to a start value.
-    *
-    *  @param start the start value of the $coll
-    *  @param len   the number of elements contained in the $coll
-    *  @param f     the function that's repeatedly applied
-    *  @return      an $coll with `len` values in the sequence `start, f(start), f(f(start)), ...`
-    */
+   *
+   *  @param start the start value of the $coll
+   *  @param len   the number of elements contained in the $coll
+   *  @param f     the function that's repeatedly applied
+   *  @return      an $coll with `len` values in the sequence `start, f(start), f(f(start)), ...`
+   */
   def iterate[A, C](start: A, len: Int)(f: A => A)(implicit canAccumulate: AccumulatorFactoryShape[A, C]): C =
     from(new collection.View.Iterate(start, len)(f))
 
   /** Produces an $coll that uses a function `f` to produce elements of type `A`
-    * and update an internal state of type `S`.
-    *
-    * @param init State initial value
-    * @param f    Computes the next element (or returns `None` to signal
-    *             the end of the collection)
-    * @tparam A   Type of the elements
-    * @tparam S   Type of the internal state
-    * @tparam C   Type (usually inferred) of the $coll
-    * @return an $coll that produces elements using `f` until `f` returns `None`
-    */
+   *  and update an internal state of type `S`.
+   *
+   *  @tparam A   Type of the elements
+   *  @tparam S   Type of the internal state
+   *  @tparam C   Type (usually inferred) of the $coll
+   *  @param init State initial value
+   *  @param f    Computes the next element (or returns `None` to signal
+   *             the end of the collection)
+   *  @return an $coll that produces elements using `f` until `f` returns `None`
+   */
   def unfold[A, S, C](init: S)(f: S => Option[(A, S)])(implicit canAccumulate: AccumulatorFactoryShape[A, C]): C =
     from(new collection.View.Unfold(init)(f))
 
   /** Produces an $coll containing a sequence of increasing of integers.
-    *
-    *  @param start the first element of the $coll
-    *  @param end   the end value of the $coll (the first value NOT contained)
-    *  @return  an $coll with values `start, start + 1, ..., end - 1`
-    */
+   *
+   *  @param start the first element of the $coll
+   *  @param end   the end value of the $coll (the first value NOT contained)
+   *  @return  an $coll with values `start, start + 1, ..., end - 1`
+   */
   def range[A: Integral, C](start: A, end: A)(implicit canAccumulate: AccumulatorFactoryShape[A, C]): C =
     from(collection.immutable.NumericRange(start, end, implicitly[Integral[A]].one))
 
   /** Produces an $coll containing equally spaced values in some integer interval.
-    *  @param start the start value of the $coll
-    *  @param end   the end value of the $coll (the first value NOT contained)
-    *  @param step  the difference between successive elements of the $coll (must be positive or negative)
-    *  @return      an $coll with values `start, start + step, ...` up to, but excluding `end`
-    */
+   *  @param start the start value of the $coll
+   *  @param end   the end value of the $coll (the first value NOT contained)
+   *  @param step  the difference between successive elements of the $coll (must be positive or negative)
+   *  @return      an $coll with values `start, start + step, ...` up to, but excluding `end`
+   */
   def range[A: Integral, C](start: A, end: A, step: A)(implicit canAccumulate: AccumulatorFactoryShape[A, C]): C =
     from(collection.immutable.NumericRange(start, end, step))
 
   /**
-    * @return A builder for $Coll objects.
-    * @tparam A the type of the ${coll}’s elements
-    * @tparam C the specific type of the $coll
-    */
+   *  @tparam A the type of the ${coll}’s elements
+   *  @tparam C the specific type of the $coll
+   *  @return A builder for $Coll objects.
+   */
   def newBuilder[A, C](implicit canAccumulate: AccumulatorFactoryShape[A, C]): collection.mutable.Builder[A, C] =
     canAccumulate.factory.newBuilder
 
   /** Produces an $coll containing the results of some element computation a number of times.
-    *  @param   n  the number of elements contained in the $coll.
-    *  @param   elem the element computation
-    *  @return  An $coll that contains the results of `n` evaluations of `elem`.
-    */
+   *  @param   n  the number of elements contained in the $coll.
+   *  @param   elem the element computation
+   *  @return  An $coll that contains the results of `n` evaluations of `elem`.
+   */
   def fill[A, C](n: Int)(elem: => A)(implicit canAccumulate: AccumulatorFactoryShape[A, C]): C =
     from(new collection.View.Fill(n)(elem))
 
   /** Produces a two-dimensional $coll containing the results of some element computation a number of times.
-    *  @param   n1  the number of elements in the 1st dimension
-    *  @param   n2  the number of elements in the 2nd dimension
-    *  @param   elem the element computation
-    *  @return  An $coll that contains the results of `n1 x n2` evaluations of `elem`.
-    */
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   elem the element computation
+   *  @return  An $coll that contains the results of `n1 x n2` evaluations of `elem`.
+   */
   def fill[A, C](n1: Int, n2: Int)(elem: => A)(implicit canAccumulate: AccumulatorFactoryShape[A, C]): AnyAccumulator[C] = 
     fill(n1)(fill(n2)(elem)(using canAccumulate))(using AccumulatorFactoryShape.anyAccumulatorFactoryShape[C])
 
   /** Produces a three-dimensional $coll containing the results of some element computation a number of times.
-    *  @param   n1  the number of elements in the 1st dimension
-    *  @param   n2  the number of elements in the 2nd dimension
-    *  @param   n3  the number of elements in the 3rd dimension
-    *  @param   elem the element computation
-    *  @return  An $coll that contains the results of `n1 x n2 x n3` evaluations of `elem`.
-    */
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   elem the element computation
+   *  @return  An $coll that contains the results of `n1 x n2 x n3` evaluations of `elem`.
+   */
   def fill[A, C](n1: Int, n2: Int, n3: Int)(elem: => A)(implicit canAccumulate: AccumulatorFactoryShape[A, C]): AnyAccumulator[AnyAccumulator[C]] =
     fill(n1)(fill(n2, n3)(elem)(using canAccumulate))(using AccumulatorFactoryShape.anyAccumulatorFactoryShape[AnyAccumulator[C]])
 
   /** Produces a four-dimensional $coll containing the results of some element computation a number of times.
-    *  @param   n1  the number of elements in the 1st dimension
-    *  @param   n2  the number of elements in the 2nd dimension
-    *  @param   n3  the number of elements in the 3rd dimension
-    *  @param   n4  the number of elements in the 4th dimension
-    *  @param   elem the element computation
-    *  @return  An $coll that contains the results of `n1 x n2 x n3 x n4` evaluations of `elem`.
-    */
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   elem the element computation
+   *  @return  An $coll that contains the results of `n1 x n2 x n3 x n4` evaluations of `elem`.
+   */
   def fill[A, C](n1: Int, n2: Int, n3: Int, n4: Int)(elem: => A)(implicit canAccumulate: AccumulatorFactoryShape[A, C]): AnyAccumulator[AnyAccumulator[AnyAccumulator[C]]] =
     fill(n1)(fill(n2, n3, n4)(elem)(using canAccumulate))(using AccumulatorFactoryShape.anyAccumulatorFactoryShape[AnyAccumulator[AnyAccumulator[C]]])
 
   /** Produces a five-dimensional $coll containing the results of some element computation a number of times.
-    *  @param   n1  the number of elements in the 1st dimension
-    *  @param   n2  the number of elements in the 2nd dimension
-    *  @param   n3  the number of elements in the 3rd dimension
-    *  @param   n4  the number of elements in the 4th dimension
-    *  @param   n5  the number of elements in the 5th dimension
-    *  @param   elem the element computation
-    *  @return  An $coll that contains the results of `n1 x n2 x n3 x n4 x n5` evaluations of `elem`.
-    */
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   n5  the number of elements in the 5th dimension
+   *  @param   elem the element computation
+   *  @return  An $coll that contains the results of `n1 x n2 x n3 x n4 x n5` evaluations of `elem`.
+   */
   def fill[A, C](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(elem: => A)(implicit canAccumulate: AccumulatorFactoryShape[A, C]): AnyAccumulator[AnyAccumulator[AnyAccumulator[AnyAccumulator[C]]]] =
     fill(n1)(fill(n2, n3, n4, n5)(elem)(using canAccumulate))(using AccumulatorFactoryShape.anyAccumulatorFactoryShape[AnyAccumulator[AnyAccumulator[AnyAccumulator[C]]]])
 
   /** Produces an $coll containing values of a given function over a range of integer values starting from 0.
-    *  @param  n   The number of elements in the $coll
-    *  @param  f   The function computing element values
-    *  @return An $coll consisting of elements `f(0), ..., f(n -1)`
-    */
+   *  @param  n   The number of elements in the $coll
+   *  @param  f   The function computing element values
+   *  @return An $coll consisting of elements `f(0), ..., f(n -1)`
+   */
   def tabulate[A, C](n: Int)(f: Int => A)(implicit canAccumulate: AccumulatorFactoryShape[A, C]): C =
     from(new collection.View.Tabulate(n)(f))
 
   /** Produces a two-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
-    *  @param   n1  the number of elements in the 1st dimension
-    *  @param   n2  the number of elements in the 2nd dimension
-    *  @param   f   The function computing element values
-    *  @return An $coll consisting of elements `f(i1, i2)`
-    *          for `0 <= i1 < n1` and `0 <= i2 < n2`.
-    */
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   f   The function computing element values
+   *  @return An $coll consisting of elements `f(i1, i2)`
+   *          for `0 <= i1 < n1` and `0 <= i2 < n2`.
+   */
   def tabulate[A, C](n1: Int, n2: Int)(f: (Int, Int) => A)(implicit canAccumulate: AccumulatorFactoryShape[A, C]): AnyAccumulator[C] =
     tabulate(n1)(i1 => tabulate(n2)(f(i1, _))(using canAccumulate))(using AccumulatorFactoryShape.anyAccumulatorFactoryShape[C])
 
   /** Produces a three-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
-    *  @param   n1  the number of elements in the 1st dimension
-    *  @param   n2  the number of elements in the 2nd dimension
-    *  @param   n3  the number of elements in the 3rd dimension
-    *  @param   f   The function computing element values
-    *  @return An $coll consisting of elements `f(i1, i2, i3)`
-    *          for `0 <= i1 < n1`, `0 <= i2 < n2`, and `0 <= i3 < n3`.
-    */
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   f   The function computing element values
+   *  @return An $coll consisting of elements `f(i1, i2, i3)`
+   *          for `0 <= i1 < n1`, `0 <= i2 < n2`, and `0 <= i3 < n3`.
+   */
   def tabulate[A, C](n1: Int, n2: Int, n3: Int)(f: (Int, Int, Int) => A)(implicit canAccumulate: AccumulatorFactoryShape[A, C]): AnyAccumulator[AnyAccumulator[C]] =
     tabulate(n1)(i1 => tabulate(n2, n3)(f(i1, _, _))(using canAccumulate))(using AccumulatorFactoryShape.anyAccumulatorFactoryShape[AnyAccumulator[C]])
 
   /** Produces a four-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
-    *  @param   n1  the number of elements in the 1st dimension
-    *  @param   n2  the number of elements in the 2nd dimension
-    *  @param   n3  the number of elements in the 3rd dimension
-    *  @param   n4  the number of elements in the 4th dimension
-    *  @param   f   The function computing element values
-    *  @return An $coll consisting of elements `f(i1, i2, i3, i4)`
-    *          for `0 <= i1 < n1`, `0 <= i2 < n2`, `0 <= i3 < n3`, and `0 <= i4 < n4`.
-    */
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   f   The function computing element values
+   *  @return An $coll consisting of elements `f(i1, i2, i3, i4)`
+   *          for `0 <= i1 < n1`, `0 <= i2 < n2`, `0 <= i3 < n3`, and `0 <= i4 < n4`.
+   */
   def tabulate[A, C](n1: Int, n2: Int, n3: Int, n4: Int)(f: (Int, Int, Int, Int) => A)(implicit canAccumulate: AccumulatorFactoryShape[A, C]): AnyAccumulator[AnyAccumulator[AnyAccumulator[C]]] =
     tabulate(n1)(i1 => tabulate(n2, n3, n4)(f(i1, _, _, _))(using canAccumulate))(using AccumulatorFactoryShape.anyAccumulatorFactoryShape[AnyAccumulator[AnyAccumulator[C]]])
 
   /** Produces a five-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
-    *  @param   n1  the number of elements in the 1st dimension
-    *  @param   n2  the number of elements in the 2nd dimension
-    *  @param   n3  the number of elements in the 3rd dimension
-    *  @param   n4  the number of elements in the 4th dimension
-    *  @param   n5  the number of elements in the 5th dimension
-    *  @param   f   The function computing element values
-    *  @return An $coll consisting of elements `f(i1, i2, i3, i4, i5)`
-    *          for `0 <= i1 < n1`, `0 <= i2 < n2`, `0 <= i3 < n3`, `0 <= i4 < n4`, and `0 <= i5 < n5`.
-    */
+   *  @param   n1  the number of elements in the 1st dimension
+   *  @param   n2  the number of elements in the 2nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
+   *  @param   n4  the number of elements in the 4th dimension
+   *  @param   n5  the number of elements in the 5th dimension
+   *  @param   f   The function computing element values
+   *  @return An $coll consisting of elements `f(i1, i2, i3, i4, i5)`
+   *          for `0 <= i1 < n1`, `0 <= i2 < n2`, `0 <= i3 < n3`, `0 <= i4 < n4`, and `0 <= i5 < n5`.
+   */
   def tabulate[A, C](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(f: (Int, Int, Int, Int, Int) => A)(implicit canAccumulate: AccumulatorFactoryShape[A, C]): AnyAccumulator[AnyAccumulator[AnyAccumulator[AnyAccumulator[C]]]] =
     tabulate(n1)(i1 => tabulate(n2, n3, n4, n5)(f(i1, _, _, _, _))(using canAccumulate))(using AccumulatorFactoryShape.anyAccumulatorFactoryShape[AnyAccumulator[AnyAccumulator[AnyAccumulator[C]]]])
 
@@ -366,8 +364,8 @@ object Accumulator {
     }
 
   /** An implicit `AccumulatorFactoryShape` is used in Accumulator factory method to return
-    * specialized variants according to the element type.
-    */
+   *  specialized variants according to the element type.
+   */
   sealed trait AccumulatorFactoryShape[A, C] {
     def factory: collection.Factory[A, C]
     def empty: C

--- a/library/src/scala/jdk/AnyAccumulator.scala
+++ b/library/src/scala/jdk/AnyAccumulator.scala
@@ -209,9 +209,8 @@ final class AnyAccumulator[A]
     ans
   }
 
-  /**
-   * Copies the elements in this `AnyAccumulator` to a specified collection. Example use:
-   * `acc.to(Vector)`.
+  /** Copies the elements in this `AnyAccumulator` to a specified collection. Example use:
+   *  `acc.to(Vector)`.
    */
   override def to[C1](factory: Factory[A, C1]): C1 = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for a Scala collection: "+totalSize.toString)

--- a/library/src/scala/jdk/CollectionConverters.scala
+++ b/library/src/scala/jdk/CollectionConverters.scala
@@ -23,15 +23,15 @@ import scala.collection.convert.{AsJavaExtensions, AsScalaExtensions}
   * Note: to create [[java.util.stream.Stream Java Streams]] that operate on Scala collections
   * (sequentially or in parallel), use [[StreamConverters]].
   *
-  * {{{
+  * ```
   *   import scala.jdk.CollectionConverters._
   *   val s: java.util.Set[String] = Set("one", "two").asJava
-  * }}}
+  * ```
   *
   * The conversions return adapters for the corresponding API, i.e., the collections are wrapped,
   * not copied. Changes to the original collection are reflected in the view, and vice versa:
   *
-  * {{{
+  * ```
   *   scala> import scala.jdk.CollectionConverters._
   *
   *   scala> val s = collection.mutable.Set("one")
@@ -44,53 +44,53 @@ import scala.collection.convert.{AsJavaExtensions, AsScalaExtensions}
   *
   *   scala> s
   *   res2: scala.collection.mutable.Set[String] = HashSet(two, one)
-  * }}}
+  * ```
   *
   * The following conversions are supported via `asScala` and `asJava`:
   *
-  * {{{
+  * ```
   *   scala.collection.Iterable       <=> java.lang.Iterable
   *   scala.collection.Iterator       <=> java.util.Iterator
   *   scala.collection.mutable.Buffer <=> java.util.List
   *   scala.collection.mutable.Set    <=> java.util.Set
   *   scala.collection.mutable.Map    <=> java.util.Map
   *   scala.collection.concurrent.Map <=> java.util.concurrent.ConcurrentMap
-  * }}}
+  * ```
   *
   * The following conversions are supported via `asScala` and through
   * specially-named extension methods to convert to Java collections, as shown:
   *
-  * {{{
+  * ```
   *   scala.collection.Iterable    <=> java.util.Collection   (via asJavaCollection)
   *   scala.collection.Iterator    <=> java.util.Enumeration  (via asJavaEnumeration)
   *   scala.collection.mutable.Map <=> java.util.Dictionary   (via asJavaDictionary)
-  * }}}
+  * ```
   *
   * In addition, the following one-way conversions are provided via `asJava`:
   *
-  * {{{
+  * ```
   *   scala.collection.Seq         => java.util.List
   *   scala.collection.mutable.Seq => java.util.List
   *   scala.collection.Set         => java.util.Set
   *   scala.collection.Map         => java.util.Map
-  * }}}
+  * ```
   *
   * The following one way conversion is provided via `asScala`:
   *
-  * {{{
+  * ```
   *   java.util.Properties => scala.collection.mutable.Map
-  * }}}
+  * ```
   *
   * In all cases, converting from a source type to a target type and back
   * again will return the original source object. For example:
   *
-  * {{{
+  * ```
   *   import scala.jdk.CollectionConverters._
   *
   *   val source = new scala.collection.mutable.ListBuffer[Int]
   *   val target: java.util.List[Int] = source.asJava
   *   val other: scala.collection.mutable.Buffer[Int] = target.asScala
   *   assert(source eq other)
-  * }}}
+  * ```
   */
 object CollectionConverters extends AsJavaExtensions with AsScalaExtensions

--- a/library/src/scala/jdk/DoubleAccumulator.scala
+++ b/library/src/scala/jdk/DoubleAccumulator.scala
@@ -280,10 +280,9 @@ final class DoubleAccumulator
     ans
   }
 
-  /**
-   * Copies the elements in this `DoubleAccumulator` to a specified collection.
-   * Note that the target collection is not specialized.
-   * Usage example: `acc.to(Vector)`
+  /** Copies the elements in this `DoubleAccumulator` to a specified collection.
+   *  Note that the target collection is not specialized.
+   *  Usage example: `acc.to(Vector)`
    */
   override def to[C1](factory: Factory[Double, C1]): C1 = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for a Scala collection: "+totalSize.toString)

--- a/library/src/scala/jdk/FunctionConverters.scala
+++ b/library/src/scala/jdk/FunctionConverters.scala
@@ -25,30 +25,30 @@ import scala.language.`2.13`
   * Using the `.asJava` extension method on a Scala function produces the most specific possible
   * Java function type:
   *
-  * {{{
+  * ```
   *   scala> import scala.jdk.FunctionConverters._
   *   scala> val f = (x: Int) => x + 1
   *
   *   scala> val jf1 = f.asJava
   *   jf1: java.util.function.IntUnaryOperator = ...
-  * }}}
+  * ```
   *
   * More generic Java function types can be created using the corresponding `asJavaXYZ` extension
   * method:
   *
-  * {{{
+  * ```
   *   scala> val jf2 = f.asJavaFunction
   *   jf2: java.util.function.Function[Int,Int] = ...
   *
   *   scala> val jf3 = f.asJavaUnaryOperator
   *   jf3: java.util.function.UnaryOperator[Int] = ...
-  * }}}
+  * ```
   *
   * Converting a Java function to Scala is done using the `asScala` extension method:
   *
-  * {{{
+  * ```
   *   scala> List(1,2,3).map(jf2.asScala)
   *   res1: List[Int] = List(2, 3, 4)
-  * }}}
+  * ```
   */
 object FunctionConverters extends Priority0FunctionExtensions

--- a/library/src/scala/jdk/IntAccumulator.scala
+++ b/library/src/scala/jdk/IntAccumulator.scala
@@ -286,10 +286,9 @@ final class IntAccumulator
     ans
   }
 
-  /**
-   * Copies the elements in this `IntAccumulator` to a specified collection.
-   * Note that the target collection is not specialized.
-   * Usage example: `acc.to(Vector)`
+  /** Copies the elements in this `IntAccumulator` to a specified collection.
+   *  Note that the target collection is not specialized.
+   *  Usage example: `acc.to(Vector)`
    */
   override def to[C1](factory: Factory[Int, C1]): C1 = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for a Scala collection: "+totalSize.toString)

--- a/library/src/scala/jdk/LongAccumulator.scala
+++ b/library/src/scala/jdk/LongAccumulator.scala
@@ -281,10 +281,9 @@ final class LongAccumulator
     ans
   }
 
-  /**
-   * Copies the elements in this `LongAccumulator` to a specified collection.
-   * Note that the target collection is not specialized.
-   * Usage example: `acc.to(Vector)`
+  /** Copies the elements in this `LongAccumulator` to a specified collection.
+   *  Note that the target collection is not specialized.
+   *  Usage example: `acc.to(Vector)`
    */
   override def to[C1](factory: Factory[Long, C1]): C1 = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for a Scala collection: "+totalSize.toString)

--- a/library/src/scala/jdk/OptionConverters.scala
+++ b/library/src/scala/jdk/OptionConverters.scala
@@ -16,34 +16,34 @@ import scala.language.`2.13`
 import java.util.{Optional, OptionalDouble, OptionalInt, OptionalLong}
 
 /** This object provides extension methods that convert between Scala `Option` and Java `Optional`
-  * types.
-  *
-  * When writing Java code, use the explicit conversion methods defined in
-  * [[javaapi.OptionConverters]] instead.
-  *
-  * Scala `Option` is extended with a `toJava` method that creates a corresponding `Optional`, and
-  * a `toJavaPrimitive` method that creates a specialized variant (e.g., `OptionalInt`) if
-  * applicable.
-  *
-  * Java `Optional` is extended with a `toScala` method and a `toJavaPrimitive` method.
-  *
-  * Finally, specialized `Optional` types are extended with `toScala` and `toJavaGeneric` methods.
-  *
-  * Example usage:
-  *
-  * {{{
-  *   import scala.jdk.OptionConverters._
-  *   val a = Option("example").toJava      // Creates java.util.Optional[String] containing "example"
-  *   val b = (None: Option[String]).toJava // Creates an empty java.util.Optional[String]
-  *   val c = a.toScala                     // Back to Option("example")
-  *   val d = b.toScala                     // Back to None typed as Option[String]
-  *   val e = Option(2.7).toJava            // java.util.Optional[Double] containing boxed 2.7
-  *   val f = Option(2.7).toJavaPrimitive   // java.util.OptionalDouble containing 2.7 (not boxed)
-  *   val g = f.toScala                     // Back to Option(2.7)
-  *   val h = f.toJavaGeneric               // Same as e
-  *   val i = e.toJavaPrimitive             // Same as f
-  * }}}
-  */
+ *  types.
+ *
+ *  When writing Java code, use the explicit conversion methods defined in
+ *  [[javaapi.OptionConverters]] instead.
+ *
+ *  Scala `Option` is extended with a `toJava` method that creates a corresponding `Optional`, and
+ *  a `toJavaPrimitive` method that creates a specialized variant (e.g., `OptionalInt`) if
+ *  applicable.
+ *
+ *  Java `Optional` is extended with a `toScala` method and a `toJavaPrimitive` method.
+ *
+ *  Finally, specialized `Optional` types are extended with `toScala` and `toJavaGeneric` methods.
+ *
+ *  Example usage:
+ *
+ *  ```
+ *   import scala.jdk.OptionConverters._
+ *   val a = Option("example").toJava      // Creates java.util.Optional[String] containing "example"
+ *   val b = (None: Option[String]).toJava // Creates an empty java.util.Optional[String]
+ *   val c = a.toScala                     // Back to Option("example")
+ *   val d = b.toScala                     // Back to None typed as Option[String]
+ *   val e = Option(2.7).toJava            // java.util.Optional[Double] containing boxed 2.7
+ *   val f = Option(2.7).toJavaPrimitive   // java.util.OptionalDouble containing 2.7 (not boxed)
+ *   val g = f.toScala                     // Back to Option(2.7)
+ *   val h = f.toJavaGeneric               // Same as e
+ *   val i = e.toJavaPrimitive             // Same as f
+ *  ```
+ */
 object OptionConverters {
   /** Provides conversions from Java `Optional` to Scala `Option` and specialized `Optional` types. */
   implicit class RichOptional[A](private val o: java.util.Optional[A]) extends AnyVal {

--- a/library/src/scala/jdk/OptionShape.scala
+++ b/library/src/scala/jdk/OptionShape.scala
@@ -19,11 +19,11 @@ import scala.language.`2.13`
 import scala.annotation.implicitNotFound
 
 /** A type class implementing conversions from a generic Scala `Option` or Java `Optional` to
-  * a specialized Java variant (for `Double`, `Int` and `Long`).
-  *
-  * @tparam A the primitive type wrapped in an option
-  * @tparam O the specialized Java `Optional` wrapping an element of type `A`
-  */
+ *  a specialized Java variant (for `Double`, `Int` and `Long`).
+ *
+ *  @tparam A the primitive type wrapped in an option
+ *  @tparam O the specialized Java `Optional` wrapping an element of type `A`
+ */
 @implicitNotFound("No specialized Optional type exists for elements of type ${A}")
 sealed abstract class OptionShape[A, O] {
   /** Converts from `Optional` to the specialized variant `O`. */

--- a/library/src/scala/jdk/StreamConverters.scala
+++ b/library/src/scala/jdk/StreamConverters.scala
@@ -25,7 +25,7 @@ import scala.collection.convert.StreamExtensions
   *
   * The methods `asJavaSeqStream` and `asJavaParStream` convert a collection to a Java Stream:
   *
-  * {{{
+  * ```
   *   scala> import scala.jdk.StreamConverters._
   *
   *   scala> val s = (1 to 10).toList.asJavaSeqStream
@@ -33,18 +33,18 @@ import scala.collection.convert.StreamExtensions
   *
   *   scala> s.map(_ * 2).filter(_ > 5).toScala(List)
   *   res1: List[Int] = List(6, 8, 10, 12, 14, 16, 18, 20)
-  * }}}
+  * ```
   *
   * Note: using parallel streams in the Scala REPL causes deadlocks, see
   * [[https://github.com/scala/bug/issues/9076]]. As a workaround, use `scala -Yrepl-class-based`.
   *
-  * {{{
+  * ```
   *   scala> def isPrime(n: Int): Boolean = !(2 +: (3 to Math.sqrt(n).toInt by 2) exists (n % _ == 0))
   *   isPrime: (n: Int)Boolean
   *
   *   scala> (10000 to 1000000).asJavaParStream.filter(isPrime).toScala(Vector)
   *   res6: scala.collection.immutable.Vector[Int] = Vector(10007, 10009, 10037, 10039, ...
-  * }}}
+  * ```
   *
   * A Java [[Stream]] provides operations on a sequence of elements. Streams are created from
   * [[java.util.Spliterator Spliterators]], which are similar to Iterators with the additional

--- a/library/src/scala/jdk/javaapi/CollectionConverters.scala
+++ b/library/src/scala/jdk/javaapi/CollectionConverters.scala
@@ -24,7 +24,7 @@ import scala.collection.convert.{AsJavaConverters, AsScalaConverters}
   * Note: to create [[java.util.stream.Stream Java Streams]] that operate on Scala collections
   * (sequentially or in parallel), use [[StreamConverters]].
   *
-  * {{{
+  * ```
   *   // Java Code
   *   import scala.jdk.javaapi.CollectionConverters;
   *   public class A {
@@ -32,45 +32,45 @@ import scala.collection.convert.{AsJavaConverters, AsScalaConverters}
   *       java.util.List<String> jl = CollectionConverters.asJava(l);
   *     }
   *   }
-  * }}}
+  * ```
   *
   * The conversions return adapters for the corresponding API, i.e., the collections are wrapped,
   * not copied. Changes to the original collection are reflected in the view, and vice versa.
   *
   * The following conversions are supported via `asScala` and `asJava`:
   *
-  * {{{
+  * ```
   *   scala.collection.Iterable       <=> java.lang.Iterable
   *   scala.collection.Iterator       <=> java.util.Iterator
   *   scala.collection.mutable.Buffer <=> java.util.List
   *   scala.collection.mutable.Set    <=> java.util.Set
   *   scala.collection.mutable.Map    <=> java.util.Map
   *   scala.collection.concurrent.Map <=> java.util.concurrent.ConcurrentMap
-  * }}}
+  * ```
   *
   * The following conversions are supported via `asScala` and through
   * specially-named methods to convert to Java collections, as shown:
   *
-  * {{{
+  * ```
   *   scala.collection.Iterable    <=> java.util.Collection   (via asJavaCollection)
   *   scala.collection.Iterator    <=> java.util.Enumeration  (via asJavaEnumeration)
   *   scala.collection.mutable.Map <=> java.util.Dictionary   (via asJavaDictionary)
-  * }}}
+  * ```
   *
   * In addition, the following one-way conversions are provided via `asJava`:
   *
-  * {{{
+  * ```
   *   scala.collection.Seq         => java.util.List
   *   scala.collection.mutable.Seq => java.util.List
   *   scala.collection.Set         => java.util.Set
   *   scala.collection.Map         => java.util.Map
-  * }}}
+  * ```
   *
   * The following one way conversion is provided via `asScala`:
   *
-  * {{{
+  * ```
   *   java.util.Properties => scala.collection.mutable.Map
-  * }}}
+  * ```
   *
   * In all cases, converting from a source type to a target type and back
   * again will return the original source object.

--- a/library/src/scala/jdk/javaapi/DurationConverters.scala
+++ b/library/src/scala/jdk/javaapi/DurationConverters.scala
@@ -20,18 +20,18 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
 /** This object contains methods that convert between Scala and Java duration types.
-  *
-  * The explicit conversion methods defined here are intended to be used in Java code. For Scala
-  * code, it is recommended to use the extension methods defined in [[scala.jdk.DurationConverters]].
-  */
+ *
+ *  The explicit conversion methods defined here are intended to be used in Java code. For Scala
+ *  code, it is recommended to use the extension methods defined in [[scala.jdk.DurationConverters]].
+ */
 object  DurationConverters {
   /** Converts a Java duration to a Scala duration. If the nanosecond part of the Java duration is
-    * zero, the returned duration will have a time unit of seconds. If there is a nanoseconds part,
-    * the Scala duration will have a time unit of nanoseconds.
-    *
-    * @throws IllegalArgumentException If the given Java Duration is out of bounds of what can be
-    *                                  expressed by [[scala.concurrent.duration.FiniteDuration]].
-    */
+   *  zero, the returned duration will have a time unit of seconds. If there is a nanoseconds part,
+   *  the Scala duration will have a time unit of nanoseconds.
+   *
+   *  @throws IllegalArgumentException If the given Java Duration is out of bounds of what can be
+   *                                  expressed by [[scala.concurrent.duration.FiniteDuration]].
+   */
   def toScala(duration: JDuration): FiniteDuration = {
     val originalSeconds = duration.getSeconds
     val originalNanos = duration.getNano
@@ -56,9 +56,9 @@ object  DurationConverters {
   }
 
   /** Converts a Scala `FiniteDuration` to a Java duration. Note that the Scala duration keeps the
-    * time unit it was created with, while a Java duration always is a pair of seconds and nanos,
-    * so the unit it lost.
-    */
+   *  time unit it was created with, while a Java duration always is a pair of seconds and nanos,
+   *  so the unit it lost.
+   */
   def toJava(duration: FiniteDuration): JDuration = {
     if (duration.length == 0) JDuration.ZERO
     else duration.unit match {

--- a/library/src/scala/jdk/javaapi/FunctionConverters.scala
+++ b/library/src/scala/jdk/javaapi/FunctionConverters.scala
@@ -18,33 +18,32 @@ package scala.jdk.javaapi
 import scala.language.`2.13`
 
 /** This object contains methods that convert between Scala and Java function types.
-  *
-  * The explicit conversion methods defined here are intended to be used in Java code. For Scala
-  * code, it is recommended to use the extension methods defined in [[scala.jdk.FunctionConverters]].
-  *
-  * For details how the function converters work, see [[scala.jdk.FunctionConverters]].
-  *
-  */
+ *
+ *  The explicit conversion methods defined here are intended to be used in Java code. For Scala
+ *  code, it is recommended to use the extension methods defined in [[scala.jdk.FunctionConverters]].
+ *
+ *  For details how the function converters work, see [[scala.jdk.FunctionConverters]].
+ */
 object FunctionConverters {
   import scala.jdk.FunctionWrappers._
 
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromBiConsumer[T, U](jf: java.util.function.BiConsumer[T, U]): scala.Function2[T, U, scala.runtime.BoxedUnit] = jf match {
     case AsJavaBiConsumer((f @ _)) => f.asInstanceOf[scala.Function2[T, U, scala.runtime.BoxedUnit]]
     case _ => new FromJavaBiConsumer[T, U](jf).asInstanceOf[scala.Function2[T, U, scala.runtime.BoxedUnit]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaBiConsumer[T, U](sf: scala.Function2[T, U, scala.runtime.BoxedUnit]): java.util.function.BiConsumer[T, U] = ((sf): AnyRef) match {
     case FromJavaBiConsumer((f @ _)) => f.asInstanceOf[java.util.function.BiConsumer[T, U]]
     case _ => new AsJavaBiConsumer[T, U](sf.asInstanceOf[scala.Function2[T, U, Unit]])
@@ -63,22 +62,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromBiPredicate[T, U](jf: java.util.function.BiPredicate[T, U]): scala.Function2[T, U, java.lang.Boolean] = jf match {
     case AsJavaBiPredicate((f @ _)) => f.asInstanceOf[scala.Function2[T, U, java.lang.Boolean]]
     case _ => new FromJavaBiPredicate[T, U](jf).asInstanceOf[scala.Function2[T, U, java.lang.Boolean]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaBiPredicate[T, U](sf: scala.Function2[T, U, java.lang.Boolean]): java.util.function.BiPredicate[T, U] = ((sf): AnyRef) match {
     case FromJavaBiPredicate((f @ _)) => f.asInstanceOf[java.util.function.BiPredicate[T, U]]
     case _ => new AsJavaBiPredicate[T, U](sf.asInstanceOf[scala.Function2[T, U, Boolean]])
@@ -97,22 +96,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromBooleanSupplier(jf: java.util.function.BooleanSupplier): scala.Function0[java.lang.Boolean] = jf match {
     case AsJavaBooleanSupplier((f @ _)) => f.asInstanceOf[scala.Function0[java.lang.Boolean]]
     case _ => new FromJavaBooleanSupplier(jf).asInstanceOf[scala.Function0[java.lang.Boolean]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaBooleanSupplier(sf: scala.Function0[java.lang.Boolean]): java.util.function.BooleanSupplier = ((sf): AnyRef) match {
     case FromJavaBooleanSupplier((f @ _)) => f.asInstanceOf[java.util.function.BooleanSupplier]
     case _ => new AsJavaBooleanSupplier(sf.asInstanceOf[scala.Function0[Boolean]])
@@ -120,22 +119,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromConsumer[T](jf: java.util.function.Consumer[T]): scala.Function1[T, scala.runtime.BoxedUnit] = jf match {
     case AsJavaConsumer((f @ _)) => f.asInstanceOf[scala.Function1[T, scala.runtime.BoxedUnit]]
     case _ => new FromJavaConsumer[T](jf).asInstanceOf[scala.Function1[T, scala.runtime.BoxedUnit]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaConsumer[T](sf: scala.Function1[T, scala.runtime.BoxedUnit]): java.util.function.Consumer[T] = ((sf): AnyRef) match {
     case FromJavaConsumer((f @ _)) => f.asInstanceOf[java.util.function.Consumer[T]]
     case _ => new AsJavaConsumer[T](sf.asInstanceOf[scala.Function1[T, Unit]])
@@ -143,22 +142,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromDoubleBinaryOperator(jf: java.util.function.DoubleBinaryOperator): scala.Function2[java.lang.Double, java.lang.Double, java.lang.Double] = jf match {
     case AsJavaDoubleBinaryOperator((f @ _)) => f.asInstanceOf[scala.Function2[java.lang.Double, java.lang.Double, java.lang.Double]]
     case _ => new FromJavaDoubleBinaryOperator(jf).asInstanceOf[scala.Function2[java.lang.Double, java.lang.Double, java.lang.Double]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaDoubleBinaryOperator(sf: scala.Function2[java.lang.Double, java.lang.Double, java.lang.Double]): java.util.function.DoubleBinaryOperator = ((sf): AnyRef) match {
     case FromJavaDoubleBinaryOperator((f @ _)) => f.asInstanceOf[java.util.function.DoubleBinaryOperator]
     case _ => new AsJavaDoubleBinaryOperator(sf.asInstanceOf[scala.Function2[Double, Double, Double]])
@@ -166,22 +165,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromDoubleConsumer(jf: java.util.function.DoubleConsumer): scala.Function1[java.lang.Double, scala.runtime.BoxedUnit] = jf match {
     case AsJavaDoubleConsumer((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Double, scala.runtime.BoxedUnit]]
     case _ => new FromJavaDoubleConsumer(jf).asInstanceOf[scala.Function1[java.lang.Double, scala.runtime.BoxedUnit]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaDoubleConsumer(sf: scala.Function1[java.lang.Double, scala.runtime.BoxedUnit]): java.util.function.DoubleConsumer = ((sf): AnyRef) match {
     case FromJavaDoubleConsumer((f @ _)) => f.asInstanceOf[java.util.function.DoubleConsumer]
     case _ => new AsJavaDoubleConsumer(sf.asInstanceOf[scala.Function1[Double, Unit]])
@@ -189,22 +188,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromDoubleFunction[R](jf: java.util.function.DoubleFunction[R]): scala.Function1[java.lang.Double, R] = jf match {
     case AsJavaDoubleFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Double, R]]
     case _ => new FromJavaDoubleFunction[R](jf).asInstanceOf[scala.Function1[java.lang.Double, R]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaDoubleFunction[R](sf: scala.Function1[java.lang.Double, R]): java.util.function.DoubleFunction[R] = ((sf): AnyRef) match {
     case FromJavaDoubleFunction((f @ _)) => f.asInstanceOf[java.util.function.DoubleFunction[R]]
     case _ => new AsJavaDoubleFunction[R](sf.asInstanceOf[scala.Function1[Double, R]])
@@ -212,22 +211,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromDoublePredicate(jf: java.util.function.DoublePredicate): scala.Function1[java.lang.Double, java.lang.Boolean] = jf match {
     case AsJavaDoublePredicate((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Double, java.lang.Boolean]]
     case _ => new FromJavaDoublePredicate(jf).asInstanceOf[scala.Function1[java.lang.Double, java.lang.Boolean]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaDoublePredicate(sf: scala.Function1[java.lang.Double, java.lang.Boolean]): java.util.function.DoublePredicate = ((sf): AnyRef) match {
     case FromJavaDoublePredicate((f @ _)) => f.asInstanceOf[java.util.function.DoublePredicate]
     case _ => new AsJavaDoublePredicate(sf.asInstanceOf[scala.Function1[Double, Boolean]])
@@ -235,22 +234,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromDoubleSupplier(jf: java.util.function.DoubleSupplier): scala.Function0[java.lang.Double] = jf match {
     case AsJavaDoubleSupplier((f @ _)) => f.asInstanceOf[scala.Function0[java.lang.Double]]
     case _ => new FromJavaDoubleSupplier(jf).asInstanceOf[scala.Function0[java.lang.Double]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaDoubleSupplier(sf: scala.Function0[java.lang.Double]): java.util.function.DoubleSupplier = ((sf): AnyRef) match {
     case FromJavaDoubleSupplier((f @ _)) => f.asInstanceOf[java.util.function.DoubleSupplier]
     case _ => new AsJavaDoubleSupplier(sf.asInstanceOf[scala.Function0[Double]])
@@ -258,22 +257,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromDoubleToIntFunction(jf: java.util.function.DoubleToIntFunction): scala.Function1[java.lang.Double, java.lang.Integer] = jf match {
     case AsJavaDoubleToIntFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Double, java.lang.Integer]]
     case _ => new FromJavaDoubleToIntFunction(jf).asInstanceOf[scala.Function1[java.lang.Double, java.lang.Integer]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaDoubleToIntFunction(sf: scala.Function1[java.lang.Double, java.lang.Integer]): java.util.function.DoubleToIntFunction = ((sf): AnyRef) match {
     case FromJavaDoubleToIntFunction((f @ _)) => f.asInstanceOf[java.util.function.DoubleToIntFunction]
     case _ => new AsJavaDoubleToIntFunction(sf.asInstanceOf[scala.Function1[Double, Int]])
@@ -281,22 +280,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromDoubleToLongFunction(jf: java.util.function.DoubleToLongFunction): scala.Function1[java.lang.Double, java.lang.Long] = jf match {
     case AsJavaDoubleToLongFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Double, java.lang.Long]]
     case _ => new FromJavaDoubleToLongFunction(jf).asInstanceOf[scala.Function1[java.lang.Double, java.lang.Long]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaDoubleToLongFunction(sf: scala.Function1[java.lang.Double, java.lang.Long]): java.util.function.DoubleToLongFunction = ((sf): AnyRef) match {
     case FromJavaDoubleToLongFunction((f @ _)) => f.asInstanceOf[java.util.function.DoubleToLongFunction]
     case _ => new AsJavaDoubleToLongFunction(sf.asInstanceOf[scala.Function1[Double, Long]])
@@ -304,22 +303,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromDoubleUnaryOperator(jf: java.util.function.DoubleUnaryOperator): scala.Function1[java.lang.Double, java.lang.Double] = jf match {
     case AsJavaDoubleUnaryOperator((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Double, java.lang.Double]]
     case _ => new FromJavaDoubleUnaryOperator(jf).asInstanceOf[scala.Function1[java.lang.Double, java.lang.Double]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaDoubleUnaryOperator(sf: scala.Function1[java.lang.Double, java.lang.Double]): java.util.function.DoubleUnaryOperator = ((sf): AnyRef) match {
     case FromJavaDoubleUnaryOperator((f @ _)) => f.asInstanceOf[java.util.function.DoubleUnaryOperator]
     case _ => new AsJavaDoubleUnaryOperator(sf.asInstanceOf[scala.Function1[Double, Double]])
@@ -338,22 +337,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromIntBinaryOperator(jf: java.util.function.IntBinaryOperator): scala.Function2[java.lang.Integer, java.lang.Integer, java.lang.Integer] = jf match {
     case AsJavaIntBinaryOperator((f @ _)) => f.asInstanceOf[scala.Function2[java.lang.Integer, java.lang.Integer, java.lang.Integer]]
     case _ => new FromJavaIntBinaryOperator(jf).asInstanceOf[scala.Function2[java.lang.Integer, java.lang.Integer, java.lang.Integer]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaIntBinaryOperator(sf: scala.Function2[java.lang.Integer, java.lang.Integer, java.lang.Integer]): java.util.function.IntBinaryOperator = ((sf): AnyRef) match {
     case FromJavaIntBinaryOperator((f @ _)) => f.asInstanceOf[java.util.function.IntBinaryOperator]
     case _ => new AsJavaIntBinaryOperator(sf.asInstanceOf[scala.Function2[Int, Int, Int]])
@@ -361,22 +360,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromIntConsumer(jf: java.util.function.IntConsumer): scala.Function1[java.lang.Integer, scala.runtime.BoxedUnit] = jf match {
     case AsJavaIntConsumer((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Integer, scala.runtime.BoxedUnit]]
     case _ => new FromJavaIntConsumer(jf).asInstanceOf[scala.Function1[java.lang.Integer, scala.runtime.BoxedUnit]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaIntConsumer(sf: scala.Function1[java.lang.Integer, scala.runtime.BoxedUnit]): java.util.function.IntConsumer = ((sf): AnyRef) match {
     case FromJavaIntConsumer((f @ _)) => f.asInstanceOf[java.util.function.IntConsumer]
     case _ => new AsJavaIntConsumer(sf.asInstanceOf[scala.Function1[Int, Unit]])
@@ -384,22 +383,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromIntFunction[R](jf: java.util.function.IntFunction[R]): scala.Function1[java.lang.Integer, R] = jf match {
     case AsJavaIntFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Integer, R]]
     case _ => new FromJavaIntFunction[R](jf).asInstanceOf[scala.Function1[java.lang.Integer, R]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaIntFunction[R](sf: scala.Function1[java.lang.Integer, R]): java.util.function.IntFunction[R] = ((sf): AnyRef) match {
     case FromJavaIntFunction((f @ _)) => f.asInstanceOf[java.util.function.IntFunction[R]]
     case _ => new AsJavaIntFunction[R](sf.asInstanceOf[scala.Function1[Int, R]])
@@ -407,22 +406,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromIntPredicate(jf: java.util.function.IntPredicate): scala.Function1[java.lang.Integer, java.lang.Boolean] = jf match {
     case AsJavaIntPredicate((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Integer, java.lang.Boolean]]
     case _ => new FromJavaIntPredicate(jf).asInstanceOf[scala.Function1[java.lang.Integer, java.lang.Boolean]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaIntPredicate(sf: scala.Function1[java.lang.Integer, java.lang.Boolean]): java.util.function.IntPredicate = ((sf): AnyRef) match {
     case FromJavaIntPredicate((f @ _)) => f.asInstanceOf[java.util.function.IntPredicate]
     case _ => new AsJavaIntPredicate(sf.asInstanceOf[scala.Function1[Int, Boolean]])
@@ -430,22 +429,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromIntSupplier(jf: java.util.function.IntSupplier): scala.Function0[java.lang.Integer] = jf match {
     case AsJavaIntSupplier((f @ _)) => f.asInstanceOf[scala.Function0[java.lang.Integer]]
     case _ => new FromJavaIntSupplier(jf).asInstanceOf[scala.Function0[java.lang.Integer]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaIntSupplier(sf: scala.Function0[java.lang.Integer]): java.util.function.IntSupplier = ((sf): AnyRef) match {
     case FromJavaIntSupplier((f @ _)) => f.asInstanceOf[java.util.function.IntSupplier]
     case _ => new AsJavaIntSupplier(sf.asInstanceOf[scala.Function0[Int]])
@@ -453,22 +452,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromIntToDoubleFunction(jf: java.util.function.IntToDoubleFunction): scala.Function1[java.lang.Integer, java.lang.Double] = jf match {
     case AsJavaIntToDoubleFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Integer, java.lang.Double]]
     case _ => new FromJavaIntToDoubleFunction(jf).asInstanceOf[scala.Function1[java.lang.Integer, java.lang.Double]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaIntToDoubleFunction(sf: scala.Function1[java.lang.Integer, java.lang.Double]): java.util.function.IntToDoubleFunction = ((sf): AnyRef) match {
     case FromJavaIntToDoubleFunction((f @ _)) => f.asInstanceOf[java.util.function.IntToDoubleFunction]
     case _ => new AsJavaIntToDoubleFunction(sf.asInstanceOf[scala.Function1[Int, Double]])
@@ -476,22 +475,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromIntToLongFunction(jf: java.util.function.IntToLongFunction): scala.Function1[java.lang.Integer, java.lang.Long] = jf match {
     case AsJavaIntToLongFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Integer, java.lang.Long]]
     case _ => new FromJavaIntToLongFunction(jf).asInstanceOf[scala.Function1[java.lang.Integer, java.lang.Long]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaIntToLongFunction(sf: scala.Function1[java.lang.Integer, java.lang.Long]): java.util.function.IntToLongFunction = ((sf): AnyRef) match {
     case FromJavaIntToLongFunction((f @ _)) => f.asInstanceOf[java.util.function.IntToLongFunction]
     case _ => new AsJavaIntToLongFunction(sf.asInstanceOf[scala.Function1[Int, Long]])
@@ -499,22 +498,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromIntUnaryOperator(jf: java.util.function.IntUnaryOperator): scala.Function1[java.lang.Integer, java.lang.Integer] = jf match {
     case AsJavaIntUnaryOperator((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Integer, java.lang.Integer]]
     case _ => new FromJavaIntUnaryOperator(jf).asInstanceOf[scala.Function1[java.lang.Integer, java.lang.Integer]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaIntUnaryOperator(sf: scala.Function1[java.lang.Integer, java.lang.Integer]): java.util.function.IntUnaryOperator = ((sf): AnyRef) match {
     case FromJavaIntUnaryOperator((f @ _)) => f.asInstanceOf[java.util.function.IntUnaryOperator]
     case _ => new AsJavaIntUnaryOperator(sf.asInstanceOf[scala.Function1[Int, Int]])
@@ -522,22 +521,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromLongBinaryOperator(jf: java.util.function.LongBinaryOperator): scala.Function2[java.lang.Long, java.lang.Long, java.lang.Long] = jf match {
     case AsJavaLongBinaryOperator((f @ _)) => f.asInstanceOf[scala.Function2[java.lang.Long, java.lang.Long, java.lang.Long]]
     case _ => new FromJavaLongBinaryOperator(jf).asInstanceOf[scala.Function2[java.lang.Long, java.lang.Long, java.lang.Long]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaLongBinaryOperator(sf: scala.Function2[java.lang.Long, java.lang.Long, java.lang.Long]): java.util.function.LongBinaryOperator = ((sf): AnyRef) match {
     case FromJavaLongBinaryOperator((f @ _)) => f.asInstanceOf[java.util.function.LongBinaryOperator]
     case _ => new AsJavaLongBinaryOperator(sf.asInstanceOf[scala.Function2[Long, Long, Long]])
@@ -545,22 +544,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromLongConsumer(jf: java.util.function.LongConsumer): scala.Function1[java.lang.Long, scala.runtime.BoxedUnit] = jf match {
     case AsJavaLongConsumer((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Long, scala.runtime.BoxedUnit]]
     case _ => new FromJavaLongConsumer(jf).asInstanceOf[scala.Function1[java.lang.Long, scala.runtime.BoxedUnit]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaLongConsumer(sf: scala.Function1[java.lang.Long, scala.runtime.BoxedUnit]): java.util.function.LongConsumer = ((sf): AnyRef) match {
     case FromJavaLongConsumer((f @ _)) => f.asInstanceOf[java.util.function.LongConsumer]
     case _ => new AsJavaLongConsumer(sf.asInstanceOf[scala.Function1[Long, Unit]])
@@ -568,22 +567,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromLongFunction[R](jf: java.util.function.LongFunction[R]): scala.Function1[java.lang.Long, R] = jf match {
     case AsJavaLongFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Long, R]]
     case _ => new FromJavaLongFunction[R](jf).asInstanceOf[scala.Function1[java.lang.Long, R]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaLongFunction[R](sf: scala.Function1[java.lang.Long, R]): java.util.function.LongFunction[R] = ((sf): AnyRef) match {
     case FromJavaLongFunction((f @ _)) => f.asInstanceOf[java.util.function.LongFunction[R]]
     case _ => new AsJavaLongFunction[R](sf.asInstanceOf[scala.Function1[Long, R]])
@@ -591,22 +590,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromLongPredicate(jf: java.util.function.LongPredicate): scala.Function1[java.lang.Long, java.lang.Boolean] = jf match {
     case AsJavaLongPredicate((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Long, java.lang.Boolean]]
     case _ => new FromJavaLongPredicate(jf).asInstanceOf[scala.Function1[java.lang.Long, java.lang.Boolean]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaLongPredicate(sf: scala.Function1[java.lang.Long, java.lang.Boolean]): java.util.function.LongPredicate = ((sf): AnyRef) match {
     case FromJavaLongPredicate((f @ _)) => f.asInstanceOf[java.util.function.LongPredicate]
     case _ => new AsJavaLongPredicate(sf.asInstanceOf[scala.Function1[Long, Boolean]])
@@ -614,22 +613,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromLongSupplier(jf: java.util.function.LongSupplier): scala.Function0[java.lang.Long] = jf match {
     case AsJavaLongSupplier((f @ _)) => f.asInstanceOf[scala.Function0[java.lang.Long]]
     case _ => new FromJavaLongSupplier(jf).asInstanceOf[scala.Function0[java.lang.Long]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaLongSupplier(sf: scala.Function0[java.lang.Long]): java.util.function.LongSupplier = ((sf): AnyRef) match {
     case FromJavaLongSupplier((f @ _)) => f.asInstanceOf[java.util.function.LongSupplier]
     case _ => new AsJavaLongSupplier(sf.asInstanceOf[scala.Function0[Long]])
@@ -637,22 +636,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromLongToDoubleFunction(jf: java.util.function.LongToDoubleFunction): scala.Function1[java.lang.Long, java.lang.Double] = jf match {
     case AsJavaLongToDoubleFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Long, java.lang.Double]]
     case _ => new FromJavaLongToDoubleFunction(jf).asInstanceOf[scala.Function1[java.lang.Long, java.lang.Double]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaLongToDoubleFunction(sf: scala.Function1[java.lang.Long, java.lang.Double]): java.util.function.LongToDoubleFunction = ((sf): AnyRef) match {
     case FromJavaLongToDoubleFunction((f @ _)) => f.asInstanceOf[java.util.function.LongToDoubleFunction]
     case _ => new AsJavaLongToDoubleFunction(sf.asInstanceOf[scala.Function1[Long, Double]])
@@ -660,22 +659,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromLongToIntFunction(jf: java.util.function.LongToIntFunction): scala.Function1[java.lang.Long, java.lang.Integer] = jf match {
     case AsJavaLongToIntFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Long, java.lang.Integer]]
     case _ => new FromJavaLongToIntFunction(jf).asInstanceOf[scala.Function1[java.lang.Long, java.lang.Integer]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaLongToIntFunction(sf: scala.Function1[java.lang.Long, java.lang.Integer]): java.util.function.LongToIntFunction = ((sf): AnyRef) match {
     case FromJavaLongToIntFunction((f @ _)) => f.asInstanceOf[java.util.function.LongToIntFunction]
     case _ => new AsJavaLongToIntFunction(sf.asInstanceOf[scala.Function1[Long, Int]])
@@ -683,22 +682,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromLongUnaryOperator(jf: java.util.function.LongUnaryOperator): scala.Function1[java.lang.Long, java.lang.Long] = jf match {
     case AsJavaLongUnaryOperator((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Long, java.lang.Long]]
     case _ => new FromJavaLongUnaryOperator(jf).asInstanceOf[scala.Function1[java.lang.Long, java.lang.Long]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaLongUnaryOperator(sf: scala.Function1[java.lang.Long, java.lang.Long]): java.util.function.LongUnaryOperator = ((sf): AnyRef) match {
     case FromJavaLongUnaryOperator((f @ _)) => f.asInstanceOf[java.util.function.LongUnaryOperator]
     case _ => new AsJavaLongUnaryOperator(sf.asInstanceOf[scala.Function1[Long, Long]])
@@ -706,22 +705,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromObjDoubleConsumer[T](jf: java.util.function.ObjDoubleConsumer[T]): scala.Function2[T, java.lang.Double, scala.runtime.BoxedUnit] = jf match {
     case AsJavaObjDoubleConsumer((f @ _)) => f.asInstanceOf[scala.Function2[T, java.lang.Double, scala.runtime.BoxedUnit]]
     case _ => new FromJavaObjDoubleConsumer[T](jf).asInstanceOf[scala.Function2[T, java.lang.Double, scala.runtime.BoxedUnit]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaObjDoubleConsumer[T](sf: scala.Function2[T, java.lang.Double, scala.runtime.BoxedUnit]): java.util.function.ObjDoubleConsumer[T] = ((sf): AnyRef) match {
     case FromJavaObjDoubleConsumer((f @ _)) => f.asInstanceOf[java.util.function.ObjDoubleConsumer[T]]
     case _ => new AsJavaObjDoubleConsumer[T](sf.asInstanceOf[scala.Function2[T, Double, Unit]])
@@ -729,22 +728,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromObjIntConsumer[T](jf: java.util.function.ObjIntConsumer[T]): scala.Function2[T, java.lang.Integer, scala.runtime.BoxedUnit] = jf match {
     case AsJavaObjIntConsumer((f @ _)) => f.asInstanceOf[scala.Function2[T, java.lang.Integer, scala.runtime.BoxedUnit]]
     case _ => new FromJavaObjIntConsumer[T](jf).asInstanceOf[scala.Function2[T, java.lang.Integer, scala.runtime.BoxedUnit]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaObjIntConsumer[T](sf: scala.Function2[T, java.lang.Integer, scala.runtime.BoxedUnit]): java.util.function.ObjIntConsumer[T] = ((sf): AnyRef) match {
     case FromJavaObjIntConsumer((f @ _)) => f.asInstanceOf[java.util.function.ObjIntConsumer[T]]
     case _ => new AsJavaObjIntConsumer[T](sf.asInstanceOf[scala.Function2[T, Int, Unit]])
@@ -752,22 +751,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromObjLongConsumer[T](jf: java.util.function.ObjLongConsumer[T]): scala.Function2[T, java.lang.Long, scala.runtime.BoxedUnit] = jf match {
     case AsJavaObjLongConsumer((f @ _)) => f.asInstanceOf[scala.Function2[T, java.lang.Long, scala.runtime.BoxedUnit]]
     case _ => new FromJavaObjLongConsumer[T](jf).asInstanceOf[scala.Function2[T, java.lang.Long, scala.runtime.BoxedUnit]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaObjLongConsumer[T](sf: scala.Function2[T, java.lang.Long, scala.runtime.BoxedUnit]): java.util.function.ObjLongConsumer[T] = ((sf): AnyRef) match {
     case FromJavaObjLongConsumer((f @ _)) => f.asInstanceOf[java.util.function.ObjLongConsumer[T]]
     case _ => new AsJavaObjLongConsumer[T](sf.asInstanceOf[scala.Function2[T, Long, Unit]])
@@ -775,22 +774,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromPredicate[T](jf: java.util.function.Predicate[T]): scala.Function1[T, java.lang.Boolean] = jf match {
     case AsJavaPredicate((f @ _)) => f.asInstanceOf[scala.Function1[T, java.lang.Boolean]]
     case _ => new FromJavaPredicate[T](jf).asInstanceOf[scala.Function1[T, java.lang.Boolean]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaPredicate[T](sf: scala.Function1[T, java.lang.Boolean]): java.util.function.Predicate[T] = ((sf): AnyRef) match {
     case FromJavaPredicate((f @ _)) => f.asInstanceOf[java.util.function.Predicate[T]]
     case _ => new AsJavaPredicate[T](sf.asInstanceOf[scala.Function1[T, Boolean]])
@@ -809,22 +808,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromToDoubleBiFunction[T, U](jf: java.util.function.ToDoubleBiFunction[T, U]): scala.Function2[T, U, java.lang.Double] = jf match {
     case AsJavaToDoubleBiFunction((f @ _)) => f.asInstanceOf[scala.Function2[T, U, java.lang.Double]]
     case _ => new FromJavaToDoubleBiFunction[T, U](jf).asInstanceOf[scala.Function2[T, U, java.lang.Double]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaToDoubleBiFunction[T, U](sf: scala.Function2[T, U, java.lang.Double]): java.util.function.ToDoubleBiFunction[T, U] = ((sf): AnyRef) match {
     case FromJavaToDoubleBiFunction((f @ _)) => f.asInstanceOf[java.util.function.ToDoubleBiFunction[T, U]]
     case _ => new AsJavaToDoubleBiFunction[T, U](sf.asInstanceOf[scala.Function2[T, U, Double]])
@@ -832,22 +831,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromToDoubleFunction[T](jf: java.util.function.ToDoubleFunction[T]): scala.Function1[T, java.lang.Double] = jf match {
     case AsJavaToDoubleFunction((f @ _)) => f.asInstanceOf[scala.Function1[T, java.lang.Double]]
     case _ => new FromJavaToDoubleFunction[T](jf).asInstanceOf[scala.Function1[T, java.lang.Double]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaToDoubleFunction[T](sf: scala.Function1[T, java.lang.Double]): java.util.function.ToDoubleFunction[T] = ((sf): AnyRef) match {
     case FromJavaToDoubleFunction((f @ _)) => f.asInstanceOf[java.util.function.ToDoubleFunction[T]]
     case _ => new AsJavaToDoubleFunction[T](sf.asInstanceOf[scala.Function1[T, Double]])
@@ -855,22 +854,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromToIntBiFunction[T, U](jf: java.util.function.ToIntBiFunction[T, U]): scala.Function2[T, U, java.lang.Integer] = jf match {
     case AsJavaToIntBiFunction((f @ _)) => f.asInstanceOf[scala.Function2[T, U, java.lang.Integer]]
     case _ => new FromJavaToIntBiFunction[T, U](jf).asInstanceOf[scala.Function2[T, U, java.lang.Integer]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaToIntBiFunction[T, U](sf: scala.Function2[T, U, java.lang.Integer]): java.util.function.ToIntBiFunction[T, U] = ((sf): AnyRef) match {
     case FromJavaToIntBiFunction((f @ _)) => f.asInstanceOf[java.util.function.ToIntBiFunction[T, U]]
     case _ => new AsJavaToIntBiFunction[T, U](sf.asInstanceOf[scala.Function2[T, U, Int]])
@@ -878,22 +877,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromToIntFunction[T](jf: java.util.function.ToIntFunction[T]): scala.Function1[T, java.lang.Integer] = jf match {
     case AsJavaToIntFunction((f @ _)) => f.asInstanceOf[scala.Function1[T, java.lang.Integer]]
     case _ => new FromJavaToIntFunction[T](jf).asInstanceOf[scala.Function1[T, java.lang.Integer]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaToIntFunction[T](sf: scala.Function1[T, java.lang.Integer]): java.util.function.ToIntFunction[T] = ((sf): AnyRef) match {
     case FromJavaToIntFunction((f @ _)) => f.asInstanceOf[java.util.function.ToIntFunction[T]]
     case _ => new AsJavaToIntFunction[T](sf.asInstanceOf[scala.Function1[T, Int]])
@@ -901,22 +900,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromToLongBiFunction[T, U](jf: java.util.function.ToLongBiFunction[T, U]): scala.Function2[T, U, java.lang.Long] = jf match {
     case AsJavaToLongBiFunction((f @ _)) => f.asInstanceOf[scala.Function2[T, U, java.lang.Long]]
     case _ => new FromJavaToLongBiFunction[T, U](jf).asInstanceOf[scala.Function2[T, U, java.lang.Long]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaToLongBiFunction[T, U](sf: scala.Function2[T, U, java.lang.Long]): java.util.function.ToLongBiFunction[T, U] = ((sf): AnyRef) match {
     case FromJavaToLongBiFunction((f @ _)) => f.asInstanceOf[java.util.function.ToLongBiFunction[T, U]]
     case _ => new AsJavaToLongBiFunction[T, U](sf.asInstanceOf[scala.Function2[T, U, Long]])
@@ -924,22 +923,22 @@ object FunctionConverters {
   
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asScalaFromToLongFunction[T](jf: java.util.function.ToLongFunction[T]): scala.Function1[T, java.lang.Long] = jf match {
     case AsJavaToLongFunction((f @ _)) => f.asInstanceOf[scala.Function1[T, java.lang.Long]]
     case _ => new FromJavaToLongFunction[T](jf).asInstanceOf[scala.Function1[T, java.lang.Long]]
   }
   
   /** Note: this method uses the boxed type `java.lang.X` (or `BoxedUnit`) instead of the
-    * primitive type `scala.X` to improve compatibility when using it in Java code (the
-    * Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
-    * [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In Scala code, add
-    * `import scala.jdk.FunctionConverters._` and use the extension methods instead.
-    */
+   *  primitive type `scala.X` to improve compatibility when using it in Java code (the
+   *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
+   *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
+   *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   */
   @inline def asJavaToLongFunction[T](sf: scala.Function1[T, java.lang.Long]): java.util.function.ToLongFunction[T] = ((sf): AnyRef) match {
     case FromJavaToLongFunction((f @ _)) => f.asInstanceOf[java.util.function.ToLongFunction[T]]
     case _ => new AsJavaToLongFunction[T](sf.asInstanceOf[scala.Function1[T, Long]])

--- a/library/src/scala/jdk/javaapi/FutureConverters.scala
+++ b/library/src/scala/jdk/javaapi/FutureConverters.scala
@@ -19,32 +19,32 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Success
 
 /** This object contains methods that convert between Scala [[scala.concurrent.Future]] and Java [[java.util.concurrent.CompletionStage]].
-  *
-  * The explicit conversion methods defined here are intended to be used in Java code. For Scala
-  * code, it is recommended to use the extension methods defined in [[scala.jdk.FutureConverters]].
-  *
-  * Note that the bridge is implemented at the read-only side of asynchronous handles, namely
-  * [[scala.concurrent.Future]] (instead of [[scala.concurrent.Promise]]) and [[java.util.concurrent.CompletionStage]] (instead of
-  * [[java.util.concurrent.CompletableFuture]]). This is intentional, as the semantics of bridging
-  * the write-handles would be prone to race conditions; if both ends (`CompletableFuture` and
-  * `Promise`) are completed independently at the same time, they may contain different values
-  * afterwards. For this reason, `toCompletableFuture` is not supported on the created
-  * `CompletionStage`s.
-  */
+ *
+ *  The explicit conversion methods defined here are intended to be used in Java code. For Scala
+ *  code, it is recommended to use the extension methods defined in [[scala.jdk.FutureConverters]].
+ *
+ *  Note that the bridge is implemented at the read-only side of asynchronous handles, namely
+ *  [[scala.concurrent.Future]] (instead of [[scala.concurrent.Promise]]) and [[java.util.concurrent.CompletionStage]] (instead of
+ *  [[java.util.concurrent.CompletableFuture]]). This is intentional, as the semantics of bridging
+ *  the write-handles would be prone to race conditions; if both ends (`CompletableFuture` and
+ *  `Promise`) are completed independently at the same time, they may contain different values
+ *  afterwards. For this reason, `toCompletableFuture` is not supported on the created
+ *  `CompletionStage`s.
+ */
 object FutureConverters {
   /** Returns a [[java.util.concurrent.CompletionStage]] that will be completed with the same value or exception as the
-    * given Scala [[scala.concurrent.Future]] when that completes. Since the Future is a read-only representation,
-    * this CompletionStage does not support the `toCompletableFuture` method.
-    *
-    * The semantics of Scala Future demand that all callbacks are invoked asynchronously by default,
-    * therefore the returned CompletionStage routes all calls to synchronous transformations to
-    * their asynchronous counterparts, i.e., `thenRun` will internally call `thenRunAsync`.
-    *
-    * @param f The Scala Future which may eventually supply the completion for the returned
-    *          CompletionStage
-    * @return a CompletionStage that runs all callbacks asynchronously and does not support the
-    *         CompletableFuture interface
-    */
+   *  given Scala [[scala.concurrent.Future]] when that completes. Since the Future is a read-only representation,
+   *  this CompletionStage does not support the `toCompletableFuture` method.
+   *
+   *  The semantics of Scala Future demand that all callbacks are invoked asynchronously by default,
+   *  therefore the returned CompletionStage routes all calls to synchronous transformations to
+   *  their asynchronous counterparts, i.e., `thenRun` will internally call `thenRunAsync`.
+   *
+   *  @param f The Scala Future which may eventually supply the completion for the returned
+   *          CompletionStage
+   *  @return a CompletionStage that runs all callbacks asynchronously and does not support the
+   *         CompletableFuture interface
+   */
   def asJava[T](f: Future[T]): CompletionStage[T] = {
     (f: @unchecked) match {
       case p: P[T] => p.wrapped
@@ -58,14 +58,14 @@ object FutureConverters {
   }
 
   /** Returns a Scala [[scala.concurrent.Future]] that will be completed with the same value or exception as the
-    * given [[java.util.concurrent.CompletionStage]] when that completes. Transformations of the returned Future are
-    * executed asynchronously as specified by the ExecutionContext that is given to the combinator
-    * methods.
-    *
-    * @param cs The CompletionStage which may eventually supply the completion for the returned
-    *           Scala Future
-    * @return a Scala Future that represents the CompletionStage's completion
-    */
+   *  given [[java.util.concurrent.CompletionStage]] when that completes. Transformations of the returned Future are
+   *  executed asynchronously as specified by the ExecutionContext that is given to the combinator
+   *  methods.
+   *
+   *  @param cs The CompletionStage which may eventually supply the completion for the returned
+   *           Scala Future
+   *  @return a Scala Future that represents the CompletionStage's completion
+   */
   def asScala[T](cs: CompletionStage[T]): Future[T] = {
     cs match {
       case cf: CF[T] => cf.wrapped

--- a/library/src/scala/jdk/javaapi/OptionConverters.scala
+++ b/library/src/scala/jdk/javaapi/OptionConverters.scala
@@ -17,17 +17,17 @@ import java.util.{Optional, OptionalDouble, OptionalInt, OptionalLong}
 import java.{lang => jl}
 
 /** This object contains methods that convert between Scala `Option` and Java `Optional` types.
-  *
-  * The explicit conversion methods defined here are intended to be used in Java code. For Scala
-  * code, it is recommended to use the extension methods defined in [[scala.jdk.OptionConverters]].
-  *
-  * @define primitiveNote Note: this method uses the boxed type `java.lang.X` instead of the
-  *                       primitive type `scala.X` to improve compatibility when using it in
-  *                       Java code (the Scala compiler emits `C[Int]` as `C[Object]` in bytecode
-  *                       due to [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In
-  *                       Scala code, add `import scala.jdk.OptionConverters._` and use the
-  *                       extension methods instead.
-  */
+ *
+ *  The explicit conversion methods defined here are intended to be used in Java code. For Scala
+ *  code, it is recommended to use the extension methods defined in [[scala.jdk.OptionConverters]].
+ *
+ *  @define primitiveNote Note: this method uses the boxed type `java.lang.X` instead of the
+ *                       primitive type `scala.X` to improve compatibility when using it in
+ *                       Java code (the Scala compiler emits `C[Int]` as `C[Object]` in bytecode
+ *                       due to [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In
+ *                       Scala code, add `import scala.jdk.OptionConverters._` and use the
+ *                       extension methods instead.
+ */
 object OptionConverters {
   /** Converts a Scala `Option` to a Java `Optional`. */
   def toJava[A](o: Option[A]): Optional[A] = o match {
@@ -36,27 +36,27 @@ object OptionConverters {
   }
 
   /** Converts a Scala `Option[java.lang.Double]` to a Java `OptionalDouble`.
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def toJavaOptionalDouble(o: Option[jl.Double]): OptionalDouble = o match {
     case Some(a) => OptionalDouble.of(a)
     case _ => OptionalDouble.empty
   }
 
   /** Converts a Scala `Option[java.lang.Integer]` to a Java `OptionalInt`.
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def toJavaOptionalInt(o: Option[jl.Integer]): OptionalInt = o match {
     case Some(a) => OptionalInt.of(a)
     case _ => OptionalInt.empty
   }
 
   /** Converts a Scala `Option[java.lang.Long]` to a Java `OptionalLong`.
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def toJavaOptionalLong(o: Option[jl.Long]): OptionalLong = o match {
     case Some(a) => OptionalLong.of(a)
     case _ => OptionalLong.empty
@@ -66,20 +66,20 @@ object OptionConverters {
   def toScala[A](o: Optional[A]): Option[A] = if (o.isPresent) Some(o.get) else None
 
   /** Converts a Java `OptionalDouble` to a Scala `Option[java.lang.Double]`.
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def toScala(o: OptionalDouble): Option[jl.Double] = if (o.isPresent) Some(o.getAsDouble) else None
 
   /** Converts a Java `OptionalInt` to a Scala `Option[java.lang.Integer]`.
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def toScala(o: OptionalInt): Option[jl.Integer] = if (o.isPresent) Some(o.getAsInt) else None
 
   /** Converts a Java `OptionalLong` to a Scala `Option[java.lang.Long]`.
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def toScala(o: OptionalLong): Option[jl.Long] = if (o.isPresent) Some(o.getAsLong) else None
 }

--- a/library/src/scala/jdk/javaapi/StreamConverters.scala
+++ b/library/src/scala/jdk/javaapi/StreamConverters.scala
@@ -17,29 +17,29 @@ import java.util.stream.{DoubleStream, IntStream, LongStream, Stream, StreamSupp
 import java.{lang => jl}
 
 /** This object contains methods to create Java Streams that operate on Scala collections
-  * (sequentially or in parallel). For more information on Java streams, consult the documentation
-  * ([[https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/stream/package-summary.html]]).
-  *
-  * The explicit conversion methods defined here are intended to be used in Java code. For Scala
-  * code, it is recommended to use the extension methods defined in [[scala.jdk.StreamConverters]].
-  *
-  * Note: to convert between Scala collections and classic Java collections, use
-  * [[CollectionConverters]].
-  *
-  * For details how the stream converters work, see [[scala.jdk.StreamConverters]].
-  *
-  * @define parNote Note: parallel processing is only efficient for collections that have a
-  *                 [[scala.collection.Stepper]] implementation which supports efficient splitting. For collections
-  *                 where this is the case, the [[scala.collection.IterableOnce.stepper `stepper`]]
-  *                 method has a return type marked `with EfficientSplit`.
-  *
-  * @define primitiveNote Note: this method uses the boxed type `java.lang.X` instead of the
-  *                       primitive type `scala.X` to improve compatibility when using it in
-  *                       Java code (the Scala compiler emits `C[Int]` as `C[Object]` in bytecode
-  *                       due to [[https://github.com/scala/bug/issues/4214 scala/bug#4214]]). In
-  *                       Scala code, add `import scala.jdk.StreamConverters._` and use the
-  *                       extension methods instead.
-  */
+ *  (sequentially or in parallel). For more information on Java streams, consult the documentation
+ *  ([[https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/stream/package-summary.html]]).
+ *
+ *  The explicit conversion methods defined here are intended to be used in Java code. For Scala
+ *  code, it is recommended to use the extension methods defined in [[scala.jdk.StreamConverters]].
+ *
+ *  Note: to convert between Scala collections and classic Java collections, use
+ *  [[CollectionConverters]].
+ *
+ *  For details how the stream converters work, see [[scala.jdk.StreamConverters]].
+ *
+ *  @define parNote Note: parallel processing is only efficient for collections that have a
+ *                 [[scala.collection.Stepper]] implementation which supports efficient splitting. For collections
+ *                 where this is the case, the [[scala.collection.IterableOnce.stepper `stepper`]]
+ *                 method has a return type marked `with EfficientSplit`.
+ *
+ *  @define primitiveNote Note: this method uses the boxed type `java.lang.X` instead of the
+ *                       primitive type `scala.X` to improve compatibility when using it in
+ *                       Java code (the Scala compiler emits `C[Int]` as `C[Object]` in bytecode
+ *                       due to [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In
+ *                       Scala code, add `import scala.jdk.StreamConverters._` and use the
+ *                       extension methods instead.
+ */
 object StreamConverters {
   /////////////////////////////////////
   // sequential streams for collections
@@ -49,41 +49,41 @@ object StreamConverters {
   def asJavaSeqStream[A](cc: IterableOnce[A]): Stream[A] = StreamSupport.stream(cc.stepper.spliterator, false)
 
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def asJavaSeqIntStream         (cc: IterableOnce[jl.Integer]):   IntStream = StreamSupport.intStream(cc.stepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def asJavaSeqIntStreamFromByte (cc: IterableOnce[jl.Byte]):      IntStream = StreamSupport.intStream(cc.stepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def asJavaSeqIntStreamFromShort(cc: IterableOnce[jl.Short]):     IntStream = StreamSupport.intStream(cc.stepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def asJavaSeqIntStreamFromChar (cc: IterableOnce[jl.Character]): IntStream = StreamSupport.intStream(cc.stepper.spliterator, false)
 
   /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for a Scala collection.
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def asJavaSeqDoubleStream         (cc: IterableOnce[jl.Double]): DoubleStream = StreamSupport.doubleStream(cc.stepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for a Scala collection.
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def asJavaSeqDoubleStreamFromFloat(cc: IterableOnce[jl.Float]):  DoubleStream = StreamSupport.doubleStream(cc.stepper.spliterator, false)
 
   /** Creates a sequential [[java.util.stream.LongStream Java LongStream]] for a Scala collection.
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def asJavaSeqLongStream(cc: IterableOnce[jl.Long]): LongStream = StreamSupport.longStream(cc.stepper.spliterator, false)
 
   // Map Key Streams
@@ -92,41 +92,41 @@ object StreamConverters {
   def asJavaSeqKeyStream[K, V](m: collection.Map[K, V]): Stream[K] = StreamSupport.stream(m.keyStepper.spliterator, false)
 
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def asJavaSeqKeyIntStream         [V](m: collection.Map[jl.Integer, V]):   IntStream = StreamSupport.intStream(m.keyStepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def asJavaSeqKeyIntStreamFromByte [V](m: collection.Map[jl.Byte, V]):      IntStream = StreamSupport.intStream(m.keyStepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def asJavaSeqKeyIntStreamFromShort[V](m: collection.Map[jl.Short, V]):     IntStream = StreamSupport.intStream(m.keyStepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def asJavaSeqKeyIntStreamFromChar [V](m: collection.Map[jl.Character, V]): IntStream = StreamSupport.intStream(m.keyStepper.spliterator, false)
 
   /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for the keys of a Scala Map.
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def asJavaSeqKeyDoubleStream         [V](m: collection.Map[jl.Double, V]): DoubleStream = StreamSupport.doubleStream(m.keyStepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for the keys of a Scala Map.
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def asJavaSeqKeyDoubleStreamFromFloat[V](m: collection.Map[jl.Float, V]):  DoubleStream = StreamSupport.doubleStream(m.keyStepper.spliterator, false)
 
   /** Creates a sequential [[java.util.stream.LongStream Java LongStream]] for the keys of a Scala Map.
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def asJavaSeqKeyLongStream[V](m: collection.Map[jl.Long, V]): LongStream = StreamSupport.longStream(m.keyStepper.spliterator, false)
 
   // Map Value Streams
@@ -135,41 +135,41 @@ object StreamConverters {
   def asJavaSeqValueStream[K, V](m: collection.Map[K, V]): Stream[V] = StreamSupport.stream(m.valueStepper.spliterator, false)
 
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def asJavaSeqValueIntStream         [K](m: collection.Map[K, jl.Integer]):   IntStream = StreamSupport.intStream(m.valueStepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def asJavaSeqValueIntStreamFromByte [K](m: collection.Map[K, jl.Byte]):      IntStream = StreamSupport.intStream(m.valueStepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def asJavaSeqValueIntStreamFromShort[K](m: collection.Map[K, jl.Short]):     IntStream = StreamSupport.intStream(m.valueStepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def asJavaSeqValueIntStreamFromChar [K](m: collection.Map[K, jl.Character]): IntStream = StreamSupport.intStream(m.valueStepper.spliterator, false)
 
   /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for the values of a
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def asJavaSeqValueDoubleStream         [K](m: collection.Map[K, jl.Double]): DoubleStream = StreamSupport.doubleStream(m.valueStepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for the values of a
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def asJavaSeqValueDoubleStreamFromFloat[K](m: collection.Map[K, jl.Float]):  DoubleStream = StreamSupport.doubleStream(m.valueStepper.spliterator, false)
 
   /** Creates a sequential [[java.util.stream.LongStream Java LongStream]] for the values of a
-    *
-    * $primitiveNote
-    */
+   *
+   *  $primitiveNote
+   */
   def asJavaSeqValueLongStream[K](m: collection.Map[K, jl.Long]): LongStream = StreamSupport.longStream(m.valueStepper.spliterator, false)
 
   ///////////////////////////////////
@@ -177,181 +177,181 @@ object StreamConverters {
   ///////////////////////////////////
 
   /** Creates a parallel [[java.util.stream.Stream Java Stream]] for a Scala collection.
-    *
-    * $parNote
-    */
+   *
+   *  $parNote
+   */
   def asJavaParStream[A](cc: IterableOnce[A]): Stream[A] = StreamSupport.stream(cc.stepper.spliterator, true)
 
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
-    *
-    * $parNote
-    *
-    * $primitiveNote
-    */
+   *
+   *  $parNote
+   *
+   *  $primitiveNote
+   */
   def asJavaParIntStream         (cc: IterableOnce[jl.Integer]):   IntStream = StreamSupport.intStream(cc.stepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
-    *
-    * $parNote
-    *
-    * $primitiveNote
-    */
+   *
+   *  $parNote
+   *
+   *  $primitiveNote
+   */
   def asJavaParIntStreamFromByte (cc: IterableOnce[jl.Byte]):      IntStream = StreamSupport.intStream(cc.stepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
-    *
-    * $parNote
-    *
-    * $primitiveNote
-    */
+   *
+   *  $parNote
+   *
+   *  $primitiveNote
+   */
   def asJavaParIntStreamFromShort(cc: IterableOnce[jl.Short]):     IntStream = StreamSupport.intStream(cc.stepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
-    *
-    * $parNote
-    *
-    * $primitiveNote
-    */
+   *
+   *  $parNote
+   *
+   *  $primitiveNote
+   */
   def asJavaParIntStreamFromChar (cc: IterableOnce[jl.Character]): IntStream = StreamSupport.intStream(cc.stepper.spliterator, true)
 
   /** Creates a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for a Scala collection.
-    *
-    * $parNote
-    *
-    * $primitiveNote
-    */
+   *
+   *  $parNote
+   *
+   *  $primitiveNote
+   */
   def asJavaParDoubleStream         (cc: IterableOnce[jl.Double]): DoubleStream = StreamSupport.doubleStream(cc.stepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for a Scala collection.
-    *
-    * $parNote
-    *
-    * $primitiveNote
-    */
+   *
+   *  $parNote
+   *
+   *  $primitiveNote
+   */
   def asJavaParDoubleStreamFromFloat(cc: IterableOnce[jl.Float]):  DoubleStream = StreamSupport.doubleStream(cc.stepper.spliterator, true)
 
   /** Creates a parallel [[java.util.stream.LongStream Java LongStream]] for a Scala collection.
-    *
-    * $parNote
-    *
-    * $primitiveNote
-    */
+   *
+   *  $parNote
+   *
+   *  $primitiveNote
+   */
   def asJavaParLongStream(cc: IterableOnce[jl.Long]): LongStream = StreamSupport.longStream(cc.stepper.spliterator, true)
 
 
   // Map Key Streams
 
   /** Creates a parallel [[java.util.stream.Stream Java Stream]] for the keys of a Scala Map.
-    *
-    * $parNote
-    */
+   *
+   *  $parNote
+   */
   def asJavaParKeyStream[K, V](m: collection.Map[K, V]): Stream[K] = StreamSupport.stream(m.keyStepper.spliterator, true)
 
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
-    *
-    * $parNote
-    *
-    * $primitiveNote
-    */
+   *
+   *  $parNote
+   *
+   *  $primitiveNote
+   */
   def asJavaParKeyIntStream         [V](m: collection.Map[jl.Integer, V]):   IntStream = StreamSupport.intStream(m.keyStepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
-    *
-    * $parNote
-    *
-    * $primitiveNote
-    */
+   *
+   *  $parNote
+   *
+   *  $primitiveNote
+   */
   def asJavaParKeyIntStreamFromByte [V](m: collection.Map[jl.Byte, V]):      IntStream = StreamSupport.intStream(m.keyStepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
-    *
-    * $parNote
-    *
-    * $primitiveNote
-    */
+   *
+   *  $parNote
+   *
+   *  $primitiveNote
+   */
   def asJavaParKeyIntStreamFromShort[V](m: collection.Map[jl.Short, V]):     IntStream = StreamSupport.intStream(m.keyStepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
-    *
-    * $parNote
-    *
-    * $primitiveNote
-    */
+   *
+   *  $parNote
+   *
+   *  $primitiveNote
+   */
   def asJavaParKeyIntStreamFromChar [V](m: collection.Map[jl.Character, V]): IntStream = StreamSupport.intStream(m.keyStepper.spliterator, true)
 
   /** Creates a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for the keys of a Scala Map.
-    *
-    * $parNote
-    *
-    * $primitiveNote
-    */
+   *
+   *  $parNote
+   *
+   *  $primitiveNote
+   */
   def asJavaParKeyDoubleStream         [V](m: collection.Map[jl.Double, V]): DoubleStream = StreamSupport.doubleStream(m.keyStepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for the keys of a Scala Map.
-    *
-    * $parNote
-    *
-    * $primitiveNote
-    */
+   *
+   *  $parNote
+   *
+   *  $primitiveNote
+   */
   def asJavaParKeyDoubleStreamFromFloat[V](m: collection.Map[jl.Float, V]):  DoubleStream = StreamSupport.doubleStream(m.keyStepper.spliterator, true)
 
   /** Creates a parallel [[java.util.stream.LongStream Java LongStream]] for the keys of a Scala Map.
-    *
-    * $parNote
-    *
-    * $primitiveNote
-    */
+   *
+   *  $parNote
+   *
+   *  $primitiveNote
+   */
   def asJavaParKeyLongStream[V](m: collection.Map[jl.Long, V]): LongStream = StreamSupport.longStream(m.keyStepper.spliterator, true)
 
   // Map Value Streams
 
   /** Creates a parallel [[java.util.stream.Stream Java Stream]] for the values of a Scala Map.
-    *
-    * $parNote
-    */
+   *
+   *  $parNote
+   */
   def asJavaParValueStream[K, V](m: collection.Map[K, V]): Stream[V] = StreamSupport.stream(m.valueStepper.spliterator, true)
 
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
-    *
-    * $parNote
-    *
-    * $primitiveNote
-    */
+   *
+   *  $parNote
+   *
+   *  $primitiveNote
+   */
   def asJavaParValueIntStream         [K](m: collection.Map[K, jl.Integer]):   IntStream = StreamSupport.intStream(m.valueStepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
-    *
-    * $parNote
-    *
-    * $primitiveNote
-    */
+   *
+   *  $parNote
+   *
+   *  $primitiveNote
+   */
   def asJavaParValueIntStreamFromByte [K](m: collection.Map[K, jl.Byte]):      IntStream = StreamSupport.intStream(m.valueStepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
-    *
-    * $parNote
-    *
-    * $primitiveNote
-    */
+   *
+   *  $parNote
+   *
+   *  $primitiveNote
+   */
   def asJavaParValueIntStreamFromShort[K](m: collection.Map[K, jl.Short]):     IntStream = StreamSupport.intStream(m.valueStepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
-    *
-    * $parNote
-    *
-    * $primitiveNote
-    */
+   *
+   *  $parNote
+   *
+   *  $primitiveNote
+   */
   def asJavaParValueIntStreamFromChar [K](m: collection.Map[K, jl.Character]): IntStream = StreamSupport.intStream(m.valueStepper.spliterator, true)
 
   /** Creates a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for the values of a Scala Map.
-    *
-    * $parNote
-    *
-    * $primitiveNote
-    */
+   *
+   *  $parNote
+   *
+   *  $primitiveNote
+   */
   def asJavaParValueDoubleStream         [K](m: collection.Map[K, jl.Double]): DoubleStream = StreamSupport.doubleStream(m.valueStepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for the values of a Scala Map.
-    *
-    * $parNote
-    *
-    * $primitiveNote
-    */
+   *
+   *  $parNote
+   *
+   *  $primitiveNote
+   */
   def asJavaParValueDoubleStreamFromFloat[K](m: collection.Map[K, jl.Float]):  DoubleStream = StreamSupport.doubleStream(m.valueStepper.spliterator, true)
 
   /** Creates a parallel [[java.util.stream.LongStream Java LongStream]] for the values of a Scala Map.
-    *
-    * $parNote
-    *
-    * $primitiveNote
-    */
+   *
+   *  $parNote
+   *
+   *  $primitiveNote
+   */
   def asJavaParValueLongStream[K](m: collection.Map[K, jl.Long]): LongStream = StreamSupport.longStream(m.valueStepper.spliterator, true)
 }

--- a/library/src/scala/jdk/package.scala
+++ b/library/src/scala/jdk/package.scala
@@ -15,11 +15,11 @@ package scala
 import scala.language.`2.13`
 
 /** The jdk package contains utilities to interact with JDK classes.
- * 
+ *
  * This packages offers a number of converters, that are able to wrap or copy
  * types from the scala library to equivalent types in the JDK class library
  * and vice versa:
- * 
+ *
  *  - [[CollectionConverters]], converting collections like [[scala.collection.Seq]],
  *    [[scala.collection.Map]], [[scala.collection.Set]],
  *    [[scala.collection.mutable.Buffer]], [[scala.collection.Iterator]]
@@ -33,16 +33,17 @@ import scala.language.`2.13`
  *    [[java.util.function.Function]], [[java.util.function.UnaryOperator]],
  *    [[java.util.function.Consumer]] and [[java.util.function.Predicate]], as
  *    well as primitive variations and Bi-variations.
- * 
+ *
  * By convention, converters that wrap an object to provide a different
  * interface to the same underlying data structure use .asScala and .asJava
  * extension methods, whereas converters that copy the underlying data structure
  * use .toScala and .toJava.
- * 
+ *
  * In the [[javaapi]] package, the same converters can be found with a
  * java-friendly interface that don't rely on implicit enrichments.
- * 
+ *
  * Additionally, this package offers [[Accumulator]]s, capable of efficiently
  * traversing JDK Streams.
- **/
+ *
+ */
 package object jdk

--- a/library/src/scala/language.scala
+++ b/library/src/scala/language.scala
@@ -18,13 +18,13 @@ import scala.annotation.compileTimeOnly
 
 /**
  *  The `scala.language` object controls the language features available to the programmer, as proposed in the
- *  [[https://docs.google.com/document/d/1nlkvpoIRkx7at1qJEZafJwthZ3GeIklTFhqmXMvTX9Q/edit '''SIP-18 document''']].
+ *  [**SIP-18 document**](https://docs.google.com/document/d/1nlkvpoIRkx7at1qJEZafJwthZ3GeIklTFhqmXMvTX9Q/edit).
  *
  *  Each of these features has to be explicitly imported into the current scope to become available:
- *  {{{
+ *  ```
  *     import language.postfixOps // or language._
  *     List(1, 2, 3) reverse
- *  }}}
+ *  ```
  *
  *  The language features are:
  *   - [[dynamics            `dynamics`]]            enables defining calls rewriting using the [[scala.Dynamic `Dynamic`]] trait
@@ -38,6 +38,7 @@ import scala.annotation.compileTimeOnly
  *  @groupname production   Language Features
  *  @groupname experimental Experimental Language Features
  *  @groupprio experimental 10
+ 
  */
 object language {
 
@@ -50,10 +51,10 @@ object language {
    *  Selections of dynamic members of existing subclasses of trait `Dynamic` are unaffected;
    *  they can be used anywhere.
    *
-   *  '''Why introduce the feature?''' To enable flexible DSLs and convenient interfacing
+   *  **Why introduce the feature?** To enable flexible DSLs and convenient interfacing
    *  with dynamic languages.
    *
-   *  '''Why control it?''' Dynamic member selection can undermine static checkability
+   *  **Why control it?** Dynamic member selection can undermine static checkability
    *  of programs. Furthermore, dynamic member selection often relies on reflection,
    *  which is not available on all platforms.
    *
@@ -64,10 +65,10 @@ object language {
   /** Only where this feature is enabled, is postfix operator notation `(expr op)` permitted.
    *  If `postfixOps` is not enabled, an expression using postfix notation is rejected by the compiler.
    *
-   *  '''Why keep the feature?''' Postfix notation is preserved for backward
+   *  **Why keep the feature?** Postfix notation is preserved for backward
    *  compatibility only. Historically, several DSLs written in Scala need the notation.
    *
-   *  '''Why control it?''' Postfix operators interact poorly with semicolon inference.
+   *  **Why control it?** Postfix operators interact poorly with semicolon inference.
    *   Most programmers avoid them for this reason alone. Postfix syntax is
    *   associated with an abuse of infix notation, `a op1 b op2 c op3`,
    *   that can be harder to read than ordinary method invocation with judicious
@@ -87,11 +88,11 @@ object language {
    *  not override any member in `Parents`. To access one of these members, a
    *  reflective call is needed.
    *
-   *  '''Why keep the feature?''' Structural types provide great flexibility because
+   *  **Why keep the feature?** Structural types provide great flexibility because
    *  they avoid the need to define inheritance hierarchies a priori. Besides,
    *  their definition falls out quite naturally from Scala’s concept of type refinement.
    *
-   *  '''Why control it?''' Reflection is not available on all platforms. Popular tools
+   *  **Why control it?** Reflection is not available on all platforms. Popular tools
    *  such as ProGuard have problems dealing with it. Even where reflection is available,
    *  reflective dispatch can lead to surprising performance degradations.
    *
@@ -107,13 +108,13 @@ object language {
    *  or an implicit method that has in its first parameter section a single,
    *  non-implicit parameter. Examples:
    *
-   *  {{{
+   *  ```
    *     implicit def intToString(i: Int): String = s"\$i"
    *     implicit val conv: Int => String = i => s"\$i"
    *     implicit val numerals: List[String] = List("zero", "one", "two", "three")
    *     implicit val strlen: String => Int = _.length
    *     implicit def listToInt[T](xs: List[T])(implicit f: T => Int): Int = xs.map(f).sum
-   *  }}}
+   *  ```
    *
    *  This language feature warns only for implicit conversions introduced by methods.
    *
@@ -123,10 +124,10 @@ object language {
    *  Implicit class definitions, which introduce a conversion to the wrapping class,
    *  also do not warn.
    *
-   *  '''Why keep the feature?''' Implicit conversions are central to many aspects
+   *  **Why keep the feature?** Implicit conversions are central to many aspects
    *  of Scala’s core libraries.
    *
-   *  '''Why control it?''' Implicit conversions are known to cause many pitfalls
+   *  **Why control it?** Implicit conversions are known to cause many pitfalls
    *  if over-used. And there is a tendency to over-use them because they look
    *  very powerful and their effects seem to be easy to understand. Also, in
    *  most situations using implicit parameters leads to a better design than
@@ -140,12 +141,12 @@ object language {
    *  If `higherKinds` is not enabled, a higher-kinded type such as `F[A]`
    *  will trigger a warning from the compiler.
    *
-   *  '''Why keep the feature?''' Higher-kinded types enable the definition of very general
+   *  **Why keep the feature?** Higher-kinded types enable the definition of very general
    *  abstractions such as functor, monad, or arrow. A significant set of advanced
    *  libraries relies on them. Higher-kinded types are also at the core of the
    *  scala-virtualized effort to produce high-performance parallel DSLs through staging.
    *
-   *  '''Why control it?''' Higher kinded types in Scala lead to a Turing-complete
+   *  **Why control it?** Higher kinded types in Scala lead to a Turing-complete
    *  type system, where compiler termination is no longer guaranteed. They tend
    *  to be useful mostly for type-level computation and for highly generic design
    *  patterns. The level of abstraction implied by these design patterns is often
@@ -170,10 +171,10 @@ object language {
    *  Existential types with wildcard type syntax such as `List[?]`,
    *  or `Map[String, ?]` are not affected.
    *
-   *  '''Why keep the feature?''' Existential types are needed to make sense of Java’s wildcard
+   *  **Why keep the feature?** Existential types are needed to make sense of Java’s wildcard
    *  types and raw types and the erased types of run-time values.
    *
-   *  '''Why control it?''' Having complex existential types in a code base usually makes
+   *  **Why control it?** Having complex existential types in a code base usually makes
    *  application code very brittle, with a tendency to produce type errors with
    *  obscure error messages. Therefore, going overboard with existential types
    *  is generally perceived not to be a good idea. Also, complicated existential types
@@ -186,11 +187,11 @@ object language {
   /** The experimental object contains features that are known to have unstable API or
    *  behavior that may change in future releases.
    *
-   *  Experimental features '''may undergo API changes''' in future releases, so production
+   *  Experimental features **may undergo API changes** in future releases, so production
    *  code should not rely on them.
    *
    *  Programmers are encouraged to try out experimental features and
-   *  [[https://github.com/scala/scala3/issues report any bugs or API inconsistencies]]
+   *  [report any bugs or API inconsistencies](https://github.com/scala/scala3/issues)
    *  they encounter so they can be improved in future releases.
    *
    *  @group experimental
@@ -205,12 +206,12 @@ object language {
      *  Macro implementations and macro applications are not governed by this
      *  language feature; they can be used anywhere.
      *
-     *  '''Why introduce the feature?''' Macros promise to make the language more regular,
+     *  **Why introduce the feature?** Macros promise to make the language more regular,
      *  replacing ad-hoc language constructs with a general powerful abstraction
      *  capability that can express them. Macros are also a more disciplined and
      *  powerful replacement for compiler plugins.
      *
-     *  '''Why control it?''' For their very power, macros can lead to code that is hard
+     *  **Why control it?** For their very power, macros can lead to code that is hard
      *  to debug and understand.
      */
     implicit lazy val macros: macros = languageFeature.experimental.macros
@@ -393,12 +394,12 @@ object language {
 
   /** Where imported, auto-tupling is disabled.
     *
-    * '''Why control the feature?''' Auto-tupling can lead to confusing and
+    * **Why control the feature?** Auto-tupling can lead to confusing and
     * brittle code in presence of overloads. In particular, surprising overloads
     * can be selected, and adding new overloads can change which overload is selected
     * in suprising ways.
     *
-    * '''Why allow it?''' Not allowing auto-tupling is difficult to reconcile with
+    * **Why allow it?** Not allowing auto-tupling is difficult to reconcile with
     * operators accepting tuples.
     */
   @compileTimeOnly("`noAutoTupling` can only be used at compile time in import statements")
@@ -406,7 +407,7 @@ object language {
 
   /** Where imported, loose equality using eqAny is disabled.
     *
-    * '''Why allow and control the feature?''' For compatibility and migration reasons,
+    * **Why allow and control the feature?** For compatibility and migration reasons,
     * strict equality is opt-in. See linked documentation for more information.
     *
     * @see [[https://dotty.epfl.ch/docs/reference/contextual/multiversal-equality]]
@@ -417,14 +418,14 @@ object language {
   /** Where imported, ad hoc extensions of non-open classes in other
    *  compilation units are allowed.
    *
-   *  '''Why control the feature?''' Ad-hoc extensions should usually be avoided
+   *  **Why control the feature?** Ad-hoc extensions should usually be avoided
    *  since they typically cannot rely on an "internal" contract between a class
    *  and its extensions. Only open classes need to specify such a contract.
    *  Ad-hoc extensions might break for future versions of the extended class,
    *  since the extended class is free to change its implementation without
    *  being constrained by an internal contract.
    *
-   *  '''Why allow it?''' An ad-hoc extension can sometimes be necessary,
+   *  **Why allow it?** An ad-hoc extension can sometimes be necessary,
    *  for instance when mocking a class in a testing framework, or to work
    *  around a bug or missing feature in the original class. Nevertheless,
    *  such extensions should be limited in scope and clearly documented.

--- a/library/src/scala/math/BigDecimal.scala
+++ b/library/src/scala/math/BigDecimal.scala
@@ -110,8 +110,7 @@ object BigDecimal {
    */
   def exact(d: Double): BigDecimal = exact(new BigDec(d))
 
-  /** Constructs a `BigDecimal` that exactly represents a `BigInt`.
-   */
+  /** Constructs a `BigDecimal` that exactly represents a `BigInt`. */
   def exact(bi: BigInt): BigDecimal = exact(new BigDec(bi.bigInteger))
 
   /** Constructs a `BigDecimal` that exactly represents a `Long`.  Note that
@@ -314,8 +313,7 @@ object BigDecimal {
   implicit def javaBigDecimal2bigDecimal(x: BigDec): BigDecimal = mapNull(x, apply(x))
 }
 
-/**
- *  `BigDecimal` represents decimal floating-point numbers of arbitrary precision.
+/** `BigDecimal` represents decimal floating-point numbers of arbitrary precision.
  *  By default, the precision approximately matches that of IEEE 128-bit floating
  *  point numbers (34 decimal digits, `HALF_EVEN` rounding mode).  Within the range
  *  of IEEE binary128 numbers, `BigDecimal` will agree with `BigInt` for both
@@ -476,28 +474,22 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
   def underlying: java.math.BigDecimal = bigDecimal
 
 
-  /** Compares this BigDecimal with the specified BigDecimal for equality.
-   */
+  /** Compares this BigDecimal with the specified BigDecimal for equality. */
   def equals (that: BigDecimal): Boolean = compare(that) == 0
 
-  /** Compares this BigDecimal with the specified BigDecimal
-   */
+  /** Compares this BigDecimal with the specified BigDecimal */
   def compare (that: BigDecimal): Int = this.bigDecimal.compareTo(that.bigDecimal)
 
-  /** Addition of BigDecimals
-   */
+  /** Addition of BigDecimals */
   def +  (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.add(that.bigDecimal, mc), mc)
 
-  /** Subtraction of BigDecimals
-   */
+  /** Subtraction of BigDecimals */
   def -  (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.subtract(that.bigDecimal, mc), mc)
 
-  /** Multiplication of BigDecimals
-   */
+  /** Multiplication of BigDecimals */
   def *  (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.multiply(that.bigDecimal, mc), mc)
 
-  /** Division of BigDecimals
-   */
+  /** Division of BigDecimals */
   def /  (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.divide(that.bigDecimal, mc), mc)
 
   /** Division and Remainder - returns tuple containing the result of
@@ -508,43 +500,35 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
     (new BigDecimal(qr(0), mc), new BigDecimal(qr(1), mc))
   }
 
-  /** Divide to Integral value.
-   */
+  /** Divide to Integral value. */
   def quot (that: BigDecimal): BigDecimal =
     new BigDecimal(this.bigDecimal.divideToIntegralValue(that.bigDecimal, mc), mc)
 
-  /** Returns the minimum of this and that, or this if the two are equal
-   */
+  /** Returns the minimum of this and that, or this if the two are equal */
   def min (that: BigDecimal): BigDecimal = (this compare that) match {
     case x if x <= 0 => this
     case _           => that
   }
 
-  /** Returns the maximum of this and that, or this if the two are equal
-   */
+  /** Returns the maximum of this and that, or this if the two are equal */
   def max (that: BigDecimal): BigDecimal = (this compare that) match {
     case x if x >= 0 => this
     case _           => that
   }
 
-  /** Remainder after dividing this by that.
-   */
+  /** Remainder after dividing this by that. */
   def remainder (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.remainder(that.bigDecimal, mc), mc)
 
-  /** Remainder after dividing this by that.
-   */
+  /** Remainder after dividing this by that. */
   def % (that: BigDecimal): BigDecimal = this.remainder(that)
 
-  /** Returns a BigDecimal whose value is this ** n.
-   */
+  /** Returns a BigDecimal whose value is this ** n. */
   def pow (n: Int): BigDecimal = new BigDecimal(this.bigDecimal.pow(n, mc), mc)
 
-  /** Returns a BigDecimal whose value is the negation of this BigDecimal
-   */
+  /** Returns a BigDecimal whose value is the negation of this BigDecimal */
   def unary_- : BigDecimal = new BigDecimal(this.bigDecimal.negate(mc), mc)
 
-  /** Returns the absolute value of this BigDecimal
-   */
+  /** Returns the absolute value of this BigDecimal */
   def abs: BigDecimal = if (signum < 0) unary_- else this
 
   /** Returns the sign of this BigDecimal;
@@ -561,8 +545,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
    */
   def sign: BigDecimal = signum
 
-  /** Returns the precision of this `BigDecimal`.
-   */
+  /** Returns the precision of this `BigDecimal`. */
   def precision: Int = this.bigDecimal.precision
 
   /** Returns a BigDecimal rounded according to the supplied MathContext settings, but
@@ -579,16 +562,13 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
     if (r eq bigDecimal) this else new BigDecimal(r, mc)
   }
 
-  /** Returns the scale of this `BigDecimal`.
-   */
+  /** Returns the scale of this `BigDecimal`. */
   def scale: Int = this.bigDecimal.scale
 
-  /** Returns the size of an ulp, a unit in the last place, of this BigDecimal.
-   */
+  /** Returns the size of an ulp, a unit in the last place, of this BigDecimal. */
   def ulp: BigDecimal = new BigDecimal(this.bigDecimal.ulp, mc)
 
-  /** Returns a new BigDecimal based on the supplied MathContext, rounded as needed.
-   */
+  /** Returns a new BigDecimal based on the supplied MathContext, rounded as needed. */
   def apply(mc: MathContext): BigDecimal = new BigDecimal(this.bigDecimal.round(mc), mc)
 
   /** Returns a `BigDecimal` whose scale is the specified value, and whose value is
@@ -654,42 +634,42 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
   def doubleValue = this.bigDecimal.doubleValue
 
   /** Converts this `BigDecimal` to a [[scala.Byte]], checking for lost information.
-    * If this `BigDecimal` has a nonzero fractional part, or is out of the possible
-    * range for a [[scala.Byte]] result, then a `java.lang.ArithmeticException` is
-    * thrown.
-    */
+   *  If this `BigDecimal` has a nonzero fractional part, or is out of the possible
+   *  range for a [[scala.Byte]] result, then a `java.lang.ArithmeticException` is
+   *  thrown.
+   */
   def toByteExact = bigDecimal.byteValueExact
 
   /** Converts this `BigDecimal` to a [[scala.Short]], checking for lost information.
-    * If this `BigDecimal` has a nonzero fractional part, or is out of the possible
-    * range for a [[scala.Short]] result, then a `java.lang.ArithmeticException` is
-    * thrown.
-    */
+   *  If this `BigDecimal` has a nonzero fractional part, or is out of the possible
+   *  range for a [[scala.Short]] result, then a `java.lang.ArithmeticException` is
+   *  thrown.
+   */
   def toShortExact = bigDecimal.shortValueExact
 
   /** Converts this `BigDecimal` to a [[scala.Int]], checking for lost information.
-    * If this `BigDecimal` has a nonzero fractional part, or is out of the possible
-    * range for an [[scala.Int]] result, then a `java.lang.ArithmeticException` is
-    * thrown.
-    */
+   *  If this `BigDecimal` has a nonzero fractional part, or is out of the possible
+   *  range for an [[scala.Int]] result, then a `java.lang.ArithmeticException` is
+   *  thrown.
+   */
   def toIntExact = bigDecimal.intValueExact
 
   /** Converts this `BigDecimal` to a [[scala.Long]], checking for lost information.
-    * If this `BigDecimal` has a nonzero fractional part, or is out of the possible
-    * range for a [[scala.Long]] result, then a `java.lang.ArithmeticException` is
-    * thrown.
-    */
+   *  If this `BigDecimal` has a nonzero fractional part, or is out of the possible
+   *  range for a [[scala.Long]] result, then a `java.lang.ArithmeticException` is
+   *  thrown.
+   */
   def toLongExact = bigDecimal.longValueExact
 
   /** Creates a partially constructed NumericRange[BigDecimal] in range
    *  `[start;end)`, where start is the target BigDecimal.  The step
    *  must be supplied via the "by" method of the returned object in order
    *  to receive the fully constructed range.  For example:
-   * {{{
-   * val partial = BigDecimal(1.0) to 2.0       // not usable yet
-   * val range = partial by 0.01                // now a NumericRange
-   * val range2 = BigDecimal(0) to 1.0 by 0.01  // all at once of course is fine too
-   * }}}
+   *  ```
+   *  val partial = BigDecimal(1.0) to 2.0       // not usable yet
+   *  val range = partial by 0.01                // now a NumericRange
+   *  val range2 = BigDecimal(0) to 1.0 by 0.01  // all at once of course is fine too
+   *  ```
    *
    *  @param end    the end value of the range (exclusive)
    *  @return       the partially constructed NumericRange
@@ -707,8 +687,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
   /** Like `until`, but inclusive of the end value. */
   def to(end: BigDecimal, step: BigDecimal) = Range.BigDecimal.inclusive(this, end, step)
 
-  /** Converts this `BigDecimal` to a scala.BigInt.
-   */
+  /** Converts this `BigDecimal` to a scala.BigInt. */
   def toBigInt: BigInt = new BigInt(this.bigDecimal.toBigInteger)
 
   /** Converts this `BigDecimal` to a scala.BigInt if it
@@ -721,8 +700,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
     }
     else None
 
-  /** Returns the decimal String representation of this BigDecimal.
-   */
+  /** Returns the decimal String representation of this BigDecimal. */
   override def toString(): String = this.bigDecimal.toString
 
 }

--- a/library/src/scala/math/BigInt.scala
+++ b/library/src/scala/math/BigInt.scala
@@ -70,9 +70,9 @@ object BigInt {
 
   /** Translates the sign-magnitude representation of a BigInt into a BigInt.
    *
-   * @param  signum    signum of the number (-1 for negative, 0 for zero, 1
+   *  @param  signum    signum of the number (-1 for negative, 0 for zero, 1
    *                   for positive).
-   * @param  magnitude big-endian binary representation of the magnitude of
+   *  @param  magnitude big-endian binary representation of the magnitude of
    *                   the number.
    */
   def apply(signum: Int, magnitude: Array[Byte]): BigInt =
@@ -90,8 +90,7 @@ object BigInt {
   def apply(numbits: Int, rnd: scala.util.Random): BigInt =
     apply(new BigInteger(numbits, rnd.self))
 
-  /** Translates the decimal String representation of a BigInt into a BigInt.
-   */
+  /** Translates the decimal String representation of a BigInt into a BigInt. */
   def apply(x: String): BigInt =
     apply(new BigInteger(x))
 
@@ -101,8 +100,7 @@ object BigInt {
   def apply(x: String, radix: Int): BigInt =
     apply(new BigInteger(x, radix))
 
-  /** Translates a `java.math.BigInteger` into a BigInt.
-   */
+  /** Translates a `java.math.BigInteger` into a BigInt. */
   def apply(x: BigInteger): BigInt = {
     if (x.bitLength <= 63) {
       val l = x.longValue
@@ -110,17 +108,14 @@ object BigInt {
     } else new BigInt(x, Long.MinValue)
   }
 
-  /** Returns a positive BigInt that is probably prime, with the specified bitLength.
-   */
+  /** Returns a positive BigInt that is probably prime, with the specified bitLength. */
   def probablePrime(bitLength: Int, rnd: scala.util.Random): BigInt =
     apply(BigInteger.probablePrime(bitLength, rnd.self))
 
-  /** Implicit conversion from `Int` to `BigInt`.
-   */
+  /** Implicit conversion from `Int` to `BigInt`. */
   implicit def int2bigInt(i: Int): BigInt = apply(i)
 
-  /** Implicit conversion from `Long` to `BigInt`.
-   */
+  /** Implicit conversion from `Long` to `BigInt`. */
   implicit def long2bigInt(l: Long): BigInt = apply(l)
 
   // For the following function, both the parameter and the return type are non-nullable.
@@ -128,8 +123,7 @@ object BigInt {
   // We intentionally keep this signature to discourage passing nulls implicitly while
   // preserving the previous behavior for backward compatibility.
 
-  /** Implicit conversion from `java.math.BigInteger` to `scala.BigInt`.
-   */
+  /** Implicit conversion from `java.math.BigInteger` to `scala.BigInt`. */
   implicit def javaBigInteger2bigInt(x: BigInteger): BigInt = mapNull(x, apply(x))
 
   // this method is adapted from Google Guava's version at
@@ -138,9 +132,7 @@ object BigInt {
   //   * Copyright (C) 2011 The Guava Authors
   //   *
   //   * Licensed under the Apache License, Version 2.0 (the "License")
-  /**
-   * Returns the greatest common divisor of a and b. Returns 0 if a == 0 && b == 0.
-   */
+  /** Returns the greatest common divisor of a and b. Returns 0 if a == 0 && b == 0. */
   private def longGcd(a: Long, b: Long): Long = {
     // both a and b must be >= 0
     if (a == 0) { // 0 % b == 0, so b divides a, but the converse doesn't hold.
@@ -181,7 +173,7 @@ object BigInt {
 
 /** A type with efficient encoding of arbitrary integers.
  *
- * It wraps `java.math.BigInteger`, with optimization for small values that can be encoded in a `Long`.
+ *  It wraps `java.math.BigInteger`, with optimization for small values that can be encoded in a `Long`.
  */
 final class BigInt private (
   @annotation.stableNull private var _bigInteger: BigInteger | Null,
@@ -218,7 +210,8 @@ final class BigInt private (
   )
 
   /** Returns whether the integer is encoded in the Long. Returns true for all values fitting in a Long except
-   *  Long.MinValue. */
+   *  Long.MinValue. 
+   */
   private def longEncoding: Boolean = _long != Long.MinValue
 
   def bigInteger: BigInteger = {
@@ -251,8 +244,7 @@ final class BigInt private (
   override def isValidInt: Boolean = _long >= Int.MinValue && _long <= Int.MaxValue /* && longEncoding */
            def isValidLong: Boolean = longEncoding || _bigInteger == BigInt.longMinValueBigInteger // rhs of || tests == Long.MinValue
 
-  /** Returns `true` iff this can be represented exactly by [[scala.Float]]; otherwise returns `false`.
-    */
+  /** Returns `true` iff this can be represented exactly by [[scala.Float]]; otherwise returns `false`. */
   def isValidFloat: Boolean = {
     val bitLen = bitLength
     (bitLen <= 24 ||
@@ -264,8 +256,7 @@ final class BigInt private (
       }
     ) && !bitLengthOverflow
   }
-  /** Returns `true` iff this can be represented exactly by [[scala.Double]]; otherwise returns `false`.
-    */
+  /** Returns `true` iff this can be represented exactly by [[scala.Double]]; otherwise returns `false`. */
   def isValidDouble: Boolean = {
     val bitLen = bitLength
     (bitLen <= 53 ||
@@ -278,9 +269,9 @@ final class BigInt private (
     ) && !bitLengthOverflow
   }
   /** Some implementations of java.math.BigInteger allow huge values with bit length greater than Int.MaxValue.
-   * The BigInteger.bitLength method returns truncated bit length in this case.
-   * This method tests if result of bitLength is valid.
-   * This method will become unnecessary if BigInt constructors reject huge BigIntegers.
+   *  The BigInteger.bitLength method returns truncated bit length in this case.
+   *  This method tests if result of bitLength is valid.
+   *  This method will become unnecessary if BigInt constructors reject huge BigIntegers.
    */
   private def bitLengthOverflow = {
     val shifted = bigInteger.shiftRight(Int.MaxValue)
@@ -291,16 +282,14 @@ final class BigInt private (
   def isWhole: Boolean = true
   def underlying: BigInteger = bigInteger
 
-  /** Compares this BigInt with the specified BigInt for equality.
-   */
+  /** Compares this BigInt with the specified BigInt for equality. */
   def equals(that: BigInt): Boolean =
     if (this.longEncoding)
       that.longEncoding && (this._long == that._long)
     else
       !that.longEncoding && (this._bigInteger == that._bigInteger)
 
-  /** Compares this BigInt with the specified BigInt
-   */
+  /** Compares this BigInt with the specified BigInt */
   def compare(that: BigInt): Int =
     if (this.longEncoding) {
       if (that.longEncoding) java.lang.Long.compare(this._long, that._long) else -that._bigInteger.nn.signum()
@@ -308,8 +297,7 @@ final class BigInt private (
       if (that.longEncoding) _bigInteger.nn.signum() else this._bigInteger.nn.compareTo(that._bigInteger)
     }
 
-  /** Addition of BigInts
-   */
+  /** Addition of BigInts */
   def +(that: BigInt): BigInt = {
     if (this.longEncoding && that.longEncoding) { // fast path
       val x = this._long
@@ -320,8 +308,7 @@ final class BigInt private (
     BigInt(this.bigInteger.add(that.bigInteger))
   }
 
-  /** Subtraction of BigInts
-   */
+  /** Subtraction of BigInts */
   def -(that: BigInt): BigInt = {
     if (this.longEncoding && that.longEncoding) { // fast path
       val x = this._long
@@ -332,8 +319,7 @@ final class BigInt private (
     BigInt(this.bigInteger.subtract(that.bigInteger))
   }
 
-  /** Multiplication of BigInts
-   */
+  /** Multiplication of BigInts */
   def *(that: BigInt): BigInt = {
     if (this.longEncoding && that.longEncoding) { // fast path
       val x = this._long
@@ -346,8 +332,7 @@ final class BigInt private (
     BigInt(this.bigInteger.multiply(that.bigInteger))
   }
 
-  /** Division of BigInts
-   */
+  /** Division of BigInts */
   def /(that: BigInt): BigInt =
   // in the fast path, note that the original code avoided storing -Long.MinValue in a long:
   //    if (this._long != Long.MinValue || that._long != -1) return BigInt(this._long / that._long)
@@ -355,15 +340,13 @@ final class BigInt private (
     if (this.longEncoding && that.longEncoding) BigInt(this._long / that._long)
     else BigInt(this.bigInteger.divide(that.bigInteger))
 
-  /** Remainder of BigInts
-   */
+  /** Remainder of BigInts */
   def %(that: BigInt): BigInt =
   // see / for the original logic regarding Long.MinValue
     if (this.longEncoding && that.longEncoding) BigInt(this._long % that._long)
     else BigInt(this.bigInteger.remainder(that.bigInteger))
 
-  /** Returns a pair of two BigInts containing (this / that) and (this % that).
-   */
+  /** Returns a pair of two BigInts containing (this / that) and (this % that). */
   def /%(that: BigInt): (BigInt, BigInt) =
     if (this.longEncoding && that.longEncoding) {
       val x = this._long
@@ -375,13 +358,11 @@ final class BigInt private (
       (BigInt(dr(0)), BigInt(dr(1)))
     }
 
-  /** Leftshift of BigInt
-   */
+  /** Leftshift of BigInt */
   def <<(n: Int): BigInt =
     if (longEncoding && n <= 0) (this >> (-n)) else BigInt(this.bigInteger.shiftLeft(n))
 
-  /** (Signed) rightshift of BigInt
-   */
+  /** (Signed) rightshift of BigInt */
   def >>(n: Int): BigInt =
     if (longEncoding && n >= 0) {
       if (n < 64) BigInt(_long >> n)
@@ -389,36 +370,31 @@ final class BigInt private (
       else BigInt(0) // for _long >= 0
     } else BigInt(this.bigInteger.shiftRight(n))
 
-  /** Bitwise and of BigInts
-   */
+  /** Bitwise and of BigInts */
   def &(that: BigInt): BigInt =
     if (this.longEncoding && that.longEncoding)
       BigInt(this._long & that._long)
     else BigInt(this.bigInteger.and(that.bigInteger))
 
-  /** Bitwise or of BigInts
-   */
+  /** Bitwise or of BigInts */
   def |(that: BigInt): BigInt =
     if (this.longEncoding && that.longEncoding)
       BigInt(this._long | that._long)
     else BigInt(this.bigInteger.or(that.bigInteger))
 
-  /** Bitwise exclusive-or of BigInts
-   */
+  /** Bitwise exclusive-or of BigInts */
   def ^(that: BigInt): BigInt =
     if (this.longEncoding && that.longEncoding)
       BigInt(this._long ^ that._long)
     else BigInt(this.bigInteger.xor(that.bigInteger))
 
-  /** Bitwise and-not of BigInts. Returns a BigInt whose value is (this & ~that).
-   */
+  /** Bitwise and-not of BigInts. Returns a BigInt whose value is (this & ~that). */
   def &~(that: BigInt): BigInt =
     if (this.longEncoding && that.longEncoding)
       BigInt(this._long & ~that._long)
     else BigInt(this.bigInteger.andNot(that.bigInteger))
 
-  /** Returns the greatest common divisor of abs(this) and abs(that)
-   */
+  /** Returns the greatest common divisor of abs(this) and abs(that) */
   def gcd(that: BigInt): BigInt =
     if (this.longEncoding) {
       if (this._long == 0) return that.abs
@@ -451,18 +427,15 @@ final class BigInt private (
       if (res >= 0) BigInt(res) else BigInt(res + that._long)
     } else BigInt(this.bigInteger.mod(that.bigInteger))
 
-  /** Returns the minimum of this and that
-   */
+  /** Returns the minimum of this and that */
   def min(that: BigInt): BigInt =
     if (this <= that) this else that
 
-  /** Returns the maximum of this and that
-   */
+  /** Returns the maximum of this and that */
   def max(that: BigInt): BigInt =
     if (this >= that) this else that
 
-  /** Returns a BigInt whose value is (<tt>this</tt> raised to the power of <tt>exp</tt>).
-   */
+  /** Returns a BigInt whose value is (<tt>this</tt> raised to the power of <tt>exp</tt>). */
   def pow(exp: Int): BigInt = BigInt(this.bigInteger.pow(exp))
 
   /** Returns a BigInt whose value is
@@ -470,16 +443,13 @@ final class BigInt private (
    */
   def modPow(exp: BigInt, m: BigInt): BigInt = BigInt(this.bigInteger.modPow(exp.bigInteger, m.bigInteger))
 
-  /** Returns a BigInt whose value is (the inverse of <tt>this</tt> modulo <tt>m</tt>).
-   */
+  /** Returns a BigInt whose value is (the inverse of <tt>this</tt> modulo <tt>m</tt>). */
   def modInverse(m: BigInt): BigInt = BigInt(this.bigInteger.modInverse(m.bigInteger))
 
-  /** Returns a BigInt whose value is the negation of this BigInt
-   */
+  /** Returns a BigInt whose value is the negation of this BigInt */
   def unary_- : BigInt = if (longEncoding) BigInt(-_long) else BigInt(this.bigInteger.negate())
 
-  /** Returns the absolute value of this BigInt
-   */
+  /** Returns the absolute value of this BigInt */
   def abs: BigInt = if (signum < 0) -this else this
 
   /** Returns the sign of this BigInt;
@@ -496,14 +466,12 @@ final class BigInt private (
    */
   def sign: BigInt = BigInt(signum)
 
-  /** Returns the bitwise complement of this BigInt
-   */
+  /** Returns the bitwise complement of this BigInt */
   def unary_~ : BigInt =
     // it is equal to -(this + 1)
     if (longEncoding && _long != Long.MaxValue) BigInt(-(_long + 1)) else BigInt(this.bigInteger.not())
 
-  /** Returns true if and only if the designated bit is set.
-   */
+  /** Returns true if and only if the designated bit is set. */
   def testBit(n: Int): Boolean =
     if (longEncoding && n >= 0) {
       if (n <= 63)
@@ -512,23 +480,20 @@ final class BigInt private (
         _long < 0 // give the sign bit
     } else this.bigInteger.testBit(n)
 
-  /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit set.
-   */
+  /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit set. */
   def setBit(n: Int): BigInt  = // note that we do not operate on the Long sign bit #63
     if (longEncoding && n <= 62 && n >= 0) BigInt(_long | (1L << n)) else BigInt(this.bigInteger.setBit(n))
 
-  /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit cleared.
-   */
+  /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit cleared. */
   def clearBit(n: Int): BigInt  = // note that we do not operate on the Long sign bit #63
     if (longEncoding && n <= 62 && n >= 0) BigInt(_long & ~(1L << n)) else BigInt(this.bigInteger.clearBit(n))
 
-  /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit flipped.
-   */
+  /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit flipped. */
   def flipBit(n: Int): BigInt  = // note that we do not operate on the Long sign bit #63
     if (longEncoding && n <= 62 && n >= 0) BigInt(_long ^ (1L << n)) else BigInt(this.bigInteger.flipBit(n))
 
   /** Returns the index of the rightmost (lowest-order) one bit in this BigInt
-   * (the number of zero bits to the right of the rightmost one bit).
+   *  (the number of zero bits to the right of the rightmost one bit).
    */
   def lowestSetBit: Int =
     if (longEncoding) {
@@ -625,16 +590,13 @@ final class BigInt private (
    */
   def until(end: BigInt, step: BigInt = BigInt(1)): NumericRange.Exclusive[BigInt] = Range.BigInt(this, end, step)
 
-  /** Like until, but inclusive of the end value.
-   */
+  /** Like until, but inclusive of the end value. */
   def to(end: BigInt, step: BigInt = BigInt(1)): NumericRange.Inclusive[BigInt] = Range.BigInt.inclusive(this, end, step)
 
-  /** Returns the decimal String representation of this BigInt.
-   */
+  /** Returns the decimal String representation of this BigInt. */
   override def toString(): String = if (longEncoding) _long.toString() else _bigInteger.toString()
 
-  /** Returns the String representation in the specified radix of this BigInt.
-   */
+  /** Returns the String representation in the specified radix of this BigInt. */
   def toString(radix: Int): String = this.bigInteger.toString(radix)
 
   /** Returns a byte array containing the two's-complement representation of

--- a/library/src/scala/math/Equiv.scala
+++ b/library/src/scala/math/Equiv.scala
@@ -22,7 +22,7 @@ import scala.annotation.migration
  *  equivalence and a representation of equivalence on some type. This
  *  trait is for representing the latter.
  *
- *  An [[https://en.wikipedia.org/wiki/Equivalence_relation equivalence relation]]
+ *  An [equivalence relation](https://en.wikipedia.org/wiki/Equivalence_relation)
  *  is a binary relation on a type. This relation is exposed as
  *  the `equiv` method of the `Equiv` trait.  The relation must be:
  *
@@ -33,21 +33,19 @@ import scala.annotation.migration
  */
 
 trait Equiv[T] extends Any with Serializable {
-  /** Returns `true` iff `x` is equivalent to `y`.
-   */
+  /** Returns `true` iff `x` is equivalent to `y`. */
   def equiv(x: T, y: T): Boolean
 }
 
 trait LowPriorityEquiv {
   self: Equiv.type =>
 
-  /**
-   * @deprecated This implicit universal `Equiv` instance allows accidentally
-   * comparing instances of types for which equality isn't well-defined or implemented.
-   * (For example, it does not make sense to compare two `Function1` instances.)
+  /** Use `Equiv.universal` explicitly instead. If you really want an implicit universal `Equiv` instance
+   *  @deprecated This implicit universal `Equiv` instance allows accidentally
+   *  comparing instances of types for which equality isn't well-defined or implemented.
+   *  (For example, it does not make sense to compare two `Function1` instances.)
    *
-   * Use `Equiv.universal` explicitly instead. If you really want an implicit universal `Equiv` instance
-   * despite the potential problems, consider `implicit def universalEquiv[T]: Equiv[T] = universal[T]`.
+   *  despite the potential problems, consider `implicit def universalEquiv[T]: Equiv[T] = universal[T]`.
    */
   @deprecated("Use explicit Equiv.universal instead. See Scaladoc entry for more information: " +
     "https://www.scala-lang.org/api/current/scala/math/Equiv$.html#universalEquiv[T]:scala.math.Equiv[T]",
@@ -96,8 +94,8 @@ object Equiv extends LowPriorityEquiv {
 
   trait ExtraImplicits {
     /** Not in the standard scope due to the potential for divergence:
-      * For instance `implicitly[Equiv[Any]]` diverges in its presence.
-      */
+     *  For instance `implicitly[Equiv[Any]]` diverges in its presence.
+     */
     implicit def seqEquiv[CC[X] <: scala.collection.Seq[X], T](implicit eqv: Equiv[T]): Equiv[CC[T]] =
       new IterableEquiv[CC, T](eqv)
 
@@ -137,39 +135,39 @@ object Equiv extends LowPriorityEquiv {
   }
 
   /** `Equiv`s for `Float`s.
-    *
-    * @define floatEquiv Because the behaviour of `Float`s specified by IEEE is
-    *                    not consistent with behaviors required of an equivalence
-    *                    relation for `NaN` (it is not reflexive), there are two
-    *                    equivalences defined for `Float`: `StrictEquiv`, which
-    *                    is reflexive, and `IeeeEquiv`, which is consistent
-    *                    with IEEE spec and floating point operations defined in
-    *                    [[scala.math]].
-    */
+   *
+   *  @define floatEquiv Because the behaviour of `Float`s specified by IEEE is
+   *                    not consistent with behaviors required of an equivalence
+   *                    relation for `NaN` (it is not reflexive), there are two
+   *                    equivalences defined for `Float`: `StrictEquiv`, which
+   *                    is reflexive, and `IeeeEquiv`, which is consistent
+   *                    with IEEE spec and floating point operations defined in
+   *                    [[scala.math]].
+   */
   object Float {
     /** An equivalence for `Float`s which is reflexive (treats all `NaN`s
-      * as equivalent), and treats `-0.0` and `0.0` as not equivalent; it
-      * behaves the same as [[java.lang.Float.compare]].
-      *
-      * $floatEquiv
-      *
-      * This equivalence may be preferable for collections.
-      *
-      * @see [[IeeeEquiv]]
-      */
+     *  as equivalent), and treats `-0.0` and `0.0` as not equivalent; it
+     *  behaves the same as [[java.lang.Float.compare]].
+     *
+     *  $floatEquiv
+     *
+     *  This equivalence may be preferable for collections.
+     *
+     *  @see [[IeeeEquiv]]
+     */
     trait StrictEquiv extends Equiv[Float] {
       def equiv(x: Float, y: Float): Boolean = java.lang.Float.compare(x, y) == 0
     }
     implicit object StrictEquiv extends StrictEquiv
 
     /** An equivalence for `Float`s which is consistent with IEEE specifications.
-      *
-      * $floatEquiv
-      *
-      * This equivalence may be preferable for numeric contexts.
-      *
-      * @see [[StrictEquiv]]
-      */
+     *
+     *  $floatEquiv
+     *
+     *  This equivalence may be preferable for numeric contexts.
+     *
+     *  @see [[StrictEquiv]]
+     */
     trait IeeeEquiv extends Equiv[Float] {
       override def equiv(x: Float, y: Float): Boolean = x == y
     }
@@ -184,39 +182,39 @@ object Equiv extends LowPriorityEquiv {
   implicit object DeprecatedFloatEquiv extends Float.StrictEquiv
 
   /** `Equiv`s for `Double`s.
-    *
-    * @define doubleEquiv Because the behaviour of `Double`s specified by IEEE is
-    *                     not consistent with behaviors required of an equivalence
-    *                     relation for `NaN` (it is not reflexive), there are two
-    *                     equivalences defined for `Double`: `StrictEquiv`, which
-    *                     is reflexive, and `IeeeEquiv`, which is consistent
-    *                     with IEEE spec and floating point operations defined in
-    *                     [[scala.math]].
-    */
+   *
+   *  @define doubleEquiv Because the behaviour of `Double`s specified by IEEE is
+   *                     not consistent with behaviors required of an equivalence
+   *                     relation for `NaN` (it is not reflexive), there are two
+   *                     equivalences defined for `Double`: `StrictEquiv`, which
+   *                     is reflexive, and `IeeeEquiv`, which is consistent
+   *                     with IEEE spec and floating point operations defined in
+   *                     [[scala.math]].
+   */
   object Double {
     /** An equivalence for `Double`s which is reflexive (treats all `NaN`s
-      * as equivalent), and treats `-0.0` and `0.0` as not equivalent; it
-      * behaves the same as [[java.lang.Double.compare]].
-      *
-      * $doubleEquiv
-      *
-      * This equivalence may be preferable for collections.
-      *
-      * @see [[IeeeEquiv]]
-      */
+     *  as equivalent), and treats `-0.0` and `0.0` as not equivalent; it
+     *  behaves the same as [[java.lang.Double.compare]].
+     *
+     *  $doubleEquiv
+     *
+     *  This equivalence may be preferable for collections.
+     *
+     *  @see [[IeeeEquiv]]
+     */
     trait StrictEquiv extends Equiv[Double] {
       def equiv(x: Double, y: Double): Boolean = java.lang.Double.compare(x, y) == 0
     }
     implicit object StrictEquiv extends StrictEquiv
 
     /** An equivalence for `Double`s which is consistent with IEEE specifications.
-      *
-      * $doubleEquiv
-      *
-      * This equivalence may be preferable for numeric contexts.
-      *
-      * @see [[StrictEquiv]]
-      */
+     *
+     *  $doubleEquiv
+     *
+     *  This equivalence may be preferable for numeric contexts.
+     *
+     *  @see [[StrictEquiv]]
+     */
     trait IeeeEquiv extends Equiv[Double] {
       def equiv(x: Double, y: Double): Boolean = x == y
     }

--- a/library/src/scala/math/Numeric.scala
+++ b/library/src/scala/math/Numeric.scala
@@ -25,9 +25,9 @@ object Numeric {
     /** These implicits create conversions from a value for which an implicit Numeric
      *  exists to the inner class which creates infix operations.  Once imported, you
      *  can write methods as follows:
-     *  {{{
+     *  ```
      *  def plus[T: Numeric](x: T, y: T) = x + y
-     *  }}}
+     *  ```
      */
     implicit def infixNumericOps[T](x: T)(implicit num: Numeric[T]): Numeric[T]#NumericOps = new num.NumericOps(x)
   }

--- a/library/src/scala/math/Ordered.scala
+++ b/library/src/scala/math/Ordered.scala
@@ -34,15 +34,15 @@ import scala.language.implicitConversions
  *  [[scala.math.PartiallyOrdered]] is an alternative to this trait for partially ordered data.
  *
  *  For example, create a simple class that implements `Ordered` and then sort it with [[scala.util.Sorting]]:
- *  {{{
+ *  ```
  *  case class OrderedClass(n:Int) extends Ordered[OrderedClass] {
- *  	def compare(that: OrderedClass) =  this.n - that.n
+ *   def compare(that: OrderedClass) =  this.n - that.n
  *  }
  *
  *  val x = Array(OrderedClass(1), OrderedClass(5), OrderedClass(3))
  *  scala.util.Sorting.quickSort(x)
  *  x
- *  }}}
+ *  ```
  *
  *  It is important that the `equals` method for an instance of `Ordered[A]` be consistent with the
  *  compare method. However, due to limitations inherent in the type erasure semantics, there is no
@@ -61,37 +61,31 @@ trait Ordered[A] extends Any with java.lang.Comparable[A] {
 
   /** Result of comparing `this` with operand `that`.
    *
-   * Implement this method to determine how instances of A will be sorted.
+   *  Implement this method to determine how instances of A will be sorted.
    *
-   * Returns `x` where:
+   *  Returns `x` where:
    *
    *   - `x < 0` when `this < that`
    *
    *   - `x == 0` when `this == that`
    *
    *   - `x > 0` when  `this > that`
-   *
    */
   def compare(that: A): Int
 
-  /** Returns true if `this` is less than `that`
-    */
+  /** Returns true if `this` is less than `that` */
   def <  (that: A): Boolean = (this compare that) <  0
 
-  /** Returns true if `this` is greater than `that`.
-    */
+  /** Returns true if `this` is greater than `that`. */
   def >  (that: A): Boolean = (this compare that) >  0
 
-  /** Returns true if `this` is less than or equal to `that`.
-    */
+  /** Returns true if `this` is less than or equal to `that`. */
   def <= (that: A): Boolean = (this compare that) <= 0
 
-  /** Returns true if `this` is greater than or equal to `that`.
-    */
+  /** Returns true if `this` is greater than or equal to `that`. */
   def >= (that: A): Boolean = (this compare that) >= 0
 
-  /** Result of comparing `this` with operand `that`.
-    */
+  /** Result of comparing `this` with operand `that`. */
   def compareTo(that: A): Int = compare(that)
 }
 

--- a/library/src/scala/math/Ordering.scala
+++ b/library/src/scala/math/Ordering.scala
@@ -21,72 +21,72 @@ import scala.annotation.migration
 import scala.annotation.unchecked.uncheckedOverride
 
 /** Ordering is a trait whose instances each represent a strategy for sorting
-  * instances of a type.
-  *
-  * Ordering's companion object defines many implicit objects to deal with
-  * subtypes of [[AnyVal]] (e.g. `Int`, `Double`), `String`, and others.
-  *
-  * To sort instances by one or more member variables, you can take advantage
-  * of these built-in orderings using [[Ordering.by]] and [[Ordering.on]]:
-  *
-  * {{{
-  * import scala.util.Sorting
-  * val pairs = Array(("a", 5, 2), ("c", 3, 1), ("b", 1, 3))
-  *
-  * // sort by 2nd element
-  * Sorting.quickSort(pairs)(Ordering.by[(String, Int, Int), Int](_._2))
-  *
-  * // sort by the 3rd element, then 1st
-  * Sorting.quickSort(pairs)(Ordering[(Int, String)].on(x => (x._3, x._1)))
-  * }}}
-  *
-  * An `Ordering[T]` is implemented by specifying the [[compare]] method,
-  * `compare(a: T, b: T): Int`, which decides how to order two instances
-  * `a` and `b`. Instances of `Ordering[T]` can be used by things like
-  * `scala.util.Sorting` to sort collections like `Array[T]`.
-  *
-  * For example:
-  *
-  * {{{
-  * import scala.util.Sorting
-  *
-  * case class Person(name:String, age:Int)
-  * val people = Array(Person("bob", 30), Person("ann", 32), Person("carl", 19))
-  *
-  * // sort by age
-  * object AgeOrdering extends Ordering[Person] {
-  *   def compare(a:Person, b:Person) = a.age.compare(b.age)
-  * }
-  * Sorting.quickSort(people)(AgeOrdering)
-  * }}}
-  *
-  * This trait and [[scala.math.Ordered]] both provide this same functionality, but
-  * in different ways. A type `T` can be given a single way to order itself by
-  * extending `Ordered`. Using `Ordering`, this same type may be sorted in many
-  * other ways. `Ordered` and `Ordering` both provide implicits allowing them to be
-  * used interchangeably.
-  *
-  * You can `import scala.math.Ordering.Implicits._` to gain access to other
-  * implicit orderings.
-  *
-  * @see [[scala.math.Ordered]], [[scala.util.Sorting]], [[scala.math.Ordering.Implicits]]
-  */
+ *  instances of a type.
+ *
+ *  Ordering's companion object defines many implicit objects to deal with
+ *  subtypes of [[AnyVal]] (e.g. `Int`, `Double`), `String`, and others.
+ *
+ *  To sort instances by one or more member variables, you can take advantage
+ *  of these built-in orderings using [[Ordering.by]] and [[Ordering.on]]:
+ *
+ *  ```
+ *  import scala.util.Sorting
+ *  val pairs = Array(("a", 5, 2), ("c", 3, 1), ("b", 1, 3))
+ *
+ *  // sort by 2nd element
+ *  Sorting.quickSort(pairs)(Ordering.by[(String, Int, Int), Int](_._2))
+ *
+ *  // sort by the 3rd element, then 1st
+ *  Sorting.quickSort(pairs)(Ordering[(Int, String)].on(x => (x._3, x._1)))
+ *  ```
+ *
+ *  An `Ordering[T]` is implemented by specifying the [[compare]] method,
+ *  `compare(a: T, b: T): Int`, which decides how to order two instances
+ *  `a` and `b`. Instances of `Ordering[T]` can be used by things like
+ *  `scala.util.Sorting` to sort collections like `Array[T]`.
+ *
+ *  For example:
+ *
+ *  ```
+ *  import scala.util.Sorting
+ *
+ *  case class Person(name:String, age:Int)
+ *  val people = Array(Person("bob", 30), Person("ann", 32), Person("carl", 19))
+ *
+ *  // sort by age
+ *  object AgeOrdering extends Ordering[Person] {
+ *   def compare(a:Person, b:Person) = a.age.compare(b.age)
+ *  }
+ *  Sorting.quickSort(people)(AgeOrdering)
+ *  ```
+ *
+ *  This trait and [[scala.math.Ordered]] both provide this same functionality, but
+ *  in different ways. A type `T` can be given a single way to order itself by
+ *  extending `Ordered`. Using `Ordering`, this same type may be sorted in many
+ *  other ways. `Ordered` and `Ordering` both provide implicits allowing them to be
+ *  used interchangeably.
+ *
+ *  You can `import scala.math.Ordering.Implicits._` to gain access to other
+ *  implicit orderings.
+ *
+ *  @see [[scala.math.Ordered]], [[scala.util.Sorting]], [[scala.math.Ordering.Implicits]]
+ */
 trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializable {
   outer =>
 
   /** Returns whether a comparison between `x` and `y` is defined, and if so
-    * the result of `compare(x, y)`.
-    */
+   *  the result of `compare(x, y)`.
+   */
   def tryCompare(x: T, y: T): Some[Int] = Some(compare(x, y))
 
  /** Returns an integer whose sign communicates how x compares to y.
-   *
-   * The result sign has the following meaning:
-   *
-   *  - negative if x < y
-   *  - positive if x > y
-   *  - zero otherwise (if x == y)
-   */
+  *
+  *  The result sign has the following meaning:
+  *
+  *  - negative if x < y
+  *  - positive if x > y
+  *  - zero otherwise (if x == y)
+  */
   def compare(x: T, y: T): Int
 
   /** Returns true if `x` <= `y` in the ordering. */
@@ -111,75 +111,75 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
   @uncheckedOverride def min[U <: T](x: U, y: U): U = if (lteq(x, y)) x else y
 
   /** Returns the opposite ordering of this one.
-    *
-    * Implementations overriding this method MUST override [[isReverseOf]]
-    * as well if they change the behavior at all (for example, caching does
-    * not require overriding it).
-    */
+   *
+   *  Implementations overriding this method MUST override [[isReverseOf]]
+   *  as well if they change the behavior at all (for example, caching does
+   *  not require overriding it).
+   */
   override def reverse: Ordering[T] = new Ordering.Reverse[T](this)
 
   /** Returns whether or not the other ordering is the opposite
-    * ordering of this one.
-    *
-    * Equivalent to `other == this.reverse`.
-    *
-    * Implementations should only override this method if they are overriding
-    * [[reverse]] as well.
-    */
+   *  ordering of this one.
+   *
+   *  Equivalent to `other == this.reverse`.
+   *
+   *  Implementations should only override this method if they are overriding
+   *  [[reverse]] as well.
+   */
   def isReverseOf(other: Ordering[?]): Boolean = other match {
     case that: Ordering.Reverse[?] => that.outer == this
     case _ => false
   }
 
   /** Given f, a function from U into T, creates an Ordering[U] whose compare
-    * function is equivalent to:
-    *
-    * {{{
-    * def compare(x:U, y:U) = Ordering[T].compare(f(x), f(y))
-    * }}}
-    */
+   *  function is equivalent to:
+   *
+   *  ```
+   *  def compare(x:U, y:U) = Ordering[T].compare(f(x), f(y))
+   *  ```
+   */
   def on[U](f: U => T): Ordering[U] = new Ordering[U] {
     def compare(x: U, y: U) = outer.compare(f(x), f(y))
   }
 
   /** Creates an Ordering[T] whose compare function returns the
-    * result of this Ordering's compare function, if it is non-zero,
-    * or else the result of `other`s compare function.
-    *
-    * @example
-    * {{{
-    * case class Pair(a: Int, b: Int)
-    *
-    * val pairOrdering = Ordering.by[Pair, Int](_.a)
-    *                            .orElse(Ordering.by[Pair, Int](_.b))
-    * }}}
-    *
-    * @param other an Ordering to use if this Ordering returns zero
-    */
+   *  result of this Ordering's compare function, if it is non-zero,
+   *  or else the result of `other`s compare function.
+   *
+   *  @example
+   *  ```
+   *  case class Pair(a: Int, b: Int)
+   *
+   *  val pairOrdering = Ordering.by[Pair, Int](_.a)
+   *                            .orElse(Ordering.by[Pair, Int](_.b))
+   *  ```
+   *
+   *  @param other an Ordering to use if this Ordering returns zero
+   */
   def orElse(other: Ordering[T]): Ordering[T] = (x, y) => {
     val res1 = outer.compare(x, y)
     if (res1 != 0) res1 else other.compare(x, y)
   }
 
   /** Given f, a function from T into S, creates an Ordering[T] whose compare
-    * function returns the result of this Ordering's compare function,
-    * if it is non-zero, or else a result equivalent to:
-    *
-    * {{{
-    * Ordering[S].compare(f(x), f(y))
-    * }}}
-    *
-    * This function is equivalent to passing the result of `Ordering.by(f)`
-    * to `orElse`.
-    *
-    * @example
-    * {{{
-    * case class Pair(a: Int, b: Int)
-    *
-    * val pairOrdering = Ordering.by[Pair, Int](_.a)
-    *                            .orElseBy[Int](_.b)
-    * }}}
-    */
+   *  function returns the result of this Ordering's compare function,
+   *  if it is non-zero, or else a result equivalent to:
+   *
+   *  ```
+   *  Ordering[S].compare(f(x), f(y))
+   *  ```
+   *
+   *  This function is equivalent to passing the result of `Ordering.by(f)`
+   *  to `orElse`.
+   *
+   *  @example
+   *  ```
+   *  case class Pair(a: Int, b: Int)
+   *
+   *  val pairOrdering = Ordering.by[Pair, Int](_.a)
+   *                            .orElseBy[Int](_.b)
+   *  ```
+   */
   def orElseBy[S](f: T => S)(implicit ord: Ordering[S]): Ordering[T] = (x, y) => {
     val res1 = outer.compare(x, y)
     if (res1 != 0) res1 else ord.compare(f(x), f(y))
@@ -187,8 +187,8 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
 
   /** This inner class defines comparison operators available for `T`.
    *
-   * It can't extend `AnyVal` because it is not a top-level class
-   * or a member of a statically accessible object.
+   *  It can't extend `AnyVal` because it is not a top-level class
+   *  or a member of a statically accessible object.
    */
   class OrderingOps(lhs: T) {
     def <(rhs: T): Boolean = lt(lhs, rhs)
@@ -201,8 +201,8 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
   }
 
   /** This implicit method augments `T` with the comparison operators defined
-    * in `scala.math.Ordering.Ops`.
-    */
+   *  in `scala.math.Ordering.Ops`.
+   */
   implicit def mkOrderingOps(lhs: T): OrderingOps = new OrderingOps(lhs)
 }
 
@@ -226,10 +226,10 @@ trait LowPriorityOrderingImplicits {
 }
 
 /** This is the companion object for the [[scala.math.Ordering]] trait.
-  *
-  * It contains many implicit orderings as well as well as methods to construct
-  * new orderings.
-  */
+ *
+ *  It contains many implicit orderings as well as well as methods to construct
+ *  new orderings.
+ */
 object Ordering extends LowPriorityOrderingImplicits {
   private final val reverseSeed  = 41
   private final val optionSeed   = 43
@@ -290,8 +290,8 @@ object Ordering extends LowPriorityOrderingImplicits {
 
   trait ExtraImplicits {
     /** Not in the standard scope due to the potential for divergence:
-      * For instance `implicitly[Ordering[Any]]` diverges in its presence.
-      */
+     *  For instance `implicitly[Ordering[Any]]` diverges in its presence.
+     */
     implicit def seqOrdering[CC[X] <: scala.collection.Seq[X], T](implicit ord: Ordering[T]): Ordering[CC[T]] =
       new IterableOrdering[CC, T](ord)
 
@@ -299,13 +299,13 @@ object Ordering extends LowPriorityOrderingImplicits {
       new IterableOrdering[CC, T](ord)
 
     /** This implicit creates a conversion from any value for which an
-      * implicit `Ordering` exists to the class which creates infix operations.
-      * With it imported, you can write methods as follows:
-      *
-      * {{{
-      * def lessThan[T: Ordering](x: T, y: T) = x < y
-      * }}}
-      */
+     *  implicit `Ordering` exists to the class which creates infix operations.
+     *  With it imported, you can write methods as follows:
+     *
+     *  ```
+     *  def lessThan[T: Ordering](x: T, y: T) = x < y
+     *  ```
+     */
     implicit def infixOrderingOps[T](x: T)(implicit ord: Ordering[T]): Ordering[T]#OrderingOps = new ord.OrderingOps(x)
   }
 
@@ -323,15 +323,15 @@ object Ordering extends LowPriorityOrderingImplicits {
   }
 
   /** Given f, a function from T into S, creates an Ordering[T] whose compare
-    * function is equivalent to:
-    *
-    * {{{
-    * def compare(x:T, y:T) = Ordering[S].compare(f(x), f(y))
-    * }}}
-    *
-    * This function is an analogue to Ordering.on where the Ordering[S]
-    * parameter is passed implicitly.
-    */
+   *  function is equivalent to:
+   *
+   *  ```
+   *  def compare(x:T, y:T) = Ordering[S].compare(f(x), f(y))
+   *  ```
+   *
+   *  This function is an analogue to Ordering.on where the Ordering[S]
+   *  parameter is passed implicitly.
+   */
   def by[T, S](f: T => S)(implicit ord: Ordering[S]): Ordering[T] = new Ordering[T] {
     def compare(x: T, y: T) = ord.compare(f(x), f(y))
     override def lt(x: T, y: T): Boolean = ord.lt(f(x), f(y))
@@ -383,58 +383,58 @@ object Ordering extends LowPriorityOrderingImplicits {
   implicit object Long extends LongOrdering
 
   /** `Ordering`s for `Float`s.
-    *
-    * The default extends `Ordering.Float.TotalOrdering`.
-    *
-    * `Ordering.Float.TotalOrdering` uses the `java.lang.Float.compare` semantics for all operations.
-    * Scala also provides the `Ordering.Float.IeeeOrdering` semantics. Which uses the IEEE 754 semantics
-    * for float ordering.
-    *
-    * Historically: `IeeeOrdering` was used in Scala from 2.10.x through 2.12.x. This changed in 2.13.0
-    * to `TotalOrdering`.
-    *
-    * Prior to Scala 2.10.0, the `Ordering` instance used semantics
-    * consistent with `java.lang.Float.compare`.
-    *
-    * Scala 2.10.0 changed the implementation of `lt`, `equiv`, `min`, etc., to be
-    * IEEE 754 compliant, while keeping the `compare` method NOT compliant,
-    * creating an internally inconsistent instance. IEEE 754 specifies that
-    * `0.0F == -0.0F`. In addition, it requires all comparisons with `Float.NaN` return
-    * `false` thus `0.0F < Float.NaN`, `0.0F > Float.NaN`, and
-    * `Float.NaN == Float.NaN` all yield `false`, analogous `None` in `flatMap`.
-    *
-    *
-    *  {{{
-    *  List(0.0F, 1.0F, 0.0F / 0.0F, -1.0F / 0.0F).sorted      // List(-Infinity, 0.0, 1.0, NaN)
-    *  List(0.0F, 1.0F, 0.0F / 0.0F, -1.0F / 0.0F).min         // -Infinity
-    *  implicitly[Ordering[Float]].lt(0.0F, 0.0F / 0.0F)       // true
-    *  {
-    *    import Ordering.Float.IeeeOrdering
-    *    List(0.0F, 1.0F, 0.0F / 0.0F, -1.0F / 0.0F).sorted    // List(-Infinity, 0.0, 1.0, NaN)
-    *    List(0.0F, 1.0F, 0.0F / 0.0F, -1.0F / 0.0F).min       // NaN
-    *    implicitly[Ordering[Float]].lt(0.0F, 0.0F / 0.0F)     // false
-    *  }
-    *  }}}
-    *
-    * @define floatOrdering Because the behavior of `Float`s specified by IEEE is
-    *                       not consistent with a total ordering when dealing with
-    *                       `NaN`, there are two orderings defined for `Float`:
-    *                       `TotalOrdering`, which is consistent with a total
-    *                       ordering, and `IeeeOrdering`, which is consistent
-    *                       as much as possible with IEEE spec and floating point
-    *                       operations defined in [[scala.math]].
-    */
+   *
+   *  The default extends `Ordering.Float.TotalOrdering`.
+   *
+   *  `Ordering.Float.TotalOrdering` uses the `java.lang.Float.compare` semantics for all operations.
+   *  Scala also provides the `Ordering.Float.IeeeOrdering` semantics. Which uses the IEEE 754 semantics
+   *  for float ordering.
+   *
+   *  Historically: `IeeeOrdering` was used in Scala from 2.10.x through 2.12.x. This changed in 2.13.0
+   *  to `TotalOrdering`.
+   *
+   *  Prior to Scala 2.10.0, the `Ordering` instance used semantics
+   *  consistent with `java.lang.Float.compare`.
+   *
+   *  Scala 2.10.0 changed the implementation of `lt`, `equiv`, `min`, etc., to be
+   *  IEEE 754 compliant, while keeping the `compare` method NOT compliant,
+   *  creating an internally inconsistent instance. IEEE 754 specifies that
+   *  `0.0F == -0.0F`. In addition, it requires all comparisons with `Float.NaN` return
+   *  `false` thus `0.0F < Float.NaN`, `0.0F > Float.NaN`, and
+   *  `Float.NaN == Float.NaN` all yield `false`, analogous `None` in `flatMap`.
+   *
+   *
+   *  ```
+   *  List(0.0F, 1.0F, 0.0F / 0.0F, -1.0F / 0.0F).sorted      // List(-Infinity, 0.0, 1.0, NaN)
+   *  List(0.0F, 1.0F, 0.0F / 0.0F, -1.0F / 0.0F).min         // -Infinity
+   *  implicitly[Ordering[Float]].lt(0.0F, 0.0F / 0.0F)       // true
+   *  {
+   *    import Ordering.Float.IeeeOrdering
+   *    List(0.0F, 1.0F, 0.0F / 0.0F, -1.0F / 0.0F).sorted    // List(-Infinity, 0.0, 1.0, NaN)
+   *    List(0.0F, 1.0F, 0.0F / 0.0F, -1.0F / 0.0F).min       // NaN
+   *    implicitly[Ordering[Float]].lt(0.0F, 0.0F / 0.0F)     // false
+   *  }
+   *  ```
+   *
+   *  @define floatOrdering Because the behavior of `Float`s specified by IEEE is
+   *                       not consistent with a total ordering when dealing with
+   *                       `NaN`, there are two orderings defined for `Float`:
+   *                       `TotalOrdering`, which is consistent with a total
+   *                       ordering, and `IeeeOrdering`, which is consistent
+   *                       as much as possible with IEEE spec and floating point
+   *                       operations defined in [[scala.math]].
+   */
   object Float {
     /** An ordering for `Float`s which is a fully consistent total ordering,
-      * and treats `NaN` as larger than all other `Float` values; it behaves
-      * the same as [[java.lang.Float.compare]].
-      *
-      * $floatOrdering
-      *
-      * This ordering may be preferable for sorting collections.
-      *
-      * @see [[IeeeOrdering]]
-      */
+     *  and treats `NaN` as larger than all other `Float` values; it behaves
+     *  the same as [[java.lang.Float.compare]].
+     *
+     *  $floatOrdering
+     *
+     *  This ordering may be preferable for sorting collections.
+     *
+     *  @see [[IeeeOrdering]]
+     */
     trait TotalOrdering extends Ordering[Float] {
       def compare(x: Float, y: Float) = java.lang.Float.compare(x, y)
     }
@@ -442,21 +442,21 @@ object Ordering extends LowPriorityOrderingImplicits {
     implicit object TotalOrdering extends TotalOrdering
 
     /** An ordering for `Float`s which is consistent with IEEE specifications
-      * whenever possible.
-      *
-      *   - `lt`, `lteq`, `equiv`, `gteq` and `gt` are consistent with primitive
-      * comparison operations for `Float`s, and return `false` when called with
-      * `NaN`.
-      *   - `min` and `max` are consistent with `math.min` and `math.max`, and
-      * return `NaN` when called with `NaN` as either argument.
-      *   - `compare` behaves the same as [[java.lang.Float.compare]].
-      *
-      * $floatOrdering
-      *
-      * This ordering may be preferable for numeric contexts.
-      *
-      * @see [[TotalOrdering]]
-      */
+     *  whenever possible.
+     *
+     *   - `lt`, `lteq`, `equiv`, `gteq` and `gt` are consistent with primitive
+     *  comparison operations for `Float`s, and return `false` when called with
+     *  `NaN`.
+     *   - `min` and `max` are consistent with `math.min` and `math.max`, and
+     *  return `NaN` when called with `NaN` as either argument.
+     *   - `compare` behaves the same as [[java.lang.Float.compare]].
+     *
+     *  $floatOrdering
+     *
+     *  This ordering may be preferable for numeric contexts.
+     *
+     *  @see [[TotalOrdering]]
+     */
     trait IeeeOrdering extends Ordering[Float] {
       def compare(x: Float, y: Float) = java.lang.Float.compare(x, y)
 
@@ -482,56 +482,56 @@ object Ordering extends LowPriorityOrderingImplicits {
   implicit object DeprecatedFloatOrdering extends Float.TotalOrdering
 
   /** `Ordering`s for `Double`s.
-    *
-    * The behavior of the comparison operations provided by the default (implicit)
-    * ordering on `Double` changed in 2.10.0 and 2.13.0.
-    * Prior to Scala 2.10.0, the `Ordering` instance used semantics
-    * consistent with `java.lang.Double.compare`.
-    *
-    * Scala 2.10.0 changed the implementation of `lt`, `equiv`, `min`, etc., to be
-    * IEEE 754 compliant, while keeping the `compare` method NOT compliant,
-    * creating an internally inconsistent instance. IEEE 754 specifies that
-    * `0.0 == -0.0`. In addition, it requires all comparisons with `Double.NaN` return
-    * `false` thus `0.0 < Double.NaN`, `0.0 > Double.NaN`, and
-    * `Double.NaN == Double.NaN` all yield `false`, analogous `None` in `flatMap`.
-    *
-    * Recognizing the limitation of the IEEE 754 semantics in terms of ordering,
-    * Scala 2.13.0 created two instances: `Ordering.Double.IeeeOrdering`, which retains
-    * the IEEE 754 semantics from Scala 2.12.x, and `Ordering.Double.TotalOrdering`,
-    * which brings back the `java.lang.Double.compare` semantics for all operations.
-    * The default extends `TotalOrdering`.
-    *
-    *  {{{
-    *  List(0.0, 1.0, 0.0 / 0.0, -1.0 / 0.0).sorted      // List(-Infinity, 0.0, 1.0, NaN)
-    *  List(0.0, 1.0, 0.0 / 0.0, -1.0 / 0.0).min         // -Infinity
-    *  implicitly[Ordering[Double]].lt(0.0, 0.0 / 0.0)   // true
-    *  {
-    *    import Ordering.Double.IeeeOrdering
-    *    List(0.0, 1.0, 0.0 / 0.0, -1.0 / 0.0).sorted    // List(-Infinity, 0.0, 1.0, NaN)
-    *    List(0.0, 1.0, 0.0 / 0.0, -1.0 / 0.0).min       // NaN
-    *    implicitly[Ordering[Double]].lt(0.0, 0.0 / 0.0) // false
-    *  }
-    *  }}}
-    *
-    * @define doubleOrdering Because the behavior of `Double`s specified by IEEE is
-    *                        not consistent with a total ordering when dealing with
-    *                        `NaN`, there are two orderings defined for `Double`:
-    *                        `TotalOrdering`, which is consistent with a total
-    *                        ordering, and `IeeeOrdering`, which is consistent
-    *                        as much as possible with IEEE spec and floating point
-    *                        operations defined in [[scala.math]].
-    */
+   *
+   *  The behavior of the comparison operations provided by the default (implicit)
+   *  ordering on `Double` changed in 2.10.0 and 2.13.0.
+   *  Prior to Scala 2.10.0, the `Ordering` instance used semantics
+   *  consistent with `java.lang.Double.compare`.
+   *
+   *  Scala 2.10.0 changed the implementation of `lt`, `equiv`, `min`, etc., to be
+   *  IEEE 754 compliant, while keeping the `compare` method NOT compliant,
+   *  creating an internally inconsistent instance. IEEE 754 specifies that
+   *  `0.0 == -0.0`. In addition, it requires all comparisons with `Double.NaN` return
+   *  `false` thus `0.0 < Double.NaN`, `0.0 > Double.NaN`, and
+   *  `Double.NaN == Double.NaN` all yield `false`, analogous `None` in `flatMap`.
+   *
+   *  Recognizing the limitation of the IEEE 754 semantics in terms of ordering,
+   *  Scala 2.13.0 created two instances: `Ordering.Double.IeeeOrdering`, which retains
+   *  the IEEE 754 semantics from Scala 2.12.x, and `Ordering.Double.TotalOrdering`,
+   *  which brings back the `java.lang.Double.compare` semantics for all operations.
+   *  The default extends `TotalOrdering`.
+   *
+   *  ```
+   *  List(0.0, 1.0, 0.0 / 0.0, -1.0 / 0.0).sorted      // List(-Infinity, 0.0, 1.0, NaN)
+   *  List(0.0, 1.0, 0.0 / 0.0, -1.0 / 0.0).min         // -Infinity
+   *  implicitly[Ordering[Double]].lt(0.0, 0.0 / 0.0)   // true
+   *  {
+   *    import Ordering.Double.IeeeOrdering
+   *    List(0.0, 1.0, 0.0 / 0.0, -1.0 / 0.0).sorted    // List(-Infinity, 0.0, 1.0, NaN)
+   *    List(0.0, 1.0, 0.0 / 0.0, -1.0 / 0.0).min       // NaN
+   *    implicitly[Ordering[Double]].lt(0.0, 0.0 / 0.0) // false
+   *  }
+   *  ```
+   *
+   *  @define doubleOrdering Because the behavior of `Double`s specified by IEEE is
+   *                        not consistent with a total ordering when dealing with
+   *                        `NaN`, there are two orderings defined for `Double`:
+   *                        `TotalOrdering`, which is consistent with a total
+   *                        ordering, and `IeeeOrdering`, which is consistent
+   *                        as much as possible with IEEE spec and floating point
+   *                        operations defined in [[scala.math]].
+   */
   object Double {
     /** An ordering for `Double`s which is a fully consistent total ordering,
-      * and treats `NaN` as larger than all other `Double` values; it behaves
-      * the same as [[java.lang.Double.compare]].
-      *
-      * $doubleOrdering
-      *
-      * This ordering may be preferable for sorting collections.
-      *
-      * @see [[IeeeOrdering]]
-      */
+     *  and treats `NaN` as larger than all other `Double` values; it behaves
+     *  the same as [[java.lang.Double.compare]].
+     *
+     *  $doubleOrdering
+     *
+     *  This ordering may be preferable for sorting collections.
+     *
+     *  @see [[IeeeOrdering]]
+     */
     trait TotalOrdering extends Ordering[Double] {
       def compare(x: Double, y: Double) = java.lang.Double.compare(x, y)
     }
@@ -539,21 +539,21 @@ object Ordering extends LowPriorityOrderingImplicits {
     implicit object TotalOrdering extends TotalOrdering
 
     /** An ordering for `Double`s which is consistent with IEEE specifications
-      * whenever possible.
-      *
-      *   - `lt`, `lteq`, `equiv`, `gteq` and `gt` are consistent with primitive
-      * comparison operations for `Double`s, and return `false` when called with
-      * `NaN`.
-      *   - `min` and `max` are consistent with `math.min` and `math.max`, and
-      * return `NaN` when called with `NaN` as either argument.
-      *   - `compare` behaves the same as [[java.lang.Double.compare]].
-      *
-      * $doubleOrdering
-      *
-      * This ordering may be preferable for numeric contexts.
-      *
-      * @see [[TotalOrdering]]
-      */
+     *  whenever possible.
+     *
+     *   - `lt`, `lteq`, `equiv`, `gteq` and `gt` are consistent with primitive
+     *  comparison operations for `Double`s, and return `false` when called with
+     *  `NaN`.
+     *   - `min` and `max` are consistent with `math.min` and `math.max`, and
+     *  return `NaN` when called with `NaN` as either argument.
+     *   - `compare` behaves the same as [[java.lang.Double.compare]].
+     *
+     *  $doubleOrdering
+     *
+     *  This ordering may be preferable for numeric contexts.
+     *
+     *  @see [[TotalOrdering]]
+     */
     trait IeeeOrdering extends Ordering[Double] {
       def compare(x: Double, y: Double) = java.lang.Double.compare(x, y)
 
@@ -624,11 +624,12 @@ object Ordering extends LowPriorityOrderingImplicits {
     new O()
   }
 
-  /** @deprecated Iterables are not guaranteed to have a consistent order, so the `Ordering`
-    *             returned by this method may not be stable or meaningful. If you are using a type
-    *             with a consistent order (such as `Seq`), use its `Ordering` (found in the
-    *             [[Implicits]] object) instead.
-    */
+  /**
+   *  @deprecated Iterables are not guaranteed to have a consistent order, so the `Ordering`
+   *             returned by this method may not be stable or meaningful. If you are using a type
+   *             with a consistent order (such as `Seq`), use its `Ordering` (found in the
+   *             [[Implicits]] object) instead.
+   */
   @deprecated("Iterables are not guaranteed to have a consistent order; if using a type with a " +
     "consistent order (e.g. Seq), use its Ordering (found in the Ordering.Implicits object)", since = "2.13.0")
   implicit def Iterable[T](implicit ord: Ordering[T]): Ordering[Iterable[T]] =

--- a/library/src/scala/math/PartialOrdering.scala
+++ b/library/src/scala/math/PartialOrdering.scala
@@ -20,22 +20,22 @@ import scala.language.`2.13`
  *  of partial ordering on some type.  This trait is for representing the
  *  latter.
  *
- *  A [[https://en.wikipedia.org/wiki/Partially_ordered_set partial ordering]] is a
+ *  A [partial ordering](https://en.wikipedia.org/wiki/Partially_ordered_set) is a
  *  binary relation on a type `T`, exposed as the `lteq` method of this trait.
  *  This relation must be:
  *
- *  - reflexive: `lteq(x, x) == '''true'''`, for any `x` of type `T`.
- *  - anti-symmetric: if `lteq(x, y) == '''true'''` and
- *    `lteq(y, x) == '''true'''`
- *    then `equiv(x, y) == '''true'''`, for any `x` and `y` of type `T`.
- *  - transitive: if `lteq(x, y) == '''true'''` and
- *    `lteq(y, z) == '''true'''` then `lteq(x, z) == '''true'''`,
+ *  - reflexive: `lteq(x, x) == **true**`, for any `x` of type `T`.
+ *  - anti-symmetric: if `lteq(x, y) == **true**` and
+ *    `lteq(y, x) == **true**`
+ *    then `equiv(x, y) == **true**`, for any `x` and `y` of type `T`.
+ *  - transitive: if `lteq(x, y) == **true**` and
+ *    `lteq(y, z) == **true**` then `lteq(x, z) == **true**`,
  *    for any `x`, `y`, and `z` of type `T`.
  *
  *  Additionally, a partial ordering induces an
- *  [[https://en.wikipedia.org/wiki/Equivalence_relation equivalence relation]]
+ *  [equivalence relation](https://en.wikipedia.org/wiki/Equivalence_relation)
  *  on a type `T`: `x` and `y` of type `T` are equivalent if and only if
- *  `lteq(x, y) && lteq(y, x) == '''true'''`. This equivalence relation is
+ *  `lteq(x, y) && lteq(y, x) == **true**`. This equivalence relation is
  *  exposed as the `equiv` method, inherited from the
  *  [[scala.math.Equiv Equiv]] trait.
  */
@@ -52,26 +52,23 @@ trait PartialOrdering[T] extends Equiv[T] {
    */
   def tryCompare(x: T, y: T): Option[Int]
 
-  /** Returns `'''true'''` iff `x` comes before `y` in the ordering.
-   */
+  /** Returns `**true**` iff `x` comes before `y` in the ordering. */
   def lteq(x: T, y: T): Boolean
 
-  /** Returns `'''true'''` iff `y` comes before `x` in the ordering.
-   */
+  /** Returns `**true**` iff `y` comes before `x` in the ordering. */
   def gteq(x: T, y: T): Boolean = lteq(y, x)
 
-  /** Returns `'''true'''` iff `x` comes before `y` in the ordering
+  /** Returns `**true**` iff `x` comes before `y` in the ordering
    *  and is not the same as `y`.
    */
   def lt(x: T, y: T): Boolean = lteq(x, y) && !equiv(x, y)
 
-  /** Returns `'''true'''` iff `y` comes before `x` in the ordering
+  /** Returns `**true**` iff `y` comes before `x` in the ordering
    *  and is not the same as `x`.
    */
   def gt(x: T, y: T): Boolean = gteq(x, y) && !equiv(x, y)
 
-  /** Returns `'''true'''` iff `x` is equivalent to `y` in the ordering.
-   */
+  /** Returns `**true**` iff `x` is equivalent to `y` in the ordering. */
   def equiv(x: T, y: T): Boolean = lteq(x,y) && lteq(y,x)
 
   def reverse : PartialOrdering[T] = new PartialOrdering[T] {

--- a/library/src/scala/math/PartiallyOrdered.scala
+++ b/library/src/scala/math/PartiallyOrdered.scala
@@ -15,18 +15,17 @@ package math
 
 import scala.language.`2.13`
 
-/** A class for partially ordered data.
- */
+/** A class for partially ordered data. */
 trait PartiallyOrdered[+A] extends Any {
 
   type AsPartiallyOrdered[B] = B => PartiallyOrdered[B]
 
-  /** Result of comparing `'''this'''` with operand `that`.
+  /** Result of comparing `**this**` with operand `that`.
    *  Returns `None` if operands are not comparable.
    *  If operands are comparable, returns `Some(x)` where
-   *  - `x < 0`    iff   `'''this''' &lt; that`
-   *  - `x == 0`   iff   `'''this''' == that`
-   *  - `x > 0`    iff   `'''this''' &gt; that`
+   *  - `x < 0`    iff   `**this** &lt; that`
+   *  - `x == 0`   iff   `**this** == that`
+   *  - `x > 0`    iff   `**this** &gt; that`
    */
   def tryCompareTo [B >: A: AsPartiallyOrdered](that: B): Option[Int]
 

--- a/library/src/scala/math/ScalaNumericConversions.scala
+++ b/library/src/scala/math/ScalaNumericConversions.scala
@@ -26,7 +26,9 @@ trait ScalaNumericConversions extends ScalaNumber with ScalaNumericAnyConversion
  *  across all the numeric types, suitable for use in value classes.
  */
 trait ScalaNumericAnyConversions extends Any {
-  /** @return `'''true'''` if this number has no decimal component, `'''false'''` otherwise. */
+  /**
+   *  @return `**true**` if this number has no decimal component, `**false**` otherwise.
+   */
   def isWhole: Boolean
 
   def byteValue: Byte
@@ -37,58 +39,58 @@ trait ScalaNumericAnyConversions extends Any {
   def doubleValue: Double
 
   /** Returns the value of this as a [[scala.Char]]. This may involve
-    * rounding or truncation.
-    */
+   *  rounding or truncation.
+   */
   def toChar = intValue.toChar
 
   /** Returns the value of this as a [[scala.Byte]]. This may involve
-    * rounding or truncation.
-    */
+   *  rounding or truncation.
+   */
   def toByte = byteValue
 
   /** Returns the value of this as a [[scala.Short]]. This may involve
-    * rounding or truncation.
-    */
+   *  rounding or truncation.
+   */
   def toShort = shortValue
 
   /** Returns the value of this as an [[scala.Int]]. This may involve
-    * rounding or truncation.
-    */
+   *  rounding or truncation.
+   */
   def toInt = intValue
 
   /** Returns the value of this as a [[scala.Long]]. This may involve
-    * rounding or truncation.
-    */
+   *  rounding or truncation.
+   */
   def toLong = longValue
 
   /** Returns the value of this as a [[scala.Float]]. This may involve
-    * rounding or truncation.
-    */
+   *  rounding or truncation.
+   */
   def toFloat = floatValue
 
   /** Returns the value of this as a [[scala.Double]]. This may involve
-    * rounding or truncation.
-    */
+   *  rounding or truncation.
+   */
   def toDouble = doubleValue
 
   /** Returns `true` iff this has a zero fractional part, and is within the
-    * range of [[scala.Byte]] MinValue and MaxValue; otherwise returns `false`.
-    */
+   *  range of [[scala.Byte]] MinValue and MaxValue; otherwise returns `false`.
+   */
   def isValidByte  = isWhole && (toInt == toByte)
 
   /** Returns `true` iff this has a zero fractional part, and is within the
-    * range of [[scala.Short]] MinValue and MaxValue; otherwise returns `false`.
-    */
+   *  range of [[scala.Short]] MinValue and MaxValue; otherwise returns `false`.
+   */
   def isValidShort = isWhole && (toInt == toShort)
 
   /** Returns `true` iff this has a zero fractional part, and is within the
-    * range of [[scala.Int]] MinValue and MaxValue; otherwise returns `false`.
-    */
+   *  range of [[scala.Int]] MinValue and MaxValue; otherwise returns `false`.
+   */
   def isValidInt   = isWhole && (toLong == toInt)
 
   /** Returns `true` iff this has a zero fractional part, and is within the
-    * range of [[scala.Char]] MinValue and MaxValue; otherwise returns `false`.
-    */
+   *  range of [[scala.Char]] MinValue and MaxValue; otherwise returns `false`.
+   */
   def isValidChar  = isWhole && (toInt >= Char.MinValue && toInt <= Char.MaxValue)
 
   protected def unifiedPrimitiveHashcode = {

--- a/library/src/scala/math/package.scala
+++ b/library/src/scala/math/package.scala
@@ -15,76 +15,76 @@ package scala
 import scala.language.`2.13`
 
 /** The package object `scala.math` contains methods for performing basic
-  * numeric operations such as elementary exponential, logarithmic, root and
-  * trigonometric functions.
-  *
-  * All methods forward to [[java.lang.Math]] unless otherwise noted.
-  *
-  * @see [[java.lang.Math]]
-  *
-  * @groupname math-const Mathematical Constants
-  * @groupprio math-const 10
-  *
-  * @groupname minmax Minimum and Maximum
-  * @groupdesc minmax Find the min or max of two numbers. Note: [[scala.collection.IterableOnceOps]] has
-  *           min and max methods which determine the min or max of a collection.
-  * @groupprio minmax 20
-  *
-  * @groupname rounding Rounding
-  * @groupprio rounding 30
-  *
-  * @groupname scaling Scaling
-  * @groupdesc scaling Scaling with rounding guarantees
-  * @groupprio scaling 40
-  *
-  * @groupname explog Exponential and Logarithmic
-  * @groupprio explog 50
-  *
-  * @groupname trig Trigonometric
-  * @groupdesc trig Arguments in radians
-  * @groupprio trig 60
-  *
-  * @groupname angle-conversion Angular Measurement Conversion
-  * @groupprio angle-conversion 70
-  *
-  * @groupname hyperbolic Hyperbolic
-  * @groupprio hyperbolic 80
-  *
-  * @groupname abs Absolute Values
-  * @groupdesc abs Determine the magnitude of a value by discarding the sign. Results are >= 0.
-  * @groupprio abs 90
-  *
-  * @groupname signs Signs
-  * @groupdesc signs For `signum` extract the sign of a value. Results are -1, 0 or 1.
-  * Note the `signum` methods are not pure forwarders to the Java versions.
-  * In particular, the return type of `java.lang.Long.signum` is `Int`,
-  * but here it is widened to `Long` so that each overloaded variant
-  * will return the same numeric type it is passed.
-  * @groupprio signs 100
-  *
-  * @groupname root-extraction Root Extraction
-  * @groupprio root-extraction 110
-  *
-  * @groupname polar-coords Polar Coordinates
-  * @groupprio polar-coords 120
-  *
-  * @groupname ulp Unit of Least Precision
-  * @groupprio ulp 130
-  *
-  * @groupname randomisation Pseudo Random Number Generation
-  * @groupprio randomisation 140
-  *
-  * @groupname exact Exact Arithmetic
-  * @groupdesc exact Integral addition, multiplication, stepping and conversion throwing ArithmeticException instead of underflowing or overflowing
-  * @groupprio exact 150
-  *
-  * @groupname modquo Modulus and Quotient
-  * @groupdesc modquo Calculate quotient values by rounding to negative infinity
-  * @groupprio modquo 160
-  *
-  * @groupname adjacent-float Adjacent Floats
-  * @groupprio adjacent-float 170
-  */
+ *  numeric operations such as elementary exponential, logarithmic, root and
+ *  trigonometric functions.
+ *
+ *  All methods forward to [[java.lang.Math]] unless otherwise noted.
+ *
+ *  @see [[java.lang.Math]]
+ *
+ *  @groupname math-const Mathematical Constants
+ *  @groupprio math-const 10
+ *
+ *  @groupname minmax Minimum and Maximum
+ *  @groupdesc minmax Find the min or max of two numbers. Note: [[scala.collection.IterableOnceOps]] has
+ *           min and max methods which determine the min or max of a collection.
+ *  @groupprio minmax 20
+ *
+ *  @groupname rounding Rounding
+ *  @groupprio rounding 30
+ *
+ *  @groupname scaling Scaling
+ *  @groupdesc scaling Scaling with rounding guarantees
+ *  @groupprio scaling 40
+ *
+ *  @groupname explog Exponential and Logarithmic
+ *  @groupprio explog 50
+ *
+ *  @groupname trig Trigonometric
+ *  @groupdesc trig Arguments in radians
+ *  @groupprio trig 60
+ *
+ *  @groupname angle-conversion Angular Measurement Conversion
+ *  @groupprio angle-conversion 70
+ *
+ *  @groupname hyperbolic Hyperbolic
+ *  @groupprio hyperbolic 80
+ *
+ *  @groupname abs Absolute Values
+ *  @groupdesc abs Determine the magnitude of a value by discarding the sign. Results are >= 0.
+ *  @groupprio abs 90
+ *
+ *  @groupname signs Signs
+ *  @groupdesc signs For `signum` extract the sign of a value. Results are -1, 0 or 1.
+ *  Note the `signum` methods are not pure forwarders to the Java versions.
+ *  In particular, the return type of `java.lang.Long.signum` is `Int`,
+ *  but here it is widened to `Long` so that each overloaded variant
+ *  will return the same numeric type it is passed.
+ *  @groupprio signs 100
+ *
+ *  @groupname root-extraction Root Extraction
+ *  @groupprio root-extraction 110
+ *
+ *  @groupname polar-coords Polar Coordinates
+ *  @groupprio polar-coords 120
+ *
+ *  @groupname ulp Unit of Least Precision
+ *  @groupprio ulp 130
+ *
+ *  @groupname randomisation Pseudo Random Number Generation
+ *  @groupprio randomisation 140
+ *
+ *  @groupname exact Exact Arithmetic
+ *  @groupdesc exact Integral addition, multiplication, stepping and conversion throwing ArithmeticException instead of underflowing or overflowing
+ *  @groupprio exact 150
+ *
+ *  @groupname modquo Modulus and Quotient
+ *  @groupdesc modquo Calculate quotient values by rounding to negative infinity
+ *  @groupprio modquo 160
+ *
+ *  @groupname adjacent-float Adjacent Floats
+ *  @groupprio adjacent-float 170
+ */
 package object math {
   /** The `Double` value that is closer than any other to `e`, the base of
    *  the natural logarithms.
@@ -140,7 +140,7 @@ package object math {
    *
    *  @param  x the ordinate coordinate
    *  @param  y the abscissa coordinate
-   *  @return the ''theta'' component of the point `(r, theta)` in polar
+   *  @return the *theta* component of the point `(r, theta)` in polar
    *          coordinates that corresponds to the point `(x, y)` in
    *          Cartesian coordinates.
    *  @group polar-coords
@@ -148,13 +148,13 @@ package object math {
   def atan2(y: Double, x: Double): Double = java.lang.Math.atan2(y, x)
 
   /** Returns the square root of the sum of the squares of both given `Double`
-    * values without intermediate underflow or overflow.
-    *
-    * The ''r'' component of the point `(r, theta)` in polar
-    * coordinates that corresponds to the point `(x, y)` in
-    * Cartesian coordinates.
-    * @group polar-coords
-    */
+   *  values without intermediate underflow or overflow.
+   *
+   *  The *r* component of the point `(r, theta)` in polar
+   *  coordinates that corresponds to the point `(x, y)` in
+   *  Cartesian coordinates.
+   *  @group polar-coords
+   */
   def hypot(x: Double, y: Double): Double = java.lang.Math.hypot(x, y)
 
   // -----------------------------------------------------------------------
@@ -167,13 +167,13 @@ package object math {
   def floor(x: Double): Double = java.lang.Math.floor(x)
 
   /** Returns the `Double` value that is closest in value to the
-    *  argument and is equal to a mathematical integer.
-    *
-    *  @param  x a `Double` value
-    *  @return the closest floating-point value to a that is equal to a
-    *          mathematical integer.
-    *  @group rounding
-    */
+   *  argument and is equal to a mathematical integer.
+   *
+   *  @param  x a `Double` value
+   *  @return the closest floating-point value to a that is equal to a
+   *          mathematical integer.
+   *  @group rounding
+   */
   def rint(x: Double): Double = java.lang.Math.rint(x)
 
   /** There is no reason to round a `Long`, but this method prevents unintended conversion to `Float` followed by rounding to `Int`.
@@ -227,13 +227,15 @@ package object math {
   /** @group minmax */
   def min(x: Double, y: Double): Double = java.lang.Math.min(x, y)
 
-  /** @group signs
-    * @note Forwards to [[java.lang.Integer]]
-    */
+  /**
+   *  @group signs
+   *  @note Forwards to [[java.lang.Integer]]
+   */
   def signum(x: Int): Int       = java.lang.Integer.signum(x)
-  /** @group signs
-    * @note Forwards to [[java.lang.Long]]
-    */
+  /**
+   *  @group signs
+   *  @note Forwards to [[java.lang.Long]]
+   */
   def signum(x: Long): Long     = java.lang.Long.signum(x)
   /** @group signs */
   def signum(x: Float): Float   = java.lang.Math.signum(x)
@@ -287,19 +289,19 @@ package object math {
   // -----------------------------------------------------------------------
 
   /** Returns the square root of a `Double` value.
-    *
-    * @param  x the number to take the square root of
-    * @return the value √x
-    * @group root-extraction
-    */
+   *
+   *  @param  x the number to take the square root of
+   *  @return the value √x
+   *  @group root-extraction
+   */
   def sqrt(x: Double): Double = java.lang.Math.sqrt(x)
 
   /** Returns the cube root of the given `Double` value.
-    *
-    * @param  x the number to take the cube root of
-    * @return the value ∛x
-    * @group root-extraction
-    */
+   *
+   *  @param  x the number to take the cube root of
+   *  @return the value ∛x
+   *  @group root-extraction
+   */
   def cbrt(x: Double): Double = java.lang.Math.cbrt(x)
 
   // -----------------------------------------------------------------------
@@ -307,27 +309,27 @@ package object math {
   // -----------------------------------------------------------------------
 
   /** Returns the value of the first argument raised to the power of the
-    *  second argument.
-    *
-    *  @param x the base.
-    *  @param y the exponent.
-    *  @return the value `x^y^`.
-    *  @group explog
-    */
+   *  second argument.
+   *
+   *  @param x the base.
+   *  @param y the exponent.
+   *  @return the value `x^y^`.
+   *  @group explog
+   */
   def pow(x: Double, y: Double): Double = java.lang.Math.pow(x, y)
 
   /** Returns Euler's number `e` raised to the power of a `Double` value.
-    *
-    *  @param  x the exponent to raise `e` to.
-    *  @return the value `e^a^`, where `e` is the base of the natural
-    *          logarithms.
-    *  @group explog
-    */
+   *
+   *  @param  x the exponent to raise `e` to.
+   *  @return the value `e^a^`, where `e` is the base of the natural
+   *          logarithms.
+   *  @group explog
+   */
   def exp(x: Double): Double = java.lang.Math.exp(x)
 
   /** Returns `exp(x) - 1`.
-    *  @group explog
-    */
+   *  @group explog
+   */
   def expm1(x: Double): Double = java.lang.Math.expm1(x)
 
   /** @group explog */
@@ -341,21 +343,21 @@ package object math {
   // -----------------------------------------------------------------------
 
   /** Returns the natural logarithm of a `Double` value.
-    *
-    *  @param  x the number to take the natural logarithm of
-    *  @return the value `logₑ(x)` where `e` is Eulers number
-    *  @group explog
-    */
+   *
+   *  @param  x the number to take the natural logarithm of
+   *  @return the value `logₑ(x)` where `e` is Eulers number
+   *  @group explog
+   */
   def log(x: Double): Double = java.lang.Math.log(x)
 
   /** Returns the natural logarithm of the sum of the given `Double` value and 1.
-    *  @group explog
-    */
+   *  @group explog
+   */
   def log1p(x: Double): Double = java.lang.Math.log1p(x)
 
   /** Returns the base 10 logarithm of the given `Double` value.
-    *  @group explog
-    */
+   *  @group explog
+   */
   def log10(x: Double): Double = java.lang.Math.log10(x)
 
   // -----------------------------------------------------------------------
@@ -363,18 +365,18 @@ package object math {
   // -----------------------------------------------------------------------
 
   /** Returns the hyperbolic sine of the given `Double` value.
-    * @group hyperbolic
-    */
+   *  @group hyperbolic
+   */
   def sinh(x: Double): Double = java.lang.Math.sinh(x)
 
   /** Returns the hyperbolic cosine of the given `Double` value.
-    * @group hyperbolic
-    */
+   *  @group hyperbolic
+   */
   def cosh(x: Double): Double = java.lang.Math.cosh(x)
 
   /** Returns the hyperbolic tangent of the given `Double` value.
-    * @group hyperbolic
-    */
+   *  @group hyperbolic
+   */
   def tanh(x: Double):Double = java.lang.Math.tanh(x)
 
   // -----------------------------------------------------------------------
@@ -382,13 +384,13 @@ package object math {
   // -----------------------------------------------------------------------
 
   /** Returns the size of an ulp of the given `Double` value.
-    * @group ulp
-    */
+   *  @group ulp
+   */
   def ulp(x: Double): Double = java.lang.Math.ulp(x)
 
   /** Returns the size of an ulp of the given `Float` value.
-    * @group ulp
-    */
+   *  @group ulp
+   */
   def ulp(x: Float): Float = java.lang.Math.ulp(x)
 
   /** @group exact */

--- a/library/src/scala/native.scala
+++ b/library/src/scala/native.scala
@@ -16,9 +16,9 @@ import scala.language.`2.13`
 
 /** Marker for native methods.
   *
-  * {{{
+  * ```
   * @native def f(x: Int, y: List[Long]): String = ...
-  * }}}
+  * ```
   *
   * A `@native` method is compiled to the platform's native method,
   * while discarding the method's body (if any). The body will be type checked if present.

--- a/library/src/scala/noinline.scala
+++ b/library/src/scala/noinline.scala
@@ -25,7 +25,7 @@ import scala.language.`2.13`
  *
  * Examples:
  *
- * {{{
+ * ```
  * @inline   final def f1(x: Int) = x
  * @noinline final def f2(x: Int) = x
  *           final def f3(x: Int) = x
@@ -38,13 +38,14 @@ import scala.language.`2.13`
  *  def t6 = f3(1): @inline     // inlined if possible
  *  def t7 = f3(1): @noinline   // not inlined
  * }
- * }}}
+ * ```
  *
  * Note: parentheses are required when annotating a callsite within a larger expression.
  *
- * {{{
+ * ```
  * def t1 = f1(1) + f1(1): @noinline   // equivalent to (f1(1) + f1(1)): @noinline
  * def t2 = f1(1) + (f1(1): @noinline) // the second call to f1 is not inlined
- * }}}
+ * ```
+ 
  */
 final class noinline extends scala.annotation.StaticAnnotation

--- a/library/src/scala/quoted/Expr.scala
+++ b/library/src/scala/quoted/Expr.scala
@@ -270,7 +270,7 @@ object Expr {
 
   /** Finds a given instance of type `T` in the current scope.
    *  Returns `Some` containing the expression of the implicit or
-   * `None` if implicit resolution failed.
+   *  `None` if implicit resolution failed.
    *
    *  @tparam T type of the implicit parameter
    */
@@ -285,7 +285,7 @@ object Expr {
   /** Finds a given instance of type `T` in the current scope,
    *  while excluding certain symbols from the initial implicit search.
    *  Returns `Some` containing the expression of the implicit or
-   * `None` if implicit resolution failed.
+   *  `None` if implicit resolution failed.
    *
    *  @tparam T type of the implicit parameter
    *  @param ignored Symbols ignored during the initial implicit search

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -50,13 +50,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     def show: String
 
     /** Pattern matches `this` against `that`. Effectively performing a deep equality check.
-    *  It does the equivalent of
-    *  ```scala sc:nocompile
-    *  this match
-    *    case '{...} => true // where the contents of the pattern are the contents of `that`
-    *    case _ => false
-    *  ```
-    */
+     *  It does the equivalent of
+     *  ```scala sc:nocompile
+     *  this match
+     *    case '{...} => true // where the contents of the pattern are the contents of `that`
+     *    case _ => false
+     *  ```
+     */
     def matches(that: Expr[Any]): Boolean
 
     /** Returns the value of this expression.
@@ -114,7 +114,6 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
    *  ```
    *
    *  See `reflectModule` for full API.
-   *
    */
   val reflect: reflectModule
 
@@ -246,7 +245,6 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
    *  +- Flags
    *
    *  ```
-   *
    */
   trait reflectModule { self: reflect.type =>
 
@@ -883,8 +881,8 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         def appliedToArgs(args: List[Term]): Apply
 
         /** The current tree applied to given argument lists:
-        *  `tree (argss(0)) ... (argss(argss.length -1))`
-        */
+         *  `tree (argss(0)) ... (argss(argss.length -1))`
+         */
         def appliedToArgss(argss: List[List[Term]]): Term
 
         /** The current tree applied to (): `tree()`. */
@@ -925,23 +923,23 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       def term(tp: TermRef): Ref
 
       /** Creates a reference tree from a symbol
-      *
-      *  If `sym` refers to a class member `foo` in class `C`,
-      *  returns a tree representing `C.this.foo`.
-      *
-      *  If `sym` refers to an object member `foo` in object C, itself in prefix
-      *  `pre` (which might include `.this`, if it contains a class),
-      *  returns `pre.C.foo`.
-      *
-      *  If `sym` refers to a local definition `foo`, returns
-      *  a tree representing `foo`.
-      *
-      *  @note In all cases, the constructed tree should only
-      *  be spliced into the places where such accesses make sense.
-      *  For example, it is incorrect to have `C.this.foo` outside
-      *  the class body of `C`, or have `foo` outside the lexical
-      *  scope for the definition of `foo`.
-      */
+       *
+       *  If `sym` refers to a class member `foo` in class `C`,
+       *  returns a tree representing `C.this.foo`.
+       *
+       *  If `sym` refers to an object member `foo` in object C, itself in prefix
+       *  `pre` (which might include `.this`, if it contains a class),
+       *  returns `pre.C.foo`.
+       *
+       *  If `sym` refers to a local definition `foo`, returns
+       *  a tree representing `foo`.
+       *
+       *  @note In all cases, the constructed tree should only
+       *  be spliced into the places where such accesses make sense.
+       *  For example, it is incorrect to have `C.this.foo` outside
+       *  the class body of `C`, or have `foo` outside the lexical
+       *  scope for the definition of `foo`.
+       */
       def apply(sym: Symbol): Ref
     }
 
@@ -1007,11 +1005,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       def apply(qualifier: Term, symbol: Symbol): Select
 
       /** Selects a field or a non-overloaded method by name
-      *
-      *  @note The method will produce an assertion error if the selected
-      *        method is overloaded. The method `overloaded` should be used
-      *        in that case.
-      */
+       *
+       *  @note The method will produce an assertion error if the selected
+       *        method is overloaded. The method `overloaded` should be used
+       *        in that case.
+       */
       def unique(qualifier: Term, name: String): Select
 
       /** Calls an overloaded method with the given type and term parameters. */
@@ -1437,7 +1435,6 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
      *    def m(...) = ...
      *    closure(m)
      *  }
-     *
      */
     type Closure <: Term
 
@@ -1495,7 +1492,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        *  Block((DefDef(_, _, params :: Nil, _, Some(rhsFn(meth, paramRefs)))) :: Nil, Closure(meth, _))
        *  ```
        *
-       * Usage:
+       *  Usage:
        *  ```
        *  val mtpe = MethodType(List("arg1"))(_ => List(TypeRepr.of[Int]), _ => TypeRepr.of[Int])
        *  Lambda(owner, mtpe, {
@@ -2028,11 +2025,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Methods of the module object `val Refined`. */
     trait RefinedModule { this: Refined.type =>
       /** Creates and types a Refined AST node.
-        * @param tpt - parent type being refined
-        * @param refinements - List of definitions represesenting refinements
-        * @param refineCls - symbol of the class of which the refinement definitions originally come from
-        * @return
-        */
+       *  @param tpt - parent type being refined
+       *  @param refinements - List of definitions represesenting refinements
+       *  @param refineCls - symbol of the class of which the refinement definitions originally come from
+       *  @return
+       */
       def apply(tpt: TypeTree, refinements: List[Definition], refineCls: Symbol): Refined
       def copy(original: Tree)(tpt: TypeTree, refinements: List[Definition]): Refined
       def unapply(x: Refined): (TypeTree, List[Definition])
@@ -2268,9 +2265,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     end TypeBoundsTreeMethods
 
     /** Type tree representing wildcard type bounds written in the source.
-    *  The wildcard type `?` (for example in in `List[?]`) will be a type tree that
-    *  represents a type but has `TypeBounds` inside.
-    */
+     *  The wildcard type `?` (for example in in `List[?]`) will be a type tree that
+     *  represents a type but has `TypeBounds` inside.
+     */
     type WildcardTypeTree <: Tree
 
     /** `TypeTest` that allows testing at runtime in a pattern match if a `Tree` is a `WildcardTypeTree`. */
@@ -2703,29 +2700,29 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         def show(using Printer[TypeRepr]): String
 
         /** Converts this `TypeRepr` to an `Type[?]`
-        *
-        *  Usage:
-        *  ```scala
-        *  //{
-        *  import scala.quoted.*
-        *  def f(using Quotes) = {
-        *    val q: Quotes = summon[Quotes]
-        *    import q.reflect.*
-        *    val typeRepr: TypeRepr = ???
-        *  //}
-        *    typeRepr.asType match
-        *      case '[t] =>
-        *        '{ val x: t = ??? }
-        *  //{
-        *  }
-        *  //}
-        *  ```
-        */
+         *
+         *  Usage:
+         *  ```scala
+         *  //{
+         *  import scala.quoted.*
+         *  def f(using Quotes) = {
+         *    val q: Quotes = summon[Quotes]
+         *    import q.reflect.*
+         *    val typeRepr: TypeRepr = ???
+         *  //}
+         *    typeRepr.asType match
+         *      case '[t] =>
+         *        '{ val x: t = ??? }
+         *  //{
+         *  }
+         *  //}
+         *  ```
+         */
         def asType: Type[?]
 
         /** Is `self` type the same as `that` type?
-        *  This is the case iff `self <:< that` and `that <:< self`.
-        */
+         *  This is the case iff `self <:< that` and `that <:< self`.
+         */
         def =:=(that: TypeRepr): Boolean
 
         /** Is this type a subtype of that type? */
@@ -2757,8 +2754,8 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         def dealiasKeepOpaques: TypeRepr
 
         /** A simplified version of this type which is equivalent wrt =:= to this type.
-        *  Reduces typerefs, applied match types, and and or types.
-        */
+         *  Reduces typerefs, applied match types, and and or types.
+         */
         def simplified: TypeRepr
 
         def classSymbol: Option[Symbol]
@@ -2776,50 +2773,50 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         def baseClasses: List[Symbol]
 
         /** The least type instance of given class which is a super-type
-        *  of this type.  Example:
-        *  {{{
-        *    class D[T]
-        *    class C extends p.D[Int]
-        *    ThisType(C).baseType(D) = p.D[Int]
-        * }}}
-        */
+         *  of this type.  Example:
+         *  ```
+         *    class D[T]
+         *    class C extends p.D[Int]
+         *    ThisType(C).baseType(D) = p.D[Int]
+         *  ```
+         */
         def baseType(cls: Symbol): TypeRepr
 
         /** Is this type an instance of a non-bottom subclass of the given class `cls`? */
         def derivesFrom(cls: Symbol): Boolean
 
         /** Is this type a function type?
-        *
-        *  @return true if the dealiased type of `self` without refinement is `FunctionN[T1, T2, ..., Tn]`
-        *
-        *  @note The function
-        *
-        *     - returns true for `given Int => Int` and `erased Int => Int`
-        *     - returns false for `List[Int]`, despite that `List[Int] <:< Int => Int`.
-        */
+         *
+         *  @return true if the dealiased type of `self` without refinement is `FunctionN[T1, T2, ..., Tn]`
+         *
+         *  @note The function
+         *
+         *     - returns true for `given Int => Int` and `erased Int => Int`
+         *     - returns false for `List[Int]`, despite that `List[Int] <:< Int => Int`.
+         */
         def isFunctionType: Boolean
 
         /** Is this type an context function type?
-        *
-        *  @see `isFunctionType`
-        */
+         *
+         *  @see `isFunctionType`
+         */
         def isContextFunctionType: Boolean
 
         /** Is this type a function type with erased parameters?
-        *
-        *  @see `isFunctionType`
-        */
+         *
+         *  @see `isFunctionType`
+         */
         def isErasedFunctionType: Boolean
 
         /** Is this type a dependent function type?
-        *
-        *  @see `isFunctionType`
-        */
+         *
+         *  @see `isFunctionType`
+         */
         def isDependentFunctionType: Boolean
 
         /** Is this type a `TupleN` type?
          *
-         * @return true if the dealiased type of `self` is `TupleN[T1, T2, ..., Tn]`
+         *  @return true if the dealiased type of `self` is `TupleN[T1, T2, ..., Tn]`
          */
         def isTupleN: Boolean
 
@@ -3230,13 +3227,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     trait RecursiveTypeModule { this: RecursiveType.type =>
 
       /** Creates a RecType, normalizing its contents. This means:
-      *
-      *   1. Nested Rec types on the type's spine are merged with the outer one.
-      *   2. Any refinement of the form `type T = z.T` on the spine of the type
-      *      where `z` refers to the created rec-type is replaced by
-      *      `type T`. This avoids infinite recursions later when we
-      *      try to follow these references.
-      */
+       *
+       *   1. Nested Rec types on the type's spine are merged with the outer one.
+       *   2. Any refinement of the form `type T = z.T` on the spine of the type
+       *      where `z` refers to the created rec-type is replaced by
+       *      `type T`. This avoids infinite recursions later when we
+       *      try to follow these references.
+       */
       def apply(parentExp: RecursiveType => TypeRepr): RecursiveType
 
       def unapply(x: RecursiveType): Some[TypeRepr]
@@ -3741,22 +3738,22 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Methods of the module object `val Implicits`. */
     trait ImplicitsModule { self: Implicits.type =>
       /** Finds a given instance of type `T` in the current scope provided by the current enclosing splice.
-      *  Returns an `ImplicitSearchResult`.
-      *
-      *  @param tpe type of the implicit parameter
-      */
+       *  Returns an `ImplicitSearchResult`.
+       *
+       *  @param tpe type of the implicit parameter
+       */
       def search(tpe: TypeRepr): ImplicitSearchResult
 
       /** Finds a given instance of type `T` in the current scope provided by the current enclosing splice,
-      *  while excluding certain symbols from the initial implicit search.
-      *  Returns an `ImplicitSearchResult`.
-      *
-      *  @param tpe type of the implicit parameter
-      *  @param ignored Symbols ignored during the initial implicit search
-      *
-      *  @note if an found given requires additional search for other given instances,
-      *  this additional search will NOT exclude the symbols from the `ignored` list.
-      */
+       *  while excluding certain symbols from the initial implicit search.
+       *  Returns an `ImplicitSearchResult`.
+       *
+       *  @param tpe type of the implicit parameter
+       *  @param ignored Symbols ignored during the initial implicit search
+       *
+       *  @note if an found given requires additional search for other given instances,
+       *  this additional search will NOT exclude the symbols from the `ignored` list.
+       */
       def searchIgnoring(tpe: TypeRepr)(ignored: Symbol*): ImplicitSearchResult
     }
 
@@ -3813,8 +3810,8 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /////////////
 
     /** Symbol of a definition.
-    *   Symbols can be compared with `==` to know if two definitions are the same.
-    */
+     *   Symbols can be compared with `==` to know if two definitions are the same.
+     */
     type Symbol <: AnyRef
 
     /** Module object of `type Symbol`. */
@@ -4022,24 +4019,24 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        *  }
        *  ```
        *
-       * @param owner The owner of the class
-       * @param name The name of the class
-       * @param parents Function returning the parent classes of the class. The first parent must not be a trait
-       * Takes the constructed class symbol as an argument. Calling `cls.typeRef.asType` as part of this function will lead to cyclic reference errors.
-       * @param decls The member declarations of the class provided the symbol of this class
-       * @param selfType The self type of the class if it has one
-       * @param clsFlags extra flags with which the class symbol should be constructed. Can be `Private` | `Protected` | `PrivateLocal` | `Local` | `Final` | `Trait` | `Abstract` | `Open`
-       * @param clsPrivateWithin the symbol within which this new class symbol should be private. May be noSymbol
-       * @param clsAnnotations annotations of the class
-       * @param conMethodType Function returning MethodOrPoly type representing the type of the constructor.
-       * Takes the result type as parameter which must be returned from the innermost MethodOrPoly and have type parameters applied if those are used.
-       * PolyType may only represent the first clause of the constructor.
-       * @param conFlags extra flags with which the constructor symbol should be constructed. Can be `Synthetic` | `Method` | `Private` | `Protected` | `PrivateLocal` | `Local`
-       * @param conPrivateWithin the symbol within which the constructor for this new class symbol should be private. May be noSymbol.
-       * @param conParamFlags extra flags with which the constructor parameter symbols should be constructed. Must match the shape of `conMethodType`.
-       * For type parameters those can be `Param` | `Deferred` | `Private` | `PrivateLocal` | `Local`.
-       * For term parameters those can be `ParamAccessor` | `Private` | `Protected` | `PrivateLocal` | `Local`
-       * @param conParamPrivateWithins the symbols within which the constructor parameters should be private. Must match the shape of `conMethodType`. Can consist of noSymbol.
+       *  @param owner The owner of the class
+       *  @param name The name of the class
+       *  @param parents Function returning the parent classes of the class. The first parent must not be a trait
+       *  Takes the constructed class symbol as an argument. Calling `cls.typeRef.asType` as part of this function will lead to cyclic reference errors.
+       *  @param decls The member declarations of the class provided the symbol of this class
+       *  @param selfType The self type of the class if it has one
+       *  @param clsFlags extra flags with which the class symbol should be constructed. Can be `Private` | `Protected` | `PrivateLocal` | `Local` | `Final` | `Trait` | `Abstract` | `Open`
+       *  @param clsPrivateWithin the symbol within which this new class symbol should be private. May be noSymbol
+       *  @param clsAnnotations annotations of the class
+       *  @param conMethodType Function returning MethodOrPoly type representing the type of the constructor.
+       *  Takes the result type as parameter which must be returned from the innermost MethodOrPoly and have type parameters applied if those are used.
+       *  PolyType may only represent the first clause of the constructor.
+       *  @param conFlags extra flags with which the constructor symbol should be constructed. Can be `Synthetic` | `Method` | `Private` | `Protected` | `PrivateLocal` | `Local`
+       *  @param conPrivateWithin the symbol within which the constructor for this new class symbol should be private. May be noSymbol.
+       *  @param conParamFlags extra flags with which the constructor parameter symbols should be constructed. Must match the shape of `conMethodType`.
+       *  For type parameters those can be `Param` | `Deferred` | `Private` | `PrivateLocal` | `Local`.
+       *  For term parameters those can be `ParamAccessor` | `Private` | `Protected` | `PrivateLocal` | `Local`
+       *  @param conParamPrivateWithins the symbols within which the constructor parameters should be private. Must match the shape of `conMethodType`. Can consist of noSymbol.
        *
        *  Term and type parameters assigned by the constructor can be obtained via `classSymbol.memberField`/`classSymbol.memberType`.
        *  This symbol starts without an accompanying definition.
@@ -4143,85 +4140,85 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       def newMethod(parent: Symbol, name: String, tpe: TypeRepr): Symbol
 
       /** Works as the other newMethod, but with additional parameters.
-      *
-      *  To define a member method of a class, use the `newMethod` within the `decls` function of `newClass`.
-      *
-      *  @param parent The owner of the method
-      *  @param name The name of the method
-      *  @param tpe The type of the method (MethodType, PolyType, ByNameType)
-      *  @param flags extra flags to with which the symbol should be constructed. `Method` flag will be added. Can be `Private | Protected | Override | Deferred | Final | Method | Implicit | Given | Local | JavaStatic | Synthetic | Artifact`
-      *  @param privateWithin the symbol within which this new method symbol should be private. May be noSymbol.
-      */
+       *
+       *  To define a member method of a class, use the `newMethod` within the `decls` function of `newClass`.
+       *
+       *  @param parent The owner of the method
+       *  @param name The name of the method
+       *  @param tpe The type of the method (MethodType, PolyType, ByNameType)
+       *  @param flags extra flags to with which the symbol should be constructed. `Method` flag will be added. Can be `Private | Protected | Override | Deferred | Final | Method | Implicit | Given | Local | JavaStatic | Synthetic | Artifact`
+       *  @param privateWithin the symbol within which this new method symbol should be private. May be noSymbol.
+       */
       // Keep: `flags` doc aligned with QuotesImpl's `validMethodFlags`
       def newMethod(parent: Symbol, name: String, tpe: TypeRepr, flags: Flags, privateWithin: Symbol): Symbol
 
       /** Generates a new val/var/lazy val symbol with the given parent, name and type.
-      *
-      *  This symbol starts without an accompanying definition.
-      *  It is the meta-programmer's responsibility to provide exactly one corresponding definition by passing
-      *  this symbol to the ValDef constructor.
-      *
-      *  Note: Also see ValDef.let
-      *
-      *  @param parent The owner of the val/var/lazy val
-      *  @param name The name of the val/var/lazy val
-      *  @param tpe The type of the val/var/lazy val
-      *  @param flags extra flags to with which the symbol should be constructed. Can be `Private | Protected | Override | Deferred | Final | Param | Implicit | Lazy | Mutable | Local | ParamAccessor | Module | Package | Case | CaseAccessor | Given | Enum | JavaStatic | Synthetic | Artifact`
-      *  @param privateWithin the symbol within which this new method symbol should be private. May be noSymbol.
-      *  @note As a macro can only splice code into the point at which it is expanded, all generated symbols must be
-      *        direct or indirect children of the reflection context's owner.
-      */
+       *
+       *  This symbol starts without an accompanying definition.
+       *  It is the meta-programmer's responsibility to provide exactly one corresponding definition by passing
+       *  this symbol to the ValDef constructor.
+       *
+       *  Note: Also see ValDef.let
+       *
+       *  @param parent The owner of the val/var/lazy val
+       *  @param name The name of the val/var/lazy val
+       *  @param tpe The type of the val/var/lazy val
+       *  @param flags extra flags to with which the symbol should be constructed. Can be `Private | Protected | Override | Deferred | Final | Param | Implicit | Lazy | Mutable | Local | ParamAccessor | Module | Package | Case | CaseAccessor | Given | Enum | JavaStatic | Synthetic | Artifact`
+       *  @param privateWithin the symbol within which this new method symbol should be private. May be noSymbol.
+       *  @note As a macro can only splice code into the point at which it is expanded, all generated symbols must be
+       *        direct or indirect children of the reflection context's owner.
+       */
       // Keep: `flags` doc aligned with QuotesImpl's `validValFlags`
       def newVal(parent: Symbol, name: String, tpe: TypeRepr, flags: Flags, privateWithin: Symbol): Symbol
 
       /** Generates a pattern bind symbol with the given parent, name and type.
-      *
-      *  This symbol starts without an accompanying definition.
-      *  It is the meta-programmer's responsibility to provide exactly one corresponding definition by passing
-      *  this symbol to the BindDef constructor.
-      *
-      *  @param parent The owner of the binding
-      *  @param name The name of the binding
-      *  @param flags extra flags to with which the symbol should be constructed. `Case` flag will be added. Can be `Case`
-      *  @param tpe The type of the binding
-      *  @note As a macro can only splice code into the point at which it is expanded, all generated symbols must be
-      *        direct or indirect children of the reflection context's owner.
-      */
+       *
+       *  This symbol starts without an accompanying definition.
+       *  It is the meta-programmer's responsibility to provide exactly one corresponding definition by passing
+       *  this symbol to the BindDef constructor.
+       *
+       *  @param parent The owner of the binding
+       *  @param name The name of the binding
+       *  @param flags extra flags to with which the symbol should be constructed. `Case` flag will be added. Can be `Case`
+       *  @param tpe The type of the binding
+       *  @note As a macro can only splice code into the point at which it is expanded, all generated symbols must be
+       *        direct or indirect children of the reflection context's owner.
+       */
       // Keep: `flags` doc aligned with QuotesImpl's `validBindFlags`
       def newBind(parent: Symbol, name: String, flags: Flags, tpe: TypeRepr): Symbol
 
       /** Generates a new type symbol for a type alias with the given parent, name and type
-        *
-        *  This symbol starts without an accompanying definition.
-        *  It is the meta-programmer's responsibility to provide exactly one corresponding definition by passing
-        *  this symbol to the TypeDef constructor.
-        *
-        *  @param parent The owner of the type
-        *  @param name The name of the type
-        *  @param flags extra flags to with which symbol can be constructed. Can be `Private` | `Protected` | `Override` | `Final` | `Infix` | `Local`
-        *  @param tpe The rhs the type alias
-        *  @param privateWithin the symbol within which this new type symbol should be private. May be noSymbol.
-        *  @note As a macro can only splice code into the point at which it is expanded, all generated symbols must be
-        *        direct or indirect children of the reflection context's owner.
-        */
+       *
+       *  This symbol starts without an accompanying definition.
+       *  It is the meta-programmer's responsibility to provide exactly one corresponding definition by passing
+       *  this symbol to the TypeDef constructor.
+       *
+       *  @param parent The owner of the type
+       *  @param name The name of the type
+       *  @param flags extra flags to with which symbol can be constructed. Can be `Private` | `Protected` | `Override` | `Final` | `Infix` | `Local`
+       *  @param tpe The rhs the type alias
+       *  @param privateWithin the symbol within which this new type symbol should be private. May be noSymbol.
+       *  @note As a macro can only splice code into the point at which it is expanded, all generated symbols must be
+       *        direct or indirect children of the reflection context's owner.
+       */
       @experimental
       // Keep: `flags` doc aligned with QuotesImpl's `validTypeAliasFlags`
       def newTypeAlias(parent: Symbol, name: String, flags: Flags, tpe: TypeRepr, privateWithin: Symbol): Symbol
 
       /** Generates a new type symbol for a type bounds with the given parent, name and type
-        *
-        *  This symbol starts without an accompanying definition.
-        *  It is the meta-programmer's responsibility to provide exactly one corresponding definition by passing
-        *  this symbol to the TypeDef constructor.
-        *
-        *  @param parent The owner of the type
-        *  @param name The name of the type
-        *  @param flags extra flags to with which symbol can be constructed. `Deferred` flag will be added. Can be `Private` | `Protected` | `Override` | `Deferred` | `Final` | `Infix` | `Local`
-        *  @param tpe The bounds of the type
-        *  @param privateWithin the symbol within which this new type symbol should be private. May be noSymbol.
-        *  @note As a macro can only splice code into the point at which it is expanded, all generated symbols must be
-        *        direct or indirect children of the reflection context's owner.
-        */
+       *
+       *  This symbol starts without an accompanying definition.
+       *  It is the meta-programmer's responsibility to provide exactly one corresponding definition by passing
+       *  this symbol to the TypeDef constructor.
+       *
+       *  @param parent The owner of the type
+       *  @param name The name of the type
+       *  @param flags extra flags to with which symbol can be constructed. `Deferred` flag will be added. Can be `Private` | `Protected` | `Override` | `Deferred` | `Final` | `Infix` | `Local`
+       *  @param tpe The bounds of the type
+       *  @param privateWithin the symbol within which this new type symbol should be private. May be noSymbol.
+       *  @note As a macro can only splice code into the point at which it is expanded, all generated symbols must be
+       *        direct or indirect children of the reflection context's owner.
+       */
       @experimental
       // Keep: `flags` doc aligned with QuotesImpl's `validBoundedTypeFlags`
       def newBoundedType(parent: Symbol, name: String, flags: Flags, tpe: TypeBounds, privateWithin: Symbol): Symbol
@@ -4303,7 +4300,6 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
          *      tp.memberType(symbol)
          *      symbol.typeRef
          *      symbol.termRef
-         *
          */
         def tree: Tree
 
@@ -4320,8 +4316,8 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         def isDefinedInCurrentRun: Boolean
 
         /** Dummy val symbol that owns all statements within the initialization of the class.
-        *  This may also contain local definitions such as classes defined in a `locally` block in the class.
-        */
+         *  This may also contain local definitions such as classes defined in a `locally` block in the class.
+         */
         def isLocalDummy: Boolean
 
         /** Is this symbol a class representing a refinement? */
@@ -4439,8 +4435,8 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         def declarations: List[Symbol]
 
         /** The symbols of each type parameter list and value parameter list of this
-          *  method, or Nil if this isn't a method.
-          */
+         *  method, or Nil if this isn't a method.
+         */
         def paramSymss: List[List[Symbol]]
 
         /** Returns all symbols overridden by this symbol. */
@@ -4560,12 +4556,12 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       extension (self: Signature)
 
         /** The signatures of the method parameters.
-          *
-          *  Each *type parameter section* is represented by a single Int corresponding
-          *  to the number of type parameters in the section.
-          *  Each *term parameter* is represented by a String corresponding to the fully qualified
-          *  name of the parameter type.
-          */
+         *
+         *  Each *type parameter section* is represented by a single Int corresponding
+         *  to the number of type parameters in the section.
+         *  Each *term parameter* is represented by a String corresponding to the fully qualified
+         *  name of the parameter type.
+         */
         def paramSigs: List[String | Int]
 
         /** The signature of the result type. */
@@ -4681,10 +4677,10 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       def Array_update: Symbol
 
       /** A dummy class symbol that is used to indicate repeated parameters
-      *  compiled by the Scala compiler.
-      *
-      *  @see Repeated
-      */
+       *  compiled by the Scala compiler.
+       *
+       *  @see Repeated
+       */
       def RepeatedParamClass: Symbol
 
       /** The class symbol of class `scala.annotation.reflection.Repeated`. */
@@ -4703,11 +4699,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       def ProductClass: Symbol
 
       /** Function-like object that maps arity to symbols for classes `scala.FunctionX`.
-      *   -  0th element is `Function0`
-      *   -  1st element is `Function1`
-      *   -  ...
-      *   -  Nth element is `FunctionN`
-      */
+       *   -  0th element is `Function0`
+       *   -  1st element is `Function1`
+       *   -  ...
+       *   -  Nth element is `FunctionN`
+       */
       @deprecated("Use overload of `FunctionClass` with 1 or 2 arguments", "3.4")
       def FunctionClass(arity: Int, isImplicit: Boolean = false, isErased: Boolean = false): Symbol
 
@@ -4730,41 +4726,41 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       def PolyFunctionClass: Symbol
 
       /** Function-like object that maps arity to symbols for classes `scala.TupleX`.
-      *   -  0th element is `NoSymbol`
-      *   -  1st element is `NoSymbol`
-      *   -  2st element is `Tuple2`
-      *   -  ...
-      *   - 22nd element is `Tuple22`
-      *   - 23nd element is `NoSymbol`  // TODO update when we will have more tuples
-      *   - ...
-      */
+       *   -  0th element is `NoSymbol`
+       *   -  1st element is `NoSymbol`
+       *   -  2st element is `Tuple2`
+       *   -  ...
+       *   - 22nd element is `Tuple22`
+       *   - 23nd element is `NoSymbol`  // TODO update when we will have more tuples
+       *   - ...
+       */
       def TupleClass(arity: Int): Symbol
 
       /** Returns `true` if `sym` is a `Tuple1`, `Tuple2`, ... `Tuple22`. */
       def isTupleClass(sym: Symbol): Boolean
 
       /** Contains Scala primitive value classes:
-      *   - Byte
-      *   - Short
-      *   - Int
-      *   - Long
-      *   - Float
-      *   - Double
-      *   - Char
-      *   - Boolean
-      *   - Unit
-      */
+       *   - Byte
+       *   - Short
+       *   - Int
+       *   - Long
+       *   - Float
+       *   - Double
+       *   - Char
+       *   - Boolean
+       *   - Unit
+       */
       def ScalaPrimitiveValueClasses: List[Symbol]
 
       /** Contains Scala numeric value classes:
-      *   - Byte
-      *   - Short
-      *   - Int
-      *   - Long
-      *   - Float
-      *   - Double
-      *   - Char
-      */
+       *   - Byte
+       *   - Short
+       *   - Int
+       *   - Long
+       *   - Float
+       *   - Double
+       *   - Char
+       */
       def ScalaNumericValueClasses: List[Symbol]
 
     }
@@ -5114,21 +5110,21 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     ///////////////
 
     /** Customizable Tree accumulator.
-    *
-    *  Usage:
-    *  ```scala
-    *  //{
-    *  def inQuotes(using q: Quotes) = {
-    *    import q.reflect.*
-    *  //}
-    *    class MyTreeAccumulator[X] extends TreeAccumulator[X] {
-    *      def foldTree(x: X, tree: Tree)(owner: Symbol): X = ???
-    *    }
-    *  //{
-    *  }
-    *  //}
-    *  ```
-    */
+     *
+     *  Usage:
+     *  ```scala
+     *  //{
+     *  def inQuotes(using q: Quotes) = {
+     *    import q.reflect.*
+     *  //}
+     *    class MyTreeAccumulator[X] extends TreeAccumulator[X] {
+     *      def foldTree(x: X, tree: Tree)(owner: Symbol): X = ???
+     *    }
+     *  //{
+     *  }
+     *  //}
+     *  ```
+     */
     trait TreeAccumulator[X]:
 
       // Ties the knot of the traversal: call `foldOver(x, tree))` to dive in the `tree` node.
@@ -5227,21 +5223,21 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
 
     /** Customizable tree traverser.
-    *
-    *  Usage:
-    *  ```scala
-    *  //{
-    *  def inQuotes(using q: Quotes) = {
-    *    import q.reflect.*
-    *  //}
-    *    class MyTraverser extends TreeTraverser {
-    *      override def traverseTree(tree: Tree)(owner: Symbol): Unit = ???
-    *    }
-    *  //{
-    *  }
-    *  //}
-    *  ```
-    */
+     *
+     *  Usage:
+     *  ```scala
+     *  //{
+     *  def inQuotes(using q: Quotes) = {
+     *    import q.reflect.*
+     *  //}
+     *    class MyTraverser extends TreeTraverser {
+     *      override def traverseTree(tree: Tree)(owner: Symbol): Unit = ???
+     *    }
+     *  //{
+     *  }
+     *  //}
+     *  ```
+     */
     trait TreeTraverser extends TreeAccumulator[Unit]:
 
       def traverseTree(tree: Tree)(owner: Symbol): Unit = traverseTreeChildren(tree)(owner)
@@ -5253,24 +5249,23 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     end TreeTraverser
 
     /** Customizable tree mapper.
-    *
-    *  Usage:
-    *  ```scala
-    *  //{
-    *  def inQuotes(using q: Quotes) = {
-    *    import q.reflect.*
-    *  //}
-    *    class MyTreeMap extends TreeMap {
-    *      override def transformTree(tree: Tree)(owner: Symbol): Tree = ???
-    *    }
-    *  //{
-    *  }
-    *  //}
-    *  ```
-    *
-    *  Use `Symbol.asQuotes` to create quotes with the correct owner within the TreeMap.
-    *
-    */
+     *
+     *  Usage:
+     *  ```scala
+     *  //{
+     *  def inQuotes(using q: Quotes) = {
+     *    import q.reflect.*
+     *  //}
+     *    class MyTreeMap extends TreeMap {
+     *      override def transformTree(tree: Tree)(owner: Symbol): Tree = ???
+     *    }
+     *  //{
+     *  }
+     *  //}
+     *  ```
+     *
+     *  Use `Symbol.asQuotes` to create quotes with the correct owner within the TreeMap.
+     */
     trait TreeMap:
 
       def transformTree(tree: Tree)(owner: Symbol): Tree = {

--- a/library/src/scala/quoted/Varargs.scala
+++ b/library/src/scala/quoted/Varargs.scala
@@ -9,8 +9,7 @@ import language.experimental.captureChecking
  */
 object Varargs {
 
-  /**
-   *  Lifts this sequence of expressions into an expression of a sequence
+  /** Lifts this sequence of expressions into an expression of a sequence
    *
    *  Transforms a sequence of expression
    *    `Seq(e1, e2, ...)` where `ei: Expr[T]`

--- a/library/src/scala/quoted/runtime/QuoteMatching.scala
+++ b/library/src/scala/quoted/runtime/QuoteMatching.scala
@@ -11,24 +11,24 @@ trait QuoteMatching:
 
   trait ExprMatchModule { self: ExprMatch.type =>
     /** Pattern matches an the scrutineeExpr against the patternExpr and returns a tuple
-    *  with the matched holes if successful.
-    *
-    *  Examples:
-    *    - `ExprMatch.unapply('{ f(0, myInt) })('{ f(0, myInt) }, _)`
-    *       will return `Some(())` (where `()` is a tuple of arity 0)
-    *    - `ExprMatch.unapply('{ f(0, myInt) })('{ f(patternHole[Int], patternHole[Int]) }, _)`
-    *       will return `Some(Tuple2('{0}, '{ myInt }))`
-    *    - `ExprMatch.unapply('{ f(0, "abc") })('{ f(0, patternHole[Int]) }, _)`
-    *       will return `None` due to the mismatch of types in the hole
-    *
-    *  Holes:
-    *    - scala.quoted.runtime.Patterns.patternHole[T]: hole that matches an expression `x` of type `Expr[U]`
-    *                                            if `U <:< T` and returns `x` as part of the match.
-    *
-    *  @param scrutinee `Expr[Any]` on which we are pattern matching
-    *  @param pattern `Expr[Any]` containing the pattern tree
-    *  @return None if it did not match, `Some(tup)` if it matched where `tup` contains `Expr[Ti]``
-    */
+     *  with the matched holes if successful.
+     *
+     *  Examples:
+     *    - `ExprMatch.unapply('{ f(0, myInt) })('{ f(0, myInt) }, _)`
+     *       will return `Some(())` (where `()` is a tuple of arity 0)
+     *    - `ExprMatch.unapply('{ f(0, myInt) })('{ f(patternHole[Int], patternHole[Int]) }, _)`
+     *       will return `Some(Tuple2('{0}, '{ myInt }))`
+     *    - `ExprMatch.unapply('{ f(0, "abc") })('{ f(0, patternHole[Int]) }, _)`
+     *       will return `None` due to the mismatch of types in the hole
+     *
+     *  Holes:
+     *    - scala.quoted.runtime.Patterns.patternHole[T]: hole that matches an expression `x` of type `Expr[U]`
+     *                                            if `U <:< T` and returns `x` as part of the match.
+     *
+     *  @param scrutinee `Expr[Any]` on which we are pattern matching
+     *  @param pattern `Expr[Any]` containing the pattern tree
+     *  @return None if it did not match, `Some(tup)` if it matched where `tup` contains `Expr[Ti]``
+     */
     def unapply[TypeBindings, Tup <: Tuple](scrutinee: Expr[Any])(using pattern: Expr[Any]): Option[Tup]
   }
 

--- a/library/src/scala/ref/Reference.scala
+++ b/library/src/scala/ref/Reference.scala
@@ -15,7 +15,7 @@ package scala.ref
 import scala.language.`2.13`
 
 /**
- * @see `java.lang.ref.Reference`
+ *  @see `java.lang.ref.Reference`
  */
 trait Reference[+T <: AnyRef] extends Function0[T] {
   /** Returns the underlying value. */

--- a/library/src/scala/ref/SoftReference.scala
+++ b/library/src/scala/ref/SoftReference.scala
@@ -21,9 +21,7 @@ class SoftReference[+T <: AnyRef](value : T, queue : ReferenceQueue[T] | Null) e
     new SoftReferenceWithWrapper[T](value, queue, this)
 }
 
-/**
- *  A companion object that implements an extractor for `SoftReference` values
- */
+/** A companion object that implements an extractor for `SoftReference` values */
 object SoftReference {
 
   /** Creates a `SoftReference` pointing to `value`. */

--- a/library/src/scala/ref/WeakReference.scala
+++ b/library/src/scala/ref/WeakReference.scala
@@ -14,8 +14,7 @@ package scala.ref
 
 import scala.language.`2.13`
 
-/**
- *  A wrapper class for java.lang.ref.WeakReference
+/** A wrapper class for java.lang.ref.WeakReference
  *  The new functionality is (1) results are Option values, instead of using null.
  *  (2) There is an extractor that maps the weak reference itself into an option.
  */

--- a/library/src/scala/reflect/ClassManifestDeprecatedApis.scala
+++ b/library/src/scala/reflect/ClassManifestDeprecatedApis.scala
@@ -49,9 +49,9 @@ trait ClassManifestDeprecatedApis[T] extends OptManifest[T] {
   }
 
   /** Tests whether the type represented by this manifest is a subtype
-    * of the type represented by `that` manifest, subject to the limitations
-    * described in the header.
-    */
+   *  of the type represented by `that` manifest, subject to the limitations
+   *  described in the header.
+   */
   @deprecated("use scala.reflect.runtime.universe.TypeTag for subtype checking instead", "2.10.0")
   def <:<(that: ClassManifest[?]): Boolean = {
     // All types which could conform to these types will override <:<.
@@ -83,9 +83,9 @@ trait ClassManifestDeprecatedApis[T] extends OptManifest[T] {
   }
 
   /** Tests whether the type represented by this manifest is a supertype
-    * of the type represented by `that` manifest, subject to the limitations
-    * described in the header.
-    */
+   *  of the type represented by `that` manifest, subject to the limitations
+   *  described in the header.
+   */
   @deprecated("use scala.reflect.runtime.universe.TypeTag for subtype checking instead", "2.10.0")
   def >:>(that: ClassManifest[?]): Boolean =
     that <:< this
@@ -186,23 +186,24 @@ object ClassManifestFactory {
   def singleType[T <: AnyRef](value: AnyRef): Manifest[T] = Manifest.singleType(value)
 
   /** ClassManifest for the class type `clazz`, where `clazz` is
-    * a top-level or static class.
-    * @note This no-prefix, no-arguments case is separate because we
-    *       it's called from ScalaRunTime.boxArray itself. If we
-    *       pass varargs as arrays into this, we get an infinitely recursive call
-    *       to boxArray. (Besides, having a separate case is more efficient)
-    */
+   *  a top-level or static class.
+   *  @note This no-prefix, no-arguments case is separate because we
+   *       it's called from ScalaRunTime.boxArray itself. If we
+   *       pass varargs as arrays into this, we get an infinitely recursive call
+   *       to boxArray. (Besides, having a separate case is more efficient)
+   */
   def classType[T](clazz: jClass[?]): ClassManifest[T] =
     new ClassTypeManifest[T](None, clazz, Nil)
 
   /** ClassManifest for the class type `clazz[args]`, where `clazz` is
-    * a top-level or static class and `args` are its type arguments */
+   *  a top-level or static class and `args` are its type arguments 
+   */
   def classType[T](clazz: jClass[?], arg1: OptManifest[?], args: OptManifest[?]*): ClassManifest[T] =
     new ClassTypeManifest[T](None, clazz, arg1 :: args.toList)
 
   /** ClassManifest for the class type `clazz[args]`, where `clazz` is
-    * a class with non-package prefix type `prefix` and type arguments `args`.
-    */
+   *  a class with non-package prefix type `prefix` and type arguments `args`.
+   */
   def classType[T](prefix: OptManifest[?], clazz: jClass[?], args: OptManifest[?]*): ClassManifest[T] =
     new ClassTypeManifest[T](Some(prefix), clazz, args.toList)
 
@@ -219,22 +220,24 @@ object ClassManifestFactory {
   }
 
   /** ClassManifest for the abstract type `prefix # name`. `upperBound` is not
-    * strictly necessary as it could be obtained by reflection. It was
-    * added so that erasure can be calculated without reflection. */
+   *  strictly necessary as it could be obtained by reflection. It was
+   *  added so that erasure can be calculated without reflection. 
+   */
   def abstractType[T](prefix: OptManifest[?], name: String, clazz: jClass[?], args: OptManifest[?]*): ClassManifest[T] =
     new AbstractTypeClassManifest(prefix, name, clazz)
 
   /** ClassManifest for the abstract type `prefix # name`. `upperBound` is not
-    * strictly necessary as it could be obtained by reflection. It was
-    * added so that erasure can be calculated without reflection.
-    * todo: remove after next bootstrap
-    */
+   *  strictly necessary as it could be obtained by reflection. It was
+   *  added so that erasure can be calculated without reflection.
+   *  todo: remove after next bootstrap
+   */
   def abstractType[T](prefix: OptManifest[?], name: String, upperbound: ClassManifest[?], args: OptManifest[?]*): ClassManifest[T] =
     new AbstractTypeClassManifest(prefix, name, upperbound.runtimeClass)
 }
 
 /** Manifest for the class type `clazz[args]`, where `clazz` is
-  * a top-level or static class */
+ *  a top-level or static class 
+ */
 @nowarn("""cat=deprecation&origin=scala\.reflect\.ClassManifest""")
 @SerialVersionUID(1L)
 private class ClassTypeManifest[T](

--- a/library/src/scala/reflect/ClassTag.scala
+++ b/library/src/scala/reflect/ClassTag.scala
@@ -19,17 +19,15 @@ import java.lang.ref.{WeakReference => jWeakReference}
 import scala.annotation.{implicitNotFound, nowarn}
 import scala.runtime.ClassValueCompat
 
-/**
+/** A `ClassTag[T]` stores the erased class of a given type `T`, accessible via the `runtimeClass`
+ *  field. This is particularly useful for instantiating `Array`s whose element types are unknown
+ *  at compile time.
  *
- * A `ClassTag[T]` stores the erased class of a given type `T`, accessible via the `runtimeClass`
- * field. This is particularly useful for instantiating `Array`s whose element types are unknown
- * at compile time.
+ *  `ClassTag`s wrap only the runtime class of a given type, without necessarily knowing all of
+ *  its argument types. This runtime information is enough for runtime `Array` creation.
  *
- * `ClassTag`s wrap only the runtime class of a given type, without necessarily knowing all of
- * its argument types. This runtime information is enough for runtime `Array` creation.
- *
- * For example:
- * {{{
+ *  For example:
+ *  ```
  *   scala> def mkArray[T : ClassTag](elems: T*) = Array[T](elems*)
  *   def mkArray[T](elems: T*)(using ClassTag[T]): Array[T]
  *
@@ -38,13 +36,12 @@ import scala.runtime.ClassValueCompat
  *
  *   scala> mkArray("Japan","Brazil","Germany")
  *   val res1: Array[String] = Array(Japan, Brazil, Germany)
- * }}}
+ *  ```
  *
- * For compile-time type information in macros, see the facilities in the
- * [[scala.quoted]] package.
- * For limited runtime type checks beyond what `Class[?]` provides, see
- * [[scala.reflect.TypeTest]] and [[scala.reflect.Typeable]].
- *
+ *  For compile-time type information in macros, see the facilities in the
+ *  [[scala.quoted]] package.
+ *  For limited runtime type checks beyond what `Class[?]` provides, see
+ *  [[scala.reflect.TypeTest]] and [[scala.reflect.Typeable]].
  */
 @nowarn("""cat=deprecation&origin=scala\.reflect\.ClassManifestDeprecatedApis""")
 @implicitNotFound(msg = "No ClassTag available for ${T}")
@@ -66,11 +63,11 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
 
   /** A ClassTag[T] can serve as an extractor that matches only objects of type T.
    *
-   * The compiler tries to turn unchecked type tests in pattern matches into checked ones
-   * by wrapping a `(_: T)` type pattern as `ct(_: T)`, where `ct` is the `ClassTag[T]` instance.
-   * Type tests necessary before calling other extractors are treated similarly.
-   * `SomeExtractor(...)` is turned into `ct(SomeExtractor(...))` if `T` in `SomeExtractor.unapply(x: T)`
-   * is uncheckable, but we have an instance of `ClassTag[T]`.
+   *  The compiler tries to turn unchecked type tests in pattern matches into checked ones
+   *  by wrapping a `(_: T)` type pattern as `ct(_: T)`, where `ct` is the `ClassTag[T]` instance.
+   *  Type tests necessary before calling other extractors are treated similarly.
+   *  `SomeExtractor(...)` is turned into `ct(SomeExtractor(...))` if `T` in `SomeExtractor.unapply(x: T)`
+   *  is uncheckable, but we have an instance of `ClassTag[T]`.
    */
   def unapply(x: Any): Option[T] =
     if (runtimeClass.isInstance(x)) Some(x.asInstanceOf[T])
@@ -88,9 +85,7 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
   }
 }
 
-/**
- * Class tags corresponding to primitive types and constructor/extractor for ClassTags.
- */
+/** Class tags corresponding to primitive types and constructor/extractor for ClassTags. */
 object ClassTag {
   private val ObjectTYPE = classOf[java.lang.Object]
   private val NothingTYPE = classOf[scala.runtime.Nothing$]

--- a/library/src/scala/reflect/Manifest.scala
+++ b/library/src/scala/reflect/Manifest.scala
@@ -27,7 +27,7 @@ import scala.collection.mutable.{ArrayBuilder, ArraySeq}
  *  which are not yet adequately represented in manifests.
  *
  *  Example usages:
- *  {{{
+ *  ```
  *    def arr[T] = new Array[T](0)                          // does not compile
  *    def arr[T](implicit m: Manifest[T]) = new Array[T](0) // compiles
  *    def arr[T: Manifest] = new Array[T](0)                // shorthand for the preceding
@@ -42,7 +42,7 @@ import scala.collection.mutable.{ArrayBuilder, ArraySeq}
  *      methods[T] find (_.getName == name) map (_.getGenericReturnType)
  *
  *    retType[Map[_, _]]("values")  // Some(scala.collection.Iterable<B>)
- *  }}}
+ *  ```
  */
 @nowarn("""cat=deprecation&origin=scala\.reflect\.ClassManifest(DeprecatedApis.*)?""")
 @implicitNotFound(msg = "No Manifest available for ${T}.")
@@ -105,23 +105,24 @@ object Manifest {
     ManifestFactory.singleType[T](value)
 
   /** Manifest for the class type `clazz[args]`, where `clazz` is
-    * a top-level or static class.
-    * @note This no-prefix, no-arguments case is separate because we
-    *       it's called from ScalaRunTime.boxArray itself. If we
-    *       pass varargs as arrays into this, we get an infinitely recursive call
-    *       to boxArray. (Besides, having a separate case is more efficient)
-    */
+   *  a top-level or static class.
+   *  @note This no-prefix, no-arguments case is separate because we
+   *       it's called from ScalaRunTime.boxArray itself. If we
+   *       pass varargs as arrays into this, we get an infinitely recursive call
+   *       to boxArray. (Besides, having a separate case is more efficient)
+   */
   def classType[T](clazz: Predef.Class[?]): Manifest[T] =
     ManifestFactory.classType[T](clazz)
 
   /** Manifest for the class type `clazz`, where `clazz` is
-    * a top-level or static class and args are its type arguments. */
+   *  a top-level or static class and args are its type arguments. 
+   */
   def classType[T](clazz: Predef.Class[T], arg1: Manifest[?], args: Manifest[?]*): Manifest[T] =
     ManifestFactory.classType[T](clazz, arg1, args*)
 
   /** Manifest for the class type `clazz[args]`, where `clazz` is
-    * a class with non-package prefix type `prefix` and type arguments `args`.
-    */
+   *  a class with non-package prefix type `prefix` and type arguments `args`.
+   */
   def classType[T](prefix: Manifest[?], clazz: Predef.Class[?], args: Manifest[?]*): Manifest[T] =
     ManifestFactory.classType[T](prefix, clazz, args*)
 
@@ -129,8 +130,9 @@ object Manifest {
     ManifestFactory.arrayType[T](arg)
 
   /** Manifest for the abstract type `prefix # name`. `upperBound` is not
-    * strictly necessary as it could be obtained by reflection. It was
-    * added so that erasure can be calculated without reflection. */
+   *  strictly necessary as it could be obtained by reflection. It was
+   *  added so that erasure can be calculated without reflection. 
+   */
   def abstractType[T](prefix: Manifest[?], name: String, upperBound: Predef.Class[?], args: Manifest[?]*): Manifest[T] =
     ManifestFactory.abstractType[T](prefix, name, upperBound, args*)
 
@@ -378,23 +380,24 @@ object ManifestFactory {
     new SingletonTypeManifest[T](value)
 
   /** Manifest for the class type `clazz[args]`, where `clazz` is
-    * a top-level or static class.
-    * @note This no-prefix, no-arguments case is separate because we
-    *       it's called from ScalaRunTime.boxArray itself. If we
-    *       pass varargs as arrays into this, we get an infinitely recursive call
-    *       to boxArray. (Besides, having a separate case is more efficient)
-    */
+   *  a top-level or static class.
+   *  @note This no-prefix, no-arguments case is separate because we
+   *       it's called from ScalaRunTime.boxArray itself. If we
+   *       pass varargs as arrays into this, we get an infinitely recursive call
+   *       to boxArray. (Besides, having a separate case is more efficient)
+   */
   def classType[T](clazz: Predef.Class[?]): Manifest[T] =
     new ClassTypeManifest[T](None, clazz, Nil)
 
   /** Manifest for the class type `clazz`, where `clazz` is
-    * a top-level or static class and args are its type arguments. */
+   *  a top-level or static class and args are its type arguments. 
+   */
   def classType[T](clazz: Predef.Class[T], arg1: Manifest[?], args: Manifest[?]*): Manifest[T] =
     new ClassTypeManifest[T](None, clazz, arg1 :: args.toList)
 
   /** Manifest for the class type `clazz[args]`, where `clazz` is
-    * a class with non-package prefix type `prefix` and type arguments `args`.
-    */
+   *  a class with non-package prefix type `prefix` and type arguments `args`.
+   */
   def classType[T](prefix: Manifest[?], clazz: Predef.Class[?], args: Manifest[?]*): Manifest[T] =
     new ClassTypeManifest[T](Some(prefix), clazz, args.toList)
 
@@ -407,7 +410,8 @@ object ManifestFactory {
   }
 
   /** Manifest for the class type `clazz[args]`, where `clazz` is
-    * a top-level or static class. */
+   *  a top-level or static class. 
+   */
   @SerialVersionUID(1L)
   private class ClassTypeManifest[T](prefix: Option[Manifest[?]],
                                      val runtimeClass: Predef.Class[?],
@@ -429,8 +433,9 @@ object ManifestFactory {
   }
 
   /** Manifest for the abstract type `prefix # name`. `upperBound` is not
-    * strictly necessary as it could be obtained by reflection. It was
-    * added so that erasure can be calculated without reflection. */
+   *  strictly necessary as it could be obtained by reflection. It was
+   *  added so that erasure can be calculated without reflection. 
+   */
   def abstractType[T](prefix: Manifest[?], name: String, upperBound: Predef.Class[?], args: Manifest[?]*): Manifest[T] =
     new AbstractTypeManifest[T](prefix, name, upperBound, args)
 
@@ -443,8 +448,7 @@ object ManifestFactory {
         (if (upperBound eq Nothing) "" else " <: "+upperBound)
   }
 
-  /** Manifest for the unknown type `_ >: L <: U` in an existential.
-    */
+  /** Manifest for the unknown type `_ >: L <: U` in an existential. */
   def wildcardType[T](lowerBound: Manifest[?], upperBound: Manifest[?]): Manifest[T] =
     new WildcardManifest[T](lowerBound, upperBound)
 

--- a/library/src/scala/reflect/TypeTest.scala
+++ b/library/src/scala/reflect/TypeTest.scala
@@ -17,11 +17,11 @@ trait TypeTest[-S, T] extends Serializable:
   /** A `TypeTest[S, T]` can serve as an extractor that matches if and only if a value of type `S` is
    *  an instance of `T`.
    *
-   * The compiler tries to turn unchecked type tests in pattern matches into checked ones
-   * by wrapping a `(_: T)` type pattern as `tt(_: T)`, where `tt` is the `TypeTest[S, T]` instance.
-   * Type tests necessary before calling other extractors are treated similarly.
-   * `SomeExtractor(...)` is turned into `tt(SomeExtractor(...))` if `T` in `SomeExtractor.unapply(x: T)`
-   * is uncheckable, but we have an instance of `TypeTest[S, T]`.
+   *  The compiler tries to turn unchecked type tests in pattern matches into checked ones
+   *  by wrapping a `(_: T)` type pattern as `tt(_: T)`, where `tt` is the `TypeTest[S, T]` instance.
+   *  Type tests necessary before calling other extractors are treated similarly.
+   *  `SomeExtractor(...)` is turned into `tt(SomeExtractor(...))` if `T` in `SomeExtractor.unapply(x: T)`
+   *  is uncheckable, but we have an instance of `TypeTest[S, T]`.
    */
   def unapply(x: S): Option[x.type & T]
 

--- a/library/src/scala/runtime/Arrays.scala
+++ b/library/src/scala/runtime/Arrays.scala
@@ -27,8 +27,7 @@ object Arrays {
     arr
   }
 
-  /** Creates an array of a reference type T.
-   */
+  /** Creates an array of a reference type T. */
   def newArray[Arr](componentType: Class[?], @unused returnType: Class[Arr], dimensions: Array[Int]): Arr =
     jlr.Array.newInstance(componentType, dimensions*).asInstanceOf[Arr]
 }

--- a/library/src/scala/runtime/LambdaDeserializer.scala
+++ b/library/src/scala/runtime/LambdaDeserializer.scala
@@ -15,33 +15,31 @@ package scala.runtime
 import scala.language.`2.13`
 import java.lang.invoke._
 
-/**
- * This class is only intended to be called by synthetic `$deserializeLambda$` method that the Scala 2.12
- * compiler will add to classes hosting lambdas.
+/** This class is only intended to be called by synthetic `$deserializeLambda$` method that the Scala 2.12
+ *  compiler will add to classes hosting lambdas.
  *
- * It is not intended to be consumed directly.
+ *  It is not intended to be consumed directly.
  */
 object LambdaDeserializer {
-  /**
-   * Deserializes a lambda by calling `LambdaMetafactory.altMetafactory` to spin up a lambda class
-   * and instantiating this class with the captured arguments.
+  /** Deserializes a lambda by calling `LambdaMetafactory.altMetafactory` to spin up a lambda class
+   *  and instantiating this class with the captured arguments.
    *
-   * A cache may be provided to ensure that subsequent deserialization of the same lambda expression
-   * is cheap, it amounts to a reflective call to the constructor of the previously created class.
-   * However, deserialization of the same lambda expression is not guaranteed to use the same class,
-   * concurrent deserialization of the same lambda expression may spin up more than one class.
+   *  A cache may be provided to ensure that subsequent deserialization of the same lambda expression
+   *  is cheap, it amounts to a reflective call to the constructor of the previously created class.
+   *  However, deserialization of the same lambda expression is not guaranteed to use the same class,
+   *  concurrent deserialization of the same lambda expression may spin up more than one class.
    *
-   * Assumptions:
+   *  Assumptions:
    *  - No additional marker interfaces are required beyond `java.io.Serializable`. These are
    *    not stored in `SerializedLambda`, so we can't reconstitute them.
    *  - No additional bridge methods are passed to `altMetafactory`. Again, these are not stored.
    *
-   * @param lookup      The factory for method handles. Must have access to the implementation method, the
+   *  @param lookup      The factory for method handles. Must have access to the implementation method, the
    *                    functional interface class, and `java.io.Serializable`.
-   * @param cache       A cache used to avoid spinning up a class for each deserialization of a given lambda. May be `null`
-   * @param serialized  The lambda to deserialize. Note that this is typically created by the `readResolve`
+   *  @param cache       A cache used to avoid spinning up a class for each deserialization of a given lambda. May be `null`
+   *  @param serialized  The lambda to deserialize. Note that this is typically created by the `readResolve`
    *                    member of the anonymous class created by `LambdaMetaFactory`.
-   * @return            An instance of the functional interface
+   *  @return            An instance of the functional interface
    */
   def deserializeLambda(lookup: MethodHandles.Lookup, cache: java.util.Map[String, MethodHandle],
                         targetMethodMap: java.util.Map[String, MethodHandle], serialized: SerializedLambda): AnyRef = {

--- a/library/src/scala/runtime/MatchCase.scala
+++ b/library/src/scala/runtime/MatchCase.scala
@@ -2,6 +2,5 @@ package scala.runtime
 
 import language.experimental.captureChecking
 
-/** A type constructor for a case in a match type.
- */
+/** A type constructor for a case in a match type. */
 final abstract class MatchCase[Pat, +Body]

--- a/library/src/scala/runtime/MethodCache.scala
+++ b/library/src/scala/runtime/MethodCache.scala
@@ -24,14 +24,16 @@ import scala.annotation.tailrec
  *  must only relate to one method as `PolyMethodCache` does not identify
  *  the method name and argument types. In practice, one variable will be
  *  generated per call point, and will uniquely relate to the method called
- *  at that point, making the method name and argument types irrelevant. */
+ *  at that point, making the method name and argument types irrelevant. 
+ */
 /* TODO: if performance is acceptable, PolyMethodCache should be made generic on the method type */
 private[scala] sealed abstract class MethodCache {
   /** Searches for a cached method in the `MethodCache` chain that
    *  is compatible with receiver class `forReceiver`. If none is cached,
    *  `null` is returned. If `null` is returned, find's caller should look-
    *  up the right method using whichever means it prefers, and add it to
-   *  the cache for later use. */
+   *  the cache for later use. 
+   */
   def find(forReceiver: JClass[?]): JMethod | Null
   def add(forReceiver: JClass[?], forMethod: JMethod): MethodCache
 }

--- a/library/src/scala/runtime/RichInt.scala
+++ b/library/src/scala/runtime/RichInt.scala
@@ -29,9 +29,9 @@ final class RichInt(val self: Int) extends AnyVal with ScalaNumberProxy[Int] wit
   override def byteValue   = self.toByte
   override def shortValue  = self.toShort
 
-  /** Returns `'''true'''` if this number has no decimal component.
-    * Always `'''true'''` for `RichInt`.
-    */
+  /** Returns `**true**` if this number has no decimal component.
+   *  Always `**true**` for `RichInt`.
+   */
   @deprecated("isWhole on an integer type is always true", "2.12.15")
   def isWhole = true
 
@@ -56,33 +56,33 @@ final class RichInt(val self: Int) extends AnyVal with ScalaNumberProxy[Int] wit
   type ResultWithoutStep = Range
 
   /**
-    * @param end The final bound of the range to make.
-    * @return A [[scala.collection.immutable.Range]] from `this` up to but
-    *         not including `end`.
-    */
+   *  @param end The final bound of the range to make.
+   *  @return A [[scala.collection.immutable.Range]] from `this` up to but
+   *         not including `end`.
+   */
   def until(end: Int): Range = Range(self, end)
 
   /**
-    * @param end The final bound of the range to make.
-    * @param step The number to increase by for each step of the range.
-    * @return A [[scala.collection.immutable.Range]] from `this` up to but
-    *         not including `end`.
-    */
+   *  @param end The final bound of the range to make.
+   *  @param step The number to increase by for each step of the range.
+   *  @return A [[scala.collection.immutable.Range]] from `this` up to but
+   *         not including `end`.
+   */
   def until(end: Int, step: Int): Range = Range(self, end, step)
 
   /** Like `until`, but includes the last index. */
   /**
-    * @param end The final bound of the range to make.
-    * @return A [[scala.collection.immutable.Range]] from `'''this'''` up to
-    *         and including `end`.
-    */
+   *  @param end The final bound of the range to make.
+   *  @return A [[scala.collection.immutable.Range]] from `**this**` up to
+   *         and including `end`.
+   */
   def to(end: Int): Range.Inclusive = Range.inclusive(self, end)
 
   /**
-    * @param end The final bound of the range to make.
-    * @param step The number to increase by for each step of the range.
-    * @return A [[scala.collection.immutable.Range]] from `'''this'''` up to
-    *         and including `end`.
-    */
+   *  @param end The final bound of the range to make.
+   *  @param step The number to increase by for each step of the range.
+   *  @return A [[scala.collection.immutable.Range]] from `**this**` up to
+   *         and including `end`.
+   */
   def to(end: Int, step: Int): Range.Inclusive = Range.inclusive(self, end, step)
 }

--- a/library/src/scala/runtime/ScalaNumberProxy.scala
+++ b/library/src/scala/runtime/ScalaNumberProxy.scala
@@ -33,20 +33,19 @@ trait ScalaNumberProxy[T] extends Any with ScalaNumericAnyConversions with Proxy
   def byteValue   = intValue.toByte
   def shortValue  = intValue.toShort
 
-  /** Returns `'''this'''` if `'''this''' < that` or `that` otherwise. */
+  /** Returns `**this**` if `**this** < that` or `that` otherwise. */
   def min(that: T): T = num.min(self, that)
-  /** Returns `'''this'''` if `'''this''' > that` or `that` otherwise. */
+  /** Returns `**this**` if `**this** > that` or `that` otherwise. */
   def max(that: T): T = num.max(self, that)
-  /** Returns the absolute value of `'''this'''`. */
+  /** Returns the absolute value of `**this**`. */
   def abs             = num.abs(self)
-  /**
-   * Returns the sign of `'''this'''`.
-   * zero if the argument is zero, -zero if the argument is -zero,
-   * one if the argument is greater than zero, -one if the argument is less than zero,
-   * and NaN if the argument is NaN where applicable.
+  /** Returns the sign of `**this**`.
+   *  zero if the argument is zero, -zero if the argument is -zero,
+   *  one if the argument is greater than zero, -one if the argument is less than zero,
+   *  and NaN if the argument is NaN where applicable.
    */
   def sign: T         = num.sign(self)
-  /** Returns the signum of `'''this'''`. */
+  /** Returns the signum of `**this**`. */
   @deprecated("use `sign` method instead", since = "2.13.0") def signum: Int = num.signum(self)
 }
 trait ScalaWholeNumberProxy[T] extends Any with ScalaNumberProxy[T] {

--- a/library/src/scala/runtime/ScalaRunTime.scala
+++ b/library/src/scala/runtime/ScalaRunTime.scala
@@ -38,8 +38,7 @@ object ScalaRunTime {
   def drop[Repr](coll: Repr, num: Int)(implicit iterable: IsIterable[Repr] { type C <: Repr }): Repr =
     iterable(coll) drop num
 
-  /** Returns the class object representing an array with element class `clazz`.
-   */
+  /** Returns the class object representing an array with element class `clazz`. */
   def arrayClass(clazz: jClass[?]): jClass[?] = {
     // newInstance throws an exception if the erasure is Void.TYPE. see scala/bug#5680
     if (clazz == java.lang.Void.TYPE) classOf[Array[Unit]]
@@ -180,15 +179,15 @@ object ScalaRunTime {
 
   /** Given any Scala value, convert it to a String.
    *
-   * The primary motivation for this method is to provide a means for
-   * correctly obtaining a String representation of a value, while
-   * avoiding the pitfalls of naively calling toString on said value.
-   * In particular, it addresses the fact that (a) toString cannot be
-   * called on null and (b) depending on the apparent type of an
-   * array, toString may or may not print it in a human-readable form.
+   *  The primary motivation for this method is to provide a means for
+   *  correctly obtaining a String representation of a value, while
+   *  avoiding the pitfalls of naively calling toString on said value.
+   *  In particular, it addresses the fact that (a) toString cannot be
+   *  called on null and (b) depending on the apparent type of an
+   *  array, toString may or may not print it in a human-readable form.
    *
-   * @param   arg   the value to stringify
-   * @return        a string representation of arg.
+   *  @param   arg   the value to stringify
+   *  @return        a string representation of arg.
    */
   def stringOf(arg: Any): String = stringOf(arg, scala.Int.MaxValue)
   def stringOf(arg: Any, maxElements: Int): String = {

--- a/library/src/scala/runtime/stdLibPatches/Predef.scala
+++ b/library/src/scala/runtime/stdLibPatches/Predef.scala
@@ -17,18 +17,17 @@ private[scala] object Predef:
   transparent inline def assert(inline assertion: Boolean): Unit =
     if !assertion then scala.runtime.Scala3RunTime.assertFailed()
 
-  /**
-   * Retrieves the single value of a type with a unique inhabitant.
+  /** Retrieves the single value of a type with a unique inhabitant.
    *
-   * @example {{{
-   * object Foo
-   * val foo = valueOf[Foo.type]
-   * // foo is Foo.type = Foo
+   *  @example ```
+   *  object Foo
+   *  val foo = valueOf[Foo.type]
+   *  // foo is Foo.type = Foo
    *
-   * val bar = valueOf[23]
-   * // bar is 23.type = 23
-   * }}}
-   * @group utilities
+   *  val bar = valueOf[23]
+   *  // bar is 23.type = 23
+   *  ```
+   *  @group utilities
    */
   inline def valueOf[T]: T = summonFrom {
     case ev: ValueOf[T] => ev.value
@@ -45,13 +44,13 @@ private[scala] object Predef:
 
   /** Strips away the nullability from a value. Note that `.nn` performs a checked cast,
    *  so if invoked on a `null` value it will throw an `NullPointerException`.
-   *  @example {{{
+   *  @example ```
    *  val s1: String | Null = "hello"
    *  val s2: String = s1.nn
    *
    *  val s3: String | Null = null
    *  val s4: String = s3.nn // throw NullPointerException
-   *  }}}
+   *  ```
    */
   extension [T](x: T | Null) inline def nn: x.type & T =
     if x.asInstanceOf[Any] == null then scala.runtime.Scala3RunTime.nnFail()
@@ -60,12 +59,14 @@ private[scala] object Predef:
   extension (inline x: AnyRef | Null)
     /** Enables an expression of type `T|Null`, where `T` is a subtype of `AnyRef`, to be checked for `null`
      *  using `eq` rather than only `==`. This is needed because `Null` no longer has
-     *  `eq` or `ne` methods, only `==` and `!=` inherited from `Any`. */
+     *  `eq` or `ne` methods, only `==` and `!=` inherited from `Any`. 
+     */
     inline infix def eq(inline y: AnyRef | Null): Boolean =
       x.asInstanceOf[AnyRef] eq y.asInstanceOf[AnyRef]
     /** Enables an expression of type `T|Null`, where `T` is a subtype of `AnyRef`, to be checked for `null`
      *  using `ne` rather than only `!=`. This is needed because `Null` no longer has
-     *  `eq` or `ne` methods, only `==` and `!=` inherited from `Any`. */
+     *  `eq` or `ne` methods, only `==` and `!=` inherited from `Any`. 
+     */
     inline infix def ne(inline y: AnyRef | Null): Boolean =
       !(x eq y)
 
@@ -83,16 +84,16 @@ private[scala] object Predef:
   infix type is[A <: AnyKind, B <: Any{type Self <: AnyKind}] = B { type Self = A }
 
   extension [T](x: T)
-    /**Asserts that a term should be exempt from static checks that can be reliably checked at runtime.
-     * @example {{{
-     * val xs: Option[Int] = Option(1)
-     * xs.runtimeChecked match
+    /** Asserts that a term should be exempt from static checks that can be reliably checked at runtime.
+     *  @example ```
+     *  val xs: Option[Int] = Option(1)
+     *  xs.runtimeChecked match
      *    case Some(x) => x // `Some(_)` can be checked at runtime, so no warning
-     * }}}
-     * @example {{{
-     * val xs: List[Int] = List(1,2,3)
-     * val y :: ys = xs.runtimeChecked // `_ :: _` can be checked at runtime, so no warning
-     * }}}
+     *  ```
+     *  @example ```
+     *  val xs: List[Int] = List(1,2,3)
+     *  val y :: ys = xs.runtimeChecked // `_ :: _` can be checked at runtime, so no warning
+     *  ```
      */
     inline def runtimeChecked: x.type @RuntimeChecked = x: @RuntimeChecked
 

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -13,11 +13,11 @@ private[scala] object language:
   /** The experimental object contains features that have been recently added but have not
    *  been thoroughly tested in production yet.
    *
-   *  Experimental features '''may undergo API changes''' in future releases, so production
+   *  Experimental features **may undergo API changes** in future releases, so production
    *  code should not rely on them.
    *
    *  Programmers are encouraged to try out experimental features and
-   *  [[https://github.com/scala/scala3/issues report any bugs or API inconsistencies]]
+   *  [report any bugs or API inconsistencies](https://github.com/scala/scala3/issues)
    *  they encounter so they can be improved in future releases.
    *
    *  @group experimental
@@ -202,12 +202,12 @@ private[scala] object language:
 
   /** Where imported, auto-tupling is disabled.
     *
-    * '''Why control the feature?''' Auto-tupling can lead to confusing and
+    * **Why control the feature?** Auto-tupling can lead to confusing and
     * brittle code in presence of overloads. In particular, surprising overloads
     * can be selected, and adding new overloads can change which overload is selected
     * in suprising ways.
     *
-    * '''Why allow it?''' Not allowing auto-tupling is difficult to reconcile with
+    * **Why allow it?** Not allowing auto-tupling is difficult to reconcile with
     * operators accepting tuples.
     */
   @compileTimeOnly("`noAutoTupling` can only be used at compile time in import statements")
@@ -215,7 +215,7 @@ private[scala] object language:
 
   /** Where imported, loose equality using eqAny is disabled.
     *
-    * '''Why allow and control the feature?''' For compatibility and migration reasons,
+    * **Why allow and control the feature?** For compatibility and migration reasons,
     * strict equality is opt-in. See linked documentation for more information.
     *
     * @see [[https://dotty.epfl.ch/docs/reference/contextual/multiversal-equality]]
@@ -226,14 +226,14 @@ private[scala] object language:
   /** Where imported, ad hoc extensions of non-open classes in other
    *  compilation units are allowed.
    *
-   *  '''Why control the feature?''' Ad-hoc extensions should usually be avoided
+   *  **Why control the feature?** Ad-hoc extensions should usually be avoided
    *  since they typically cannot rely on an "internal" contract between a class
    *  and its extensions. Only open classes need to specify such a contract.
    *  Ad-hoc extensions might break for future versions of the extended class,
    *  since the extended class is free to change its implementation without
    *  being constrained by an internal contract.
    *
-   *  '''Why allow it?''' An ad-hoc extension can sometimes be necessary,
+   *  **Why allow it?** An ad-hoc extension can sometimes be necessary,
    *  for instance when mocking a class in a testing framework, or to work
    *  around a bug or missing feature in the original class. Nevertheless,
    *  such extensions should be limited in scope and clearly documented.

--- a/library/src/scala/specialized.scala
+++ b/library/src/scala/specialized.scala
@@ -18,15 +18,15 @@ import Specializable._
 
 /** Annotate type parameters on which code should be automatically
  *  specialized. For example:
- *  {{{
+ *  ```
  *    class MyList[@specialized T] ...
- *  }}}
+ *  ```
  *
  *  Type T can be specialized on a subset of the primitive types by
  *  specifying a list of primitive types to specialize at:
- *  {{{
+ *  ```
  *    class MyList[@specialized(Int, Double, Boolean) T] ..
- *  }}}
+ *  ```
  */
 // class tspecialized[T](group: Group[T]) extends scala.annotation.StaticAnnotation {
 

--- a/library/src/scala/sys/BooleanProp.scala
+++ b/library/src/scala/sys/BooleanProp.scala
@@ -16,8 +16,7 @@ package sys
 import scala.language.`2.13`
 import scala.language.implicitConversions
 
-/** A few additional conveniences for Boolean properties.
- */
+/** A few additional conveniences for Boolean properties. */
 trait BooleanProp extends Prop[Boolean] {
   /** The semantics of value are determined at Prop creation.  See methods
    *  `valueIsTrue` and `keyExists` in object BooleanProp for examples.
@@ -81,8 +80,7 @@ object BooleanProp {
    */
   def keyExists[T](key: String): BooleanProp = new BooleanPropImpl(key, s => s == "" || s.equalsIgnoreCase("true"))
 
-  /** A constant true or false property which ignores all method calls.
-   */
+  /** A constant true or false property which ignores all method calls. */
   def constant(key: String, isOn: Boolean): BooleanProp = new ConstantImpl(key, isOn)
 
   implicit def booleanPropAsBoolean(b: BooleanProp): Boolean = b.value

--- a/library/src/scala/sys/Prop.scala
+++ b/library/src/scala/sys/Prop.scala
@@ -22,8 +22,7 @@ import scala.language.`2.13`
  *  See `scala.sys.SystemProperties` for an example usage.
  */
 trait Prop[+T] {
-  /** The full name of the property, e.g., "java.awt.headless".
-   */
+  /** The full name of the property, e.g., "java.awt.headless". */
   def key: String
 
   /** If the key exists in the properties map, converts the value
@@ -46,8 +45,7 @@ trait Prop[+T] {
    */
   def set(newValue: String): String | Null
 
-  /** Sets the property with a value of the represented type.
-   */
+  /** Sets the property with a value of the represented type. */
   def setValue[T1 >: T](value: T1): T
 
   /** Gets the current string value if any.  Will not return null: use
@@ -56,16 +54,14 @@ trait Prop[+T] {
    */
   def get: String
 
-  /** Some(value) if the property is set, None otherwise.
-   */
+  /** Some(value) if the property is set, None otherwise. */
   def option: Option[T]
 
   // Do not open until 2.12.
   //** This value if the property is set, an alternative value otherwise. */
   //def or[T1 >: T](alt: => T1): T1
 
-  /** Removes the property from the underlying map.
-   */
+  /** Removes the property from the underlying map. */
   def clear(): Unit
 
   /** A value of type `T` for use when the property is unset.

--- a/library/src/scala/sys/PropImpl.scala
+++ b/library/src/scala/sys/PropImpl.scala
@@ -16,8 +16,7 @@ package sys
 import scala.language.`2.13`
 import scala.collection.mutable
 
-/** The internal implementation of scala.sys.Prop.
- */
+/** The internal implementation of scala.sys.Prop. */
 private[sys] class PropImpl[+T](val key: String, valueFn: String => T) extends Prop[T] {
   def value: T = if (isSet) valueFn(get) else zero
   def isSet    = underlying contains key

--- a/library/src/scala/sys/SystemProperties.scala
+++ b/library/src/scala/sys/SystemProperties.scala
@@ -60,9 +60,9 @@ extends mutable.AbstractMap[String, String | Null] {
 
 /** The values in SystemProperties can be used to access and manipulate
  *  designated system properties.  See `scala.sys.Prop` for particulars.
- *  @example {{{
+ *  @example ```
  *    if (!headless.isSet) headless.enable()
- *  }}}
+ *  ```
  */
 object SystemProperties {
   /** An unenforceable, advisory only place to do some synchronization when

--- a/library/src/scala/sys/process/BasicIO.scala
+++ b/library/src/scala/sys/process/BasicIO.scala
@@ -20,18 +20,17 @@ import java.io.{ BufferedReader, InputStreamReader, FilterInputStream, FilterOut
 import java.util.concurrent.LinkedBlockingQueue
 import scala.annotation.tailrec
 
-/**
-  * This object contains factories for [[scala.sys.process.ProcessIO]],
-  * which can be used to control the I/O of a [[scala.sys.process.Process]]
-  * when a [[scala.sys.process.ProcessBuilder]] is started with the `run`
-  * command.
-  *
-  * It also contains some helper methods that can be used to in the creation of
-  * `ProcessIO`.
-  *
-  * It is used by other classes in the package in the implementation of various
-  * features, but can also be used by client code.
-  */
+/** This object contains factories for [[scala.sys.process.ProcessIO]],
+ *  which can be used to control the I/O of a [[scala.sys.process.Process]]
+ *  when a [[scala.sys.process.ProcessBuilder]] is started with the `run`
+ *  command.
+ *
+ *  It also contains some helper methods that can be used to in the creation of
+ *  `ProcessIO`.
+ *
+ *  It is used by other classes in the package in the implementation of various
+ *  features, but can also be used by client code.
+ */
 object BasicIO {
   /** Size of the buffer used in all the functions that copy data. */
   final val BufferSize = 8192
@@ -90,69 +89,69 @@ object BasicIO {
   }
 
   /** Creates a `ProcessIO` from a function `String => Unit`. It can attach the
-    * process input to stdin, and it will either send the error stream to
-    * stderr, or to a `ProcessLogger`.
-    *
-    * For example, the `ProcessIO` created below will print all normal output
-    * while ignoring all error output. No input will be provided.
-    * {{{
-    * import scala.sys.process.BasicIO
-    * val errToDevNull = BasicIO(false, println(_), None)
-    * }}}
-    *
-    * @param withIn True if the process input should be attached to stdin.
-    * @param output A function that will be called with the process output.
-    * @param log    An optional `ProcessLogger` to which the output should be
-    *               sent. If `None`, output will be sent to stderr.
-    * @return A `ProcessIO` with the characteristics above.
-    */
+   *  process input to stdin, and it will either send the error stream to
+   *  stderr, or to a `ProcessLogger`.
+   *
+   *  For example, the `ProcessIO` created below will print all normal output
+   *  while ignoring all error output. No input will be provided.
+   *  ```
+   *  import scala.sys.process.BasicIO
+   *  val errToDevNull = BasicIO(false, println(_), None)
+   *  ```
+   *
+   *  @param withIn True if the process input should be attached to stdin.
+   *  @param output A function that will be called with the process output.
+   *  @param log    An optional `ProcessLogger` to which the output should be
+   *               sent. If `None`, output will be sent to stderr.
+   *  @return A `ProcessIO` with the characteristics above.
+   */
   def apply(withIn: Boolean, output: String => Unit, log: Option[ProcessLogger]) =
     new ProcessIO(input(withIn), processFully(output), getErr(log))
 
   /** Creates a `ProcessIO` that appends its output to an `Appendable`. It can
-    * attach the process input to stdin, and it will either send the error
-    * stream to stderr, or to a `ProcessLogger`.
-    *
-    * For example, the `ProcessIO` created by the function below will store the
-    * normal output on the buffer provided, and print all error on stderr. The
-    * input will be read from stdin.
-    * {{{
-    * import scala.sys.process.{BasicIO, ProcessLogger}
-    * val printer = ProcessLogger(println(_))
-    * def appendToBuffer(b: StringBuffer) = BasicIO(true, b, Some(printer))
-    * }}}
-    *
-    * @param withIn True if the process input should be attached to stdin.
-    * @param buffer An `Appendable` which will receive the process normal
-    *               output.
-    * @param log    An optional `ProcessLogger` to which the output should be
-    *               sent. If `None`, output will be sent to stderr.
-    * @return A `ProcessIO` with the characteristics above.
-    */
+   *  attach the process input to stdin, and it will either send the error
+   *  stream to stderr, or to a `ProcessLogger`.
+   *
+   *  For example, the `ProcessIO` created by the function below will store the
+   *  normal output on the buffer provided, and print all error on stderr. The
+   *  input will be read from stdin.
+   *  ```
+   *  import scala.sys.process.{BasicIO, ProcessLogger}
+   *  val printer = ProcessLogger(println(_))
+   *  def appendToBuffer(b: StringBuffer) = BasicIO(true, b, Some(printer))
+   *  ```
+   *
+   *  @param withIn True if the process input should be attached to stdin.
+   *  @param buffer An `Appendable` which will receive the process normal
+   *               output.
+   *  @param log    An optional `ProcessLogger` to which the output should be
+   *               sent. If `None`, output will be sent to stderr.
+   *  @return A `ProcessIO` with the characteristics above.
+   */
   def apply(withIn: Boolean, buffer: Appendable, log: Option[ProcessLogger]) =
     new ProcessIO(input(withIn), processFully(buffer), getErr(log))
 
   /** Creates a `ProcessIO` from a `ProcessLogger`. It can attach the
-    * process input to stdin.
-    *
-    * @param withIn True if the process input should be attached to stdin.
-    * @param log    A `ProcessLogger` to receive all output, normal and error.
-    * @return A `ProcessIO` with the characteristics above.
-    */
+   *  process input to stdin.
+   *
+   *  @param withIn True if the process input should be attached to stdin.
+   *  @param log    A `ProcessLogger` to receive all output, normal and error.
+   *  @return A `ProcessIO` with the characteristics above.
+   */
   def apply(withIn: Boolean, log: ProcessLogger) =
     new ProcessIO(input(withIn), processOutFully(log), processErrFully(log))
 
   /** Returns a function `InputStream => Unit` given an optional
-    * `ProcessLogger`. If no logger is passed, the function will send the output
-    * to stderr. This function can be used to create a
-    * [[scala.sys.process.ProcessIO]].
-    *
-    * @param log An optional `ProcessLogger` to which the contents of
-    *            the `InputStream` will be sent.
-    * @return A function `InputStream => Unit` (used by
-    *          [[scala.sys.process.ProcessIO]]) which will send the data to
-    *          either the provided `ProcessLogger` or, if `None`, to stderr.
-    */
+   *  `ProcessLogger`. If no logger is passed, the function will send the output
+   *  to stderr. This function can be used to create a
+   *  [[scala.sys.process.ProcessIO]].
+   *
+   *  @param log An optional `ProcessLogger` to which the contents of
+   *            the `InputStream` will be sent.
+   *  @return A function `InputStream => Unit` (used by
+   *          [[scala.sys.process.ProcessIO]]) which will send the data to
+   *          either the provided `ProcessLogger` or, if `None`, to stderr.
+   */
   def getErr(log: Option[ProcessLogger]) = log match {
     case Some(lg) => processErrFully(lg)
     case None     => toStdErr
@@ -165,27 +164,27 @@ object BasicIO {
   def close(c: Closeable) = try c.close() catch { case _: IOException => () }
 
   /** Returns a function `InputStream => Unit` that appends all data read to the
-    * provided `Appendable`. This function can be used to create a
-    * [[scala.sys.process.ProcessIO]]. The buffer will be appended line by line.
-    *
-    * @param buffer An `Appendable` such as `StringBuilder` or `StringBuffer`.
-    * @return A function `InputStream => Unit` (used by
-    *          [[scala.sys.process.ProcessIO]] which will append all data read
-    *          from the stream to the buffer.
-    */
+   *  provided `Appendable`. This function can be used to create a
+   *  [[scala.sys.process.ProcessIO]]. The buffer will be appended line by line.
+   *
+   *  @param buffer An `Appendable` such as `StringBuilder` or `StringBuffer`.
+   *  @return A function `InputStream => Unit` (used by
+   *          [[scala.sys.process.ProcessIO]] which will append all data read
+   *          from the stream to the buffer.
+   */
   def processFully(buffer: Appendable): InputStream => Unit = processFully(appendLine(buffer))
 
   /** Returns a function `InputStream => Unit` that will call the passed
-    * function with all data read. This function can be used to create a
-    * [[scala.sys.process.ProcessIO]]. The `processLine` function will be called
-    * with each line read, and `Newline` will be appended after each line.
-    *
-    * @param processLine A function that will be called with all data read from
-    *                    the stream.
-    * @return A function `InputStream => Unit` (used by
-    *          [[scala.sys.process.ProcessIO]] which will call `processLine`
-    *          with all data read from the stream.
-    */
+   *  function with all data read. This function can be used to create a
+   *  [[scala.sys.process.ProcessIO]]. The `processLine` function will be called
+   *  with each line read, and `Newline` will be appended after each line.
+   *
+   *  @param processLine A function that will be called with all data read from
+   *                    the stream.
+   *  @return A function `InputStream => Unit` (used by
+   *          [[scala.sys.process.ProcessIO]] which will call `processLine`
+   *          with all data read from the stream.
+   */
   def processFully(processLine: String => Unit): InputStream => Unit = in => {
     val reader = new BufferedReader(new InputStreamReader(in))
     try processLinesFully(processLine)(() => reader.readLine())
@@ -219,9 +218,9 @@ object BasicIO {
   def connectToIn(o: OutputStream): Unit = transferFully(Uncloseable protect stdin, o)
 
   /** Returns a function `OutputStream => Unit` that either reads the content
-    * from stdin or does nothing but close the stream. This function can be used by
-    * [[scala.sys.process.ProcessIO]].
-    */
+   *  from stdin or does nothing but close the stream. This function can be used by
+   *  [[scala.sys.process.ProcessIO]].
+   */
   def input(connect: Boolean): OutputStream => Unit = if (connect) connectToStdIn else connectNoOp
 
   /** A sentinel value telling ProcessBuilderImpl to redirect. */
@@ -237,18 +236,18 @@ object BasicIO {
   def standard(in: OutputStream => Unit): ProcessIO = new ProcessIO(in, toStdOut, toStdErr)
 
   /** Sends all the input from the stream to stderr, and closes the input stream
-   * afterwards.
+   *  afterwards.
    */
   def toStdErr = (in: InputStream) => transferFully(in, stderr)
 
   /** Sends all the input from the stream to stdout, and closes the input stream
-   * afterwards.
+   *  afterwards.
    */
   def toStdOut = (in: InputStream) => transferFully(in, stdout)
 
   /** Copies all input from the input stream to the output stream. Closes the
-    * input stream once it's all read.
-    */
+   *  input stream once it's all read.
+   */
   def transferFully(in: InputStream, out: OutputStream): Unit =
     try transferFullyImpl(in, out)
     catch onIOInterrupt(())

--- a/library/src/scala/sys/process/Parser.scala
+++ b/library/src/scala/sys/process/Parser.scala
@@ -15,8 +15,7 @@ package scala.sys.process
 import scala.language.`2.13`
 import scala.annotation.tailrec
 
-/** A simple enough command line parser using shell quote conventions.
- */
+/** A simple enough command line parser using shell quote conventions. */
 private[scala] object Parser {
   private final val DQ = '"'
   private final val SQ = '\''

--- a/library/src/scala/sys/process/Process.scala
+++ b/library/src/scala/sys/process/Process.scala
@@ -51,55 +51,76 @@ object Process extends ProcessImpl with ProcessCreation { }
  */
 trait ProcessCreation {
   /** Creates a [[scala.sys.process.ProcessBuilder]] from a `String`, including the
-    * parameters.
-    *
-    * @example {{{ apply("cat file.txt") }}}
-    */
+   *  parameters.
+   *
+   *  @example
+   *  ```
+   *  apply("cat file.txt")
+   *  ```
+   */
   def apply(command: String): ProcessBuilder                         = apply(command, None)
 
   /** Creates a [[scala.sys.process.ProcessBuilder]] from a sequence of `String`,
-    * where the head is the command and each element of the tail is a parameter.
-    *
-    * @example {{{ apply("cat" :: files) }}}
-    */
+   *  where the head is the command and each element of the tail is a parameter.
+   *
+   *  @example
+   *  ```
+   *  apply("cat" :: files)
+   *  ```
+   */
   def apply(command: scala.collection.Seq[String]): ProcessBuilder   = apply(command, None)
 
   /** Creates a [[scala.sys.process.ProcessBuilder]] from a command represented by a `String`,
-    * and a sequence of `String` representing the arguments.
-    *
-    * @example {{{ apply("cat", files) }}}
-    */
+   *  and a sequence of `String` representing the arguments.
+   *
+   *  @example
+   *  ```
+   *  apply("cat", files)
+   *  ```
+   */
   def apply(command: String, arguments: scala.collection.Seq[String]): ProcessBuilder = apply(command +: arguments, None)
 
   /** Creates a [[scala.sys.process.ProcessBuilder]] with working dir set to `File` and extra
-    * environment variables.
-    *
-    * @example {{{ apply("java", new java.io.File("/opt/app"), "CLASSPATH" -> "library.jar") }}}
-    */
+   *  environment variables.
+   *
+   *  @example
+   *  ```
+   *  apply("java", new java.io.File("/opt/app"), "CLASSPATH" -> "library.jar")
+   *  ```
+   */
   def apply(command: String, cwd: File, extraEnv: (String, String)*): ProcessBuilder =
     apply(command, Some(cwd), extraEnv*)
 
   /** Creates a [[scala.sys.process.ProcessBuilder]] with working dir set to `File` and extra
-    * environment variables.
-    *
-    * @example {{{ apply("java" :: javaArgs, new java.io.File("/opt/app"), "CLASSPATH" -> "library.jar") }}}
-    */
+   *  environment variables.
+   *
+   *  @example
+   *  ```
+   *  apply("java" :: javaArgs, new java.io.File("/opt/app"), "CLASSPATH" -> "library.jar")
+   *  ```
+   */
   def apply(command: scala.collection.Seq[String], cwd: File, extraEnv: (String, String)*): ProcessBuilder =
     apply(command, Some(cwd), extraEnv*)
 
   /** Creates a [[scala.sys.process.ProcessBuilder]] with working dir optionally set to
-    * `File` and extra environment variables.
-    *
-    * @example {{{ apply("java", params.get("cwd"), "CLASSPATH" -> "library.jar") }}}
-    */
+   *  `File` and extra environment variables.
+   *
+   *  @example
+   *  ```
+   *  apply("java", params.get("cwd"), "CLASSPATH" -> "library.jar")
+   *  ```
+   */
   def apply(command: String, cwd: Option[File], extraEnv: (String, String)*): ProcessBuilder =
     apply(Parser.tokenize(command), cwd, extraEnv*)
 
   /** Creates a [[scala.sys.process.ProcessBuilder]] with working dir optionally set to
-    * `File` and extra environment variables.
-    *
-    * @example {{{ apply("java" :: javaArgs, params.get("cwd"), "CLASSPATH" -> "library.jar") }}}
-    */
+   *  `File` and extra environment variables.
+   *
+   *  @example
+   *  ```
+   *  apply("java" :: javaArgs, params.get("cwd"), "CLASSPATH" -> "library.jar")
+   *  ```
+   */
   def apply(command: scala.collection.Seq[String], cwd: Option[File], extraEnv: (String, String)*): ProcessBuilder = {
     val jpb = new JProcessBuilder(command.toArray*)
     cwd foreach (jpb.directory(_))
@@ -108,67 +129,67 @@ trait ProcessCreation {
   }
 
   /** Creates a [[scala.sys.process.ProcessBuilder]] from a `java.lang.ProcessBuilder`.
-    *
-    * @example {{{
-    * apply((new java.lang.ProcessBuilder("ls", "-l")) directory new java.io.File(System.getProperty("user.home")))
-    * }}}
-    */
+   *
+   *  @example ```
+   *  apply((new java.lang.ProcessBuilder("ls", "-l")) directory new java.io.File(System.getProperty("user.home")))
+   *  ```
+   */
   def apply(builder: JProcessBuilder): ProcessBuilder = new Simple(builder)
 
   /** Creates a [[scala.sys.process.ProcessBuilder]] from a `java.io.File`. This
-    * `ProcessBuilder` can then be used as a `Source` or a `Sink`, so one can
-    * pipe things from and to it.
-    */
+   *  `ProcessBuilder` can then be used as a `Source` or a `Sink`, so one can
+   *  pipe things from and to it.
+   */
   def apply(file: File): FileBuilder                  = new FileImpl(file)
 
   /** Creates a [[scala.sys.process.ProcessBuilder]] from a `java.net.URL`. This
-    * `ProcessBuilder` can then be used as a `Source`, so that one can pipe things
-    * from it.
-    */
+   *  `ProcessBuilder` can then be used as a `Source`, so that one can pipe things
+   *  from it.
+   */
   def apply(url: URL): URLBuilder                     = new URLImpl(url)
 
   /** Creates a [[scala.sys.process.ProcessBuilder]] from a `Boolean`. This can be
-    * to force an exit value.
-    */
+   *  to force an exit value.
+   */
   def apply(value: Boolean): ProcessBuilder           = apply(value.toString, if (value) 0 else 1)
 
   /** Creates a [[scala.sys.process.ProcessBuilder]] from a `String` name and a
-    * `Boolean`. This can be used to force an exit value, with the name being
-    * used for `toString`.
-    */
+   *  `Boolean`. This can be used to force an exit value, with the name being
+   *  used for `toString`.
+   */
   def apply(name: String, exitValue: => Int): ProcessBuilder = new Dummy(name, exitValue)
 
   /** Creates a sequence of [[scala.sys.process.ProcessBuilder.Source]] from a sequence of
-    * something else for which there's an implicit conversion to `Source`.
-    */
+   *  something else for which there's an implicit conversion to `Source`.
+   */
   def applySeq[T](builders: scala.collection.Seq[T])(implicit convert: T => Source): scala.collection.Seq[Source] = builders.map(convert)
 
   /** Creates a [[scala.sys.process.ProcessBuilder]] from one or more
-    * [[scala.sys.process.ProcessBuilder.Source]], which can then be
-    * piped to something else.
-    *
-    * This will concatenate the output of all sources. For example:
-    *
-    * {{{
-    * import scala.sys.process._
-    * import scala.sys.process.Process.cat
-    * import java.net.URL
-    * import java.io.File
-    *
-    * val spde = new URL("http://technically.us/spde.html")
-    * val dispatch = new URL("https://dispatchhttp.org/Dispatch.html")
-    * val build = new File("project/build.properties")
-    * cat(spde, dispatch, build) #| "grep -i scala" !
-    * }}}
-    */
+   *  [[scala.sys.process.ProcessBuilder.Source]], which can then be
+   *  piped to something else.
+   *
+   *  This will concatenate the output of all sources. For example:
+   *
+   *  ```
+   *  import scala.sys.process._
+   *  import scala.sys.process.Process.cat
+   *  import java.net.URL
+   *  import java.io.File
+   *
+   *  val spde = new URL("http://technically.us/spde.html")
+   *  val dispatch = new URL("https://dispatchhttp.org/Dispatch.html")
+   *  val build = new File("project/build.properties")
+   *  cat(spde, dispatch, build) #| "grep -i scala" !
+   *  ```
+   */
   def cat(file: Source, files: Source*): ProcessBuilder = cat(file +: files)
 
   /** Creates a [[scala.sys.process.ProcessBuilder]] from a non-empty sequence
-    * of [[scala.sys.process.ProcessBuilder.Source]], which can then be
-    * piped to something else.
-    *
-    * This will concatenate the output of all sources.
-    */
+   *  of [[scala.sys.process.ProcessBuilder.Source]], which can then be
+   *  piped to something else.
+   *
+   *  This will concatenate the output of all sources.
+   */
   def cat(files: scala.collection.Seq[Source]): ProcessBuilder = {
     require(files.nonEmpty)
     files.map(_.cat).reduceLeft(_ #&& _)
@@ -176,48 +197,48 @@ trait ProcessCreation {
 }
 
 /** Provides implicit conversions for the factories offered by [[scala.sys.process.Process]]'s
-  * companion object. These implicits can then be used to decrease the noise in a pipeline
-  * of commands, making it look more shell-like. They are available through the package object
-  * [[scala.sys.process]].
-  */
+ *  companion object. These implicits can then be used to decrease the noise in a pipeline
+ *  of commands, making it look more shell-like. They are available through the package object
+ *  [[scala.sys.process]].
+ */
 trait ProcessImplicits {
   import Process._
 
   /** Returns a sequence of [[scala.sys.process.ProcessBuilder.Source]] from a sequence
-    * of values for which an implicit conversion to `Source` is available.
-    */
+   *  of values for which an implicit conversion to `Source` is available.
+   */
   implicit def buildersToProcess[T](builders: scala.collection.Seq[T])(implicit convert: T => Source): scala.collection.Seq[Source] = applySeq(builders)
 
   /** Implicitly convert a `java.lang.ProcessBuilder` into a Scala one. */
   implicit def builderToProcess(builder: JProcessBuilder): ProcessBuilder = apply(builder)
 
   /** Implicitly convert a `java.io.File` into a
-    * [[scala.sys.process.ProcessBuilder.FileBuilder]], which can be used as
-    * either input or output of a process. For example:
-    * {{{
-    * import scala.sys.process._
-    * "ls" #> new java.io.File("dirContents.txt") !
-    * }}}
-    */
+   *  [[scala.sys.process.ProcessBuilder.FileBuilder]], which can be used as
+   *  either input or output of a process. For example:
+   *  ```
+   *  import scala.sys.process._
+   *  "ls" #> new java.io.File("dirContents.txt") !
+   *  ```
+   */
   implicit def fileToProcess(file: File): FileBuilder                     = apply(file)
 
   /** Implicitly convert a `java.net.URL` into a
-    * [[scala.sys.process.ProcessBuilder.URLBuilder]] , which can be used as
-    * input to a process. For example:
-    * {{{
-    * import scala.sys.process._
-    * Seq("xmllint", "--html", "-") #< new java.net.URL("https://www.scala-lang.org") #> new java.io.File("fixed.html") !
-    * }}}
-    */
+   *  [[scala.sys.process.ProcessBuilder.URLBuilder]] , which can be used as
+   *  input to a process. For example:
+   *  ```
+   *  import scala.sys.process._
+   *  Seq("xmllint", "--html", "-") #< new java.net.URL("https://www.scala-lang.org") #> new java.io.File("fixed.html") !
+   *  ```
+   */
   implicit def urlToProcess(url: URL): URLBuilder                         = apply(url)
 
   /** Implicitly convert a `String` into a [[scala.sys.process.ProcessBuilder]]. */
   implicit def stringToProcess(command: String): ProcessBuilder           = apply(command)
 
   /** Implicitly convert a sequence of `String` into a
-    * [[scala.sys.process.ProcessBuilder]]. The first argument will be taken to
-    * be the command to be executed, and the remaining will be its arguments.
-    * When using this, arguments may contain spaces.
-    */
+   *  [[scala.sys.process.ProcessBuilder]]. The first argument will be taken to
+   *  be the command to be executed, and the remaining will be its arguments.
+   *  When using this, arguments may contain spaces.
+   */
   implicit def stringSeqToProcess(command: scala.collection.Seq[String]): ProcessBuilder = apply(command)
 }

--- a/library/src/scala/sys/process/ProcessBuilder.scala
+++ b/library/src/scala/sys/process/ProcessBuilder.scala
@@ -19,378 +19,378 @@ import processInternal._
 import ProcessBuilder.{Sink, Source}
 
 /** Represents a sequence of one or more external processes that can be
-  * executed. A `ProcessBuilder` can be a single external process, or a
-  * combination of other `ProcessBuilder`. One can control where the
-  * output of an external process will go to, and where its input will come
-  * from, or leave that decision to whoever starts it.
-  *
-  * One creates a `ProcessBuilder` through factories provided in
-  * [[scala.sys.process.Process]]'s companion object, or implicit conversions
-  * based on these factories made available in the package object
-  * [[scala.sys.process]]. Here are some examples:
-  * {{{
-  * import scala.sys.process._
-  *
-  * // Executes "ls" and sends output to stdout
-  * "ls".!
-  *
-  * // Execute "ls" and assign a `LazyList[String]` of its output to "contents".
-  * val contents = Process("ls").lazyLines
-  *
-  * // Here we use a `Seq` to make the parameter whitespace-safe
-  * def contentsOf(dir: String): String = Seq("ls", dir).!!
-  * }}}
-  *
-  * The methods of `ProcessBuilder` are divided in three categories: the ones that
-  * combine two `ProcessBuilder` to create a third, the ones that redirect input
-  * or output of a `ProcessBuilder`, and the ones that execute
-  * the external processes associated with it.
-  *
-  * ==Combining `ProcessBuilder`==
-  *
-  * Two existing `ProcessBuilder` can be combined in the following ways:
-  *
-  *   - They can be executed in parallel, with the output of the first being fed
-  *     as input to the second, like Unix pipes. This is achieved with the `#|`
-  *     method.
-  *   - They can be executed in sequence, with the second starting as soon as
-  *     the first ends. This is done by the `###` method.
-  *   - The execution of the second one can be conditioned by the return code
-  *     (exit status) of the first, either only when it's zero, or only when it's
-  *     not zero. The methods `#&&` and `#||` accomplish these tasks.
-  *
-  * ==Redirecting Input/Output==
-  *
-  * Though control of input and output can be done when executing the process,
-  * there's a few methods that create a new `ProcessBuilder` with a
-  * pre-configured input or output. They are `#<`, `#>` and `#>>`, and may take
-  * as input either another `ProcessBuilder` (like the pipe described above), or
-  * something else such as a `java.io.File` or a `java.io.InputStream`.
-  * For example:
-  * {{{
-  * new URL("https://databinder.net/dispatch/About") #> "grep JSON" #>> new File("About_JSON") !
-  * }}}
-  *
-  * ==Starting Processes==
-  *
-  * To execute all external commands associated with a `ProcessBuilder`, one
-  * may use one of four groups of methods. Each of these methods have various
-  * overloads and variations to enable further control over the I/O. These
-  * methods are:
-  *
-  *   - `run`: the most general method, it returns a
-  *     [[scala.sys.process.Process]] immediately, and the external command
-  *     executes concurrently.
-  *   - `!`: blocks until all external commands exit, and returns the exit code
-  *     of the last one in the chain of execution.
-  *   - `!!`: blocks until all external commands exit, and returns a `String`
-  *     with the output generated.
-  *   - `lazyLines`: returns immediately like `run`, and the output being generated
-  *     is provided through a `LazyList[String]`. Getting the next element of that
-  *     `LazyList` may block until it becomes available. This method will throw an
-  *     exception if the return code is different than zero -- if this is not
-  *     desired, use the `lazyLines_!` method.
-  *
-  * ==Handling Input and Output==
-  *
-  * If not specified, the input of the external commands executed with `run` or
-  * `!` will not be tied to anything, and the output will be redirected to the
-  * stdout and stderr of the Scala process. For the methods `!!` and `lazyLines`, no
-  * input will be provided, and the output will be directed according to the
-  * semantics of these methods.
-  *
-  * Some methods will cause stdin to be used as input. Output can be controlled
-  * with a [[scala.sys.process.ProcessLogger]] -- `!!` and `lazyLines` will only
-  * redirect error output when passed a `ProcessLogger`. If one desires full
-  * control over input and output, then a [[scala.sys.process.ProcessIO]] can be
-  * used with `run`.
-  *
-  * For example, we could silence the error output from `lazyLines_!` like this:
-  * {{{
-  * val etcFiles = "find /etc" lazyLines_! ProcessLogger(line => ())
-  * }}}
-  *
-  * ==Extended Example==
-  *
-  * Let's examine in detail one example of usage:
-  * {{{
-  * import scala.sys.process._
-  * "find src -name *.scala -exec grep null {} ;"  #|  "xargs test -z"  #&&  "echo null-free"  #||  "echo null detected"  !
-  * }}}
-  * Note that every `String` is implicitly converted into a `ProcessBuilder`
-  * through the implicits imported from [[scala.sys.process]]. These `ProcessBuilder` are then
-  * combined in three different ways.
-  *
-  *   1. `#|` pipes the output of the first command into the input of the second command. It
-  *      mirrors a shell pipe (`|`).
-  *   1. `#&&` conditionally executes the second command if the previous one finished with
-  *      exit value 0. It mirrors shell's `&&`.
-  *   1. `#||` conditionally executes the third command if the exit value of the previous
-  *      command is different than zero. It mirrors shell's `||`.
-  *
-  * Finally, `!` at the end executes the commands, and returns the exit value.
-  * Whatever is printed will be sent to the Scala process standard output. If
-  * we wanted to capture it, we could run that with `!!` instead.
-  *
-  * Note: though it is not shown above, the equivalent of a shell's `;` would be
-  * `###`. The reason for this name is that `;` is a reserved token in Scala.
-  *
-  */
+ *  executed. A `ProcessBuilder` can be a single external process, or a
+ *  combination of other `ProcessBuilder`. One can control where the
+ *  output of an external process will go to, and where its input will come
+ *  from, or leave that decision to whoever starts it.
+ *
+ *  One creates a `ProcessBuilder` through factories provided in
+ *  [[scala.sys.process.Process]]'s companion object, or implicit conversions
+ *  based on these factories made available in the package object
+ *  [[scala.sys.process]]. Here are some examples:
+ *  ```
+ *  import scala.sys.process._
+ *
+ *  // Executes "ls" and sends output to stdout
+ *  "ls".!
+ *
+ *  // Execute "ls" and assign a `LazyList[String]` of its output to "contents".
+ *  val contents = Process("ls").lazyLines
+ *
+ *  // Here we use a `Seq` to make the parameter whitespace-safe
+ *  def contentsOf(dir: String): String = Seq("ls", dir).!!
+ *  ```
+ *
+ *  The methods of `ProcessBuilder` are divided in three categories: the ones that
+ *  combine two `ProcessBuilder` to create a third, the ones that redirect input
+ *  or output of a `ProcessBuilder`, and the ones that execute
+ *  the external processes associated with it.
+ *
+ *  ## Combining `ProcessBuilder`
+ *
+ *  Two existing `ProcessBuilder` can be combined in the following ways:
+ *
+ *   - They can be executed in parallel, with the output of the first being fed
+ *     as input to the second, like Unix pipes. This is achieved with the `#|`
+ *     method.
+ *   - They can be executed in sequence, with the second starting as soon as
+ *     the first ends. This is done by the `###` method.
+ *   - The execution of the second one can be conditioned by the return code
+ *     (exit status) of the first, either only when it's zero, or only when it's
+ *     not zero. The methods `#&&` and `#||` accomplish these tasks.
+ *
+ *  ## Redirecting Input/Output
+ *
+ *  Though control of input and output can be done when executing the process,
+ *  there's a few methods that create a new `ProcessBuilder` with a
+ *  pre-configured input or output. They are `#<`, `#>` and `#>>`, and may take
+ *  as input either another `ProcessBuilder` (like the pipe described above), or
+ *  something else such as a `java.io.File` or a `java.io.InputStream`.
+ *  For example:
+ *  ```
+ *  new URL("https://databinder.net/dispatch/About") #> "grep JSON" #>> new File("About_JSON") !
+ *  ```
+ *
+ *  ## Starting Processes
+ *
+ *  To execute all external commands associated with a `ProcessBuilder`, one
+ *  may use one of four groups of methods. Each of these methods have various
+ *  overloads and variations to enable further control over the I/O. These
+ *  methods are:
+ *
+ *   - `run`: the most general method, it returns a
+ *     [[scala.sys.process.Process]] immediately, and the external command
+ *     executes concurrently.
+ *   - `!`: blocks until all external commands exit, and returns the exit code
+ *     of the last one in the chain of execution.
+ *   - `!!`: blocks until all external commands exit, and returns a `String`
+ *     with the output generated.
+ *   - `lazyLines`: returns immediately like `run`, and the output being generated
+ *     is provided through a `LazyList[String]`. Getting the next element of that
+ *     `LazyList` may block until it becomes available. This method will throw an
+ *     exception if the return code is different than zero -- if this is not
+ *     desired, use the `lazyLines_!` method.
+ *
+ *  ## Handling Input and Output
+ *
+ *  If not specified, the input of the external commands executed with `run` or
+ *  `!` will not be tied to anything, and the output will be redirected to the
+ *  stdout and stderr of the Scala process. For the methods `!!` and `lazyLines`, no
+ *  input will be provided, and the output will be directed according to the
+ *  semantics of these methods.
+ *
+ *  Some methods will cause stdin to be used as input. Output can be controlled
+ *  with a [[scala.sys.process.ProcessLogger]] -- `!!` and `lazyLines` will only
+ *  redirect error output when passed a `ProcessLogger`. If one desires full
+ *  control over input and output, then a [[scala.sys.process.ProcessIO]] can be
+ *  used with `run`.
+ *
+ *  For example, we could silence the error output from `lazyLines_!` like this:
+ *  ```
+ *  val etcFiles = "find /etc" lazyLines_! ProcessLogger(line => ())
+ *  ```
+ *
+ *  ## Extended Example
+ *
+ *  Let's examine in detail one example of usage:
+ *  ```
+ *  import scala.sys.process._
+ *  "find src -name *.scala -exec grep null {} ;"  #|  "xargs test -z"  #&&  "echo null-free"  #||  "echo null detected"  !
+ *  ```
+ *  Note that every `String` is implicitly converted into a `ProcessBuilder`
+ *  through the implicits imported from [[scala.sys.process]]. These `ProcessBuilder` are then
+ *  combined in three different ways.
+ *
+ *   1. `#|` pipes the output of the first command into the input of the second command. It
+ *      mirrors a shell pipe (`|`).
+ *   1. `#&&` conditionally executes the second command if the previous one finished with
+ *      exit value 0. It mirrors shell's `&&`.
+ *   1. `#||` conditionally executes the third command if the exit value of the previous
+ *      command is different than zero. It mirrors shell's `||`.
+ *
+ *  Finally, `!` at the end executes the commands, and returns the exit value.
+ *  Whatever is printed will be sent to the Scala process standard output. If
+ *  we wanted to capture it, we could run that with `!!` instead.
+ *
+ *  Note: though it is not shown above, the equivalent of a shell's `;` would be
+ *  `###`. The reason for this name is that `;` is a reserved token in Scala.
+ */
 trait ProcessBuilder extends Source with Sink {
   /** Starts the process represented by this builder, blocks until it exits, and
-    * returns the output as a String.  Standard error is sent to the console.  If
-    * the exit code is non-zero, an exception is thrown.
-    */
+   *  returns the output as a String.  Standard error is sent to the console.  If
+   *  the exit code is non-zero, an exception is thrown.
+   */
   def !! : String
 
   /** Starts the process represented by this builder, blocks until it exits, and
-    * returns the output as a String.  Standard error is sent to the provided
-    * ProcessLogger.  If the exit code is non-zero, an exception is thrown.
-    */
+   *  returns the output as a String.  Standard error is sent to the provided
+   *  ProcessLogger.  If the exit code is non-zero, an exception is thrown.
+   */
   def !!(log: ProcessLogger): String
 
   /** Starts the process represented by this builder, blocks until it exits, and
-    * returns the output as a String.  Standard error is sent to the console.  If
-    * the exit code is non-zero, an exception is thrown.  The newly started
-    * process reads from standard input of the current process.
-    */
+   *  returns the output as a String.  Standard error is sent to the console.  If
+   *  the exit code is non-zero, an exception is thrown.  The newly started
+   *  process reads from standard input of the current process.
+   */
   def !!< : String
 
   /** Starts the process represented by this builder, blocks until it exits, and
-    * returns the output as a String.  Standard error is sent to the provided
-    * ProcessLogger.  If the exit code is non-zero, an exception is thrown.  The
-    * newly started process reads from standard input of the current process.
-    */
+   *  returns the output as a String.  Standard error is sent to the provided
+   *  ProcessLogger.  If the exit code is non-zero, an exception is thrown.  The
+   *  newly started process reads from standard input of the current process.
+   */
   def !!<(log: ProcessLogger): String
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a `LazyList` that blocks when lines are not available but the process has not
-    * completed.  Standard error is sent to the console.  If the process exits
-    * with a non-zero value, the `LazyList` will provide all lines up to termination
-    * and then throw an exception.
-    */
+   *  a `LazyList` that blocks when lines are not available but the process has not
+   *  completed.  Standard error is sent to the console.  If the process exits
+   *  with a non-zero value, the `LazyList` will provide all lines up to termination
+   *  and then throw an exception.
+   */
   def lazyLines: LazyList[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-   * a `LazyList` that blocks when lines are not available but the process has not
-   * completed.
-   * The producer process will block if the given capacity of lines if filled
-   * without being consumed from the `LazyList`.
-   * Standard error is sent to the console.  If the process exits
-   * with a non-zero value, the `LazyList` will provide all lines up to termination
-   * and then throw an exception.
+   *  a `LazyList` that blocks when lines are not available but the process has not
+   *  completed.
+   *  The producer process will block if the given capacity of lines if filled
+   *  without being consumed from the `LazyList`.
+   *  Standard error is sent to the console.  If the process exits
+   *  with a non-zero value, the `LazyList` will provide all lines up to termination
+   *  and then throw an exception.
    */
   def lazyLines(capacity: Integer): LazyList[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a `LazyList` that blocks when lines are not available but the process has not
-    * completed.  Standard error is sent to the provided `ProcessLogger`.  If the
-    * process exits with a non-zero value, the `LazyList` will provide all lines up
-    * to termination and then throw an exception.
-    */
+   *  a `LazyList` that blocks when lines are not available but the process has not
+   *  completed.  Standard error is sent to the provided `ProcessLogger`.  If the
+   *  process exits with a non-zero value, the `LazyList` will provide all lines up
+   *  to termination and then throw an exception.
+   */
   def lazyLines(log: ProcessLogger): LazyList[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-   * a `LazyList` that blocks when lines are not available but the process has not
-   * completed.
-   * The producer process will block if the given capacity of lines if filled
-   * without being consumed from the `LazyList`.
-   * Standard error is sent to the provided `ProcessLogger`.  If the
-   * process exits with a non-zero value, the `LazyList` will provide all lines up
-   * to termination and then throw an exception.
+   *  a `LazyList` that blocks when lines are not available but the process has not
+   *  completed.
+   *  The producer process will block if the given capacity of lines if filled
+   *  without being consumed from the `LazyList`.
+   *  Standard error is sent to the provided `ProcessLogger`.  If the
+   *  process exits with a non-zero value, the `LazyList` will provide all lines up
+   *  to termination and then throw an exception.
    */
   def lazyLines(log: ProcessLogger, capacity: Integer): LazyList[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a `LazyList` that blocks when lines are not available but the process has not
-    * completed.  Standard error is sent to the console. If the process exits
-    * with a non-zero value, the `LazyList` will provide all lines up to termination
-    * but will not throw an exception.
-    */
+   *  a `LazyList` that blocks when lines are not available but the process has not
+   *  completed.  Standard error is sent to the console. If the process exits
+   *  with a non-zero value, the `LazyList` will provide all lines up to termination
+   *  but will not throw an exception.
+   */
   def lazyLines_! : LazyList[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-   * a `LazyList` that blocks when lines are not available but the process has not
-   * completed.
-   * The producer process will block if the given capacity of lines if filled
-   * without being consumed from the stream.
-   * Standard error is sent to the console. If the process exits
-   * with a non-zero value, the `LazyList` will provide all lines up to termination
-   * but will not throw an exception.
+   *  a `LazyList` that blocks when lines are not available but the process has not
+   *  completed.
+   *  The producer process will block if the given capacity of lines if filled
+   *  without being consumed from the stream.
+   *  Standard error is sent to the console. If the process exits
+   *  with a non-zero value, the `LazyList` will provide all lines up to termination
+   *  but will not throw an exception.
    */
   def lazyLines_!(capacity: Integer): LazyList[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a `LazyList` that blocks when lines are not available but the process has not
-    * completed.  Standard error is sent to the provided `ProcessLogger`. If the
-    * process exits with a non-zero value, the `LazyList` will provide all lines up
-    * to termination but will not throw an exception.
-    */
+   *  a `LazyList` that blocks when lines are not available but the process has not
+   *  completed.  Standard error is sent to the provided `ProcessLogger`. If the
+   *  process exits with a non-zero value, the `LazyList` will provide all lines up
+   *  to termination but will not throw an exception.
+   */
   def lazyLines_!(log: ProcessLogger): LazyList[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-   * a `LazyList` that blocks when lines are not available but the process has not
-   * completed.
-   * The producer process will block if the given capacity of lines if filled
-   * without being consumed from the stream.
-   * Standard error is sent to the provided `ProcessLogger`. If the
-   * process exits with a non-zero value, the `LazyList` will provide all lines up
-   * to termination but will not throw an exception.
+   *  a `LazyList` that blocks when lines are not available but the process has not
+   *  completed.
+   *  The producer process will block if the given capacity of lines if filled
+   *  without being consumed from the stream.
+   *  Standard error is sent to the provided `ProcessLogger`. If the
+   *  process exits with a non-zero value, the `LazyList` will provide all lines up
+   *  to termination but will not throw an exception.
    */
   def lazyLines_!(log: ProcessLogger, capacity: Integer): LazyList[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a `Stream` that blocks when lines are not available but the process has not
-    * completed.  Standard error is sent to the console.  If the process exits
-    * with a non-zero value, the `Stream` will provide all lines up to termination
-    * and then throw an exception.
-    */
+   *  a `Stream` that blocks when lines are not available but the process has not
+   *  completed.  Standard error is sent to the console.  If the process exits
+   *  with a non-zero value, the `Stream` will provide all lines up to termination
+   *  and then throw an exception.
+   */
   @deprecated("use lazyLines", since = "2.13.0")
   def lineStream: Stream[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a `Stream` that blocks when lines are not available but the process has not
-    * completed.
-    * The producer process will block if the given capacity of lines if filled
-    * without being consumed from the stream.
-    * Standard error is sent to the console.  If the process exits
-    * with a non-zero value, the `Stream` will provide all lines up to termination
-    * and then throw an exception.
-    */
+   *  a `Stream` that blocks when lines are not available but the process has not
+   *  completed.
+   *  The producer process will block if the given capacity of lines if filled
+   *  without being consumed from the stream.
+   *  Standard error is sent to the console.  If the process exits
+   *  with a non-zero value, the `Stream` will provide all lines up to termination
+   *  and then throw an exception.
+   */
   @deprecated("use lazyLines", since = "2.13.0")
   def lineStream(capacity: Integer): Stream[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a `Stream` that blocks when lines are not available but the process has not
-    * completed.  Standard error is sent to the provided `ProcessLogger`.  If the
-    * process exits with a non-zero value, the `Stream` will provide all lines up
-    * to termination and then throw an exception.
-    */
+   *  a `Stream` that blocks when lines are not available but the process has not
+   *  completed.  Standard error is sent to the provided `ProcessLogger`.  If the
+   *  process exits with a non-zero value, the `Stream` will provide all lines up
+   *  to termination and then throw an exception.
+   */
   @deprecated("use lazyLines", since = "2.13.0")
   def lineStream(log: ProcessLogger): Stream[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a `Stream` that blocks when lines are not available but the process has not
-    * completed.
-    * The producer process will block if the given capacity of lines if filled
-    * without being consumed from the stream.
-    * Standard error is sent to the provided `ProcessLogger`.  If the
-    * process exits with a non-zero value, the `Stream` will provide all lines up
-    * to termination and then throw an exception.
-    */
+   *  a `Stream` that blocks when lines are not available but the process has not
+   *  completed.
+   *  The producer process will block if the given capacity of lines if filled
+   *  without being consumed from the stream.
+   *  Standard error is sent to the provided `ProcessLogger`.  If the
+   *  process exits with a non-zero value, the `Stream` will provide all lines up
+   *  to termination and then throw an exception.
+   */
   @deprecated("use lazyLines", since = "2.13.0")
   def lineStream(log: ProcessLogger, capacity: Integer): Stream[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a `Stream` that blocks when lines are not available but the process has not
-    * completed.  Standard error is sent to the console. If the process exits
-    * with a non-zero value, the `Stream` will provide all lines up to termination
-    * but will not throw an exception.
-    */
+   *  a `Stream` that blocks when lines are not available but the process has not
+   *  completed.  Standard error is sent to the console. If the process exits
+   *  with a non-zero value, the `Stream` will provide all lines up to termination
+   *  but will not throw an exception.
+   */
   @deprecated("use lazyLines_!", since = "2.13.0")
   def lineStream_! : Stream[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a `Stream` that blocks when lines are not available but the process has not
-    * completed.
-    * The producer process will block if the given capacity of lines if filled
-    * without being consumed from the stream.
-    * Standard error is sent to the console. If the process exits
-    * with a non-zero value, the `Stream` will provide all lines up to termination
-    * but will not throw an exception.
-    */
+   *  a `Stream` that blocks when lines are not available but the process has not
+   *  completed.
+   *  The producer process will block if the given capacity of lines if filled
+   *  without being consumed from the stream.
+   *  Standard error is sent to the console. If the process exits
+   *  with a non-zero value, the `Stream` will provide all lines up to termination
+   *  but will not throw an exception.
+   */
   @deprecated("use lazyLines_!", since = "2.13.0")
   def lineStream_!(capacity: Integer): Stream[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a `Stream` that blocks when lines are not available but the process has not
-    * completed.  Standard error is sent to the provided `ProcessLogger`. If the
-    * process exits with a non-zero value, the `Stream` will provide all lines up
-    * to termination but will not throw an exception.
-    */
+   *  a `Stream` that blocks when lines are not available but the process has not
+   *  completed.  Standard error is sent to the provided `ProcessLogger`. If the
+   *  process exits with a non-zero value, the `Stream` will provide all lines up
+   *  to termination but will not throw an exception.
+   */
   @deprecated("use lazyLines_!", since = "2.13.0")
   def lineStream_!(log: ProcessLogger): Stream[String]
 
   /** Starts the process represented by this builder.  The output is returned as
-    * a `Stream` that blocks when lines are not available but the process has not
-    * completed.
-    * The producer process will block if the given capacity of lines if filled
-    * without being consumed from the stream.
-    * Standard error is sent to the provided `ProcessLogger`. If the
-    * process exits with a non-zero value, the `Stream` will provide all lines up
-    * to termination but will not throw an exception.
-    */
+   *  a `Stream` that blocks when lines are not available but the process has not
+   *  completed.
+   *  The producer process will block if the given capacity of lines if filled
+   *  without being consumed from the stream.
+   *  Standard error is sent to the provided `ProcessLogger`. If the
+   *  process exits with a non-zero value, the `Stream` will provide all lines up
+   *  to termination but will not throw an exception.
+   */
   @deprecated("use lazyLines_!", since = "2.13.0")
   def lineStream_!(log: ProcessLogger, capacity: Integer): Stream[String]
 
   /** Starts the process represented by this builder, blocks until it exits, and
-    * returns the exit code.  Standard output and error are sent to the console.
-    */
+   *  returns the exit code.  Standard output and error are sent to the console.
+   */
   def ! : Int
 
   /** Starts the process represented by this builder, blocks until it exits, and
-    * returns the exit code.  Standard output and error are sent to the given
-    * ProcessLogger.
-    */
+   *  returns the exit code.  Standard output and error are sent to the given
+   *  ProcessLogger.
+   */
   def !(log: ProcessLogger): Int
 
   /** Starts the process represented by this builder, blocks until it exits, and
-    * returns the exit code.  Standard output and error are sent to the console.
-    * The newly started process reads from standard input of the current process.
-    */
+   *  returns the exit code.  Standard output and error are sent to the console.
+   *  The newly started process reads from standard input of the current process.
+   */
   def !< : Int
 
   /** Starts the process represented by this builder, blocks until it exits, and
-    * returns the exit code.  Standard output and error are sent to the given
-    * ProcessLogger.  The newly started process reads from standard input of the
-    * current process.
-    */
+   *  returns the exit code.  Standard output and error are sent to the given
+   *  ProcessLogger.  The newly started process reads from standard input of the
+   *  current process.
+   */
   def !<(log: ProcessLogger): Int
 
   /** Starts the process represented by this builder.  Standard output and error
-   * are sent to the console.*/
+   *  are sent to the console.
+   */
   def run(): Process
 
   /** Starts the process represented by this builder.  Standard output and error
-    * are sent to the given ProcessLogger.
-    */
+   *  are sent to the given ProcessLogger.
+   */
   def run(log: ProcessLogger): Process
 
   /** Starts the process represented by this builder.  I/O is handled by the
-    * given ProcessIO instance.
-    */
+   *  given ProcessIO instance.
+   */
   def run(io: ProcessIO): Process
 
   /** Starts the process represented by this builder.  Standard output and error
-    * are sent to the console.  The newly started process reads from standard
-    * input of the current process if `connectInput` is true.
-    */
+   *  are sent to the console.  The newly started process reads from standard
+   *  input of the current process if `connectInput` is true.
+   */
   def run(connectInput: Boolean): Process
 
   /** Starts the process represented by this builder.  Standard output and error
-    * are sent to the given ProcessLogger.  The newly started process reads from
-    * standard input of the current process if `connectInput` is true.
-    */
+   *  are sent to the given ProcessLogger.  The newly started process reads from
+   *  standard input of the current process if `connectInput` is true.
+   */
   def run(log: ProcessLogger, connectInput: Boolean): Process
 
   /** Constructs a command that runs this command first and then `other` if this
-    * command succeeds.
-    */
+   *  command succeeds.
+   */
   def #&& (other: ProcessBuilder): ProcessBuilder
 
   /** Constructs a command that runs this command first and then `other` if this
-    * command does not succeed.
-    */
+   *  command does not succeed.
+   */
   def #|| (other: ProcessBuilder): ProcessBuilder
 
   /** Constructs a command that will run this command and pipes the output to
-    * `other`.  `other` must be a simple command.
-    */
+   *  `other`.  `other` must be a simple command.
+   */
   def #| (other: ProcessBuilder): ProcessBuilder
 
   /** Constructs a command that will run this command and then `other`.  The
-    * exit code will be the exit code of `other`.
-    */
+   *  exit code will be the exit code of `other`.
+   */
   def ### (other: ProcessBuilder): ProcessBuilder
 
 
@@ -398,11 +398,11 @@ trait ProcessBuilder extends Source with Sink {
   def canPipeTo: Boolean
 
   /** True if this command has an exit code which should be propagated to the
-    * user.  Given a pipe between A and B, if B.hasExitValue is true then the
-    * exit code will be the one from B; if it is false, the one from A.  This
-    * exists to prevent output redirections (implemented as pipes) from masking
-    * useful process error codes.
-    */
+   *  user.  Given a pipe between A and B, if B.hasExitValue is true then the
+   *  exit code will be the one from B; if it is false, the one from A.  This
+   *  exists to prevent output redirections (implemented as pipes) from masking
+   *  useful process error codes.
+   */
   def hasExitValue: Boolean
 }
 
@@ -414,8 +414,8 @@ object ProcessBuilder extends ProcessBuilderImpl {
   }
 
   /** Used when creating [[scala.sys.process.ProcessBuilder.Source]] and/or
-    * [[scala.sys.process.ProcessBuilder.Sink]] from a file.
-    */
+   *  [[scala.sys.process.ProcessBuilder.Sink]] from a file.
+   */
   trait FileBuilder extends Sink with Source {
     /** Appends the contents of a `java.io.File` to this file. */
     def #<<(f: File): ProcessBuilder
@@ -431,8 +431,8 @@ object ProcessBuilder extends ProcessBuilderImpl {
   }
 
   /** Represents everything that can be used as an input to a
-    * [[scala.sys.process.ProcessBuilder]].
-    */
+   *  [[scala.sys.process.ProcessBuilder]].
+   */
   trait Source {
     protected def toSource: ProcessBuilder
 
@@ -443,9 +443,9 @@ object ProcessBuilder extends ProcessBuilderImpl {
     def #>> (f: File): ProcessBuilder = toFile(f, append = true)
 
     /** Writes the output stream of this process to the given OutputStream. The
-      * argument is call-by-name, so the stream is recreated, written, and closed each
-      * time this process is executed.
-      */
+     *  argument is call-by-name, so the stream is recreated, written, and closed each
+     *  time this process is executed.
+     */
     def #>(out: => OutputStream): ProcessBuilder = #> (new OStreamBuilder(out, "<output stream>"))
 
     /** Writes the output stream of this process to a [[scala.sys.process.ProcessBuilder]]. */
@@ -457,8 +457,8 @@ object ProcessBuilder extends ProcessBuilderImpl {
   }
 
   /** Represents everything that can receive an output from a
-    * [[scala.sys.process.ProcessBuilder]].
-    */
+   *  [[scala.sys.process.ProcessBuilder]].
+   */
   trait Sink {
     protected def toSink: ProcessBuilder
 
@@ -469,9 +469,9 @@ object ProcessBuilder extends ProcessBuilderImpl {
     def #< (f: URL): ProcessBuilder = #< (new URLInput(f))
 
     /** Reads the given InputStream into the input stream of this process. The
-      * argument is call-by-name, so the stream is recreated, read, and closed each
-      * time this process is executed.
-      */
+     *  argument is call-by-name, so the stream is recreated, read, and closed each
+     *  time this process is executed.
+     */
     def #<(in: => InputStream): ProcessBuilder = #< (new IStreamBuilder(in, "<input stream>"))
 
     /** Reads the output of a [[scala.sys.process.ProcessBuilder]] into the input stream of this process. */

--- a/library/src/scala/sys/process/ProcessIO.scala
+++ b/library/src/scala/sys/process/ProcessIO.scala
@@ -18,39 +18,39 @@ import scala.language.`2.13`
 import processInternal._
 
 /** This class is used to control the I/O of every
-  * [[scala.sys.process.Process]]. The functions used to create it will be
-  * called with the process streams once it has been started. It might not be
-  * necessary to use `ProcessIO` directly --
-  * [[scala.sys.process.ProcessBuilder]] can return the process output to the
-  * caller, or use a [[scala.sys.process.ProcessLogger]] which avoids direct
-  * interaction with a stream. One can even use the factories at `BasicIO` to
-  * create a `ProcessIO`, or use its helper methods when creating one's own
-  * `ProcessIO`.
-  *
-  * When creating a `ProcessIO`, it is important to ''close all streams'' when
-  * finished, since the JVM might use system resources to capture the process
-  * input and output, and will not release them unless the streams are
-  * explicitly closed.
-  *
-  * `ProcessBuilder` will call `writeInput`, `processOutput` and `processError`
-  * in separate threads, and if daemonizeThreads is true, they will all be
-  * marked as daemon threads.
-  *
-  * @param writeInput Function that will be called with the `OutputStream` to
-  *                   which all input to the process must be written. This will
-  *                   be called in a newly spawned thread.
-  * @param processOutput Function that will be called with the `InputStream`
-  *                      from which all normal output of the process must be
-  *                      read from. This will be called in a newly spawned
-  *                      thread.
-  * @param processError Function that will be called with the `InputStream` from
-  *                     which all error output of the process must be read from.
-  *                     This will be called in a newly spawned thread.
-  * @param daemonizeThreads Indicates whether the newly spawned threads that
-  *                         will run `processOutput`, `processError` and
-  *                         `writeInput` should be marked as daemon threads.
-  * @note Failure to close the passed streams may result in resource leakage.
-  */
+ *  [[scala.sys.process.Process]]. The functions used to create it will be
+ *  called with the process streams once it has been started. It might not be
+ *  necessary to use `ProcessIO` directly --
+ *  [[scala.sys.process.ProcessBuilder]] can return the process output to the
+ *  caller, or use a [[scala.sys.process.ProcessLogger]] which avoids direct
+ *  interaction with a stream. One can even use the factories at `BasicIO` to
+ *  create a `ProcessIO`, or use its helper methods when creating one's own
+ *  `ProcessIO`.
+ *
+ *  When creating a `ProcessIO`, it is important to *close all streams* when
+ *  finished, since the JVM might use system resources to capture the process
+ *  input and output, and will not release them unless the streams are
+ *  explicitly closed.
+ *
+ *  `ProcessBuilder` will call `writeInput`, `processOutput` and `processError`
+ *  in separate threads, and if daemonizeThreads is true, they will all be
+ *  marked as daemon threads.
+ *
+ *  @param writeInput Function that will be called with the `OutputStream` to
+ *                   which all input to the process must be written. This will
+ *                   be called in a newly spawned thread.
+ *  @param processOutput Function that will be called with the `InputStream`
+ *                      from which all normal output of the process must be
+ *                      read from. This will be called in a newly spawned
+ *                      thread.
+ *  @param processError Function that will be called with the `InputStream` from
+ *                     which all error output of the process must be read from.
+ *                     This will be called in a newly spawned thread.
+ *  @param daemonizeThreads Indicates whether the newly spawned threads that
+ *                         will run `processOutput`, `processError` and
+ *                         `writeInput` should be marked as daemon threads.
+ *  @note Failure to close the passed streams may result in resource leakage.
+ */
 final class ProcessIO(
   val writeInput: OutputStream => Unit,
   val processOutput: InputStream => Unit,

--- a/library/src/scala/sys/process/ProcessLogger.scala
+++ b/library/src/scala/sys/process/ProcessLogger.scala
@@ -18,39 +18,37 @@ import scala.language.`2.13`
 import java.io._
 
 /** Encapsulates the output and error streams of a running process. This is used
-  * by [[scala.sys.process.ProcessBuilder]] when starting a process, as an
-  * alternative to [[scala.sys.process.ProcessIO]], which can be more difficult
-  * to use. Note that a `ProcessLogger` will be used to create a `ProcessIO`
-  * anyway. The object `BasicIO` has some functions to do that.
-  *
-  * Here is an example that counts the number of lines in the normal and error
-  * output of a process:
-  * {{{
-  * import scala.sys.process._
-  *
-  * var normalLines = 0
-  * var errorLines = 0
-  * val countLogger = ProcessLogger(line => normalLines += 1,
-  *                                 line => errorLines += 1)
-  * "find /etc" ! countLogger
-  * }}}
-  *
-  *  @see [[scala.sys.process.ProcessBuilder]]
-  */
+ *  by [[scala.sys.process.ProcessBuilder]] when starting a process, as an
+ *  alternative to [[scala.sys.process.ProcessIO]], which can be more difficult
+ *  to use. Note that a `ProcessLogger` will be used to create a `ProcessIO`
+ *  anyway. The object `BasicIO` has some functions to do that.
+ *
+ *  Here is an example that counts the number of lines in the normal and error
+ *  output of a process:
+ *  ```
+ *  import scala.sys.process._
+ *
+ *  var normalLines = 0
+ *  var errorLines = 0
+ *  val countLogger = ProcessLogger(line => normalLines += 1,
+ *                                 line => errorLines += 1)
+ *  "find /etc" ! countLogger
+ *  ```
+ *
+ *  @see [[scala.sys.process.ProcessBuilder]]
+ */
 trait ProcessLogger {
-  /** Will be called with each line read from the process output stream.
-   */
+  /** Will be called with each line read from the process output stream. */
   def out(s: => String): Unit
 
-  /** Will be called with each line read from the process error stream.
-   */
+  /** Will be called with each line read from the process error stream. */
   def err(s: => String): Unit
 
   /** If a process is begun with one of these `ProcessBuilder` methods:
-   *  {{{
+   *  ```
    *    def !(log: ProcessLogger): Int
    *    def !<(log: ProcessLogger): Int
-   *  }}}
+   *  ```
    *  The run will be wrapped in a call to buffer.  This gives the logger
    *  an opportunity to set up and tear down buffering.  At present the
    *  library implementations of `ProcessLogger` simply execute the body

--- a/library/src/scala/sys/process/package.scala
+++ b/library/src/scala/sys/process/package.scala
@@ -31,20 +31,20 @@ import scala.language.`2.13`
     * external command can be as simple as `"ls".!`, or as complex as building a
     * pipeline of commands such as this:
     *
-    * {{{
+    * ```
     * import scala.sys.process._
     * "ls" #| "grep .scala" #&& Seq("sh", "-c", "scalac *.scala") #|| "echo nothing found" lazyLines
-    * }}}
+    * ```
     *
     * We describe below the general concepts and architecture of the package,
     * and then take a closer look at each of the categories mentioned above.
     *
-    * ==Concepts and Architecture==
+    * ## Concepts and Architecture
     *
     * The underlying basis for the whole package is Java's `Process` and
     * `ProcessBuilder` classes. While there's no need to use these Java classes,
     * they impose boundaries on what is possible. One cannot, for instance,
-    * retrieve a ''process id'' for whatever is executing.
+    * retrieve a *process id* for whatever is executing.
     *
     * When executing an external process, one can provide a command's name,
     * arguments to it, the directory in which it will be executed and what
@@ -70,7 +70,7 @@ import scala.language.`2.13`
     * another, they'll be executed simultaneously, and each will be passed a
     * `ProcessIO` that will copy the output of one to the input of the other.
     *
-    * ==What to Run and How==
+    * ## What to Run and How
     *
     * The central component of the process execution DSL is the
     * [[scala.sys.process.ProcessBuilder]] trait. It is `ProcessBuilder` that
@@ -104,7 +104,7 @@ import scala.language.`2.13`
     *   - The `Process` representing it (`run` methods)
     *
     * Some simple examples of these methods:
-    * {{{
+    * ```
     * import scala.sys.process._
     *
     * // This uses ! to get the exit code
@@ -119,12 +119,12 @@ import scala.language.`2.13`
     *   val cmd = Seq("find", baseDir, "-name", "*.scala", "-type", "f")
     *   cmd.lazyLines
     * }
-    * }}}
+    * ```
     *
     * We'll see more details about controlling I/O of the process in the next
     * section.
     *
-    * ==Handling Input and Output==
+    * ## Handling Input and Output
     *
     * In the underlying Java model, once a `Process` has been started, one can
     * get `java.io.InputStream` and `java.io.OutputStream` representing its
@@ -154,7 +154,7 @@ import scala.language.`2.13`
     *   - This package object itself, with a few implicit conversions.
     *
     * Some examples of I/O handling:
-    * {{{
+    * ```
     * import scala.sys.process._
     *
     * // An overly complex way of computing size of a compressed file
@@ -178,7 +178,7 @@ import scala.language.`2.13`
     *   val lazyLines = cmd lazyLines_! ProcessLogger(buffer append _)
     *   (lazyLines, buffer)
     * }
-    * }}}
+    * ```
     *
     * Instances of the java classes `java.io.File` and `java.net.URL` can both
     * be used directly as input to other processes, and `java.io.File` can be
@@ -186,17 +186,17 @@ import scala.language.`2.13`
     * without any intervening process, though that's not a design goal or
     * recommended usage. For example, the following code will copy a web page to
     * a file:
-    * {{{
+    * ```
     * import java.io.File
     * import java.net.URL
     * import scala.sys.process._
     * new URL("https://www.scala-lang.org/") #> new File("scala-lang.html") !
-    * }}}
+    * ```
     *
     * More information about the other ways of controlling I/O can be found
     * in the Scaladoc for the associated objects, traits and classes.
     *
-    * ==Running the Process==
+    * ## Running the Process
     *
     * Paradoxically, this is the simplest component of all, and the one least
     * likely to be interacted with. It consists solely of

--- a/library/src/scala/throws.scala
+++ b/library/src/scala/throws.scala
@@ -14,16 +14,15 @@ package scala
 
 import scala.language.`2.13`
 
-/**
- * Annotation for specifying the exceptions thrown by a method.
- * For example:
- * {{{
- * class Reader(fname: String) {
+/** Annotation for specifying the exceptions thrown by a method.
+ *  For example:
+ *  ```
+ *  class Reader(fname: String) {
  *   private val in = new BufferedReader(new FileReader(fname))
  *   @throws[IOException]("if the file doesn't exist")
  *   def read() = in.read()
- * }
- * }}}
+ *  }
+ *  ```
  */
 final class throws[T <: Throwable](cause: String = "") extends scala.annotation.StaticAnnotation {
   def this(clazz: Class[T]) = this("")

--- a/library/src/scala/typeConstraints.scala
+++ b/library/src/scala/typeConstraints.scala
@@ -16,85 +16,85 @@ import scala.language.`2.13`
 import scala.annotation.implicitNotFound
 
 /** An instance of `A <:< B` witnesses that `A` is a subtype of `B`.
-  *  Requiring an implicit argument of the type `A <:< B` encodes
-  *  the generalized constraint `A <: B`.
-  *
-  *  To constrain any abstract type `T` that's in scope in a method's
-  *  argument list (not just the method's own type parameters) simply
-  *  add an implicit argument of type `T <:< U`, where `U` is the required
-  *  upper bound; or for lower-bounds, use: `L <:< T`, where `L` is the
-  *  required lower bound.
-  *
-  *  In case of any confusion over which method goes in what direction, all the "Co" methods (including
-  *  [[apply]]) go from left to right in the type ("with" the type), and all the "Contra" methods go
-  *  from right to left ("against" the type). E.g., [[apply]] turns a `From` into a `To`, and
-  *  [[substituteContra]] replaces the `To`s in a type with `From`s.
-  *
-  *  In part contributed by Jason Zaugg.
-  *
-  *  @tparam From a type which is proved a subtype of `To`
-  *  @tparam To a type which is proved a supertype of `From`
-  *
-  *  @example [[scala.Option#flatten]]
-  *           {{{
-  *            sealed trait Option[+A] {
-  *              // def flatten[B, A <: Option[B]]: Option[B] = ...
-  *              // won't work, since the A in flatten shadows the class-scoped A.
-  *              def flatten[B](implicit ev: A <:< Option[B]): Option[B]
-  *                = if(isEmpty) None else ev(get)
-  *              // Because (A <:< Option[B]) <: (A => Option[B]), ev can be called to turn the
-  *              // A from get into an Option[B], and because ev is implicit, that call can be
-  *              // left out and inserted automatically.
-  *            }
-  *           }}}
-  *
-  *  @see [[=:=]] for expressing equality constraints
-  *
-  *  @define isProof This method is impossible to implement without `throw`ing or otherwise "cheating" unless
-  *                  `From <: To`, so it ensures that this really represents a subtyping relationship.
-  *  @define contraCo contravariant in the first argument and covariant in the second
-  *  @define contraCon a contravariant type constructor
-  *  @define coCon a covariant type constructor
-  *  @define sameDiff but with a (potentially) different type
-  *  @define tp <:<
-  */
+ *  Requiring an implicit argument of the type `A <:< B` encodes
+ *  the generalized constraint `A <: B`.
+ *
+ *  To constrain any abstract type `T` that's in scope in a method's
+ *  argument list (not just the method's own type parameters) simply
+ *  add an implicit argument of type `T <:< U`, where `U` is the required
+ *  upper bound; or for lower-bounds, use: `L <:< T`, where `L` is the
+ *  required lower bound.
+ *
+ *  In case of any confusion over which method goes in what direction, all the "Co" methods (including
+ *  [[apply]]) go from left to right in the type ("with" the type), and all the "Contra" methods go
+ *  from right to left ("against" the type). E.g., [[apply]] turns a `From` into a `To`, and
+ *  [[substituteContra]] replaces the `To`s in a type with `From`s.
+ *
+ *  In part contributed by Jason Zaugg.
+ *
+ *  @tparam From a type which is proved a subtype of `To`
+ *  @tparam To a type which is proved a supertype of `From`
+ *
+ *  @example [[scala.Option#flatten]]
+ *           ```
+ *            sealed trait Option[+A] {
+ *              // def flatten[B, A <: Option[B]]: Option[B] = ...
+ *              // won't work, since the A in flatten shadows the class-scoped A.
+ *              def flatten[B](implicit ev: A <:< Option[B]): Option[B]
+ *                = if(isEmpty) None else ev(get)
+ *              // Because (A <:< Option[B]) <: (A => Option[B]), ev can be called to turn the
+ *              // A from get into an Option[B], and because ev is implicit, that call can be
+ *              // left out and inserted automatically.
+ *            }
+ *           ```
+ *
+ *  @see [[=:=]] for expressing equality constraints
+ *
+ *  @define isProof This method is impossible to implement without `throw`ing or otherwise "cheating" unless
+ *                  `From <: To`, so it ensures that this really represents a subtyping relationship.
+ *  @define contraCo contravariant in the first argument and covariant in the second
+ *  @define contraCon a contravariant type constructor
+ *  @define coCon a covariant type constructor
+ *  @define sameDiff but with a (potentially) different type
+ *  @define tp <:<
+ */
 // All of these methods are reimplemented unsafely in =:=.singleton to avoid any indirection.
 // They are here simply for reference as the "correct", safe implementations.
 @implicitNotFound(msg = "Cannot prove that ${From} <:< ${To}.")
 sealed abstract class <:<[-From, +To] extends (From => To) with Serializable {
   /** Substitute `To` for `From` and `From` for `To` in the type `F[To, From]`, given that `F` is $contraCo.
-    *  Essentially swaps `To` and `From` in `ftf`'s type.
-    *
-    *  Equivalent in power to each of [[substituteCo]] and [[substituteContra]].
-    *
-    *  $isProof
-    *
-    *  @return `ftf`, $sameDiff
-    */
+   *  Essentially swaps `To` and `From` in `ftf`'s type.
+   *
+   *  Equivalent in power to each of [[substituteCo]] and [[substituteContra]].
+   *
+   *  $isProof
+   *
+   *  @return `ftf`, $sameDiff
+   */
   def substituteBoth[F[-_, +_]](ftf: F[To, From]): F[From, To]
   // = substituteCo[({type G[+T] = F[From, T]})#G](substituteContra[({type G[-T] = F[T, From})#G](ftf))
   // = substituteContra[({type G[-T] = F[T, To]})#G](substituteCo[({type G[+T] = F[From, T]})#G](ftf))
   /** Substitutes the `From` in the type `F[From]`, where `F` is $coCon, for `To`.
-    *
-    *  Equivalent in power to each of [[substituteBoth]] and [[substituteContra]].
-    *
-    *  $isProof
-    *
-    *  @return `ff`, $sameDiff
-    */
+   *
+   *  Equivalent in power to each of [[substituteBoth]] and [[substituteContra]].
+   *
+   *  $isProof
+   *
+   *  @return `ff`, $sameDiff
+   */
   def substituteCo[F[+_]](ff: F[From]): F[To] = {
     type G[-_, +T] = F[T]
     substituteBoth[G](ff)
   }
   // = substituteContra[({type G[-T] = F[T] => F[To]})#G](identity)(ff)
   /** Substitutes the `To` in the type `F[To]`, where `F` is $contraCon, for `From`.
-    *
-    *  Equivalent in power to each of [[substituteBoth]] and [[substituteCo]].
-    *
-    *  $isProof
-    *
-    *  @return `ft`, $sameDiff
-    */
+   *
+   *  Equivalent in power to each of [[substituteBoth]] and [[substituteCo]].
+   *
+   *  $isProof
+   *
+   *  @return `ft`, $sameDiff
+   */
   def substituteContra[F[-_]](ft: F[To]): F[From] = {
     type G[-T, +_] = F[T]
     substituteBoth[G](ft)
@@ -102,12 +102,12 @@ sealed abstract class <:<[-From, +To] extends (From => To) with Serializable {
   // = substituteCo[({type G[+T] = F[T] => F[From]})#G](identity)(ft)
 
   /** Coerce a `From` into a `To`. This is guaranteed to be the identity function.
-    *
-    *  This method is often called implicitly as an implicit `A $tp B` doubles as an implicit view `A => B`.
-    *
-    *  @param f some value of type `From`
-    *  @return `f`, $sameDiff
-    */
+   *
+   *  This method is often called implicitly as an implicit `A $tp B` doubles as an implicit view `A => B`.
+   *
+   *  @param f some value of type `From`
+   *  @return `f`, $sameDiff
+   */
   override def apply(f: From): To = {
     type Id[+X] = X
     substituteCo[Id](f)
@@ -175,32 +175,32 @@ object <:< {
 }
 
 /** An instance of `A =:= B` witnesses that the types `A` and `B` are equal. It also acts as a `A <:< B`,
-  *  but not a `B <:< A` (directly) due to restrictions on subclassing.
-  *
-  *  In case of any confusion over which method goes in what direction, all the "Co" methods (including
-  *  [[apply]]) go from left to right in the type ("with" the type), and all the "Contra" methods go
-  *  from right to left ("against" the type). E.g., [[apply]] turns a `From` into a `To`, and
-  *  [[substituteContra]] replaces the `To`s in a type with `From`s.
-  *
-  *  @tparam From a type which is proved equal to `To`
-  *  @tparam To a type which is proved equal to `From`
-  *
-  *  @example An in-place variant of [[scala.collection.mutable.ArrayBuffer#transpose]] {{{
-  *            implicit class BufOps[A](private val buf: ArrayBuffer[A]) extends AnyVal {
-  *              def inPlaceTranspose[E]()(implicit ev: A =:= ArrayBuffer[E]) = ???
-  *              // Because ArrayBuffer is invariant, we can't make do with just a A <:< ArrayBuffer[E]
-  *              // Getting buffers *out* from buf would work, but adding them back *in* wouldn't.
-  *            }
-  *           }}}
-  *  @see [[<:<]] for expressing subtyping constraints
-  *
-  *  @define isProof This method is impossible to implement without `throw`ing or otherwise "cheating" unless
-  *                  `From = To`, so it ensures that this really represents a type equality.
-  *  @define contraCo a type constructor of two arguments
-  *  @define contraCon any type constructor
-  *  @define coCon any type constructor
-  *  @define tp =:=
-  */
+ *  but not a `B <:< A` (directly) due to restrictions on subclassing.
+ *
+ *  In case of any confusion over which method goes in what direction, all the "Co" methods (including
+ *  [[apply]]) go from left to right in the type ("with" the type), and all the "Contra" methods go
+ *  from right to left ("against" the type). E.g., [[apply]] turns a `From` into a `To`, and
+ *  [[substituteContra]] replaces the `To`s in a type with `From`s.
+ *
+ *  @tparam From a type which is proved equal to `To`
+ *  @tparam To a type which is proved equal to `From`
+ *
+ *  @example An in-place variant of [[scala.collection.mutable.ArrayBuffer#transpose]] ```
+ *            implicit class BufOps[A](private val buf: ArrayBuffer[A]) extends AnyVal {
+ *              def inPlaceTranspose[E]()(implicit ev: A =:= ArrayBuffer[E]) = ???
+ *              // Because ArrayBuffer is invariant, we can't make do with just a A <:< ArrayBuffer[E]
+ *              // Getting buffers *out* from buf would work, but adding them back *in* wouldn't.
+ *            }
+ *           ```
+ *  @see [[<:<]] for expressing subtyping constraints
+ *
+ *  @define isProof This method is impossible to implement without `throw`ing or otherwise "cheating" unless
+ *                  `From = To`, so it ensures that this really represents a type equality.
+ *  @define contraCo a type constructor of two arguments
+ *  @define contraCon any type constructor
+ *  @define coCon any type constructor
+ *  @define tp =:=
+ */
 // Most of the notes on <:< above apply to =:= as well
 @implicitNotFound(msg = "Cannot prove that ${From} =:= ${To}.")
 sealed abstract class =:=[From, To] extends (From <:< To) with Serializable {

--- a/library/src/scala/unchecked.scala
+++ b/library/src/scala/unchecked.scala
@@ -26,13 +26,13 @@ import scala.language.`2.13`
  *  at runtime.  In most cases one can and should address the
  *  warning instead of suppressing it.
  *
- *  {{{
+ *  ```
  *    // This would normally warn "match is not exhaustive"
  *    // because `None` is not covered.
  *    def f(x: Option[String]) = (x: @unchecked) match { case Some(y) => y }
  *    // This would normally warn "type pattern is unchecked"
  *    // but here will blindly cast the head element to String.
  *    def g(xs: Any) = xs match { case x: List[String @unchecked] => x.head }
- *  }}}
+ *  ```
  */
 final class unchecked extends scala.annotation.Annotation {}

--- a/library/src/scala/util/ChainingOps.scala
+++ b/library/src/scala/util/ChainingOps.scala
@@ -20,47 +20,46 @@ trait ChainingSyntax {
   @inline implicit final def scalaUtilChainingOps[A](a: A): ChainingOps[A] = new ChainingOps(a)
 }
 
-/** Adds chaining methods `tap` and `pipe` to every type.
- */
+/** Adds chaining methods `tap` and `pipe` to every type. */
 final class ChainingOps[A](private val self: A) extends AnyVal {
   /** Applies `f` to the value for its side effects, and returns the original value.
-    *
-    * {{{
-    *   scala> import scala.util.chaining._
-    *
-    *   scala> val xs = List(1, 2, 3).tap(ys => println("debug " + ys.toString))
-    *   debug List(1, 2, 3)
-    *   xs: List[Int] = List(1, 2, 3)
-    * }}}
-    *
-    *  @param f      the function to apply to the value.
-    *  @tparam U     the result type of the function `f`.
-    *  @return       the original value `self`.
-    */
+   *
+   *  ```
+   *   scala> import scala.util.chaining._
+   *
+   *   scala> val xs = List(1, 2, 3).tap(ys => println("debug " + ys.toString))
+   *   debug List(1, 2, 3)
+   *   xs: List[Int] = List(1, 2, 3)
+   *  ```
+   *
+   *  @tparam U     the result type of the function `f`.
+   *  @param f      the function to apply to the value.
+   *  @return       the original value `self`.
+   */
   def tap[U](f: A => U): A = {
     f(self)
     self
   }
 
   /** Converts the value by applying the function `f`.
-    *
-    * {{{
-    *   scala> import scala.util.chaining._
-    *
-    *   scala> val times6 = (_: Int) * 6
-    *   times6: Int => Int = \$\$Lambda\$2023/975629453@17143b3b
-    *
-    *   scala> val i = (1 - 2 - 3).pipe(times6).pipe(scala.math.abs)
-    *   i: Int = 24
-    * }}}
-    *
-    * Note: `(1 - 2 - 3).pipe(times6)` may have a small amount of overhead at
-    * runtime compared to the equivalent  `{ val temp = 1 - 2 - 3; times6(temp) }`.
-    *
-    *  @param f      the function to apply to the value.
-    *  @tparam B     the result type of the function `f`.
-    *  @return       a new value resulting from applying the given function
-    *                `f` to this value.
-    */
+   *
+   *  ```
+   *   scala> import scala.util.chaining._
+   *
+   *   scala> val times6 = (_: Int) * 6
+   *   times6: Int => Int = \$\$Lambda\$2023/975629453@17143b3b
+   *
+   *   scala> val i = (1 - 2 - 3).pipe(times6).pipe(scala.math.abs)
+   *   i: Int = 24
+   *  ```
+   *
+   *  Note: `(1 - 2 - 3).pipe(times6)` may have a small amount of overhead at
+   *  runtime compared to the equivalent  `{ val temp = 1 - 2 - 3; times6(temp) }`.
+   *
+   *  @tparam B     the result type of the function `f`.
+   *  @param f      the function to apply to the value.
+   *  @return       a new value resulting from applying the given function
+   *                `f` to this value.
+   */
   def pipe[B](f: A => B): B = f(self)
 }

--- a/library/src/scala/util/CommandLineParser.scala
+++ b/library/src/scala/util/CommandLineParser.scala
@@ -6,9 +6,9 @@ import language.experimental.captureChecking
 object CommandLineParser {
 
   /** An exception raised for an illegal command line.
-    *  @param idx  The index of the argument that's faulty (starting from 0)
-    *  @param msg  The error message
-    */
+   *  @param idx  The index of the argument that's faulty (starting from 0)
+   *  @param msg  The error message
+   */
   class ParseError(val idx: Int, val msg: String) extends Exception
 
   /** Parses command line argument `s`, which has index `n`, as a value of type `T`.

--- a/library/src/scala/util/DynamicVariable.scala
+++ b/library/src/scala/util/DynamicVariable.scala
@@ -26,12 +26,12 @@ import java.lang.InheritableThreadLocal
  *  parameterless closure, executes. When the second argument finishes,
  *  the variable reverts to the previous value.
  *
- *  {{{
+ *  ```
  *  someDynamicVariable.withValue(newValue) {
  *    // ... code called in here that calls value ...
  *    // ... will be given back the newValue ...
  *  }
- *  }}}
+ *  ```
  *
  *  Each thread gets its own stack of bindings.  When a
  *  new thread is created, the `DynamicVariable` gets a copy
@@ -48,11 +48,11 @@ class DynamicVariable[T](init: T) {
   def value: T = tl.get.asInstanceOf[T]
 
   /** Sets the value of the variable while executing the specified
-    * thunk.
-    *
-    * @param newval The value to which to set the variable
-    * @param thunk The code to evaluate under the new setting
-    */
+   *  thunk.
+   *
+   *  @param newval The value to which to set the variable
+   *  @param thunk The code to evaluate under the new setting
+   */
   def withValue[S](newval: T)(thunk: => S): S = {
     val oldval = value
     tl.set(newval)
@@ -62,8 +62,8 @@ class DynamicVariable[T](init: T) {
   }
 
   /** Change the currently bound value, discarding the old value.
-    * Usually withValue() gives better semantics.
-    */
+   *  Usually withValue() gives better semantics.
+   */
   def value_=(newval: T) = tl.set(newval)
 
   override def toString(): String = "DynamicVariable(" + value + ")"

--- a/library/src/scala/util/Either.scala
+++ b/library/src/scala/util/Either.scala
@@ -27,7 +27,7 @@ import scala.language.`2.13`
  *  For example, you could use `Either[String, Int]` to indicate whether a
  *  received input is a `String` or an `Int`.
  *
- *  {{{
+ *  ```
  *  import scala.io.StdIn._
  *  val in = readLine("Type Either a string or an Int: ")
  *  val result: Either[String,Int] =
@@ -40,19 +40,19 @@ import scala.language.`2.13`
  *    case Right(x) => s"You passed me the Int: \$x, which I will increment. \$x + 1 = \${x+1}"
  *    case Left(x)  => s"You passed me the String: \$x"
  *  }
- *  }}}
+ *  ```
  *
  *  `Either` is right-biased, which means that `Right` is assumed to be the default case to
  *  operate on. If it is `Left`, operations like `map` and `flatMap` return the `Left` value unchanged:
  *
- *  {{{
+ *  ```
  *  def doubled(i: Int) = i * 2
  *  Right(42).map(doubled) // Right(84)
  *  Left(42).map(doubled)  // Left(42)
- *  }}}
+ *  ```
  *
  *  Since `Either` defines the methods `map` and `flatMap`, it can also be used in for comprehensions:
- *  {{{
+ *  ```
  *  val right1 = Right(1)   : Right[Double, Int]
  *  val right2 = Right(2)
  *  val right3 = Right(3)
@@ -95,7 +95,7 @@ import scala.language.`2.13`
  *    if i > 0
  *  } yield i
  *
- *  }}}
+ *  ```
  *
  *  Since `for` comprehensions use `map` and `flatMap`, the types
  *  of function parameters used in the expression must be inferred.
@@ -104,7 +104,7 @@ import scala.language.`2.13`
  *  type argument for type parameter `B`, the right value. Otherwise,
  *  it might be inferred as `Nothing`.
  *
- *  {{{
+ *  ```
  *  for {
  *    x <- left23
  *    y <- right1
@@ -125,7 +125,7 @@ import scala.language.`2.13`
  *    z <- left23
  *  } yield x + y + z
  *  // Left(42.0), but unexpectedly a `Either[Double,String]`
- *  }}}
+ *  ```
  */
 sealed abstract class Either[+A, +B] extends Product with Serializable {
   /** Projects this `Either` as a `Left`.
@@ -133,14 +133,14 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
    *  This allows for-comprehensions over the left side of `Either` instances,
    *  reversing `Either`'s usual right-bias.
    *
-   *  For example {{{
+   *  For example ```
    *  for (s <- Left("flower").left) yield s.length // Left(6)
-   *  }}}
+   *  ```
    *
    *  Continuing the analogy with [[scala.Option]], a `LeftProjection` declares
    *  that `Left` should be analogous to `Some` in some code.
    *
-   *  {{{
+   *  ```
    *  // using Option
    *  def interactWithDB(x: Query): Option[Result] =
    *    try Some(getResultFromDatabase(x))
@@ -170,7 +170,7 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
    *   }
    *   // only report errors
    *   for (e <- interactWithDB(someQuery).left) log(s"query failed, reason was \$e")
-   *   }}}
+   *   ```
    */
   def left = Either.LeftProjection(this)
 
@@ -183,13 +183,13 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
 
   /** Applies `fa` if this is a `Left` or `fb` if this is a `Right`.
    *
-   *  @example {{{
+   *  @example ```
    *  val result = util.Try("42".toInt).toEither
    *  result.fold(
    *    e => s"Operation failed with \$e",
    *    v => s"Operation produced value: \$v"
    *  )
-   *  }}}
+   *  ```
    *
    *  @param fa the function to apply if this is a `Left`
    *  @param fb the function to apply if this is a `Right`
@@ -202,18 +202,18 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
 
   /** If this is a `Left`, then return the left value in `Right` or vice versa.
    *
-   *  @example {{{
+   *  @example ```
    *  val left: Either[String, Int]  = Left("left")
    *  val right: Either[Int, String] = left.swap // Result: Right("left")
-   *  }}}
-   *  @example {{{
+   *  ```
+   *  @example ```
    *  val right = Right(2)
    *  val left  = Left(3)
    *  for {
    *    r1 <- right
    *    r2 <- left.swap
    *  } yield r1 * r2 // Right(6)
-   *  }}}
+   *  ```
    */
   def swap: Either[B, A] = this match {
     case Left(a)  => Right(a)
@@ -223,20 +223,20 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
   /** Joins an `Either` through `Right`.
    *
    *  This method requires that the right side of this `Either` is itself
-   *  an `Either` type. That is, this must be some type like: {{{
+   *  an `Either` type. That is, this must be some type like: ```
    *  Either[A, Either[A, C]]
-   *  }}} (which respects the type parameter bounds, shown below.)
+   *  ``` (which respects the type parameter bounds, shown below.)
    *
    *  If this instance is a `Right[Either[A, C]]` then the contained `Either[A, C]`
    *  will be returned, otherwise this value will be returned unmodified.
    *
-   *  @example {{{
+   *  @example ```
    *  Right[String, Either[String, Int]](Right(12)).joinRight // Result: Right(12)
    *  Right[String, Either[String, Int]](Left("flower")).joinRight // Result: Left("flower")
    *  Left[String, Either[String, Int]]("flower").joinRight // Result: Left("flower")
-   *  }}}
+   *  ```
    *
-   * This method, and `joinLeft`, are analogous to `Option#flatten`
+   *  This method, and `joinLeft`, are analogous to `Option#flatten`
    */
   def joinRight[A1 >: A, B1 >: B, C](implicit ev: B1 <:< Either[A1, C]): Either[A1, C] = this match {
     case Right(b) => b
@@ -246,18 +246,18 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
   /** Joins an `Either` through `Left`.
    *
    *  This method requires that the left side of this `Either` is itself an
-   *  `Either` type. That is, this must be some type like: {{{
+   *  `Either` type. That is, this must be some type like: ```
    *  Either[Either[C, B], B]
-   *  }}} (which respects the type parameter bounds, shown below.)
+   *  ``` (which respects the type parameter bounds, shown below.)
    *
    *  If this instance is a `Left[Either[C, B]]` then the contained `Either[C, B]`
    *  will be returned, otherwise this value will be returned unmodified.
    *
-   *  {{{
+   *  ```
    *  Left[Either[Int, String], String](Right("flower")).joinLeft // Result: Right("flower")
    *  Left[Either[Int, String], String](Left(12)).joinLeft // Result: Left(12)
    *  Right[Either[Int, String], String]("daisy").joinLeft // Result: Right("daisy")
-   *  }}}
+   *  ```
    *
    *  This method, and `joinRight`, are analogous to `Option#flatten`.
    */
@@ -268,10 +268,10 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
 
   /** Executes the given side-effecting function if this is a `Right`.
    *
-   *  {{{
+   *  ```
    *  Right(12).foreach(println) // prints "12"
    *  Left(12).foreach(println)  // doesn't print
-   *  }}}
+   *  ```
    *  @param f The side-effecting function to execute.
    */
   def foreach[U](f: B => U): Unit = this match {
@@ -281,10 +281,10 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
 
   /** Returns the value from this `Right` or the given argument if this is a `Left`.
    *
-   *  {{{
+   *  ```
    *  Right(12).getOrElse(17) // 12
    *  Left(12).getOrElse(17)  // 17
-   *  }}}
+   *  ```
    */
   def getOrElse[B1 >: B](or: => B1): B1 = this match {
     case Right(b) => b
@@ -293,11 +293,11 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
 
   /** Returns this `Right` or the given argument if this is a `Left`.
    *
-   *  {{{
+   *  ```
    *  Right(1) orElse Left(2) // Right(1)
    *  Left(1) orElse Left(2)  // Left(2)
    *  Left(1) orElse Left(2) orElse Right(3) // Right(3)
-   *  }}}
+   *  ```
    */
   def orElse[A1 >: A, B1 >: B](or: => Either[A1, B1]): Either[A1, B1] = this match {
     case Right(_) => this
@@ -307,7 +307,7 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
   /** Returns `true` if this is a `Right` and its value is equal to `elem` (as determined by `==`),
    *  returns `false` otherwise.
    *
-   *  {{{
+   *  ```
    *  // Returns true because value of Right is "something" which equals "something".
    *  Right("something") contains "something"
    *
@@ -316,7 +316,7 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
    *
    *  // Returns false because it's not a Right value.
    *  Left("something") contains "something"
-   *  }}}
+   *  ```
    *
    *  @param elem    the element to test.
    *  @return `true` if this is a `Right` value equal to `elem`.
@@ -329,11 +329,11 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
   /** Returns `true` if `Left` or returns the result of the application of
    *  the given predicate to the `Right` value.
    *
-   *  {{{
+   *  ```
    *  Right(12).forall(_ > 10)    // true
    *  Right(7).forall(_ > 10)     // false
    *  Left(12).forall(_ => false) // true
-   *  }}}
+   *  ```
    */
   def forall(f: B => Boolean): Boolean = this match {
     case Right(b) => f(b)
@@ -343,11 +343,11 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
   /** Returns `false` if `Left` or returns the result of the application of
    *  the given predicate to the `Right` value.
    *
-   *  {{{
+   *  ```
    *  Right(12).exists(_ > 10)   // true
    *  Right(7).exists(_ > 10)    // false
    *  Left(12).exists(_ => true) // false
-   *  }}}
+   *  ```
    */
   def exists(p: B => Boolean): Boolean = this match {
     case Right(b) => p(b)
@@ -365,28 +365,28 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
 
 
   /** Returns the right value if this is right
-    * or this value if this is left
-    *
-    * @example {{{
-    * val  l: Either[String, Either[String, Int]] = Left("pancake")
-    * val rl: Either[String, Either[String, Int]] = Right(Left("flounder"))
-    * val rr: Either[String, Either[String, Int]] = Right(Right(7))
-    *
-    *  l.flatten //Either[String, Int]: Left("pancake")
-    * rl.flatten //Either[String, Int]: Left("flounder")
-    * rr.flatten //Either[String, Int]: Right(7)
-    * }}}
-    *
-    * Equivalent to `flatMap(id => id)`
-    */
+   *  or this value if this is left
+   *
+   *  @example ```
+   *  val  l: Either[String, Either[String, Int]] = Left("pancake")
+   *  val rl: Either[String, Either[String, Int]] = Right(Left("flounder"))
+   *  val rr: Either[String, Either[String, Int]] = Right(Right(7))
+   *
+   *  l.flatten //Either[String, Int]: Left("pancake")
+   *  rl.flatten //Either[String, Int]: Left("flounder")
+   *  rr.flatten //Either[String, Int]: Right(7)
+   *  ```
+   *
+   *  Equivalent to `flatMap(id => id)`
+   */
   def flatten[A1 >: A, B1](implicit ev: B <:< Either[A1, B1]): Either[A1, B1] = flatMap(ev)
 
   /** The given function is applied if this is a `Right`.
    *
-   *  {{{
+   *  ```
    *  Right(12).map(x => "flower") // Result: Right("flower")
    *  Left(12).map(x => "flower")  // Result: Left(12)
-   *  }}}
+   *  ```
    */
   def map[B1](f: B => B1): Either[A, B1] = this match {
     case Right(b) => Right(f(b))
@@ -398,11 +398,11 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
    *  or `Left(zero)` if this is a `Right` and the given predicate `p` does not hold for the right value,
    *  or `Left` with the existing value of `Left` if this is a `Left`.
    *
-   * {{{
-   * Right(12).filterOrElse(_ > 10, -1)   // Right(12)
-   * Right(7).filterOrElse(_ > 10, -1)    // Left(-1)
-   * Left(7).filterOrElse(_ => false, -1) // Left(7)
-   * }}}
+   *  ```
+   *  Right(12).filterOrElse(_ > 10, -1)   // Right(12)
+   *  Right(7).filterOrElse(_ > 10, -1)    // Left(-1)
+   *  Left(7).filterOrElse(_ => false, -1) // Left(7)
+   *  ```
    */
   def filterOrElse[A1 >: A](p: B => Boolean, zero: => A1): Either[A1, B] = this match {
     case Right(b) if !p(b) => Left(zero)
@@ -412,10 +412,10 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
   /** Returns a `Seq` containing the `Right` value if
    *  it exists or an empty `Seq` if this is a `Left`.
    *
-   * {{{
-   * Right(12).toSeq // Seq(12)
-   * Left(12).toSeq  // Seq()
-   * }}}
+   *  ```
+   *  Right(12).toSeq // Seq(12)
+   *  Left(12).toSeq  // Seq()
+   *  ```
    */
   def toSeq: collection.immutable.Seq[B] = this match {
     case Right(b) => collection.immutable.Seq(b)
@@ -425,10 +425,10 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
   /** Returns a `Some` containing the `Right` value
    *  if it exists or a `None` if this is a `Left`.
    *
-   * {{{
-   * Right(12).toOption // Some(12)
-   * Left(12).toOption  // None
-   * }}}
+   *  ```
+   *  Right(12).toOption // Some(12)
+   *  Left(12).toOption  // None
+   *  ```
    */
   def toOption: Option[B] = this match {
     case Right(b) => Some(b)
@@ -442,53 +442,49 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
 
   /** Returns `true` if this is a `Left`, `false` otherwise.
    *
-   *  {{{
+   *  ```
    *  Left("tulip").isLeft // true
    *  Right("venus fly-trap").isLeft // false
-   *  }}}
+   *  ```
    */
   def isLeft: Boolean
 
   /** Returns `true` if this is a `Right`, `false` otherwise.
    *
-   *  {{{
+   *  ```
    *  Left("tulip").isRight // false
    *  Right("venus fly-trap").isRight // true
-   *  }}}
+   *  ```
    */
   def isRight: Boolean
 }
 
-/** The left side of the disjoint union, as opposed to the [[scala.util.Right]] side.
- */
+/** The left side of the disjoint union, as opposed to the [[scala.util.Right]] side. */
 final case class Left[+A, +B](value: A) extends Either[A, B] {
   def isLeft  = true
   def isRight = false
 
-  /**
-    * Upcasts this `Left[A, B]` to `Either[A, B1]`
-    * {{{
-    *   Left(1)                   // Either[Int, Nothing]
-    *   Left(1).withRight[String] // Either[Int, String]
-    * }}}
-    */
+  /** Upcasts this `Left[A, B]` to `Either[A, B1]`
+   *  ```
+   *   Left(1)                   // Either[Int, Nothing]
+   *   Left(1).withRight[String] // Either[Int, String]
+   *  ```
+   */
   def withRight[B1 >: B]: Either[A, B1] = this
 
 }
 
-/** The right side of the disjoint union, as opposed to the [[scala.util.Left]] side.
- */
+/** The right side of the disjoint union, as opposed to the [[scala.util.Left]] side. */
 final case class Right[+A, +B](value: B) extends Either[A, B] {
   def isLeft  = false
   def isRight = true
 
-  /**
-    * Upcasts this `Right[A, B]` to `Either[A1, B]`
-    * {{{
-    *   Right("x")               // Either[Nothing, String]
-    *   Right("x").withLeft[Int] // Either[Int, String]
-    * }}}
-    */
+  /** Upcasts this `Right[A, B]` to `Either[A1, B]`
+   *  ```
+   *   Right("x")               // Either[Nothing, String]
+   *   Right("x").withLeft[Int] // Either[Int, String]
+   *  ```
+   */
   def withLeft[A1 >: A]: Either[A1, B] = this
 
 }
@@ -498,13 +494,13 @@ object Either {
   /** If the condition is satisfied, return the given `B` in `Right`,
    *  otherwise, return the given `A` in `Left`.
    *
-   *  {{{
+   *  ```
    *  val userInput: String = readLine()
    *  Either.cond(
    *    userInput.forall(_.isDigit) && userInput.size == 10,
    *    PhoneNumber(userInput),
    *    s"The input (\$userInput) does not look like a phone number"
-   *  }}}
+   *  ```
    */
   def cond[A, B](test: Boolean, right: => B, left: => A): Either[A, B] =
     if (test) Right(right) else Left(left)
@@ -512,12 +508,12 @@ object Either {
   /** Allows use of a `merge` method to extract values from Either instances
    *  regardless of whether they are Left or Right.
    *
-   *  {{{
+   *  ```
    *  val l = Left(List(1)): Either[List[Int], Vector[Int]]
    *  val r = Right(Vector(1)): Either[List[Int], Vector[Int]]
    *  l.merge: Seq[Int] // List(1)
    *  r.merge: Seq[Int] // Vector(1)
-   *  }}}
+   *  ```
    */
   implicit class MergeableEither[A](private val x: Either[A, A]) extends AnyVal {
     def merge: A = x match {
@@ -534,10 +530,10 @@ object Either {
     /** Returns the value from this `Left` or throws `NoSuchElementException`
      *  if this is a `Right`.
      *
-     *  {{{
+     *  ```
      *  Left(12).left.get  // 12
      *  Right(12).left.get // NoSuchElementException
-     *  }}}
+     *  ```
      *
      *  @throws NoSuchElementException if the projection is [[scala.util.Right]]
      */
@@ -549,10 +545,10 @@ object Either {
 
     /** Executes the given side-effecting function if this is a `Left`.
      *
-     *  {{{
+     *  ```
      *  Left(12).left.foreach(x => println(x))  // prints "12"
      *  Right(12).left.foreach(x => println(x)) // doesn't print
-     *  }}}
+     *  ```
      *  @param f The side-effecting function to execute.
      */
     def foreach[U](f: A => U): Unit = e match {
@@ -562,10 +558,10 @@ object Either {
 
     /** Returns the value from this `Left` or the given argument if this is a `Right`.
      *
-     *  {{{
+     *  ```
      *  Left(12).left.getOrElse(17)  // 12
      *  Right(12).left.getOrElse(17) // 17
-     *  }}}
+     *  ```
      */
     def getOrElse[A1 >: A](or: => A1): A1 = e match {
       case Left(a) => a
@@ -575,11 +571,11 @@ object Either {
     /** Returns `true` if `Right` or returns the result of the application of
      *  the given function to the `Left` value.
      *
-     *  {{{
+     *  ```
      *  Left(12).left.forall(_ > 10)  // true
      *  Left(7).left.forall(_ > 10)   // false
      *  Right(12).left.forall(_ > 10) // true
-     *  }}}
+     *  ```
      */
     def forall(p: A => Boolean): Boolean = e match {
       case Left(a) => p(a)
@@ -589,11 +585,11 @@ object Either {
     /** Returns `false` if `Right` or returns the result of the application of
      *  the given function to the `Left` value.
      *
-     *  {{{
+     *  ```
      *  Left(12).left.exists(_ > 10)  // true
      *  Left(7).left.exists(_ > 10)   // false
      *  Right(12).left.exists(_ > 10) // false
-     *  }}}
+     *  ```
      */
     def exists(p: A => Boolean): Boolean = e match {
       case Left(a) => p(a)
@@ -602,10 +598,10 @@ object Either {
 
     /** Binds the given function across `Left`.
      *
-     *  {{{
+     *  ```
      *  Left(12).left.flatMap(x => Left("scala")) // Left("scala")
      *  Right(12).left.flatMap(x => Left("scala")) // Right(12)
-     *  }}}
+     *  ```
      *  @param f The function to bind across `Left`.
      */
     def flatMap[A1, B1 >: B](f: A => Either[A1, B1]): Either[A1, B1] = e match {
@@ -615,10 +611,10 @@ object Either {
 
     /** Maps the function argument through `Left`.
      *
-     *  {{{
+     *  ```
      *  Left(12).left.map(_ + 2) // Left(14)
      *  Right[Int, Int](12).left.map(_ + 2) // Right(12)
-     *  }}}
+     *  ```
      */
     def map[A1](f: A => A1): Either[A1, B] = e match {
       case Left(a) => Left(f(a))
@@ -628,11 +624,11 @@ object Either {
     /** Returns `None` if this is a `Right` or if the given predicate
      *  `p` does not hold for the left value, otherwise, returns a `Left`.
      *
-     *  {{{
+     *  ```
      *  Left(12).left.filter(_ > 10)  // Some(Left(12))
      *  Left(7).left.filter(_ > 10)   // None
      *  Right(12).left.filter(_ > 10) // None
-     *  }}}
+     *  ```
      */
     @deprecated("Use `filterToOption`, which more accurately reflects the return type", "2.13.0")
     def filter[B1](p: A => Boolean): Option[Either[A, B1]] = e match {
@@ -643,11 +639,11 @@ object Either {
     /** Returns `None` if this is a `Right` or if the given predicate
      *  `p` does not hold for the left value, otherwise, returns a `Left`.
      *
-     *  {{{
+     *  ```
      *  Left(12).left.filterToOption(_ > 10)  // Some(Left(12))
      *  Left(7).left.filterToOption(_ > 10)   // None
      *  Right(12).left.filterToOption(_ > 10) // None
-     *  }}}
+     *  ```
      */
     def filterToOption[B1](p: A => Boolean): Option[Either[A, B1]] = e match {
       case x @ Left(a) if p(a) => Some(x.asInstanceOf[Either[A, B1]])
@@ -657,10 +653,10 @@ object Either {
     /** Returns a `Seq` containing the `Left` value if it exists or an empty
      *  `Seq` if this is a `Right`.
      *
-     *  {{{
+     *  ```
      *  Left(12).left.toSeq // Seq(12)
      *  Right(12).left.toSeq // Seq()
-     *  }}}
+     *  ```
      */
     def toSeq: Seq[A] = e match {
       case Left(a) => Seq(a)
@@ -670,10 +666,10 @@ object Either {
     /** Returns a `Some` containing the `Left` value if it exists or a
      *  `None` if this is a `Right`.
      *
-     *  {{{
+     *  ```
      *  Left(12).left.toOption // Some(12)
      *  Right(12).left.toOption // None
-     *  }}}
+     *  ```
      */
     def toOption: Option[A] = e match {
       case Left(a) => Some(a)
@@ -693,12 +689,12 @@ object Either {
     /** Returns the value from this `Right` or throws
      *  `NoSuchElementException` if this is a `Left`.
      *
-     *  {{{
+     *  ```
      *  Right(12).right.get // 12
      *  Left(12).right.get // NoSuchElementException
-     *  }}}
+     *  ```
      *
-     * @throws NoSuchElementException if the projection is `Left`.
+     *  @throws NoSuchElementException if the projection is `Left`.
      */
     @deprecated("Use `Either.toOption.get` instead", "2.13.0")
     def get: B = e match {
@@ -708,10 +704,10 @@ object Either {
 
     /** Executes the given side-effecting function if this is a `Right`.
      *
-     *  {{{
+     *  ```
      *  Right(12).right.foreach(x => println(x)) // prints "12"
      *  Left(12).right.foreach(x => println(x))  // doesn't print
-     *  }}}
+     *  ```
      *  @param f The side-effecting function to execute.
      */
     def foreach[U](f: B => U): Unit = e match {
@@ -721,10 +717,10 @@ object Either {
 
     /** Returns the value from this `Right` or the given argument if this is a `Left`.
      *
-     *  {{{
+     *  ```
      *  Right(12).right.getOrElse(17) // 12
      *  Left(12).right.getOrElse(17)  // 17
-     *  }}}
+     *  ```
      */
     def getOrElse[B1 >: B](or: => B1): B1 = e match {
       case Right(b) => b
@@ -734,11 +730,11 @@ object Either {
     /** Returns `true` if `Left` or returns the result of the application of
      *  the given function to the `Right` value.
      *
-     *  {{{
+     *  ```
      *  Right(12).right.forall(_ > 10) // true
      *  Right(7).right.forall(_ > 10)  // false
      *  Left(12).right.forall(_ > 10)  // true
-     *  }}}
+     *  ```
      */
     def forall(f: B => Boolean): Boolean = e match {
       case Right(b) => f(b)
@@ -748,11 +744,11 @@ object Either {
     /** Returns `false` if `Left` or returns the result of the application of
      *  the given function to the `Right` value.
      *
-     *  {{{
+     *  ```
      *  Right(12).right.exists(_ > 10)  // true
      *  Right(7).right.exists(_ > 10)   // false
      *  Left(12).right.exists(_ > 10)   // false
-     *  }}}
+     *  ```
      */
     def exists(p: B => Boolean): Boolean = e match {
       case Right(b) => p(b)
@@ -770,10 +766,10 @@ object Either {
 
     /** The given function is applied if this is a `Right`.
      *
-     *  {{{
+     *  ```
      *  Right(12).right.map(x => "flower") // Result: Right("flower")
      *  Left(12).right.map(x => "flower")  // Result: Left(12)
-     *  }}}
+     *  ```
      */
     def map[B1](f: B => B1): Either[A, B1] = e match {
       case Right(b) => Right(f(b))
@@ -784,11 +780,11 @@ object Either {
      *  given predicate `p` does not hold for the right value,
      *  otherwise, returns a `Right`.
      *
-     * {{{
-     * Right(12).right.filter(_ > 10) // Some(Right(12))
-     * Right(7).right.filter(_ > 10)  // None
-     * Left(12).right.filter(_ > 10)  // None
-     * }}}
+     *  ```
+     *  Right(12).right.filter(_ > 10) // Some(Right(12))
+     *  Right(7).right.filter(_ > 10)  // None
+     *  Left(12).right.filter(_ > 10)  // None
+     *  ```
      */
     @deprecated("Use `filterToOption`, which more accurately reflects the return type", "2.13.0")
     def filter[A1](p: B => Boolean): Option[Either[A1, B]] = e match {
@@ -800,11 +796,11 @@ object Either {
      *  given predicate `p` does not hold for the right value,
      *  otherwise, returns a `Right`.
      *
-     * {{{
-     * Right(12).right.filterToOption(_ > 10) // Some(Right(12))
-     * Right(7).right.filterToOption(_ > 10)  // None
-     * Left(12).right.filterToOption(_ > 10)  // None
-     * }}}
+     *  ```
+     *  Right(12).right.filterToOption(_ > 10) // Some(Right(12))
+     *  Right(7).right.filterToOption(_ > 10)  // None
+     *  Left(12).right.filterToOption(_ > 10)  // None
+     *  ```
      */
     def filterToOption[A1](p: B => Boolean): Option[Either[A1, B]] = e match {
       case r @ Right(b) if p(b) => Some(r.asInstanceOf[Either[A1, B]])
@@ -814,10 +810,10 @@ object Either {
     /** Returns a `Seq` containing the `Right` value if
      *  it exists or an empty `Seq` if this is a `Left`.
      *
-     * {{{
-     * Right(12).right.toSeq // Seq(12)
-     * Left(12).right.toSeq // Seq()
-     * }}}
+     *  ```
+     *  Right(12).right.toSeq // Seq(12)
+     *  Left(12).right.toSeq // Seq()
+     *  ```
      */
     def toSeq: Seq[B] = e match {
       case Right(b) => Seq(b)
@@ -827,10 +823,10 @@ object Either {
     /** Returns a `Some` containing the `Right` value
      *  if it exists or a `None` if this is a `Left`.
      *
-     * {{{
-     * Right(12).right.toOption // Some(12)
-     * Left(12).right.toOption // None
-     * }}}
+     *  ```
+     *  Right(12).right.toOption // Some(12)
+     *  Left(12).right.toOption // None
+     *  ```
      */
     def toOption: Option[B] = e match {
       case Right(b) => Some(b)

--- a/library/src/scala/util/FromDigits.scala
+++ b/library/src/scala/util/FromDigits.scala
@@ -5,8 +5,7 @@ import annotation.internal.sharable
 
 import language.experimental.captureChecking
 
-/** A type class for types that admit numeric literals.
- */
+/** A type class for types that admit numeric literals. */
 trait FromDigits[T] {
 
   /** Converts `digits` string to value of type `T`
@@ -14,9 +13,9 @@ trait FromDigits[T] {
    *  - sign `+` or `-`
    *  - sequence of digits between 0 and 9
    *
-   * @throws FromDigits.MalformedNumber if digit string is not legal for the given type
-   * @throws FromDigits.NumberTooLarge  if value of result does not fit into `T`'s range
-   * @throws FromDigits.NumberTooSmall  in case of numeric underflow (e.g. a non-zero
+   *  @throws FromDigits.MalformedNumber if digit string is not legal for the given type
+   *  @throws FromDigits.NumberTooLarge  if value of result does not fit into `T`'s range
+   *  @throws FromDigits.NumberTooSmall  in case of numeric underflow (e.g. a non-zero
    *                         floating point literal that produces a zero value)
    */
   def fromDigits(digits: String): T

--- a/library/src/scala/util/Properties.scala
+++ b/library/src/scala/util/Properties.scala
@@ -175,14 +175,14 @@ private[scala] trait PropertiesTrait {
    *    is equal to or higher than the version denoted by the given string.
    *  @throws NumberFormatException if the given string is not a version string
    *
-   *  @example {{{
+   *  @example ```
    *  // In this example, the runtime's Java specification is assumed to be at version 8.
    *  isJavaAtLeast("1.8")            // true
    *  isJavaAtLeast("8")              // true
    *  isJavaAtLeast("9")              // false
    *  isJavaAtLeast("9.1")            // false
    *  isJavaAtLeast("1.9")            // throws
-   *  }}}
+   *  ```
    */
   def isJavaAtLeast(version: String): Boolean = {
     def versionOf(s: String, depth: Int): (Int, String) =

--- a/library/src/scala/util/Sorting.scala
+++ b/library/src/scala/util/Sorting.scala
@@ -18,24 +18,24 @@ import scala.reflect.ClassTag
 import scala.math.Ordering
 
 /** The `Sorting` object provides convenience wrappers for `java.util.Arrays.sort`.
-  * Methods that defer to `java.util.Arrays.sort` say that they do or under what
-  * conditions that they do.
-  *
-  * `Sorting` also implements a general-purpose quicksort and stable (merge) sort
-  * for those cases where `java.util.Arrays.sort` could only be used at the cost
-  * of a large memory penalty.  If performance rather than memory usage is the
-  * primary concern, one may wish to find alternate strategies to use
-  * `java.util.Arrays.sort` directly e.g. by boxing primitives to use
-  * a custom ordering on them.
-  *
-  * `Sorting` provides methods where you can provide a comparison function, or
-  * can request a sort of items that are [[scala.math.Ordered]] or that
-  * otherwise have an implicit or explicit [[scala.math.Ordering]].
-  *
-  * Note also that high-performance non-default sorts for numeric types
-  * are not provided.  If this is required, it is advisable to investigate
-  * other libraries that cover this use case.
-  */
+ *  Methods that defer to `java.util.Arrays.sort` say that they do or under what
+ *  conditions that they do.
+ *
+ *  `Sorting` also implements a general-purpose quicksort and stable (merge) sort
+ *  for those cases where `java.util.Arrays.sort` could only be used at the cost
+ *  of a large memory penalty.  If performance rather than memory usage is the
+ *  primary concern, one may wish to find alternate strategies to use
+ *  `java.util.Arrays.sort` directly e.g. by boxing primitives to use
+ *  a custom ordering on them.
+ *
+ *  `Sorting` provides methods where you can provide a comparison function, or
+ *  can request a sort of items that are [[scala.math.Ordered]] or that
+ *  otherwise have an implicit or explicit [[scala.math.Ordering]].
+ *
+ *  Note also that high-performance non-default sorts for numeric types
+ *  are not provided.  If this is required, it is advisable to investigate
+ *  other libraries that cover this use case.
+ */
 object Sorting {
   /** Sorts an array of Doubles using `java.util.Arrays.sort`. */
   def quickSort(a: Array[Double]): Unit = java.util.Arrays.sort(a)
@@ -49,9 +49,9 @@ object Sorting {
   private final val qsortThreshold = 16
 
   /** Sorts array `a` with quicksort, using the Ordering on its elements.
-    * This algorithm sorts in place, so no additional memory is used aside from
-    * what might be required to box individual elements during comparison.
-    */
+   *  This algorithm sorts in place, so no additional memory is used aside from
+   *  what might be required to box individual elements during comparison.
+   */
   def quickSort[K: Ordering](a: Array[K]): Unit = {
     // Must have iN >= i0 or math will fail.  Also, i0 >= 0.
     def inner(a: Array[K], i0: Int, iN: Int, ord: Ordering[K]): Unit = {
@@ -252,31 +252,33 @@ object Sorting {
   }
 
   /** Sorts array `a` using the Ordering on its elements, preserving the original ordering where possible.
-    * Uses `java.util.Arrays.sort` unless `K` is a primitive type. This is the same as `stableSort(a, 0, a.length)`. */
+   *  Uses `java.util.Arrays.sort` unless `K` is a primitive type. This is the same as `stableSort(a, 0, a.length)`. 
+   */
   @`inline` def stableSort[K: Ordering](a: Array[K]): Unit = stableSort(a, 0, a.length)
 
   /** Sorts array `a` or a part of it using the Ordering on its elements, preserving the original ordering where possible.
-    * Uses `java.util.Arrays.sort` unless `K` is a primitive type.
-    *
-    * @param a The array to sort
-    * @param from The first index in the array to sort
-    * @param until The last index (exclusive) in the array to sort
-    */
+   *  Uses `java.util.Arrays.sort` unless `K` is a primitive type.
+   *
+   *  @param a The array to sort
+   *  @param from The first index in the array to sort
+   *  @param until The last index (exclusive) in the array to sort
+   */
   def stableSort[K: Ordering](a: Array[K], from: Int, until: Int): Unit = sort(a, from, until, Ordering[K])
 
   /** Sorts array `a` using function `f` that computes the less-than relation for each element.
-    * Uses `java.util.Arrays.sort` unless `K` is a primitive type. This is the same as `stableSort(a, f, 0, a.length)`. */
+   *  Uses `java.util.Arrays.sort` unless `K` is a primitive type. This is the same as `stableSort(a, f, 0, a.length)`. 
+   */
   @`inline` def stableSort[K](a: Array[K], f: (K, K) => Boolean): Unit = stableSort(a, f, 0, a.length)
 
   // TODO: make this fast for primitive K (could be specialized if it didn't go through Ordering)
   /** Sorts array `a` or a part of it using function `f` that computes the less-than relation for each element.
-    * Uses `java.util.Arrays.sort` unless `K` is a primitive type.
-    *
-    * @param a The array to sort
-    * @param f A function that computes the less-than relation for each element
-    * @param from The first index in the array to sort
-    * @param until The last index (exclusive) in the array to sort
-    */
+   *  Uses `java.util.Arrays.sort` unless `K` is a primitive type.
+   *
+   *  @param a The array to sort
+   *  @param f A function that computes the less-than relation for each element
+   *  @param from The first index in the array to sort
+   *  @param until The last index (exclusive) in the array to sort
+   */
   def stableSort[K](a: Array[K], f: (K, K) => Boolean, from: Int, until: Int): Unit = sort(a, from, until, Ordering fromLessThan f)
 
   /** A sorted Array, using the Ordering for the elements in the sequence `a`.  Uses `java.util.Arrays.sort` unless `K` is a primitive type. */

--- a/library/src/scala/util/Try.scala
+++ b/library/src/scala/util/Try.scala
@@ -17,19 +17,18 @@ import scala.language.`2.13`
 import scala.runtime.Statics
 import scala.util.control.NonFatal
 
-/**
- * The `Try` type represents a computation that may fail during evaluation by raising an exception.
- * It holds either a successfully computed value or the exception that was thrown.
- * This is similar to the [[scala.util.Either]] type, but with different semantics.
+/** The `Try` type represents a computation that may fail during evaluation by raising an exception.
+ *  It holds either a successfully computed value or the exception that was thrown.
+ *  This is similar to the [[scala.util.Either]] type, but with different semantics.
  *
- * Instances of `Try[T]` are an instance of either [[scala.util.Success]][T] or [[scala.util.Failure]][T].
+ *  Instances of `Try[T]` are an instance of either [[scala.util.Success]][T] or [[scala.util.Failure]][T].
  *
- * For example, consider a computation that performs division on user-defined input.
- * `Try` can reduce or eliminate the need for explicit exception handling in all of the places
- * where an exception might be thrown.
+ *  For example, consider a computation that performs division on user-defined input.
+ *  `Try` can reduce or eliminate the need for explicit exception handling in all of the places
+ *  where an exception might be thrown.
  *
- * Example:
- * {{{
+ *  Example:
+ *  ```
  *   import scala.io.StdIn
  *   import scala.util.{Try, Success, Failure}
  *
@@ -48,69 +47,56 @@ import scala.util.control.NonFatal
  *     }
  *   }
  *
- * }}}
+ *  ```
  *
- * An important property of `Try` shown in the above example is its ability to ''pipeline'', or chain, operations,
- * catching exceptions along the way. The `flatMap` and `map` combinators in the above example each essentially
- * pass off either their successfully completed value, wrapped in the `Success` type for it to be further operated
- * upon by the next combinator in the chain, or the exception wrapped in the `Failure` type usually to be simply
- * passed on down the chain. Combinators such as `recover` and `recoverWith` are designed to provide some type of
- * default behavior in the case of failure.
+ *  An important property of `Try` shown in the above example is its ability to *pipeline*, or chain, operations,
+ *  catching exceptions along the way. The `flatMap` and `map` combinators in the above example each essentially
+ *  pass off either their successfully completed value, wrapped in the `Success` type for it to be further operated
+ *  upon by the next combinator in the chain, or the exception wrapped in the `Failure` type usually to be simply
+ *  passed on down the chain. Combinators such as `recover` and `recoverWith` are designed to provide some type of
+ *  default behavior in the case of failure.
  *
- * ''Note'': only non-fatal exceptions are caught by the combinators on `Try` (see [[scala.util.control.NonFatal]]).
- * Serious system errors, on the other hand, will be thrown.
+ *  *Note*: only non-fatal exceptions are caught by the combinators on `Try` (see [[scala.util.control.NonFatal]]).
+ *  Serious system errors, on the other hand, will be thrown.
  *
- * ''Note:'': all Try combinators will catch exceptions and return failure unless otherwise specified in the documentation.
+ *  *Note:*: all Try combinators will catch exceptions and return failure unless otherwise specified in the documentation.
  */
 sealed abstract class Try[+T] extends Product with Serializable {
 
-  /** Returns `true` if the `Try` is a `Failure`, `false` otherwise.
-   */
+  /** Returns `true` if the `Try` is a `Failure`, `false` otherwise. */
   def isFailure: Boolean
 
-  /** Returns `true` if the `Try` is a `Success`, `false` otherwise.
-   */
+  /** Returns `true` if the `Try` is a `Success`, `false` otherwise. */
   def isSuccess: Boolean
 
   /** Returns the value from this `Success` or the given `default` argument if this is a `Failure`.
    *
-   * ''Note:'': This will throw an exception if it is not a success and default throws an exception.
+   *  *Note:*: This will throw an exception if it is not a success and default throws an exception.
    */
   def getOrElse[U >: T](default: => U): U
 
-  /** Returns this `Try` if it's a `Success` or the given `default` argument if this is a `Failure`.
-   */
+  /** Returns this `Try` if it's a `Success` or the given `default` argument if this is a `Failure`. */
   def orElse[U >: T](default: => Try[U]): Try[U]
 
-  /** Returns the value from this `Success` or throws the exception if this is a `Failure`.
-   */
+  /** Returns the value from this `Success` or throws the exception if this is a `Failure`. */
   def get: T
 
-  /**
-   * Applies the given function `f` if this is a `Success`, otherwise returns `Unit` if this is a `Failure`.
+  /** Applies the given function `f` if this is a `Success`, otherwise returns `Unit` if this is a `Failure`.
    *
-   * ''Note:'' If `f` throws, then this method may throw an exception.
+   *  *Note:* If `f` throws, then this method may throw an exception.
    */
   def foreach[U](f: T => U): Unit
 
-  /**
-   * Returns the given function applied to the value from this `Success` or returns this if this is a `Failure`.
-   */
+  /** Returns the given function applied to the value from this `Success` or returns this if this is a `Failure`. */
   def flatMap[U](f: T => Try[U]): Try[U]
 
-  /**
-   * Maps the given function to the value from this `Success` or returns this if this is a `Failure`.
-   */
+  /** Maps the given function to the value from this `Success` or returns this if this is a `Failure`. */
   def map[U](f: T => U): Try[U]
 
-  /**
-   * Applies the given partial function to the value from this `Success` or returns this if this is a `Failure`.
-   */
+  /** Applies the given partial function to the value from this `Success` or returns this if this is a `Failure`. */
   def collect[U](pf: PartialFunction[T, U]): Try[U]
 
-  /**
-   * Converts this to a `Failure` if the predicate is not satisfied.
-   */
+  /** Converts this to a `Failure` if the predicate is not satisfied. */
   def filter(p: T => Boolean): Try[T]
 
   /** Creates a non-strict filter, which eventually converts this to a `Failure`
@@ -120,8 +106,8 @@ sealed abstract class Try[+T] extends Product with Serializable {
    *        Instead, it restricts the domain of subsequent
    *        `map`, `flatMap`, `foreach`, and `withFilter` operations.
    *
-   * As Try is a one-element collection, this may be a bit overkill,
-   * but it's consistent with withFilter on Option and the other collections.
+   *  As Try is a one-element collection, this may be a bit overkill,
+   *  but it's consistent with withFilter on Option and the other collections.
    *
    *  @param p   the predicate used to test elements.
    *  @return    an object of class `WithFilter`, which supports
@@ -142,32 +128,26 @@ sealed abstract class Try[+T] extends Product with Serializable {
     def withFilter(q: T => Boolean): WithFilter = new WithFilter(x => p(x) && q(x))
   }
 
-  /**
-   * Applies the given function `f` if this is a `Failure`, otherwise returns this if this is a `Success`.
-   * This is like `flatMap` for the exception.
+  /** Applies the given function `f` if this is a `Failure`, otherwise returns this if this is a `Success`.
+   *  This is like `flatMap` for the exception.
    */
   def recoverWith[U >: T](pf: PartialFunction[Throwable, Try[U]]): Try[U]
 
-  /**
-   * Applies the given function `f` if this is a `Failure`, otherwise returns this if this is a `Success`.
-   * This is like map for the exception.
+  /** Applies the given function `f` if this is a `Failure`, otherwise returns this if this is a `Success`.
+   *  This is like map for the exception.
    */
   def recover[U >: T](pf: PartialFunction[Throwable, U]): Try[U]
 
-  /**
-   * Returns `None` if this is a `Failure` or a `Some` containing the value if this is a `Success`.
-   */
+  /** Returns `None` if this is a `Failure` or a `Some` containing the value if this is a `Success`. */
   def toOption: Option[T]
 
-  /**
-   * Transforms a nested `Try`, ie, a `Try` of type `Try[Try[T]]`,
-   * into an un-nested `Try`, ie, a `Try` of type `Try[T]`.
+  /** Transforms a nested `Try`, ie, a `Try` of type `Try[Try[T]]`,
+   *  into an un-nested `Try`, ie, a `Try` of type `Try[T]`.
    */
   def flatten[U](implicit ev: T <:< Try[U]): Try[U]
 
-  /**
-   * Inverts this `Try`. If this is a `Failure`, returns its exception wrapped in a `Success`.
-   * If this is a `Success`, returns a `Failure` containing an `UnsupportedOperationException`.
+  /** Inverts this `Try`. If this is a `Failure`, returns its exception wrapped in a `Success`.
+   *  If this is a `Success`, returns a `Failure` containing an `UnsupportedOperationException`.
    */
   def failed: Try[Throwable]
 
@@ -176,27 +156,24 @@ sealed abstract class Try[+T] extends Product with Serializable {
    */
   def transform[U](s: T => Try[U], f: Throwable => Try[U]): Try[U]
 
-  /**
-   * Returns `Left` with `Throwable` if this is a `Failure`, otherwise returns `Right` with `Success` value.
-   */
+  /** Returns `Left` with `Throwable` if this is a `Failure`, otherwise returns `Right` with `Success` value. */
   def toEither: Either[Throwable, T]
 
-  /**
-   * Applies `fa` if this is a `Failure` or `fb` if this is a `Success`.
-   * If `fb` is initially applied and throws an exception,
-   * then `fa` is applied with this exception.
+  /** Applies `fa` if this is a `Failure` or `fb` if this is a `Success`.
+   *  If `fb` is initially applied and throws an exception,
+   *  then `fa` is applied with this exception.
    *
-   * @example {{{
-   * val result: Try[Int] = Try { string.toInt }
-   * log(result.fold(
+   *  @example ```
+   *  val result: Try[Int] = Try { string.toInt }
+   *  log(result.fold(
    *   ex => "Operation failed with " + ex,
    *   v => "Operation produced value: " + v
-   * ))
-   * }}}
+   *  ))
+   *  ```
    *
-   * @param fa the function to apply if this is a `Failure`
-   * @param fb the function to apply if this is a `Success`
-   * @return the results of applying the function
+   *  @param fa the function to apply if this is a `Failure`
+   *  @param fb the function to apply if this is a `Success`
+   *  @return the results of applying the function
    */
   def fold[U](fa: Throwable => U, fb: T => U): U
 

--- a/library/src/scala/util/Using.scala
+++ b/library/src/scala/util/Using.scala
@@ -17,163 +17,163 @@ import scala.util.control.{ControlThrowable, NonFatal}
 import scala.runtime.ScalaRunTime.nullForGC
 
 /** A utility for performing automatic resource management. It can be used to perform an
-  * operation using resources, after which it releases the resources in reverse order
-  * of their creation.
-  *
-  * ==Usage==
-  *
-  * There are multiple ways to automatically manage resources with `Using`. If you only need
-  * to manage a single resource, the [[Using.apply `apply`]] method is easiest; it wraps the
-  * resource opening, operation, and resource releasing in a `Try`.
-  *
-  * Example:
-  * {{{
-  * import java.io.{BufferedReader, FileReader}
-  * import scala.util.{Try, Using}
-  *
-  * val lines: Try[Seq[String]] =
-  *   Using(new BufferedReader(new FileReader("file.txt"))) { reader =>
-  *     Iterator.continually(reader.readLine()).takeWhile(_ != null).toSeq
-  *   }
-  * }}}
-  *
-  * If you need to manage multiple resources, [[Using.Manager$.apply `Using.Manager`]] should
-  * be used. It allows the managing of arbitrarily many resources, whose creation, use, and
-  * release are all wrapped in a `Try`.
-  *
-  * Example:
-  * {{{
-  * import java.io.{BufferedReader, FileReader}
-  * import scala.util.{Try, Using}
-  *
-  * val files = List("file1.txt", "file2.txt", "file3.txt", "file4.txt")
-  * val lines: Try[Seq[String]] = Using.Manager { use =>
-  *   // acquire resources
-  *   def mkreader(filename: String) = use(new BufferedReader(new FileReader(filename)))
-  *
-  *   // use your resources here
-  *   def lines(reader: BufferedReader): Iterator[String] =
-  *     Iterator.continually(reader.readLine()).takeWhile(_ != null)
-  *
-  *   files.map(mkreader).flatMap(lines)
-  * }
-  * }}}
-  *
-  * Composed or "wrapped" resources may be acquired in order of construction,
-  * if "underlying" resources are not closed. Although redundant in this case,
-  * here is the previous example with a wrapped call to `use`:
-  * {{{
-  *   def mkreader(filename: String) = use(new BufferedReader(use(new FileReader(filename))))
-  * }}}
-  *
-  * Custom resources can be registered on construction by requiring an implicit `Manager`.
-  * This ensures they will be released even if composition fails:
-  * {{{
-  * import scala.util.Using
-  *
-  * case class X(x: String)(implicit mgr: Using.Manager) extends AutoCloseable {
-  *   override def close() = println(s"CLOSE $x")
-  *   mgr.acquire(this)
-  * }
-  * case class Y(y: String)(x: String)(implicit mgr: Using.Manager) extends AutoCloseable {
-  *   val xres = X(x)
-  *   override def close() = println(s"CLOSE $y")
-  *   // an error during construction releases previously acquired resources
-  *   require(y != null, "y is null")
-  *   mgr.acquire(this)
-  * }
-  *
-  * Using.Manager { implicit mgr =>
-  *   val y = Y("Y")("X")
-  *   println(s"USE $y")
-  * }
-  * println {
-  *   Using.Manager { implicit mgr =>
-  *     Y(null)("X")
-  *   }
-  * } // Failure(java.lang.IllegalArgumentException: requirement failed: y is null)
-  * }}}
-  *
-  * If you wish to avoid wrapping management and operations in a `Try`, you can use
-  * [[Using.resource `Using.resource`]], which throws any exceptions that occur.
-  *
-  * Example:
-  * {{{
-  * import java.io.{BufferedReader, FileReader}
-  * import scala.util.Using
-  *
-  * val lines: Seq[String] =
-  *   Using.resource(new BufferedReader(new FileReader("file.txt"))) { reader =>
-  *     Iterator.continually(reader.readLine()).takeWhile(_ != null).toSeq
-  *   }
-  * }}}
-  *
-  * ==Suppression Behavior==
-  *
-  * If two exceptions are thrown (e.g., by an operation and closing a resource),
-  * one of them is re-thrown, and the other is
-  * [[java.lang.Throwable#addSuppressed added to it as a suppressed exception]].
-  * If the two exceptions are of different 'severities' (see below), the one of a higher
-  * severity is re-thrown, and the one of a lower severity is added to it as a suppressed
-  * exception. If the two exceptions are of the same severity, the one thrown first is
-  * re-thrown, and the one thrown second is added to it as a suppressed exception.
-  * If an exception is a [[scala.util.control.ControlThrowable `ControlThrowable`]], or
-  * if it does not support suppression (see
-  * [[java.lang.Throwable `Throwable`'s constructor with an `enableSuppression` parameter]]),
-  * an exception that would have been suppressed is instead discarded.
-  *
-  * Exceptions are ranked from highest to lowest severity as follows:
-  *   - `java.lang.VirtualMachineError`
-  *   - `java.lang.LinkageError`
-  *   - `java.lang.InterruptedException` and `java.lang.ThreadDeath`
-  *   - [[scala.util.control.NonFatal fatal exceptions]], excluding `scala.util.control.ControlThrowable`
-  *   - all other exceptions, excluding `scala.util.control.ControlThrowable`
-  *   - `scala.util.control.ControlThrowable`
-  *
-  * When more than two exceptions are thrown, the first two are combined and
-  * re-thrown as described above, and each successive exception thrown is combined
-  * as it is thrown.
-  *
-  * @define suppressionBehavior See the main doc for [[Using `Using`]] for full details of
-  *                             suppression behavior.
-  */
+ *  operation using resources, after which it releases the resources in reverse order
+ *  of their creation.
+ *
+ *  ## Usage
+ *
+ *  There are multiple ways to automatically manage resources with `Using`. If you only need
+ *  to manage a single resource, the [[Using.apply `apply`]] method is easiest; it wraps the
+ *  resource opening, operation, and resource releasing in a `Try`.
+ *
+ *  Example:
+ *  ```
+ *  import java.io.{BufferedReader, FileReader}
+ *  import scala.util.{Try, Using}
+ *
+ *  val lines: Try[Seq[String]] =
+ *   Using(new BufferedReader(new FileReader("file.txt"))) { reader =>
+ *     Iterator.continually(reader.readLine()).takeWhile(_ != null).toSeq
+ *   }
+ *  ```
+ *
+ *  If you need to manage multiple resources, [[Using.Manager$.apply `Using.Manager`]] should
+ *  be used. It allows the managing of arbitrarily many resources, whose creation, use, and
+ *  release are all wrapped in a `Try`.
+ *
+ *  Example:
+ *  ```
+ *  import java.io.{BufferedReader, FileReader}
+ *  import scala.util.{Try, Using}
+ *
+ *  val files = List("file1.txt", "file2.txt", "file3.txt", "file4.txt")
+ *  val lines: Try[Seq[String]] = Using.Manager { use =>
+ *   // acquire resources
+ *   def mkreader(filename: String) = use(new BufferedReader(new FileReader(filename)))
+ *
+ *   // use your resources here
+ *   def lines(reader: BufferedReader): Iterator[String] =
+ *     Iterator.continually(reader.readLine()).takeWhile(_ != null)
+ *
+ *   files.map(mkreader).flatMap(lines)
+ *  }
+ *  ```
+ *
+ *  Composed or "wrapped" resources may be acquired in order of construction,
+ *  if "underlying" resources are not closed. Although redundant in this case,
+ *  here is the previous example with a wrapped call to `use`:
+ *  ```
+ *   def mkreader(filename: String) = use(new BufferedReader(use(new FileReader(filename))))
+ *  ```
+ *
+ *  Custom resources can be registered on construction by requiring an implicit `Manager`.
+ *  This ensures they will be released even if composition fails:
+ *  ```
+ *  import scala.util.Using
+ *
+ *  case class X(x: String)(implicit mgr: Using.Manager) extends AutoCloseable {
+ *   override def close() = println(s"CLOSE $x")
+ *   mgr.acquire(this)
+ *  }
+ *  case class Y(y: String)(x: String)(implicit mgr: Using.Manager) extends AutoCloseable {
+ *   val xres = X(x)
+ *   override def close() = println(s"CLOSE $y")
+ *   // an error during construction releases previously acquired resources
+ *   require(y != null, "y is null")
+ *   mgr.acquire(this)
+ *  }
+ *
+ *  Using.Manager { implicit mgr =>
+ *   val y = Y("Y")("X")
+ *   println(s"USE $y")
+ *  }
+ *  println {
+ *   Using.Manager { implicit mgr =>
+ *     Y(null)("X")
+ *   }
+ *  } // Failure(java.lang.IllegalArgumentException: requirement failed: y is null)
+ *  ```
+ *
+ *  If you wish to avoid wrapping management and operations in a `Try`, you can use
+ *  [[Using.resource `Using.resource`]], which throws any exceptions that occur.
+ *
+ *  Example:
+ *  ```
+ *  import java.io.{BufferedReader, FileReader}
+ *  import scala.util.Using
+ *
+ *  val lines: Seq[String] =
+ *   Using.resource(new BufferedReader(new FileReader("file.txt"))) { reader =>
+ *     Iterator.continually(reader.readLine()).takeWhile(_ != null).toSeq
+ *   }
+ *  ```
+ *
+ *  ## Suppression Behavior
+ *
+ *  If two exceptions are thrown (e.g., by an operation and closing a resource),
+ *  one of them is re-thrown, and the other is
+ *  [[java.lang.Throwable#addSuppressed added to it as a suppressed exception]].
+ *  If the two exceptions are of different 'severities' (see below), the one of a higher
+ *  severity is re-thrown, and the one of a lower severity is added to it as a suppressed
+ *  exception. If the two exceptions are of the same severity, the one thrown first is
+ *  re-thrown, and the one thrown second is added to it as a suppressed exception.
+ *  If an exception is a [[scala.util.control.ControlThrowable `ControlThrowable`]], or
+ *  if it does not support suppression (see
+ *  [[java.lang.Throwable `Throwable`'s constructor with an `enableSuppression` parameter]]),
+ *  an exception that would have been suppressed is instead discarded.
+ *
+ *  Exceptions are ranked from highest to lowest severity as follows:
+ *   - `java.lang.VirtualMachineError`
+ *   - `java.lang.LinkageError`
+ *   - `java.lang.InterruptedException` and `java.lang.ThreadDeath`
+ *   - [[scala.util.control.NonFatal fatal exceptions]], excluding `scala.util.control.ControlThrowable`
+ *   - all other exceptions, excluding `scala.util.control.ControlThrowable`
+ *   - `scala.util.control.ControlThrowable`
+ *
+ *  When more than two exceptions are thrown, the first two are combined and
+ *  re-thrown as described above, and each successive exception thrown is combined
+ *  as it is thrown.
+ *
+ *  @define suppressionBehavior See the main doc for [[Using `Using`]] for full details of
+ *                             suppression behavior.
+ */
 object Using {
   /** Performs an operation using a resource, and then releases the resource,
-    * even if the operation throws an exception.
-    *
-    * $suppressionBehavior
-    *
-    * @return a [[Try]] containing an exception if one or more were thrown,
-    *         or the result of the operation if no exceptions were thrown
-    */
+   *  even if the operation throws an exception.
+   *
+   *  $suppressionBehavior
+   *
+   *  @return a [[Try]] containing an exception if one or more were thrown,
+   *         or the result of the operation if no exceptions were thrown
+   */
   def apply[R: Releasable, A](resource: => R)(f: R => A): Try[A] = Try { Using.resource(resource)(f) }
 
   /** A resource manager.
-    *
-    * Resources can be registered with the manager by calling [[acquire `acquire`]];
-    * such resources will be released in reverse order of their acquisition
-    * when the manager is closed, regardless of any exceptions thrown
-    * during use.
-    *
-    * $suppressionBehavior
-    *
-    * @note It is recommended for API designers to require an implicit `Manager`
-    *       for the creation of custom resources, and to call `acquire` during those
-    *       resources' construction. Doing so guarantees that the resource ''must'' be
-    *       automatically managed, and makes it impossible to forget to do so.
-    *
-    *
-    *       Example:
-    *       {{{
-    *       class SafeFileReader(file: File)(implicit manager: Using.Manager)
-    *         extends BufferedReader(new FileReader(file)) {
-    *
-    *         def this(fileName: String)(implicit manager: Using.Manager) = this(new File(fileName))
-    *
-    *         manager.acquire(this)
-    *       }
-    *       }}}
-    */
+   *
+   *  Resources can be registered with the manager by calling [[acquire `acquire`]];
+   *  such resources will be released in reverse order of their acquisition
+   *  when the manager is closed, regardless of any exceptions thrown
+   *  during use.
+   *
+   *  $suppressionBehavior
+   *
+   *  @note It is recommended for API designers to require an implicit `Manager`
+   *       for the creation of custom resources, and to call `acquire` during those
+   *       resources' construction. Doing so guarantees that the resource *must* be
+   *       automatically managed, and makes it impossible to forget to do so.
+   *
+   *
+   *       Example:
+   *       ```
+   *       class SafeFileReader(file: File)(implicit manager: Using.Manager)
+   *         extends BufferedReader(new FileReader(file)) {
+   *
+   *         def this(fileName: String)(implicit manager: Using.Manager) = this(new File(fileName))
+   *
+   *         manager.acquire(this)
+   *       }
+   *       ```
+   */
   final class Manager private {
     import Manager._
 
@@ -181,17 +181,17 @@ object Using {
     private var resources: List[Resource[?]] = Nil
 
     /** Registers the specified resource with this manager, so that
-      * the resource is released when the manager is closed, and then
-      * returns the (unmodified) resource.
-      */
+     *  the resource is released when the manager is closed, and then
+     *  returns the (unmodified) resource.
+     */
     def apply[R: Releasable](resource: R): resource.type = {
       acquire(resource)
       resource
     }
 
     /** Registers the specified resource with this manager, so that
-      * the resource is released when the manager is closed.
-      */
+     *  the resource is released when the manager is closed.
+     */
     def acquire[R: Releasable](resource: R): Unit = {
       if (resource == null) throw new NullPointerException("null resource")
       if (closed) throw new IllegalStateException("Manager has already been closed")
@@ -227,33 +227,33 @@ object Using {
 
   object Manager {
     /** Performs an operation using a `Manager`, then closes the `Manager`,
-      * releasing its resources (in reverse order of acquisition).
-      *
-      * Example:
-      * {{{
-      * val lines = Using.Manager { use =>
-      *   use(new BufferedReader(new FileReader("file.txt"))).lines()
-      * }
-      * }}}
-      *
-      * If using resources which require an implicit `Manager` as a parameter,
-      * this method should be invoked with an `implicit` modifier before the function
-      * parameter:
-      *
-      * Example:
-      * {{{
-      * val lines = Using.Manager { implicit use =>
-      *   new SafeFileReader("file.txt").lines()
-      * }
-      * }}}
-      *
-      * See the main doc for [[Using `Using`]] for full details of suppression behavior.
-      *
-      * @param op the operation to perform using the manager
-      * @tparam A the return type of the operation
-      * @return a [[Try]] containing an exception if one or more were thrown,
-      *         or the result of the operation if no exceptions were thrown
-      */
+     *  releasing its resources (in reverse order of acquisition).
+     *
+     *  Example:
+     *  ```
+     *  val lines = Using.Manager { use =>
+     *   use(new BufferedReader(new FileReader("file.txt"))).lines()
+     *  }
+     *  ```
+     *
+     *  If using resources which require an implicit `Manager` as a parameter,
+     *  this method should be invoked with an `implicit` modifier before the function
+     *  parameter:
+     *
+     *  Example:
+     *  ```
+     *  val lines = Using.Manager { implicit use =>
+     *   new SafeFileReader("file.txt").lines()
+     *  }
+     *  ```
+     *
+     *  See the main doc for [[Using `Using`]] for full details of suppression behavior.
+     *
+     *  @tparam A the return type of the operation
+     *  @param op the operation to perform using the manager
+     *  @return a [[Try]] containing an exception if one or more were thrown,
+     *         or the result of the operation if no exceptions were thrown
+     */
     def apply[A](op: Manager => A): Try[A] = Try { (new Manager).manage(op) }
 
     private final class Resource[R](resource: R)(implicit releasable: Releasable[R]) {
@@ -278,18 +278,18 @@ object Using {
   }
 
   /** Performs an operation using a resource, and then releases the resource,
-    * even if the operation throws an exception. This method behaves similarly
-    * to Java's try-with-resources.
-    *
-    * $suppressionBehavior
-    *
-    * @param resource the resource
-    * @param body     the operation to perform with the resource
-    * @tparam R the type of the resource
-    * @tparam A the return type of the operation
-    * @return the result of the operation, if neither the operation nor
-    *         releasing the resource throws
-    */
+   *  even if the operation throws an exception. This method behaves similarly
+   *  to Java's try-with-resources.
+   *
+   *  $suppressionBehavior
+   *
+   *  @tparam R the type of the resource
+   *  @tparam A the return type of the operation
+   *  @param resource the resource
+   *  @param body     the operation to perform with the resource
+   *  @return the result of the operation, if neither the operation nor
+   *         releasing the resource throws
+   */
   def resource[R, A](resource: R)(body: R => A)(implicit releasable: Releasable[R]): A = {
     if (resource == null) throw new NullPointerException("null resource")
 
@@ -311,20 +311,20 @@ object Using {
   }
 
   /** Performs an operation using two resources, and then releases the resources
-    * in reverse order, even if the operation throws an exception. This method
-    * behaves similarly to Java's try-with-resources.
-    *
-    * $suppressionBehavior
-    *
-    * @param resource1 the first resource
-    * @param resource2 the second resource
-    * @param body      the operation to perform using the resources
-    * @tparam R1 the type of the first resource
-    * @tparam R2 the type of the second resource
-    * @tparam A  the return type of the operation
-    * @return the result of the operation, if neither the operation nor
-    *         releasing the resources throws
-    */
+   *  in reverse order, even if the operation throws an exception. This method
+   *  behaves similarly to Java's try-with-resources.
+   *
+   *  $suppressionBehavior
+   *
+   *  @tparam R1 the type of the first resource
+   *  @tparam R2 the type of the second resource
+   *  @tparam A  the return type of the operation
+   *  @param resource1 the first resource
+   *  @param resource2 the second resource
+   *  @param body      the operation to perform using the resources
+   *  @return the result of the operation, if neither the operation nor
+   *         releasing the resources throws
+   */
   def resources[R1: Releasable, R2: Releasable, A](
       resource1: R1,
       resource2: => R2
@@ -337,22 +337,22 @@ object Using {
     }
 
   /** Performs an operation using three resources, and then releases the resources
-    * in reverse order, even if the operation throws an exception. This method
-    * behaves similarly to Java's try-with-resources.
-    *
-    * $suppressionBehavior
-    *
-    * @param resource1 the first resource
-    * @param resource2 the second resource
-    * @param resource3 the third resource
-    * @param body      the operation to perform using the resources
-    * @tparam R1 the type of the first resource
-    * @tparam R2 the type of the second resource
-    * @tparam R3 the type of the third resource
-    * @tparam A  the return type of the operation
-    * @return the result of the operation, if neither the operation nor
-    *         releasing the resources throws
-    */
+   *  in reverse order, even if the operation throws an exception. This method
+   *  behaves similarly to Java's try-with-resources.
+   *
+   *  $suppressionBehavior
+   *
+   *  @tparam R1 the type of the first resource
+   *  @tparam R2 the type of the second resource
+   *  @tparam R3 the type of the third resource
+   *  @tparam A  the return type of the operation
+   *  @param resource1 the first resource
+   *  @param resource2 the second resource
+   *  @param resource3 the third resource
+   *  @param body      the operation to perform using the resources
+   *  @return the result of the operation, if neither the operation nor
+   *         releasing the resources throws
+   */
   def resources[R1: Releasable, R2: Releasable, R3: Releasable, A](
       resource1: R1,
       resource2: => R2,
@@ -368,24 +368,24 @@ object Using {
     }
 
   /** Performs an operation using four resources, and then releases the resources
-    * in reverse order, even if the operation throws an exception. This method
-    * behaves similarly to Java's try-with-resources.
-    *
-    * $suppressionBehavior
-    *
-    * @param resource1 the first resource
-    * @param resource2 the second resource
-    * @param resource3 the third resource
-    * @param resource4 the fourth resource
-    * @param body      the operation to perform using the resources
-    * @tparam R1 the type of the first resource
-    * @tparam R2 the type of the second resource
-    * @tparam R3 the type of the third resource
-    * @tparam R4 the type of the fourth resource
-    * @tparam A  the return type of the operation
-    * @return the result of the operation, if neither the operation nor
-    *         releasing the resources throws
-    */
+   *  in reverse order, even if the operation throws an exception. This method
+   *  behaves similarly to Java's try-with-resources.
+   *
+   *  $suppressionBehavior
+   *
+   *  @tparam R1 the type of the first resource
+   *  @tparam R2 the type of the second resource
+   *  @tparam R3 the type of the third resource
+   *  @tparam R4 the type of the fourth resource
+   *  @tparam A  the return type of the operation
+   *  @param resource1 the first resource
+   *  @param resource2 the second resource
+   *  @param resource3 the third resource
+   *  @param resource4 the fourth resource
+   *  @param body      the operation to perform using the resources
+   *  @return the result of the operation, if neither the operation nor
+   *         releasing the resources throws
+   */
   def resources[R1: Releasable, R2: Releasable, R3: Releasable, R4: Releasable, A](
       resource1: R1,
       resource2: => R2,
@@ -404,19 +404,19 @@ object Using {
     }
 
   /** A type class describing how to release a particular type of resource.
-    *
-    * A resource is anything which needs to be released, closed, or otherwise cleaned up
-    * in some way after it is finished being used, and for which waiting for the object's
-    * garbage collection to be cleaned up would be unacceptable. For example, an instance of
-    * [[java.io.OutputStream]] would be considered a resource, because it is important to close
-    * the stream after it is finished being used.
-    *
-    * An instance of `Releasable` is needed in order to automatically manage a resource
-    * with [[Using `Using`]]. An implicit instance is provided for all types extending
-    * [[java.lang.AutoCloseable]].
-    *
-    * @tparam R the type of the resource
-    */
+   *
+   *  A resource is anything which needs to be released, closed, or otherwise cleaned up
+   *  in some way after it is finished being used, and for which waiting for the object's
+   *  garbage collection to be cleaned up would be unacceptable. For example, an instance of
+   *  [[java.io.OutputStream]] would be considered a resource, because it is important to close
+   *  the stream after it is finished being used.
+   *
+   *  An instance of `Releasable` is needed in order to automatically manage a resource
+   *  with [[Using `Using`]]. An implicit instance is provided for all types extending
+   *  [[java.lang.AutoCloseable]].
+   *
+   *  @tparam R the type of the resource
+   */
   trait Releasable[-R] {
     /** Releases the specified resource. */
     def release(resource: R): Unit

--- a/library/src/scala/util/boundary.scala
+++ b/library/src/scala/util/boundary.scala
@@ -16,17 +16,17 @@ import scala.annotation.implicitNotFound
  *    - Better performance: breaks to enclosing scopes in the same method can
  *      be rewritten to jumps.
  *
- * Example usage:
- * 
- * ```scala
- * import scala.util.boundary, boundary.break
+ *  Example usage:
  *
- * def firstIndex[T](xs: List[T], elem: T): Int =
+ *  ```scala
+ *  import scala.util.boundary, boundary.break
+ *
+ *  def firstIndex[T](xs: List[T], elem: T): Int =
  *   boundary:
  *     for (x, i) <- xs.zipWithIndex do
  *       if x == elem then break(i)
  *     -1
- * ```
+ *  ```
  */
 object boundary:
 
@@ -48,8 +48,7 @@ object boundary:
       // SAFETY: labels cannot leak from [[Break]], and is only used for equality comparison.
       new Break(label.unsafeAssumePure, value)
 
-  /** Labels are targets indicating which boundary will be exited by a `break`.
-   */
+  /** Labels are targets indicating which boundary will be exited by a `break`. */
   @implicitNotFound("explain=A Label is generated from an enclosing `scala.util.boundary` call.\nMaybe that boundary is missing?")
   final class Label[-T] extends caps.Control
 

--- a/library/src/scala/util/control/Breaks.scala
+++ b/library/src/scala/util/control/Breaks.scala
@@ -42,7 +42,7 @@ import scala.language.`2.13`
  *  convenience value `Breaks`.
  *
  *  Example usage:
- *  {{{
+ *  ```
  *  val mybreaks = new Breaks
  *  import mybreaks.{break, breakable}
  *
@@ -52,20 +52,20 @@ import scala.language.`2.13`
  *      f(x)
  *    }
  *  }
- *  }}}
+ *  ```
  *  Calls to `break` from one instance of `Breaks` will never
  *  resume at the `breakable` of some other instance.
  *
  *  Any intervening exception handlers should use `NonFatal`,
  *  or use `Try` for evaluation:
- *  {{{
+ *  ```
  *  val mybreaks = new Breaks
  *  import mybreaks.{break, breakable}
  *
  *  breakable {
  *    for (x <- xs) Try { if (quit) break else f(x) }.foreach(println)
  *  }
- *  }}}
+ *  ```
  */
 class Breaks {
 
@@ -85,13 +85,13 @@ class Breaks {
   /** Try a computation that produces a value, supplying a default
    *  to be used if the computation terminates with a `break`.
    *
-   * {{{
-   * tryBreakable {
+   *  ```
+   *  tryBreakable {
    *   (1 to 3).map(i => if (math.random < .5) break else i * 2)
-   * } catchBreak {
+   *  } catchBreak {
    *   Vector.empty
-   * }
-   * }}}
+   *  }
+   *  ```
    */
   def tryBreakable[T](op: => T): TryBlock[T] =
     new TryBlock[T] {
@@ -111,7 +111,7 @@ class Breaks {
 /** An object that can be used for the break control abstraction.
  *
  *  Example usage:
- *  {{{
+ *  ```
  *  import Breaks.{break, breakable}
  *
  *  breakable {
@@ -119,7 +119,7 @@ class Breaks {
  *      if (...) break
  *    }
  *  }
- *  }}}
+ *  ```
  */
 object Breaks extends Breaks
 

--- a/library/src/scala/util/control/ControlThrowable.scala
+++ b/library/src/scala/util/control/ControlThrowable.scala
@@ -20,7 +20,7 @@ import scala.language.`2.13`
  *
  *  As a convenience, `NonFatal` does not match `ControlThrowable`.
  *
- *  {{{
+ *  ```
  *  import scala.util.control.{Breaks, NonFatal}, Breaks.{break, breakable}
  *
  *  breakable {
@@ -33,7 +33,7 @@ import scala.language.`2.13`
  *      }
  *    }
  *  }
- *  }}}
+ *  ```
  *
  *  Suppression is disabled, because flow control should not suppress
  *  an exceptional condition. Stack traces are also disabled, allowing

--- a/library/src/scala/util/control/Exception.scala
+++ b/library/src/scala/util/control/Exception.scala
@@ -28,10 +28,10 @@ import scala.language.implicitConversions
  *  `opt`, `either` or `withTry` methods. Taken together the classes provide a DSL for composing catch and finally
  *  behaviors.
  *
- *  === Examples ===
+ *  ### Examples
  *
  *  Creates a `Catch` which handles specified exceptions.
- *  {{{
+ *  ```
  *  import scala.util.control.Exception._
  *  import java.net._
  *
@@ -50,10 +50,10 @@ import scala.language.implicitConversions
  *  val defaultUrl = new URL("http://example.com")
  *  //  URL(http://example.com) because htt/xx throws MalformedURLException
  *  val x4: URL = failAsValue(classOf[MalformedURLException])(defaultUrl)(new URL("htt/xx"))
- *  }}}
+ *  ```
  *
  *  Creates a `Catch` which logs exceptions using `handling` and `by`.
- *  {{{
+ *  ```
  *  def log(t: Throwable): Unit = t.printStackTrace
  *
  *  val withThrowableLogging: Catch[Unit] = handling(classOf[MalformedURLException]) by (log)
@@ -75,10 +75,10 @@ import scala.language.implicitConversions
  *  //   &lt;!DOCTYPE html&gt;
  *  //   &lt;html&gt;
  *  withThrowableLogging { printUrl(goodUrl) }
- *  }}}
+ *  ```
  *
  *  Use `unwrapping` to create a `Catch` that unwraps exceptions before rethrowing.
- *  {{{
+ *  ```
  *  class AppException(cause: Throwable) extends RuntimeException(cause)
  *
  *  val unwrappingCatch: Catch[Nothing] = unwrapping(classOf[AppException])
@@ -89,20 +89,20 @@ import scala.language.implicitConversions
  *  //   java.lang.NullPointerException
  *  //     at .calcResult(&lt;console&gt;:17)
  *  val result = unwrappingCatch(calcResult)
- *  }}}
+ *  ```
  *
  *  Use `failAsValue` to provide a default when a specified exception is caught.
  *
- *  {{{
+ *  ```
  *  val inputDefaulting: Catch[Int] = failAsValue(classOf[NumberFormatException])(0)
  *  val candidatePick = "seven" // scala.io.StdIn.readLine()
  *
  *  // Int = 0
  *  val pick = inputDefaulting(candidatePick.toInt)
- *  }}}
+ *  ```
  *
  *  Compose multiple `Catch`s with `or` to build a `Catch` that provides default values varied by exception.
- *  {{{
+ *  ```
  *  val formatDefaulting: Catch[Int] = failAsValue(classOf[NumberFormatException])(0)
  *  val nullDefaulting: Catch[Int] = failAsValue(classOf[NullPointerException])(-1)
  *  val otherDefaulting: Catch[Int] = nonFatalCatch withApply(_ => -100)
@@ -122,7 +122,7 @@ import scala.language.implicitConversions
  *
  *  // Int = 22
  *  combinedDefaulting(p("11"))
- *  }}}
+ *  ```
  *
  *  @groupname composition-catch Catch behavior composition
  *  @groupprio composition-catch 10
@@ -252,12 +252,13 @@ object Exception {
     def either[U >: T](body: => U): Either[Throwable, U] = toEither(Right(body))
 
     /** Applies this catch logic to the supplied body, mapping the result
-     * into `Try[T]` - `Failure` if an exception was caught, `Success(T)` otherwise.
+     *  into `Try[T]` - `Failure` if an exception was caught, `Success(T)` otherwise.
      */
     def withTry[U >: T](body: => U): scala.util.Try[U] = toTry(Success(body))
 
     /** Creates a `Catch` object with the same `isDefinedAt` logic as this one,
-      * but with the supplied `apply` method replacing the current one. */
+     *  but with the supplied `apply` method replacing the current one. 
+     */
     def withApply[U](f: Throwable => U): Catch[U] = {
       val pf2 = new Catcher[U] {
         def isDefinedAt(x: Throwable): Boolean = pf isDefinedAt x
@@ -278,17 +279,17 @@ object Exception {
 
   /** The empty `Catch` object.
    *  @group canned-behavior
-   **/
+   */
   final val noCatch: Catch[Nothing] = new Catch(nothingCatcher) withDesc "<nothing>"
 
   /** A `Catch` object which catches everything.
    *  @group canned-behavior
-   **/
+   */
   final def allCatch[T]: Catch[T] = new Catch(allCatcher[T]) withDesc "<everything>"
 
   /** A `Catch` object which catches non-fatal exceptions.
    *  @group canned-behavior
-   **/
+   */
   final def nonFatalCatch[T]: Catch[T] = new Catch(nonFatalCatcher[T]) withDesc "<non-fatal>"
 
   /** Creates a `Catch` object which will catch any of the supplied exceptions.
@@ -337,13 +338,13 @@ object Exception {
   }
 
   /** Returns a partially constructed `Catch` object, which you must give
-    * an exception handler function as an argument to `by`.
-    * @example
-    * {{{
-    *   handling(classOf[MalformedURLException], classOf[NullPointerException]) by (_.printStackTrace)
-    * }}}
-    *  @group dsl
-    */
+   *  an exception handler function as an argument to `by`.
+   *  @example
+   *  ```
+   *   handling(classOf[MalformedURLException], classOf[NullPointerException]) by (_.printStackTrace)
+   *  ```
+   *  @group dsl
+   */
   def handling[T](exceptions: Class[?]*): By[Throwable => T, Catch[T]] = {
     def fun(f: Throwable => T): Catch[T] = catching(exceptions*) withApply f
     new By[Throwable => T, Catch[T]](fun)

--- a/library/src/scala/util/control/NonFatal.scala
+++ b/library/src/scala/util/control/NonFatal.scala
@@ -15,16 +15,15 @@ package util.control
 
 import scala.language.`2.13`
 
-/**
- * Extractor of non-fatal Throwables. Will not match fatal errors like `VirtualMachineError`
- * (for example, `OutOfMemoryError` and `StackOverflowError`, subclasses of `VirtualMachineError`), `ThreadDeath`,
- * `LinkageError`, `InterruptedException`, `ControlThrowable`.
+/** Extractor of non-fatal Throwables. Will not match fatal errors like `VirtualMachineError`
+ *  (for example, `OutOfMemoryError` and `StackOverflowError`, subclasses of `VirtualMachineError`), `ThreadDeath`,
+ *  `LinkageError`, `InterruptedException`, `ControlThrowable`.
  *
- * Note that [[scala.util.control.ControlThrowable]], an internal Throwable, is not matched by
- * `NonFatal` (and would therefore be thrown).
+ *  Note that [[scala.util.control.ControlThrowable]], an internal Throwable, is not matched by
+ *  `NonFatal` (and would therefore be thrown).
  *
- * For example, all harmless Throwables can be caught by:
- * {{{
+ *  For example, all harmless Throwables can be caught by:
+ *  ```
  *   try {
  *     // dangerous stuff
  *   } catch {
@@ -32,20 +31,16 @@ import scala.language.`2.13`
  *    // or
  *     case e if NonFatal(e) => log.error(e, "Something not that bad.")
  *   }
- * }}}
+ *  ```
  */
 object NonFatal {
-  /**
-   * Returns true if the provided `Throwable` is to be considered non-fatal, or false if it is to be considered fatal
-   */
+  /** Returns true if the provided `Throwable` is to be considered non-fatal, or false if it is to be considered fatal */
   @annotation.nowarn("cat=deprecation")  // avoid warning on mention of ThreadDeath
   def apply(t: Throwable): Boolean = t match {
     // VirtualMachineError includes OutOfMemoryError and other fatal errors
     case _: VirtualMachineError | _: ThreadDeath | _: InterruptedException | _: LinkageError | _: ControlThrowable => false
     case _ => true
   }
-  /**
-   * Returns `Some`(t) if `NonFatal`(t) == true, otherwise `None`
-   */
+  /** Returns `Some`(t) if `NonFatal`(t) == true, otherwise `None` */
   def unapply(t: Throwable): Option[Throwable] = if (apply(t)) Some(t) else None
 }

--- a/library/src/scala/util/control/TailCalls.scala
+++ b/library/src/scala/util/control/TailCalls.scala
@@ -26,7 +26,7 @@ import annotation.tailrec
  *  [[https://blog.higher-order.com/assets/trampolines.pdf]]
  *
  *  Here's a usage example:
- *  {{{
+ *  ```
  *  import scala.util.control.TailCalls._
  *
  *  def isEven(xs: List[Int]): TailRec[Boolean] =
@@ -44,19 +44,19 @@ import annotation.tailrec
  *    } yield x + y
  *
  *  fib(40).result
- *  }}}
+ *  ```
  */
 object TailCalls {
 
-  /** This class represents a tailcalling computation.
-   */
+  /** This class represents a tailcalling computation. */
   sealed abstract class TailRec[+A] {
 
     /** Continue the computation with `f`. */
     final def map[B](f: A => B): TailRec[B] = flatMap(a => Call(() => Done(f(a))))
 
     /** Continue the computation with `f` and merge the trampolining
-     *  of this computation with that of `f`. */
+     *  of this computation with that of `f`. 
+     */
     final def flatMap[B](f: A => TailRec[B]): TailRec[B] = this match {
       case Done(a)         => Call(() => f(a))
       case Call(_)         => Cont(this, f)
@@ -65,7 +65,8 @@ object TailCalls {
     }
 
     /** Returns either the next step of the tailcalling computation,
-      * or the result if there are no more steps. */
+     *  or the result if there are no more steps. 
+     */
     @tailrec final def resume: Either[() => TailRec[A], A] = this match {
       case Done(a)    => Right(a)
       case Call(k)    => Left(k)
@@ -76,8 +77,7 @@ object TailCalls {
       }
     }
 
-    /** Returns the result of the tailcalling computation.
-     */
+    /** Returns the result of the tailcalling computation. */
     @tailrec final def result: A = this match {
       case Done(a)    => a
       case Call(t)    => t().result
@@ -93,11 +93,13 @@ object TailCalls {
   protected case class Call[A](rest: () => TailRec[A]) extends TailRec[A]
 
   /** Internal class representing the final result returned from a tailcalling
-   *  computation. */
+   *  computation. 
+   */
   protected case class Done[A](value: A) extends TailRec[A]
 
   /** Internal class representing a continuation with function A => TailRec[B].
-   *  It is needed for the flatMap to be implemented. */
+   *  It is needed for the flatMap to be implemented. 
+   */
   protected case class Cont[A, B](a: TailRec[A], f: A => TailRec[B]) extends TailRec[B]
 
   /** Perform a tailcall.

--- a/library/src/scala/util/hashing/ByteswapHashing.scala
+++ b/library/src/scala/util/hashing/ByteswapHashing.scala
@@ -15,8 +15,7 @@ package util.hashing
 
 import scala.language.`2.13`
 
-/** A fast multiplicative hash by Phil Bagwell.
- */
+/** A fast multiplicative hash by Phil Bagwell. */
 final class ByteswapHashing[T] extends Hashing[T] {
 
   def hash(v: T) = byteswap32(v.##)
@@ -30,8 +29,7 @@ object ByteswapHashing {
     def hash(v: T) = byteswap32(h.hash(v))
   }
 
-  /** Composes another `Hashing` with the Byteswap hash.
-   */
+  /** Composes another `Hashing` with the Byteswap hash. */
   def chain[T](h: Hashing[T]): Hashing[T] = new Chained(h)
 
 }

--- a/library/src/scala/util/hashing/MurmurHash3.scala
+++ b/library/src/scala/util/hashing/MurmurHash3.scala
@@ -26,7 +26,8 @@ private[hashing] class MurmurHash3 {
 
   /** May optionally be used as the last mixing step. Is a little bit faster than mix,
    *  as it does no further mixing of the resulting hash. For the last element this is not
-   *  necessary as the hash is thoroughly mixed during finalization anyway. */
+   *  necessary as the hash is thoroughly mixed during finalization anyway. 
+   */
   final def mixLast(hash: Int, data: Int): Int = {
     var k = data
 
@@ -137,8 +138,8 @@ private[hashing] class MurmurHash3 {
   }
 
   /** Computes a hash that depends on the order of its arguments. Potential range
-    * hashes are recognized to produce a hash that is compatible with rangeHash.
-    */
+   *  hashes are recognized to produce a hash that is compatible with rangeHash.
+   */
   final def orderedHash(xs: IterableOnce[Any], seed: Int): Int = {
     val it = xs.iterator
     var h = seed
@@ -173,8 +174,8 @@ private[hashing] class MurmurHash3 {
   }
 
   /** Computes the hash of an array. Potential range hashes are recognized to produce a
-    * hash that is compatible with rangeHash.
-    */
+   *  hash that is compatible with rangeHash.
+   */
   final def arrayHash[@specialized T](a: Array[T], seed: Int): Int = {
     var h = seed
     val l = a.length
@@ -210,9 +211,9 @@ private[hashing] class MurmurHash3 {
   }
 
   /** Computes the hash of a Range with at least 2 elements. Ranges with fewer
-    * elements need to use seqHash instead. The `last` parameter must be the
-    * actual last element produced by a Range, not the nominal `end`.
-    */
+   *  elements need to use seqHash instead. The `last` parameter must be the
+   *  actual last element produced by a Range, not the nominal `end`.
+   */
   final def rangeHash(start: Int, step: Int, last: Int, seed: Int): Int =
     avalanche(mix(mix(mix(seed, start), step), last))
 
@@ -252,8 +253,8 @@ private[hashing] class MurmurHash3 {
   }
 
   /** Computes the hash of an IndexedSeq. Potential range hashes are recognized to produce a
-    * hash that is compatible with rangeHash.
-    */
+   *  hash that is compatible with rangeHash.
+   */
   final def indexedSeqHash(a: scala.collection.IndexedSeq[Any], seed: Int): Int = {
     var h = seed
     val l = a.length
@@ -289,8 +290,8 @@ private[hashing] class MurmurHash3 {
   }
 
   /** Computes the hash of a List. Potential range hashes are recognized to produce a
-    * hash that is compatible with rangeHash.
-    */
+   *  hash that is compatible with rangeHash.
+   */
   final def listHash(xs: scala.collection.immutable.List[?], seed: Int): Int = {
     var n = 0
     var h = seed
@@ -324,28 +325,27 @@ private[hashing] class MurmurHash3 {
   }
 }
 
-/**
- * An implementation of Austin Appleby's MurmurHash 3 algorithm
- * (MurmurHash3_x86_32). This object contains methods that hash
- * values of various types as well as means to construct `Hashing`
- * objects.
+/** An implementation of Austin Appleby's MurmurHash 3 algorithm
+ *  (MurmurHash3_x86_32). This object contains methods that hash
+ *  values of various types as well as means to construct `Hashing`
+ *  objects.
  *
- * This algorithm is designed to generate well-distributed non-cryptographic
- * hashes. It is designed to hash data in 32 bit chunks (ints).
+ *  This algorithm is designed to generate well-distributed non-cryptographic
+ *  hashes. It is designed to hash data in 32 bit chunks (ints).
  *
- * The mix method needs to be called at each step to update the intermediate
- * hash value. For the last chunk to incorporate into the hash mixLast may
- * be used instead, which is slightly faster. Finally finalizeHash needs to
- * be called to compute the final hash value.
+ *  The mix method needs to be called at each step to update the intermediate
+ *  hash value. For the last chunk to incorporate into the hash mixLast may
+ *  be used instead, which is slightly faster. Finally finalizeHash needs to
+ *  be called to compute the final hash value.
  *
- * This is based on the earlier MurmurHash3 code by Rex Kerr, but the
- * MurmurHash3 algorithm was since changed by its creator Austin Appleby
- * to remedy some weaknesses and improve performance. This represents the
- * latest and supposedly final version of the algorithm (revision 136). Even
- * so, test the generated hashes in between Scala versions, even for point
- * releases, as fast, non-cryptographic hashing algorithms evolve rapidly.
+ *  This is based on the earlier MurmurHash3 code by Rex Kerr, but the
+ *  MurmurHash3 algorithm was since changed by its creator Austin Appleby
+ *  to remedy some weaknesses and improve performance. This represents the
+ *  latest and supposedly final version of the algorithm (revision 136). Even
+ *  so, test the generated hashes in between Scala versions, even for point
+ *  releases, as fast, non-cryptographic hashing algorithms evolve rapidly.
  *
- * @see [[https://github.com/aappleby/smhasher]]
+ *  @see [[https://github.com/aappleby/smhasher]]
  */
 object MurmurHash3 extends MurmurHash3 {
   final val arraySeed       = 0x3c074a61
@@ -367,41 +367,39 @@ object MurmurHash3 extends MurmurHash3 {
   @deprecated("use `caseClassHash` instead", "2.13.17")
   def productHash(x: Product): Int = caseClassHash(x, productSeed, null)
 
-  /**
-   * Computes the `hashCode` of a case class instance. This method returns the same value as `x.hashCode`
-   * if `x` is an instance of a case class with the default, synthetic `hashCode`.
+  /** Computes the `hashCode` of a case class instance. This method returns the same value as `x.hashCode`
+   *  if `x` is an instance of a case class with the default, synthetic `hashCode`.
    *
-   * This method can be used to implement case classes with a cached `hashCode`:
-   * {{{
-   * case class C(data: Data) {
+   *  This method can be used to implement case classes with a cached `hashCode`:
+   *  ```
+   *  case class C(data: Data) {
    *   override lazy val hashCode: Int = MurmurHash3.caseClassHash(this)
-   * }
-   * }}}
+   *  }
+   *  ```
    *
-   * '''NOTE''': For case classes (or subclasses) that override `productPrefix`, the `caseClassName` parameter
-   * needs to be specified in order to obtain the same result as the synthetic `hashCode`. Otherwise, the value
-   * is not in sync with the case class `equals` method (scala/bug#13033).
+   *  **NOTE**: For case classes (or subclasses) that override `productPrefix`, the `caseClassName` parameter
+   *  needs to be specified in order to obtain the same result as the synthetic `hashCode`. Otherwise, the value
+   *  is not in sync with the case class `equals` method (scala/bug#13033).
    *
-   * {{{
-   * scala> case class C(x: Int) { override def productPrefix = "Y" }
+   *  ```
+   *  scala> case class C(x: Int) { override def productPrefix = "Y" }
    *
-   * scala> C(1).hashCode
-   * val res0: Int = -668012062
+   *  scala> C(1).hashCode
+   *  val res0: Int = -668012062
    *
-   * scala> MurmurHash3.caseClassHash(C(1))
-   * val res1: Int = 1015658380
+   *  scala> MurmurHash3.caseClassHash(C(1))
+   *  val res1: Int = 1015658380
    *
-   * scala> MurmurHash3.caseClassHash(C(1), "C")
-   * val res2: Int = -668012062
-   * }}}
+   *  scala> MurmurHash3.caseClassHash(C(1), "C")
+   *  val res2: Int = -668012062
+   *  ```
    */
   def caseClassHash(x: Product, caseClassName: String | Null = null): Int = caseClassHash(x, productSeed, caseClassName)
 
   private[scala] def arraySeqHash[@specialized T](a: Array[T]): Int = arrayHash(a, seqSeed)
   private[scala] def tuple2Hash(x: Any, y: Any): Int = tuple2Hash(x.##, y.##, productSeed)
 
-  /** To offer some potential for optimization.
-   */
+  /** To offer some potential for optimization. */
   def seqHash(xs: scala.collection.Seq[?]): Int    = xs match {
     case xs: scala.collection.IndexedSeq[?] => indexedSeqHash(xs, seqSeed)
     case xs: List[?] => listHash(xs, seqSeed)

--- a/library/src/scala/util/hashing/package.scala
+++ b/library/src/scala/util/hashing/package.scala
@@ -17,8 +17,7 @@ import scala.language.`2.13`
 
 package object hashing {
 
-  /** Fast multiplicative hash with a nice distribution.
-   */
+  /** Fast multiplicative hash with a nice distribution. */
   def byteswap32(v: Int): Int = {
     var hc = v * 0x9e3775cd
     hc = java.lang.Integer.reverseBytes(hc)

--- a/library/src/scala/util/matching/Regex.scala
+++ b/library/src/scala/util/matching/Regex.scala
@@ -10,18 +10,17 @@
  * additional information regarding copyright ownership.
  */
 
-/**
- * This package is concerned with regular expression (regex) matching against strings,
- * with the main goal of pulling out information from those matches, or replacing
- * them with something else.
+/** This package is concerned with regular expression (regex) matching against strings,
+ *  with the main goal of pulling out information from those matches, or replacing
+ *  them with something else.
  *
- * [[scala.util.matching.Regex]] is the class users instantiate to do regular expression matching.
+ *  [[scala.util.matching.Regex]] is the class users instantiate to do regular expression matching.
  *
- * The companion object to [[scala.util.matching.Regex]] contains supporting members:
- * * [[scala.util.matching.Regex.Match]] makes more information about a match available.
- * * [[scala.util.matching.Regex.MatchIterator]] is used to iterate over matched strings.
- * * [[scala.util.matching.Regex.MatchData]] is just a base trait for the above classes.
- * * [[scala.util.matching.Regex.Groups]] extracts group from a [[scala.util.matching.Regex.Match]]
+ *  The companion object to [[scala.util.matching.Regex]] contains supporting members:
+ *  * [[scala.util.matching.Regex.Match]] makes more information about a match available.
+ *  * [[scala.util.matching.Regex.MatchIterator]] is used to iterate over matched strings.
+ *  * [[scala.util.matching.Regex.MatchData]] is just a base trait for the above classes.
+ *  * [[scala.util.matching.Regex.Groups]] extracts group from a [[scala.util.matching.Regex.Match]]
  *   without recomputing the match.
  */
 package scala.util.matching
@@ -33,9 +32,8 @@ import java.util.regex.{ Pattern, Matcher }
 /** A regular expression is used to determine whether a string matches a pattern
  *  and, if it does, to extract or transform the parts that match.
  *
- *  === Usage ===
-
- *  This class delegates to the [[https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/regex/package-summary.html java.util.regex]] package of the Java Platform.
+ *  ### Usage
+ *  This class delegates to the [java.util.regex](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/regex/package-summary.html) package of the Java Platform.
  *  See the documentation for [[java.util.regex.Pattern]] for details about
  *  the regular expression syntax for pattern strings.
  *
@@ -46,56 +44,56 @@ import java.util.regex.{ Pattern, Matcher }
  *  The canonical way to create a `Regex` is by using the method `r`, provided
  *  implicitly for strings:
  *
- *  {{{
+ *  ```
  *  val date = raw"(\d{4})-(\d{2})-(\d{2})".r
- *  }}}
+ *  ```
  *
  *  Since escapes are not processed in multi-line string literals, using triple quotes
  *  avoids having to escape the backslash character, so that `"\\d"` can be written `"""\d"""`.
  *  The same result is achieved with certain interpolators, such as `raw"\d".r` or
  *  a custom interpolator `r"\d"` that also compiles the `Regex`.
  *
- *  === Extraction ===
+ *  ### Extraction
  *  To extract the capturing groups when a `Regex` is matched, use it as
  *  an extractor in a pattern match:
  *
- *  {{{
+ *  ```
  *  "2004-01-20" match {
  *    case date(year, month, day) => s"\$year was a good year for PLs."
  *  }
- *  }}}
+ *  ```
  *
  *  To check only whether the `Regex` matches, ignoring any groups,
  *  use a sequence wildcard:
  *
- *  {{{
+ *  ```
  *  "2004-01-20" match {
  *    case date(_*) => "It's a date!"
  *  }
- *  }}}
+ *  ```
  *
  *  That works because a `Regex` extractor produces a sequence of strings.
  *  Extracting only the year from a date could also be expressed with
  *  a sequence wildcard:
  *
- *  {{{
+ *  ```
  *  "2004-01-20" match {
  *    case date(year, _*) => s"\$year was a good year for PLs."
  *  }
- *  }}}
+ *  ```
  *
  *  In a pattern match, `Regex` normally matches the entire input.
  *  However, an unanchored `Regex` finds the pattern anywhere
  *  in the input.
  *
- *  {{{
+ *  ```
  *  val embeddedDate = date.unanchored
  *  "Date: 2004-01-20 17:25:18 GMT (10 years, 28 weeks, 5 days, 17 hours and 51 minutes ago)" match {
  *    case embeddedDate("2004", "01", "20") => "A Scala is born."
  *  }
- *  }}}
+ *  ```
  *
- *  === Find Matches ===
+ *  ### Find Matches
  *  To find or replace matches of the pattern, use the various find and replace methods.
  *  For each method, there is a version for working with matched strings and
  *  another for working with `Match` objects.
@@ -104,43 +102,43 @@ import java.util.regex.{ Pattern, Matcher }
  *  can also be accomplished using `findFirstMatchIn`. The `findFirst` methods return an `Option`
  *  which is non-empty if a match is found, or `None` for no match:
  *
- *  {{{
+ *  ```
  *  val dates = "Important dates in history: 2004-01-20, 1958-09-05, 2010-10-06, 2011-07-15"
  *  val firstDate = date.findFirstIn(dates).getOrElse("No date found.")
  *  val firstYear = for (m <- date.findFirstMatchIn(dates)) yield m.group(1)
- *  }}}
+ *  ```
  *
  *  To find all matches:
  *
- *  {{{
+ *  ```
  *  val allYears = for (m <- date.findAllMatchIn(dates)) yield m.group(1)
- *  }}}
+ *  ```
  *
  *  To check whether input is matched by the regex:
  *
- *  {{{
+ *  ```
  *  date.matches("2018-03-01")                     // true
  *  date.matches("Today is 2018-03-01")            // false
  *  date.unanchored.matches("Today is 2018-03-01") // true
- *  }}}
+ *  ```
  *
  *  To iterate over the matched strings, use `findAllIn`, which returns a special iterator
  *  that can be queried for the `MatchData` of the last match:
  *
- *  {{{
+ *  ```
  *  val mi = date.findAllIn(dates)
  *  while (mi.hasNext) {
  *    val d = mi.next
  *    if (mi.group(1).toInt < 1960) println(s"\$d: An oldie but goodie.")
  *  }
- *  }}}
+ *  ```
  *
  *  Although the `MatchIterator` returned by `findAllIn` is used like any `Iterator`,
  *  with alternating calls to `hasNext` and `next`, `hasNext` has the additional
  *  side effect of advancing the underlying matcher to the next unconsumed match.
  *  This effect is visible in the `MatchData` representing the "current match".
  *
- *  {{{
+ *  ```
  *  val r = "(ab+c)".r
  *  val s = "xxxabcyyyabbczzz"
  *  r.findAllIn(s).start    // 3
@@ -152,7 +150,7 @@ import java.util.regex.{ Pattern, Matcher }
  *  mi.hasNext              // true
  *  mi.start                // 9
  *  mi.next()               // "abbc"
- *  }}}
+ *  ```
  *
  *  The example shows that methods on `MatchData` such as `start` will advance to
  *  the first match, if necessary. It also shows that `hasNext` will advance to
@@ -164,32 +162,32 @@ import java.util.regex.{ Pattern, Matcher }
  *
  *  Note that `findAllIn` finds matches that don't overlap. (See [[findAllIn]] for more examples.)
  *
- *  {{{
+ *  ```
  *  val num = raw"(\d+)".r
  *  val all = num.findAllIn("123").toList  // List("123"), not List("123", "23", "3")
- *  }}}
+ *  ```
  *
- *  === Replace Text ===
+ *  ### Replace Text
  *  Text replacement can be performed unconditionally or as a function of the current match:
  *
- *  {{{
+ *  ```
  *  val redacted    = date.replaceAllIn(dates, "XXXX-XX-XX")
  *  val yearsOnly   = date.replaceAllIn(dates, m => m.group(1))
  *  val months      = (0 to 11).map { i => val c = Calendar.getInstance; c.set(2014, i, 1); f"\$c%tb" }
  *  val reformatted = date.replaceAllIn(dates, _ match { case date(y,m,d) => f"\${months(m.toInt - 1)} \$d, \$y" })
- *  }}}
+ *  ```
  *
  *  Pattern matching the `Match` against the `Regex` that created it does not reapply the `Regex`.
  *  In the expression for `reformatted`, each `date` match is computed once. But it is possible to apply a
  *  `Regex` to a `Match` resulting from a different pattern:
  *
- *  {{{
+ *  ```
  *  val docSpree = """2011(?:-\d{2}){2}""".r
  *  val docView  = date.replaceAllIn(dates, _ match {
  *    case docSpree() => "Historic doc spree!"
  *    case _          => "Something else happened"
  *  })
- *  }}}
+ *  ```
  *
  *  @see [[java.util.regex.Pattern]]
  *
@@ -215,10 +213,10 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *
    *  If group names are supplied, they can be used this way:
    *
-   *  {{{
+   *  ```
    *  val namedDate  = new Regex("""(\d\d\d\d)-(\d\d)-(\d\d)""", "year", "month", "day")
    *  val namedYears = for (m <- namedDate findAllMatchIn dates) yield m group "year"
-   *  }}}
+   *  ```
    *
    *  Inline group names are preferred over group names supplied to the constructor
    *  when retrieving matched groups by name. Group names supplied to the constructor
@@ -246,7 +244,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *
    *  For example:
    *
-   *  {{{
+   *  ```
    *  val p1 = "ab*c".r
    *  val p1Matches = "abbbc" match {
    *    case p1() => true               // no groups
@@ -279,7 +277,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *    case p4(_, c) => c
    *    case _        => ""
    *  }
-   *  }}}
+   *  ```
    *
    *  @param  s     The string to match
    *  @return       The matches
@@ -297,7 +295,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *
    *  For example:
    *
-   *  {{{
+   *  ```
    *  val cat = "cat"
    *  // the case must consume the group to match
    *  val r = """(\p{Lower})""".r
@@ -317,7 +315,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *  val r = """((.))""".r
    *  cat(0) match { case r(_) => true }    // matches
    *  cat(0) match { case r(_,_) => true }  // no match
-   *  }}}
+   *  ```
    *
    *  @param  c     The Char to match
    *  @return       The match
@@ -360,22 +358,22 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *  followed by the next match that follows the input consumed by the
    *  first match:
    *
-   *  {{{
+   *  ```
    *  val hat  = "hat[^a]+".r
    *  val hathaway = "hathatthattthatttt"
    *  val hats = hat.findAllIn(hathaway).toList                     // List(hath, hattth)
    *  val pos  = hat.findAllMatchIn(hathaway).map(_.start).toList   // List(0, 7)
-   *  }}}
+   *  ```
    *
    *  To return overlapping matches, it is possible to formulate a regular expression
    *  with lookahead (`?=`) that does not consume the overlapping region.
    *
-   *  {{{
+   *  ```
    *  val madhatter = "(h)(?=(at[^a]+))".r
    *  val madhats   = madhatter.findAllMatchIn(hathaway).map {
    *    case madhatter(x,y) => s"\$x\$y"
    *  }.toList                                       // List(hath, hatth, hattth, hatttt)
-   *  }}}
+   *  ```
    *
    *  Attempting to retrieve match information after exhausting the iterator
    *  results in [[java.lang.IllegalStateException]].
@@ -383,7 +381,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *
    *  @param source The text to match against.
    *  @return       A [[scala.util.matching.Regex.MatchIterator]] of matched substrings.
-   *  @example      {{{for (words <- """\w+""".r findAllIn "A simple example.") yield words}}}
+   *  @example      ```for (words <- """\w+""".r findAllIn "A simple example.") yield words ```
    */
   def findAllIn(source: CharSequence): MatchIterator = new Regex.MatchIterator(source, this, groupNames)
 
@@ -392,7 +390,10 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *
    *  @param source The text to match against.
    *  @return       A [[scala.collection.Iterator]] of [[scala.util.matching.Regex.Match]] for all matches.
-   *  @example      {{{for (words <- """\w+""".r findAllMatchIn "A simple example.") yield words.start}}}
+   *  @example
+   *  ```
+   *  for (words <- """\w+""".r findAllMatchIn "A simple example.") yield words.start
+   *  ```
    */
   def findAllMatchIn(source: CharSequence): Iterator[Match] = {
     val matchIterator = findAllIn(source)
@@ -410,7 +411,10 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *
    *  @param source The text to match against.
    *  @return       An [[scala.Option]] of the first matching string in the text.
-   *  @example      {{{"""\w+""".r findFirstIn "A simple example." foreach println // prints "A"}}}
+   *  @example
+   *  ```
+   *  """\w+""".r findFirstIn "A simple example." foreach println // prints "A"
+   *  ```
    */
   def findFirstIn(source: CharSequence): Option[String] = {
     val m = pattern.matcher(source)
@@ -425,7 +429,10 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *
    *  @param source The text to match against.
    *  @return       A [[scala.Option]] of [[scala.util.matching.Regex.Match]] of the first matching string in the text.
-   *  @example      {{{("""[a-z]""".r findFirstMatchIn "A simple example.") map (_.start) // returns `Some(2)`, the index of the first match in the text}}}
+   *  @example
+   *  ```
+   *  ("""[a-z]""".r findFirstMatchIn "A simple example.") map (_.start) // returns `Some(2)`, the index of the first match in the text
+   *  ```
    */
   def findFirstMatchIn(source: CharSequence): Option[Match] = {
     val m = pattern.matcher(source)
@@ -441,7 +448,10 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *
    *  @param source The text to match against.
    *  @return       A [[scala.Option]] of the matched prefix.
-   *  @example      {{{"""\p{Lower}""".r findPrefixOf "A simple example." // returns `None`, since the text does not begin with a lowercase letter}}}
+   *  @example
+   *  ```
+   *  """\p{Lower}""".r findPrefixOf "A simple example." // returns `None`, since the text does not begin with a lowercase letter
+   *  ```
    */
   def findPrefixOf(source: CharSequence): Option[String] = {
     val m = pattern.matcher(source)
@@ -457,7 +467,10 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *
    *  @param source The text to match against.
    *  @return       A [[scala.Option]] of the [[scala.util.matching.Regex.Match]] of the matched string.
-   *  @example      {{{"""\w+""".r findPrefixMatchOf "A simple example." map (_.after) // returns `Some(" simple example.")`}}}
+   *  @example
+   *  ```
+   *  """\w+""".r findPrefixMatchOf "A simple example." map (_.after) // returns `Some(" simple example.")`
+   *  ```
    */
   def findPrefixMatchOf(source: CharSequence): Option[Match] = {
     val m = pattern.matcher(source)
@@ -465,14 +478,17 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
   }
 
   /** Returns whether this `Regex` matches the given character sequence.
-    *
-    * Like the extractor, this method takes anchoring into account.
-    *
-    * @param source The text to match against
-    * @return       true if and only if `source` matches this `Regex`.
-    * @see          [[Regex#unanchored]]
-    * @example      {{{"""\d+""".r matches "123" // returns true}}}
-    */
+   *
+   *  Like the extractor, this method takes anchoring into account.
+   *
+   *  @param source The text to match against
+   *  @return       true if and only if `source` matches this `Regex`.
+   *  @see          [[Regex#unanchored]]
+   *  @example
+   *  ```
+   *  """\d+""".r matches "123" // returns true
+   *  ```
+   */
   def matches(source: CharSequence): Boolean =
     runMatcher(pattern.matcher(source))
 
@@ -483,30 +499,32 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *  @param target      The string to match
    *  @param replacement The string that will replace each match
    *  @return            The resulting string
-   *  @example           {{{"""\d+""".r replaceAllIn ("July 15", "<NUMBER>") // returns "July <NUMBER>"}}}
+   *  @example
+   *  ```
+   *  """\d+""".r replaceAllIn ("July 15", "<NUMBER>") // returns "July <NUMBER>"
+   *  ```
    */
   def replaceAllIn(target: CharSequence, replacement: String): String = {
     val m = pattern.matcher(target)
     m.replaceAll(replacement)
   }
 
-  /**
-   * Replaces all matches using a replacer function. The replacer function takes a
-   * [[scala.util.matching.Regex.Match]] so that extra information can be obtained
-   * from the match. For example:
+  /** Replaces all matches using a replacer function. The replacer function takes a
+   *  [[scala.util.matching.Regex.Match]] so that extra information can be obtained
+   *  from the match. For example:
    *
-   * {{{
-   * import scala.util.matching.Regex
-   * val datePattern = new Regex("""(\d\d\d\d)-(\d\d)-(\d\d)""", "year", "month", "day")
-   * val text = "From 2011-07-15 to 2011-07-17"
-   * val repl = datePattern replaceAllIn (text, m => s"\${m group "month"}/\${m group "day"}")
-   * }}}
+   *  ```
+   *  import scala.util.matching.Regex
+   *  val datePattern = new Regex("""(\d\d\d\d)-(\d\d)-(\d\d)""", "year", "month", "day")
+   *  val text = "From 2011-07-15 to 2011-07-17"
+   *  val repl = datePattern replaceAllIn (text, m => s"\${m group "month"}/\${m group "day"}")
+   *  ```
    *
-   * $replacementString
+   *  $replacementString
    *
-   * @param target      The string to match.
-   * @param replacer    The function which maps a match to another string.
-   * @return            The target string after replacements.
+   *  @param target      The string to match.
+   *  @param replacer    The function which maps a match to another string.
+   *  @return            The target string after replacements.
    */
   def replaceAllIn(target: CharSequence, replacer: Match => String): String = {
     val rit = new Regex.MatchIterator(target, this, groupNames).replacementData
@@ -515,26 +533,25 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
     rit.replaced
   }
 
-  /**
-   * Replaces some of the matches using a replacer function that returns an [[scala.Option]].
-   * The replacer function takes a [[scala.util.matching.Regex.Match]] so that extra
-   * information can be obtained from the match. For example:
+  /** Replaces some of the matches using a replacer function that returns an [[scala.Option]].
+   *  The replacer function takes a [[scala.util.matching.Regex.Match]] so that extra
+   *  information can be obtained from the match. For example:
    *
-   * {{{
-   * import scala.util.matching.Regex._
+   *  ```
+   *  import scala.util.matching.Regex._
    *
-   * val vars = Map("x" -> "a var", "y" -> """some \$ and \ signs""")
-   * val text = "A text with variables %x, %y and %z."
-   * val varPattern = """%(\w+)""".r
-   * val mapper = (m: Match) => vars get (m group 1) map (quoteReplacement(_))
-   * val repl = varPattern replaceSomeIn (text, mapper)
-   * }}}
+   *  val vars = Map("x" -> "a var", "y" -> """some \$ and \ signs""")
+   *  val text = "A text with variables %x, %y and %z."
+   *  val varPattern = """%(\w+)""".r
+   *  val mapper = (m: Match) => vars get (m group 1) map (quoteReplacement(_))
+   *  val repl = varPattern replaceSomeIn (text, mapper)
+   *  ```
    *
-   * $replacementString
+   *  $replacementString
    *
-   * @param target      The string to match.
-   * @param replacer    The function which optionally maps a match to another string.
-   * @return            The target string after replacements.
+   *  @param target      The string to match.
+   *  @param replacer    The function which optionally maps a match to another string.
+   *  @return            The target string after replacements.
    */
   def replaceSomeIn(target: CharSequence, replacer: Match => Option[String]): String = {
     val rit = new Regex.MatchIterator(target, this, groupNames).replacementData
@@ -577,7 +594,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *
    *  Calling `anchored` returns the original `Regex`.
    *
-   *  {{{
+   *  ```
    *  val date = """(\d\d\d\d)-(\d\d)-(\d\d)""".r.unanchored
    *
    *  val date(year, month, day) = "Date 2011-07-15"                       // OK
@@ -586,7 +603,7 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *    case date(year, month, day) => s"Copyright \$year"                  // OK
    *    case _                      => "No copyright"
    *  }
-   *  }}}
+   *  ```
    *
    *  @return        The new unanchored regex
    */
@@ -761,11 +778,10 @@ object Regex {
    *  This can be used to help writing replacer functions when you
    *  are not interested in match data. For example:
    *
-   *  {{{
+   *  ```
    *  import scala.util.matching.Regex.Match
    *  """\w+""".r replaceAllIn ("A simple example.", _ match { case Match(s) => s.toUpperCase })
-   *  }}}
-   *
+   *  ```
    */
   object Match {
     def unapply(m: Match): Some[String] = Some(m.matched.nn)
@@ -774,13 +790,13 @@ object Regex {
   /** An extractor object that yields the groups in the match. Using this extractor
    *  rather than the original `Regex` ensures that the match is not recomputed.
    *
-   *  {{{
+   *  ```
    *  import scala.util.matching.Regex.Groups
    *
    *  val date = """(\d\d\d\d)-(\d\d)-(\d\d)""".r
    *  val text = "The doc spree happened on 2011-07-15."
    *  val day = date replaceAllIn(text, _ match { case Groups(_, month, day) => s"\$month/\$day" })
-   *  }}}
+   *  ```
    */
   object Groups {
     def unapplySeq(m: Match): Option[Seq[String | Null]] = {
@@ -881,8 +897,7 @@ object Regex {
     }
   }
 
-  /** Internal trait used by `replaceAllIn` and `replaceSomeIn`.
-   */
+  /** Internal trait used by `replaceAllIn` and `replaceSomeIn`. */
   private[matching] trait Replacement {
     protected def matcher: Matcher
 
@@ -902,7 +917,10 @@ object Regex {
    *
    *  All regex metacharacters in the input match themselves literally in the output.
    *
-   *  @example {{{List("US\$", "CAN\$").map(Regex.quote).mkString("|").r}}}
+   *  @example
+   *  ```
+   *  List("US\$", "CAN\$").map(Regex.quote).mkString("|").r
+   *  ```
    */
   def quote(text: String): String = Pattern.quote(text)
 
@@ -916,7 +934,10 @@ object Regex {
    *
    *  @param text The string one wishes to use as literal replacement.
    *  @return A string that can be used to replace matches with `text`.
-   *  @example {{{"CURRENCY".r.replaceAllIn(input, Regex quoteReplacement "US\$")}}}
+   *  @example
+   *  ```
+   *  "CURRENCY".r.replaceAllIn(input, Regex quoteReplacement "US\$")
+   *  ```
    */
   def quoteReplacement(text: String): String = Matcher.quoteReplacement(text)
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2945,14 +2945,8 @@ object ScaladocConfigs {
       .add(ExternalMappings(List(javaExternalMapping)))
       .add(DocRootContent((stdlib / "src" / "rootdoc.txt").toString))
       .add(CommentSyntax(List(
-        // Only the files below use markdown syntax (Scala 3 specific sources)
-        s"$stdlib/src/scala/NamedTuple.scala=markdown",
-        s"$stdlib/src/scala/Tuple.scala=markdown",
-        s"$stdlib/src/scala/compiletime=markdown",
-        s"$stdlib/src/scala/quoted=markdown",
-        s"$stdlib/src/scala/util/boundary.scala=markdown",
-        // Scala 2 sources use wiki syntax, we keep it as the default
-        "wiki"
+        // Markdown syntax is used by default for all sources
+        "markdown"
       )))
       .add(VersionsDictionaryUrl("https://scala-lang.org/api/versions.json"))
       .add(DocumentSyntheticTypes(true))

--- a/tests/neg-custom-args/captures/boundary.check
+++ b/tests/neg-custom-args/captures/boundary.check
@@ -17,8 +17,8 @@
    |--------------------------------------------------------------------------------------------------------------------
    |Inline stack trace
    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from boundary.scala:73
-73 |    val local = Label[T]()
+   |This location contains code that was inlined from boundary.scala:72
+72 |    val local = Label[T]()
    |                ^^^^^^^^^^
     --------------------------------------------------------------------------------------------------------------------
    |
@@ -57,8 +57,8 @@
    |--------------------------------------------------------------------------------------------------------------------
    |Inline stack trace
    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from boundary.scala:75
-75 |    catch case ex: Break[T] @unchecked =>
+   |This location contains code that was inlined from boundary.scala:74
+74 |    catch case ex: Break[T] @unchecked =>
    |                   ^
     --------------------------------------------------------------------------------------------------------------------
    |

--- a/tests/neg-macros/annot-crash.check
+++ b/tests/neg-macros/annot-crash.check
@@ -3,5 +3,5 @@
   |^^^^^^
   |Failed to evaluate macro annotation '@crash'.
   |  Caused by class scala.NotImplementedError: an implementation is missing
-  |    scala.Predef$.$qmark$qmark$qmark(Predef.scala:387)
+  |    scala.Predef$.$qmark$qmark$qmark(Predef.scala:383)
   |    crash.transform(Macro_1.scala:7)

--- a/tests/neg/i24460.check
+++ b/tests/neg/i24460.check
@@ -6,13 +6,13 @@
     |-------------------------------------------------------------------------------------------------------------------
     |Inline stack trace
     |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    |This location contains code that was inlined from Predef.scala:154
-154 |  inline def valueOf[T]: T = summonFrom {
+    |This location contains code that was inlined from Predef.scala:151
+151 |  inline def valueOf[T]: T = summonFrom {
     |                             ^
-155 |    case ev: ValueOf[T] => ev.value
-156 |  }
+152 |    case ev: ValueOf[T] => ev.value
+153 |  }
     |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    |This location contains code that was inlined from Predef.scala:154
+    |This location contains code that was inlined from Predef.scala:151
   7 |      case _: (h *: t) => valueOf[`h` & T] +: singletons[T, t]
     |                          ^^^^^^^^^^^^^^^^
      -------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The following style changes are made in this commit:

  1. Use markdown syntax instead of wikidoc syntax for code blocks, headings, bold, italic, and links.
  2. Standardize comment indentation to use two spaces after the asterisk (` *  `).
  3. Consolidate simple single-sentence docstrings onto one line.
  4. Order `@tparam` tags before `@param` tags consistently.

  Only doc comments are changed, and only to make the above formatting changes.

  ### Syntax conversions

  | Element | Wikidoc | Markdown |
  |---------|---------|----------|
  | Code block | `{{{...}}}` | ` ``` ... ``` ` |
  | H2 heading | `==Heading==` | `## Heading` |
  | H3 heading | `===Heading===` | `### Heading` |
  | Bold | `'''text'''` | `**text**` |
  | Italic | `''text''` | `*text*` |
  | Bold italic | `'''''text'''''` | `***text***` |
  | Link | `[[URL text]]` | `[text](URL)` |

 ### Note on API links

External URL links (e.g., `[[https://docs.scala-lang.org/... text]]`) are converted to markdown syntax (`[text](url)`). However, links to code artifacts such as `[[scala.Option]]`, `[[scala.concurrent.Future]]`, or `[[java.util.regex.Pattern]]` are intentionally left in wikidoc syntax. Scaladoc's markdown support does not extend to these internal API reference links—they only resolve correctly when written in the `[[fully.qualified.Name]]` wikidoc format.

### Reasoning

We decided to use "Scaladoc style, with gutter asterisks aligned in column two," described in the Scaladoc Style Guide, because that was the most commonly used style in standard library doc comments:

https://docs.scala-lang.org/style/scaladoc.html

We decided to use markdown because it is the recommended approach for Scala 3. We wanted to make the doc comments consistent in formatting prior to making PRs to fill in missing text.

The tool used to make these changes is here: 

https://github.com/artimahub/scala3/tree/feature-todo-writer/todo-writer

The commands used were:

```
sbt "run ../library --skip-todo --migrate-markdown"
sbt "run ../library-js --skip-todo --migrate-markdown"
sbt "run ../library-aux --skip-todo --migrate-markdown"
```

I wanted to make a single PR that just makes formatting consistent before making one that makes text changes. My plan is that once this is merged, to run the todo-writer tool without `--skip-todo`, then use AI to fill in the missing `@tparam`, `@param`, and `@return` tags. (There are 5278 of those.) To make that PR easier to review, this one focuses just on the formatting changes.

I checked all of the diffs, which took a while, but I was unable to get a fully passing test run. I was also unable to get a fully passing test run in main, so I am submitting this and will watch the CI results.

This PR also makes `"markdown"` the default in `project/Build.scala`. Previously the default was `"wiki"`.
