### PR TITLE
[docs] Ensure source links of stable release API are pointing to release tag

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2849,7 +2849,7 @@ object ScaladocConfigs {
   private lazy val currentYear: String = java.util.Calendar.getInstance().get(java.util.Calendar.YEAR).toString
 
   def dottyExternalMapping = ".*scala/.*::scaladoc3::https://dotty.epfl.ch/api/"
-  def javaExternalMapping = ".*java/.*::javadoc::https://docs.oracle.com/javase/8/docs/api/"
+  def javaExternalMapping = ".*java/.*::javadoc::https://docs.oracle.com/en/java/javase/17/docs/api/"
   def defaultSourceLinks(version: String, allowGitSHA: Boolean = true) = {
     def dottySrcLink(v: String) = sys.env.get("GITHUB_SHA") match {
       case Some(sha) if allowGitSHA => s"github://scala/scala3/$sha"


### PR DESCRIPTION
Fixes #25071 

Also makes the Java external mapping to point to JDK 17 sources instead of JDK 8 

Most of Scala 3.3.1-3.8.1 API docs were checked for this issue, regenerated if needed and uploaded to docs API server