### PR TITLE
Fix named arguments evaluation order with by-name parameters

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1216,8 +1216,8 @@ trait Applications extends Compatibility {
             // with all non-explicit default parameters at the end in declaration order.
             val orderedArgDefs = {
               // Indices of original typed arguments that are lifted by liftArgs
-              val impureArgIndices = typedArgBuf.zipWithIndex.collect {
-                case (arg, idx) if !lifter.noLift(arg) => idx
+              val impureArgIndices = typedArgBuf.lazyZip(methodType.paramInfos).zipWithIndex.collect {
+                case ((arg, tp), idx) if lifter.wouldLift(arg, tp) => idx
               }
               def position(arg: Trees.Tree[T]) = {
                 val i = args.indexOf(arg)

--- a/tests/run/evaluation-order.check
+++ b/tests/run/evaluation-order.check
@@ -1,0 +1,2 @@
+b evaluated
+c evaluated

--- a/tests/run/evaluation-order.scala
+++ b/tests/run/evaluation-order.scala
@@ -1,0 +1,11 @@
+abstract class Foo(a: => Int, b: Int, c: Int)
+
+object Bar extends Foo(
+  b = { println("b evaluated"); 2 },
+  c = { println("c evaluated"); 3 },
+  a = { println("a evaluated"); 1 }
+)
+
+object Test:
+  def main(args: Array[String]): Unit =
+    Bar  // trigger initialization


### PR DESCRIPTION
Fix #25160 
(https://github.com/scala/scala3/issues/24201 is kinda variant of this issue, it's default argument is involved. In that case, we use `LiftComplex` instead of `LiftImpure`, and lifting `ExprType` is the problem...)

---

Previously, when named arguments were reordered and by-name parameters were there, arguments were evaluated in wired order.

```scala
abstract class Foo(a: => Int, b: Int, c: Int)

object Bar extends Foo(
  b = { println("b evaluated"); 2 },  // call-site position 0
  c = { println("c evaluated"); 3 },  // call-site position 1
  a = { println("a evaluated"); 1 }   // call-site position 2 (by-name, shouldn't be evaluated)
)

object Main {
  def main(args: Array[String]): Unit = {
    Bar
  }
}
```

It should be evaluated in `b evaluated` -> `c evaluated` (call-site order), but actually, `c evaluated` and then `b evaluated`.

---

The problem was in `impureArgIndices` which use `lifter.noLift(arg)` for all arguments, while `liftArgs` uses different lifters based on parameter type: `liftArgs` uses `exprLifter` for by-name parameters.

```scala
val impureArgIndices = typedArgBuf.zipWithIndex.collect {
  case (arg, idx) if !lifter.noLift(arg) => idx
}
```

- For the above case, it's `[0, 1, 2]` but it should be `[1, 2]` because `a` won't be lifted (because `exprLifter = NoLift` for `LiftImpure`).
- Later, it's zipped with `argDefBuf` which should be a list of actually lifted definitions `[def_b, def_c]`.
- `argDefBuf.zip(impureArgIndices)` will be `[(def_b, 0), (def_c, 1)]`
- sort by `originalIndices` (call-site positions) `[2, 0, 1]` (because it's `b, c, a` at call-site) -> `[def_c, def_b]`

```scala
// ...
scala.util.Sorting.stableSort[(Tree, Int), Int](
  argDefBuf.zip(impureArgIndices), (arg, idx) => originalIndex(idx)).map(_._1)
```

---

This commit fixes by `Application` to use the same logic as `Lifter`s to check the argument would be lifted or not.

- The above example now have `[1, 2]` for `impureArgIndices`
- `argDefBuf.zip(impureArgIndices)` will be `[(def_b, 1), (def_c, 2)]`
- sort by `originalIndices` (call-site positions) `[2, 0, 1]` -> `[def_b, def_c]`.


