### PR TITLE
Don't generate bridge methods for inaccessible Java package-private methods

### DIFF
--- a/tests/run/java-package-private-bridge/JavaBase.java
+++ b/tests/run/java-package-private-bridge/JavaBase.java
@@ -1,0 +1,7 @@
+package jpkg;
+
+public class JavaBase {
+    Object packagePrivate() {
+        return "base";
+    }
+}

--- a/tests/run/java-package-private-bridge/JavaChild.java
+++ b/tests/run/java-package-private-bridge/JavaChild.java
@@ -1,0 +1,8 @@
+package jpkg;
+
+public class JavaChild extends JavaBase {
+    @Override
+    String packagePrivate() {
+        return "child";
+    }
+}

--- a/tests/run/java-package-private-bridge/MyJTable.scala
+++ b/tests/run/java-package-private-bridge/MyJTable.scala
@@ -1,0 +1,3 @@
+package other
+
+class MyJTable extends javax.swing.JTable

--- a/tests/run/java-package-private-bridge/ScalaChild.scala
+++ b/tests/run/java-package-private-bridge/ScalaChild.scala
@@ -1,0 +1,3 @@
+package other
+
+class ScalaChild extends jpkg.JavaChild

--- a/tests/run/java-package-private-bridge/Test.scala
+++ b/tests/run/java-package-private-bridge/Test.scala
@@ -1,0 +1,20 @@
+// scalajs: --skip
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val hasBridge1 = classOf[other.ScalaChild].getDeclaredMethods.exists { m =>
+      m.getName == "packagePrivate" &&
+      m.getReturnType == classOf[Object]
+    }
+    assert(!hasBridge1,
+      s"ScalaChild should not have bridge for packagePrivate")
+
+    // JTable case
+    val hasBridge2 = classOf[other.MyJTable].getDeclaredMethods.exists { m =>
+      m.getName == "dropLocationForPoint" &&
+      m.getReturnType == classOf[javax.swing.TransferHandler.DropLocation]
+    }
+    assert(!hasBridge2,
+      s"MyJTable should not have bridge for dropLocationForPoint")
+  }
+}


### PR DESCRIPTION

Fixes #25098

When a Java class has a package-private method inheritance that has different signature after erasure,
and a Scala class in a different package extends it, we should not generate a bridge method because the target method is inaccessible.

For example:
```java
// jpkg/JavaBase.java
package jpkg;
public class JavaBase {
    Object getValue() { return "base"; }
}

// jpkg/JavaChild.java
package jpkg;
public class JavaChild extends JavaBase {
    @Override
    String getValue() { return "child"; }
}
```

```scala
// other/ScalaChild.scala
package other
class ScalaChild extends jpkg.JavaChild
```

Previously, Scala would generate an unusable bridge method in ScalaChild:
```java
public Object getValue() { return this.getValue(); }
```

This bridge would fail at runtime with `IllegalAccessError` because it tries to call the package-private method from outside the package.

The fix adds an accessibility check in `Bridges.scala` to skip bridge generation when the target method is not accessible from the class being compiled.