### PR TITLE
Scaladoc Overload Method Link Fix

### DIFF
--- a/scaladoc-testcases/src/tests/overloadedMethods.scala
+++ b/scaladoc-testcases/src/tests/overloadedMethods.scala
@@ -1,0 +1,490 @@
+package tests.overloadedMethods
+
+import scala.collection.mutable.Buffer
+import scala.collection.mutable.Map
+import scala.collection.mutable.Set
+import scala.collection.mutable.Seq
+import scala.collection.mutable.Iterable
+import scala.collection.Iterator
+import scala.collection.immutable.List
+import java.util.Properties
+
+/**
+ * Test class with overloaded methods for testing link resolution.
+ */
+class OverloadedMethods:
+  /**
+   * Overloaded method with Buffer parameter.
+   */
+  def processBuffer[A](b: Buffer[A]): Unit = ???
+
+  /**
+   * Overloaded method with Map parameter.
+   */
+  def processMap[K, V](m: Map[K, V]): Unit = ???
+
+  /**
+   * Overloaded method with Set parameter.
+   */
+  def processSet[A](s: Set[A]): Unit = ???
+
+  /**
+   * Overloaded method with Seq parameter.
+   */
+  def processSeq[A](s: Seq[A]): Unit = ???
+
+  /**
+   * Overloaded method with Iterator parameter.
+   */
+  def processIterator[A](it: Iterator[A]): Unit = ???
+
+  /**
+   * Overloaded method with Iterable parameter.
+   */
+  def processIterable[A](it: Iterable[A]): Unit = ???
+
+  /**
+   * Overloaded method with List parameter.
+   */
+  def processList[A](l: List[A]): Unit = ???
+
+  /**
+   * Overloaded method with Properties parameter.
+   */
+  def processProperties(p: Properties): Unit = ???
+
+  /**
+   * Method with multiple overloads - simple version.
+   */
+  def transform(x: Int): Int = x * 2
+
+  /**
+   * Method with multiple overloads - Buffer version.
+   */
+  def transform[A](b: Buffer[A]): Buffer[A] = b
+
+  /**
+   * Method with multiple overloads - Map version.
+   */
+  def transform[K, V](m: Map[K, V]): Map[K, V] = m
+
+  /**
+   * Method with multiple overloads - Set version.
+   */
+  def transform[A](s: Set[A]): Set[A] = s
+
+  /**
+   * Method with multiple overloads - Seq version.
+   */
+  def transform[A](s: Seq[A]): Seq[A] = s
+
+  /**
+   * Method with multiple overloads - Iterator version.
+   */
+  def transform[A](it: Iterator[A]): Iterator[A] = it
+
+  /**
+   * Method with multiple overloads - Iterable version.
+   */
+  def transform[A](it: Iterable[A]): Iterable[A] = it
+
+  /**
+   * Method with multiple overloads - List version.
+   */
+  def transform[A](l: List[A]): List[A] = l
+
+  /**
+   * Method with multiple overloads - Properties version.
+   */
+  def transform(p: Properties): Properties = p
+
+/**
+ * Test object with overloaded methods.
+ */
+object OverloadedMethods:
+  /**
+   * Static overloaded method with Buffer parameter.
+   */
+  def asJava[A](b: Buffer[A]): java.util.List[A] = ???
+
+  /**
+   * Static overloaded method with Map parameter.
+   */
+  def asJava[K, V](m: Map[K, V]): java.util.Map[K, V] = ???
+
+  /**
+   * Static overloaded method with Set parameter.
+   */
+  def asJava[A](s: Set[A]): java.util.Set[A] = ???
+
+  /**
+   * Static overloaded method with Seq parameter.
+   */
+  def asJava[A](s: Seq[A]): java.util.List[A] = ???
+
+  /**
+   * Static overloaded method with Iterator parameter.
+   */
+  def asJava[A](it: Iterator[A]): java.util.Iterator[A] = ???
+
+  /**
+   * Static overloaded method with Iterable parameter.
+   */
+  def asJava[A](it: Iterable[A]): java.util.Collection[A] = ???
+
+  /**
+   * Static overloaded method with List parameter.
+   */
+  def asJava[A](l: List[A]): java.util.List[A] = ???
+
+  /**
+   * Static overloaded method with Properties parameter.
+   */
+  def asJava(p: Properties): java.util.Map[AnyRef, AnyRef] = ???
+
+/**
+ * Test class with links to overloaded methods.
+ * These should resolve correctly to the specific overloads.
+ */
+class OverloadedLinks:
+  /**
+   * Link to processBuffer overload.
+   * [[tests.overloadedMethods.OverloadedMethods.processBuffer[A](b:scala.collection.mutable.Buffer[A])*]]
+   */
+  def testBufferLink: Unit = ???
+
+  /**
+   * Link to processMap overload.
+   * [[tests.overloadedMethods.OverloadedMethods.processMap[K,V](m:scala.collection.mutable.Map[K,V])*]]
+   */
+  def testMapLink: Unit = ???
+
+  /**
+   * Link to processSet overload.
+   * [[tests.overloadedMethods.OverloadedMethods.processSet[A](s:scala.collection.mutable.Set[A])*]]
+   */
+  def testSetLink: Unit = ???
+
+  /**
+   * Link to processSeq overload.
+   * [[tests.overloadedMethods.OverloadedMethods.processSeq[A](s:scala.collection.mutable.Seq[A])*]]
+   */
+  def testSeqLink: Unit = ???
+
+  /**
+   * Link to processIterator overload.
+   * [[tests.overloadedMethods.OverloadedMethods.processIterator[A](it:scala.collection.Iterator[A])*]]
+   */
+  def testIteratorLink: Unit = ???
+
+  /**
+   * Link to processIterable overload.
+   * [[tests.overloadedMethods.OverloadedMethods.processIterable[A](it:scala.collection.mutable.Iterable[A])*]]
+   */
+  def testIterableLink: Unit = ???
+
+  /**
+   * Link to processList overload.
+   * [[tests.overloadedMethods.OverloadedMethods.processList[A](l:scala.collection.immutable.List[A])*]]
+   */
+  def testListLink: Unit = ???
+
+  /**
+   * Link to processProperties overload.
+   * [[tests.overloadedMethods.OverloadedMethods.processProperties(p:java.util.Properties)*]]
+   */
+  def testPropertiesLink: Unit = ???
+
+  /**
+   * Link to transform overload with Buffer.
+   * [[tests.overloadedMethods.OverloadedMethods.transform[A](b:scala.collection.mutable.Buffer[A])*]]
+   */
+  def testTransformBufferLink: Unit = ???
+
+  /**
+   * Link to transform overload with Map.
+   * [[tests.overloadedMethods.OverloadedMethods.transform[K,V](m:scala.collection.mutable.Map[K,V])*]]
+   */
+  def testTransformMapLink: Unit = ???
+
+  /**
+   * Link to transform overload with Set.
+   * [[tests.overloadedMethods.OverloadedMethods.transform[A](s:scala.collection.mutable.Set[A])*]]
+   */
+  def testTransformSetLink: Unit = ???
+
+  /**
+   * Link to transform overload with Seq.
+   * [[tests.overloadedMethods.OverloadedMethods.transform[A](s:scala.collection.mutable.Seq[A])*]]
+   */
+  def testTransformSeqLink: Unit = ???
+
+  /**
+   * Link to transform overload with Iterator.
+   * [[tests.overloadedMethods.OverloadedMethods.transform[A](it:scala.collection.Iterator[A])*]]
+   */
+  def testTransformIteratorLink: Unit = ???
+
+  /**
+   * Link to transform overload with Iterable.
+   * [[tests.overloadedMethods.OverloadedMethods.transform[A](it:scala.collection.mutable.Iterable[A])*]]
+   */
+  def testTransformIterableLink: Unit = ???
+
+  /**
+   * Link to transform overload with List.
+   * [[tests.overloadedMethods.OverloadedMethods.transform[A](l:scala.collection.immutable.List[A])*]]
+   */
+  def testTransformListLink: Unit = ???
+
+  /**
+   * Link to transform overload with Properties.
+   * [[tests.overloadedMethods.OverloadedMethods.transform(p:java.util.Properties)*]]
+   */
+  def testTransformPropertiesLink: Unit = ???
+
+  /**
+   * Link to static asJava overload with Buffer.
+   * [[tests.overloadedMethods.OverloadedMethods.asJava[A](b:scala.collection.mutable.Buffer[A])*]]
+   */
+  def testAsJavaBufferLink: Unit = ???
+
+  /**
+   * Link to static asJava overload with Map.
+   * [[tests.overloadedMethods.OverloadedMethods.asJava[K,V](m:scala.collection.mutable.Map[K,V])*]]
+   */
+  def testAsJavaMapLink: Unit = ???
+
+  /**
+   * Link to static asJava overload with Set.
+   * [[tests.overloadedMethods.OverloadedMethods.asJava[A](s:scala.collection.mutable.Set[A])*]]
+   */
+  def testAsJavaSetLink: Unit = ???
+
+  /**
+   * Link to static asJava overload with Seq.
+   * [[tests.overloadedMethods.OverloadedMethods.asJava[A](s:scala.collection.mutable.Seq[A])*]]
+   */
+  def testAsJavaSeqLink: Unit = ???
+
+  /**
+   * Link to static asJava overload with Iterator.
+   * [[tests.overloadedMethods.OverloadedMethods.asJava[A](it:scala.collection.Iterator[A])*]]
+   */
+  def testAsJavaIteratorLink: Unit = ???
+
+  /**
+   * Link to static asJava overload with Iterable.
+   * [[tests.overloadedMethods.OverloadedMethods.asJava[A](it:scala.collection.mutable.Iterable[A])*]]
+   */
+  def testAsJavaIterableLink: Unit = ???
+
+  /**
+   * Link to static asJava overload with List.
+   * [[tests.overloadedMethods.OverloadedMethods.asJava[A](l:scala.collection.immutable.List[A])*]]
+   */
+  def testAsJavaListLink: Unit = ???
+
+  /**
+   * Link to static asJava overload with Properties.
+   * [[tests.overloadedMethods.OverloadedMethods.asJava(p:java.util.Properties)*]]
+   */
+  def testAsJavaPropertiesLink: Unit = ???
+
+  /**
+   * Link to simple transform overload (no collection parameter).
+   * [[tests.overloadedMethods.OverloadedMethods.transform(x:Int)*]]
+   */
+  def testTransformSimpleLink: Unit = ???
+
+// Custom types for testing non-collection type overload resolution
+
+/**
+ * A custom type for testing overload resolution with non-collection types.
+ */
+class CustomTypeA(val value: Int)
+
+/**
+ * Another custom type for testing overload resolution.
+ */
+class CustomTypeB(val name: String)
+
+/**
+ * Test class with overloaded methods using custom (non-collection) types.
+ * This tests that overload resolution works with any types, not just hardcoded collections.
+ */
+class CustomTypeOverloads:
+  /**
+   * Process method overloaded with CustomTypeA.
+   */
+  def process(x: CustomTypeA): Unit = ???
+
+  /**
+   * Process method overloaded with CustomTypeB.
+   */
+  def process(x: CustomTypeB): Unit = ???
+
+  /**
+   * Process method overloaded with Int.
+   */
+  def process(x: Int): Unit = ???
+
+  /**
+   * Process method overloaded with String.
+   */
+  def process(x: String): Unit = ???
+
+/**
+ * Test class with overloaded methods that have multiple parameters.
+ * This tests that overload resolution correctly matches ALL parameter types, not just one.
+ */
+class MultiParamOverloads:
+  /**
+   * Merge method with Buffer and Set parameters.
+   */
+  def merge[A](a: Buffer[A], b: Set[A]): Unit = ???
+
+  /**
+   * Merge method with Set and Buffer parameters (reversed order).
+   */
+  def merge[A](a: Set[A], b: Buffer[A]): Unit = ???
+
+  /**
+   * Merge method with two Maps.
+   */
+  def merge[K, V](a: Map[K, V], b: Map[K, V]): Unit = ???
+
+  /**
+   * Combine method with Int and String.
+   */
+  def combine(a: Int, b: String): Unit = ???
+
+  /**
+   * Combine method with String and Int (reversed order).
+   */
+  def combine(a: String, b: Int): Unit = ???
+
+  /**
+   * Combine method with three parameters.
+   */
+  def combine(a: Int, b: String, c: Boolean): Unit = ???
+
+/**
+ * Test class with links to custom type overloads.
+ */
+class CustomTypeLinks:
+  /**
+   * Link to process with CustomTypeA.
+   * [[tests.overloadedMethods.CustomTypeOverloads.process(x:tests.overloadedMethods.CustomTypeA)*]]
+   */
+  def testCustomTypeALink: Unit = ???
+
+  /**
+   * Link to process with CustomTypeB.
+   * [[tests.overloadedMethods.CustomTypeOverloads.process(x:tests.overloadedMethods.CustomTypeB)*]]
+   */
+  def testCustomTypeBLink: Unit = ???
+
+/**
+ * Test class with links to multi-parameter overloads.
+ */
+class MultiParamLinks:
+  /**
+   * Link to merge with Buffer and Set.
+   * [[tests.overloadedMethods.MultiParamOverloads.merge[A](a:scala.collection.mutable.Buffer[A],b:scala.collection.mutable.Set[A])*]]
+   */
+  def testMergeBufferSetLink: Unit = ???
+
+  /**
+   * Link to merge with Set and Buffer (reversed).
+   * [[tests.overloadedMethods.MultiParamOverloads.merge[A](a:scala.collection.mutable.Set[A],b:scala.collection.mutable.Buffer[A])*]]
+   */
+  def testMergeSetBufferLink: Unit = ???
+
+  /**
+   * Link to combine with Int and String.
+   * [[tests.overloadedMethods.MultiParamOverloads.combine(a:Int,b:String)*]]
+   */
+  def testCombineIntStringLink: Unit = ???
+
+  /**
+   * Link to combine with String and Int (reversed).
+   * [[tests.overloadedMethods.MultiParamOverloads.combine(a:String,b:Int)*]]
+   */
+  def testCombineStringIntLink: Unit = ???
+
+/**
+ * Test class with overloaded methods where one takes no parameters.
+ * This tests that empty parameter lists are correctly distinguished from
+ * missing signatures.
+ */
+class NoArgOverloads:
+  /**
+   * No-argument version of the method.
+   */
+  def action(): String = "no-arg"
+
+  /**
+   * Single Int argument version.
+   */
+  def action(x: Int): String = "int-arg"
+
+  /**
+   * Single String argument version.
+   */
+  def action(s: String): String = "string-arg"
+
+  /**
+   * Two argument version.
+   */
+  def action(x: Int, y: String): String = "two-args"
+
+  /**
+   * No-argument getter.
+   */
+  def getValue(): Int = 42
+
+  /**
+   * Getter with index.
+   */
+  def getValue(index: Int): Int = index
+
+/**
+ * Test class with links to no-arg overloads.
+ */
+class NoArgLinks:
+  /**
+   * Link to no-arg action.
+   * [[tests.overloadedMethods.NoArgOverloads.action()*]]
+   */
+  def testNoArgAction: Unit = ???
+
+  /**
+   * Link to Int arg action.
+   * [[tests.overloadedMethods.NoArgOverloads.action(x:Int)*]]
+   */
+  def testIntArgAction: Unit = ???
+
+  /**
+   * Link to String arg action.
+   * [[tests.overloadedMethods.NoArgOverloads.action(s:String)*]]
+   */
+  def testStringArgAction: Unit = ???
+
+  /**
+   * Link to two-arg action.
+   * [[tests.overloadedMethods.NoArgOverloads.action(x:Int,y:String)*]]
+   */
+  def testTwoArgAction: Unit = ???
+
+  /**
+   * Link to no-arg getValue.
+   * [[tests.overloadedMethods.NoArgOverloads.getValue()*]]
+   */
+  def testNoArgGetValue: Unit = ???
+
+  /**
+   * Link to getValue with index.
+   * [[tests.overloadedMethods.NoArgOverloads.getValue(index:Int)*]]
+   */
+  def testIntArgGetValue: Unit = ???

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/MemberLookup.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/MemberLookup.scala
@@ -180,11 +180,31 @@ trait MemberLookup {
         val sel = MemberLookup.Selector.fromString(q)
         val res = sel.kind match {
           case MemberLookup.SelectorKind.NoForce =>
-            val lookedUp = localLookup(sel, owner).toSeq
+            // Extract just the method name from the signature (removing type params and param list)
+            val methodName = extractMethodName(sel.ident)
+            val nameSel = MemberLookup.Selector(methodName, sel.kind)
+            val lookedUp = localLookup(nameSel, owner).toSeq
             // note: those flag lookups are necessary b/c for objects we return their classes
-            lookedUp.find(s => s.isType && !s.flags.is(Flags.Module)).orElse(
-              lookedUp.find(s => s.isTerm || s.flags.is(Flags.Module))
-            )
+            val typeMatch = lookedUp.find(s => s.isType && !s.flags.is(Flags.Module))
+            if typeMatch.isDefined then typeMatch
+            else {
+              val termMatches =
+                lookedUp.filter(s => s.isTerm || s.flags.is(Flags.Module))
+              if termMatches.size <= 1 then termMatches.headOption
+              else {
+                // Multiple overloads found, try to match based on signature in query
+                parseSignatureParams(sel.ident) match {
+                  case Some(queryParamTypes) =>
+                    // Signature was provided, try to find matching overload
+                    termMatches.find { sym =>
+                      matchesParameterTypes(sym, queryParamTypes)
+                    }.orElse(termMatches.headOption)
+                  case None =>
+                    // No signature provided, fall back to first match
+                    termMatches.headOption
+                }
+              }
+            }
           case _ =>
             localLookup(sel, owner).nextOption
         }
@@ -219,6 +239,110 @@ trait MemberLookup {
           .orElse(tp.flatMap(downwardLookup(qs, _)))
           .orElse(tm.flatMap(downwardLookup(qs, _)))
         }
+    }
+  }
+
+  /** Parse parameter types from a method signature.
+   *  Input: "[A](b:scala.collection.mutable.Buffer[A],c:Int)"
+   *  Output: Some(List("scala.collection.mutable.Buffer", "Int"))
+   *
+   *  Returns:
+   *  - None if no parameter list is present (e.g., "method" or "method[A]")
+   *  - Some(Nil) if parameter list is empty (e.g., "method()")
+   *  - Some(List(...)) if parameters are present
+   */
+  private def parseSignatureParams(signature: String): Option[List[String]] = {
+    // Normalize the signature by removing backslashes (they're used in scaladoc to escape dots)
+    val normalizedSignature = signature.replace("\\.", ".")
+
+    // Find the parameter list (after any type params)
+    val parenStart = normalizedSignature.indexOf('(')
+    if parenStart == -1 then return None
+
+    val parenEnd = normalizedSignature.lastIndexOf(')')
+    if parenEnd == -1 || parenEnd <= parenStart then return None
+
+    val paramList = normalizedSignature.substring(parenStart + 1, parenEnd)
+    if paramList.isEmpty then return Some(Nil)
+
+    // Split by comma, respecting nested brackets
+    val params = scala.collection.mutable.ListBuffer[String]()
+    var depth = 0
+    var start = 0
+    for i <- 0 until paramList.length do
+      val c = paramList.charAt(i)
+      if c == '[' then depth += 1
+      else if c == ']' then depth -= 1
+      else if c == ',' && depth == 0 then
+        params += paramList.substring(start, i).trim
+        start = i + 1
+    params += paramList.substring(start).trim
+
+    // Extract type from each "name:Type" pair, stripping type arguments
+    Some(params.toList.flatMap { param =>
+      val colonIdx = param.indexOf(':')
+      if colonIdx == -1 then None
+      else
+        val typePart = param.substring(colonIdx + 1).trim
+        // Remove type arguments to get the base type
+        val bracketIdx = typePart.indexOf('[')
+        val baseType = if bracketIdx == -1 then typePart else typePart.substring(0, bracketIdx)
+        Some(baseType)
+    })
+  }
+
+  /** Extract simple type name from a possibly qualified type.
+   *  "scala.collection.mutable.Buffer[A]" -> "Buffer"
+   *  "Int" -> "Int"
+   */
+  private def extractSimpleTypeName(qualifiedType: String): String = {
+    // Remove type arguments first
+    val withoutTypeArgs = qualifiedType.indexOf('[') match {
+      case -1 => qualifiedType
+      case i => qualifiedType.substring(0, i)
+    }
+    // Get last segment after '.'
+    withoutTypeArgs.split('.').last
+  }
+
+  /** Extract just the method name from a signature, removing type parameters and parameter lists.
+   *  For example, from "asJava[A](b:scala.collection.mutable.Buffer[A])*" extracts "asJava".
+   */
+  private def extractMethodName(signature: String): String = {
+    // Find the first occurrence of [ or (, and return everything before it
+    val bracketIndex = signature.indexOf('[')
+    val parenIndex = signature.indexOf('(')
+    if bracketIndex == -1 && parenIndex == -1 then signature
+    else {
+      val firstSpecial = if bracketIndex == -1 then parenIndex else if parenIndex == -1 then bracketIndex else math.min(bracketIndex, parenIndex)
+      signature.substring(0, firstSpecial)
+    }
+  }
+
+  /** Check if a method's parameter types match the expected parameter types from the query.
+   *  This compares the simple type names of all parameters in order, which could, theoretically,
+   * have edge cases with same-named types in different packages
+   */
+  private def matchesParameterTypes(using Quotes)(sym: reflect.Symbol, queryParamTypes: List[String]): Boolean = {
+    import reflect._
+
+    def getMethodParamTypes(tpe: TypeRepr): Option[List[String]] = tpe match {
+      case MethodType(_, paramTypes, _) =>
+        Some(paramTypes.map(pt => extractSimpleTypeName(pt.show)))
+      case PolyType(_, _, resType) =>
+        getMethodParamTypes(resType)
+      case _ => None
+    }
+
+    try {
+      getMethodParamTypes(sym.info) match {
+        case Some(actualTypes) =>
+          val querySimpleTypes = queryParamTypes.map(extractSimpleTypeName)
+          actualTypes == querySimpleTypes
+        case None => false
+      }
+    } catch {
+      case _: Exception => false
     }
   }
 }

