### PR TITLE
Track dependencies on macro annotation `transform` method

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Inlining.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Inlining.scala
@@ -124,6 +124,8 @@ class Inlining extends MacroTransform, IdentityDenotTransformer {
               traverse(t.constr)
               t.parents.foreach(traverse)
               t.body.foreach(traverse)
+            case t if t.symbol.hasMacroAnnotation =>
+              collector.traverse(t)
             case _ =>
               traverseChildren(tree)
         catch

--- a/compiler/src/dotty/tools/dotc/transform/MacroAnnotations.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MacroAnnotations.scala
@@ -34,9 +34,13 @@ object MacroAnnotations:
   end extension
 
   extension (sym: Symbol)
+    /** Get the annotation of this symbol that implements `scala.annation.MacroAnnotation` */
+    def getMacroAnnotation(using Context): Option[Annotation] =
+      sym.getAnnotation(defn.MacroAnnotationClass)
+
     /** Is this symbol annotated with an annotation that implements `scala.annation.MacroAnnotation` */
     def hasMacroAnnotation(using Context): Boolean =
-      sym.getAnnotation(defn.MacroAnnotationClass).isDefined
+      getMacroAnnotation.isDefined
   end extension
 
   /** Expands every macro annotation that is on this tree.

--- a/sbt-test/source-dependencies/macro-annotation-transform/Annotation.scala
+++ b/sbt-test/source-dependencies/macro-annotation-transform/Annotation.scala
@@ -1,0 +1,14 @@
+package example
+
+import java.nio.file.Files
+import scala.quoted.*
+
+final class annot extends annotation.MacroAnnotation {
+  def transform(using q: Quotes)(
+    definition: q.reflect.Definition,
+    companion: Option[q.reflect.Definition],
+  ): List[q.reflect.Definition] = {
+    Files.writeString(outputFile, "transform1")
+    List(definition)
+  }
+}

--- a/sbt-test/source-dependencies/macro-annotation-transform/Test.scala
+++ b/sbt-test/source-dependencies/macro-annotation-transform/Test.scala
@@ -1,0 +1,3 @@
+package example
+
+@annot object Test

--- a/sbt-test/source-dependencies/macro-annotation-transform/build.sbt
+++ b/sbt-test/source-dependencies/macro-annotation-transform/build.sbt
@@ -1,0 +1,13 @@
+name := "macro-annotation-transform"
+scalacOptions += "-experimental"
+Compile / sourceGenerators += Def.task {
+  val file = (Compile / sourceManaged).value / "OutputFile.scala"
+  IO.write(
+    file,
+    s"""
+      |package example
+      |val outputFile = java.nio.file.Paths.get("${baseDirectory.value}").resolve("output").resolve("actual.txt")
+      |""".stripMargin.trim
+  )
+  Seq(file)
+}

--- a/sbt-test/source-dependencies/macro-annotation-transform/changes/Annotation.scala
+++ b/sbt-test/source-dependencies/macro-annotation-transform/changes/Annotation.scala
@@ -1,0 +1,14 @@
+package example
+
+import java.nio.file.Files
+import scala.quoted.*
+
+final class annot extends annotation.MacroAnnotation {
+  def transform(using q: Quotes)(
+    definition: q.reflect.Definition,
+    companion: Option[q.reflect.Definition],
+  ): List[q.reflect.Definition] = {
+    Files.writeString(outputFile, "transform2")
+    List(definition)
+  }
+}

--- a/sbt-test/source-dependencies/macro-annotation-transform/output/expected1.txt
+++ b/sbt-test/source-dependencies/macro-annotation-transform/output/expected1.txt
@@ -1,0 +1,1 @@
+transform1

--- a/sbt-test/source-dependencies/macro-annotation-transform/output/expected2.txt
+++ b/sbt-test/source-dependencies/macro-annotation-transform/output/expected2.txt
@@ -1,0 +1,1 @@
+transform2

--- a/sbt-test/source-dependencies/macro-annotation-transform/project/DottyInjectedPlugin.scala
+++ b/sbt-test/source-dependencies/macro-annotation-transform/project/DottyInjectedPlugin.scala
@@ -1,0 +1,11 @@
+import sbt._
+import Keys._
+
+object DottyInjectedPlugin extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+
+  override val projectSettings = Seq(
+    scalaVersion := sys.props("plugin.scalaVersion")
+  )
+}

--- a/sbt-test/source-dependencies/macro-annotation-transform/test
+++ b/sbt-test/source-dependencies/macro-annotation-transform/test
@@ -1,0 +1,5 @@
+> compile
+$ must-mirror output/actual.txt output/expected1.txt
+$ copy-file changes/Annotation.scala Annotation.scala
+> compile
+$ must-mirror output/actual.txt output/expected2.txt


### PR DESCRIPTION
This is intended to fix #22999 by updating `ExtractDependencies.scala` to track dependencies on a macro annotations' `transform` methods.

It's currently not working as intended though, and I'm not sure why, but I'm hoping someone can help me figure it out.

I've added debug logging locally to print out `rec.foundDeps` before [the call to `rec.sendToZinc()`](https://github.com/scala/scala3/blob/35264cff88f7f01a4b7a4a4458a7f381ca838778/compiler/src/dotty/tools/dotc/transform/Inlining.scala#L54), and I can see that `module class Test$` in my scripted test has these dependencies:

```scala
classes:
  (module class Test$,[DependencyByMemberRef])
  (class Unit,[DependencyByMemberRef])
  (class Object,[DependencyByMemberRef, DependencyByInheritance])
  (module class scala,[DependencyByMemberRef])
  (class Nothing,[DependencyByMemberRef])
  (class annot,[DependencyByMemberRef])
  (class Any,[DependencyByMemberRef])
  (class Class,[DependencyByMemberRef])
  (class ModuleSerializationProxy,[DependencyByMemberRef])

names:
  (Test,[Default])
  (Class,[Default])
  (Unit,[Default])
  (java;lang;Object;init;,[Default])
  (ModuleSerializationProxy,[Default])
  (Nothing,[Default])
  (Test,[Default])
  (transform,[Default])
  (AnyRef,[Default])
  (Object,[Default])
  (Any,[Default])
  (scala;runtime;ModuleSerializationProxy;init;,[Default])
```

Note the dependencies on `(class annot,[DependencyByMemberRef])` in the `classes` section, and on `(transform,[Default])` in the `names` section. These are the macro annotation and its `transform` method, respectively.

Even with this in place, the scripted test fails because `Test.scala` isn't being recompiled after changing `Annotation.scala`.

If anyone has any thoughts or could help point me in the right direction I'd really appreciate it.