### PR TITLE
[docs] Reintroduce reference pages for stabilized features

### DIFF
--- a/docs/_docs/reference/experimental/better-fors.md
+++ b/docs/_docs/reference/experimental/better-fors.md
@@ -1,8 +1,11 @@
 ---
 layout: doc-page
 title: "Better fors"
-redirectFrom: /preview/better-fors.html
 nightlyOf: https://docs.scala-lang.org/scala3/reference/experimental/better-fors.html
+redirectFrom: /preview/better-fors.html
 ---
 
-This is now a standard Scala 3 feature. See [https://docs.scala-lang.org/scala3/reference/other-changed-features/better-fors.html] for an up-to-date doc page.
+No longer experimental.
+
+This is now a standard features since Scala 3.8.
+See [Better Fors reference](https://docs.scala-lang.org/scala3/reference/other-changed-features/better-fors.html) for an up-to-date doc page.

--- a/docs/_docs/reference/experimental/fewer-braces.md
+++ b/docs/_docs/reference/experimental/fewer-braces.md
@@ -4,4 +4,7 @@ title: "Fewer Braces"
 nightlyOf: https://docs.scala-lang.org/scala3/reference/experimental/fewer-braces.html
 ---
 
+No longer experimental.
+This is now a standard feature since Scala 3.3.
+
 The documentation contained in this file is now part of the [indentation page](../other-new-features/indentation.html).

--- a/docs/_docs/reference/experimental/generalized-method-syntax.md
+++ b/docs/_docs/reference/experimental/generalized-method-syntax.md
@@ -1,0 +1,9 @@
+---
+layout: doc-page
+title: "Generalized Method Syntax"
+---
+
+No longer experimental.
+
+This is now a standard Scala 3 feature since Scala 3.6.
+See [Generalized Method Syntax reference](https://docs.scala-lang.org/scala3/reference/other-new-features/generalized-method-syntax.html) for an up-to-date doc page.

--- a/docs/_docs/reference/experimental/named-tuples.md
+++ b/docs/_docs/reference/experimental/named-tuples.md
@@ -1,0 +1,10 @@
+---
+layout: doc-page
+title: "Named Tuples"
+redirectFrom: /preview/named-tuples.html
+---
+
+No longer experimental.
+
+This is now a standard Scala 3 feature since Scala 3.7.
+See [Named Tuples references](https://docs.scala-lang.org/scala3/reference/other-new-features/named-tuples.html) for an up-to-date doc page.

--- a/docs/_docs/reference/experimental/runtimeChecked.md
+++ b/docs/_docs/reference/experimental/runtimeChecked.md
@@ -1,8 +1,11 @@
 ---
 layout: doc-page
 title: "The runtimeChecked method"
-redirectFrom: /preview/runtimeChecked.html
 nightlyOf: https://docs.scala-lang.org/scala3/reference/experimental/runtimeChecked.html
+redirectFrom: /preview/runtimeChecked.html
 ---
 
-This is now a standard Scala 3 feature. See [https://docs.scala-lang.org/scala3/reference/other-changed-features/runtimeChecked.html] for an up-to-date doc page.
+No longer experimental.
+
+This is now a standard feature since Scala 3.8.
+See [Runtime Checked reference](https://docs.scala-lang.org/scala3/reference/other-changed-features/runtimeChecked.html) for an up-to-date doc page.

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -153,6 +153,10 @@ subsection:
         hidden: true
       - page: reference/experimental/fewer-braces.md
         hidden: true
+      - page: reference/experimental/generalized-method-syntax.md
+        hidden: true
+      - page: reference/experimental/named-tuples.md
+        hidden: true
       - page: reference/experimental/canthrow.md
       - page: reference/experimental/erased-defs.md
       - page: reference/experimental/erased-defs-spec.md

--- a/project/scripts/expected-links/reference-expected-links.txt
+++ b/project/scripts/expected-links/reference-expected-links.txt
@@ -84,10 +84,12 @@
 ./experimental/erased-defs.html
 ./experimental/explicit-nulls.html
 ./experimental/fewer-braces.html
+./experimental/generalized-method-syntax.html
 ./experimental/index.html
 ./experimental/into.html
 ./experimental/main-annotation.html
 ./experimental/modularity.html
+./experimental/named-tuples.html
 ./experimental/named-typeargs-spec.html
 ./experimental/named-typeargs.html
 ./experimental/numeric-literals.html
@@ -159,6 +161,7 @@
 ./preview/better-fors.html
 ./preview/index.html
 ./preview/into.html
+./preview/named-tuples.html
 ./preview/overview.html
 ./preview/runtimeChecked.html
 ./soft-modifier.html


### PR DESCRIPTION
API docs generated for releases contain links to reference docs. During stabilization of some features we're removed existing pages resulting in API doc links pointing to non existing pages .

Every link listed in expectedLinks MUST be preserved in the future docs