--- a/scaladoc/test/dotty/tools/scaladoc/tasty/comments/QueryParserTests.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/tasty/comments/QueryParserTests.scala
@@ -48,6 +48,61 @@ class QueryParserTests {
     testSuccess("#foo\\(ignoredOverloadDefinition*", StrictMemberId("foo(ignoredOverloadDefinition*"))
     testSuccess("#bar\\[ignoredOverloadDefinition*", StrictMemberId("bar[ignoredOverloadDefinition*"))
 
+    // Test overloaded method signature parsing
+    testSuccess("processBuffer[A](b:scala.collection.mutable.Buffer[A])*", Id("processBuffer[A](b:scala.collection.mutable.Buffer[A])*"))
+    testSuccess("processMap[K,V](m:scala.collection.mutable.Map[K,V])*", Id("processMap[K,V](m:scala.collection.mutable.Map[K,V])*"))
+    testSuccess("processSet[A](s:scala.collection.mutable.Set[A])*", Id("processSet[A](s:scala.collection.mutable.Set[A])*"))
+    testSuccess("processSeq[A](s:scala.collection.mutable.Seq[A])*", Id("processSeq[A](s:scala.collection.mutable.Seq[A])*"))
+    testSuccess("processIterator[A](it:scala.collection.Iterator[A])*", Id("processIterator[A](it:scala.collection.Iterator[A])*"))
+    testSuccess("processIterable[A](it:scala.collection.mutable.Iterable[A])*", Id("processIterable[A](it:scala.collection.mutable.Iterable[A])*"))
+    testSuccess("processList[A](l:scala.collection.immutable.List[A])*", Id("processList[A](l:scala.collection.immutable.List[A])*"))
+    testSuccess("processProperties(p:java.util.Properties)*", Id("processProperties(p:java.util.Properties)*"))
+
+    // Test qualified identifiers with overloaded method signatures
+    testSuccess("tests.overloadedMethods.OverloadedMethods.processBuffer[A](b:scala.collection.mutable.Buffer[A])*",
+      l2q("tests".dot, "overloadedMethods".dot, "OverloadedMethods".dot)("processBuffer[A](b:scala.collection.mutable.Buffer[A])*"))
+    testSuccess("tests.overloadedMethods.OverloadedMethods.processMap[K,V](m:scala.collection.mutable.Map[K,V])*",
+      l2q("tests".dot, "overloadedMethods".dot, "OverloadedMethods".dot)("processMap[K,V](m:scala.collection.mutable.Map[K,V])*"))
+    testSuccess("tests.overloadedMethods.OverloadedMethods.processSet[A](s:scala.collection.mutable.Set[A])*",
+      l2q("tests".dot, "overloadedMethods".dot, "OverloadedMethods".dot)("processSet[A](s:scala.collection.mutable.Set[A])*"))
+
+    // Test method with multiple parameter types in signature
+    testSuccess("transform[K,V](m:scala.collection.mutable.Map[K,V])*", Id("transform[K,V](m:scala.collection.mutable.Map[K,V])*"))
+    testSuccess("transform[A](b:scala.collection.mutable.Buffer[A])*", Id("transform[A](b:scala.collection.mutable.Buffer[A])*"))
+    testSuccess("transform(x:Int)*", Id("transform(x:Int)*"))
+
+    // Test edge cases for overload signatures
+    // Nested generics
+    testSuccess("foo[A](x:Map[String,List[A]])*", Id("foo[A](x:Map[String,List[A]])*"))
+    testSuccess("f[A,B](x:Either[Option[A],List[B]])*", Id("f[A,B](x:Either[Option[A],List[B]])*"))
+
+    // Multiple parameters
+    testSuccess("bar(a:Int,b:String)*", Id("bar(a:Int,b:String)*"))
+    testSuccess("baz(a:Int,b:String,c:Boolean)*", Id("baz(a:Int,b:String,c:Boolean)*"))
+    testSuccess("merge(a:Buffer[_],b:Set[_])*", Id("merge(a:Buffer[_],b:Set[_])*"))
+
+    // Empty parameters (no-arg methods)
+    testSuccess("noArgs()*", Id("noArgs()*"))
+    testSuccess("action()*", Id("action()*"))
+    testSuccess("pkg.Class.action()*", l2q("pkg".dot, "Class".dot)("action()*"))
+
+    // No type parameters
+    testSuccess("simpleMethod(x:Int)*", Id("simpleMethod(x:Int)*"))
+    testSuccess("twoParams(a:String,b:Boolean)*", Id("twoParams(a:String,b:Boolean)*"))
+
+    // Deeply nested types
+    testSuccess("complex[A](x:Map[String,Map[Int,List[A]]])*", Id("complex[A](x:Map[String,Map[Int,List[A]]])*"))
+
+    // Custom/user-defined types
+    testSuccess("process(x:tests.CustomType)*", Id("process(x:tests.CustomType)*"))
+    testSuccess("handle(x:com.example.MyClass)*", Id("handle(x:com.example.MyClass)*"))
+
+    // Qualified identifiers with complex signatures
+    testSuccess("pkg.Class.method[A](x:Map[String,List[A]])*",
+      l2q("pkg".dot, "Class".dot)("method[A](x:Map[String,List[A]])*"))
+    testSuccess("a.b.c.method(a:Int,b:String)*",
+      l2q("a".dot, "b".dot, "c".dot)("method(a:Int,b:String)*"))
+
     testFailAt("#", 1)
     testFailAt("#`", 2)
     testFailAt("``", 2)


### PR DESCRIPTION
Fixed incorrect reference to overload methods, example can be seen at https://www.scala-lang.org/api/3.7.4/scala/collection/convert/AsJavaExtensions$BufferHasAsJava.html , where the asJava method it is linked to asJava method that takes Map, which is wrong, it should link to asJava that takes Buffer.