### PR TITLE
Extension check handles hiBound of opaque type

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -1131,8 +1131,11 @@ object RefChecks {
    *  An extension method is hidden if it does not offer a parameter that is not subsumed
    *  by the corresponding parameter of the member with the same name (or of all alternatives of an overload).
    *
-   *  This check is suppressed if the method is an override. (Because the type of the receiver
-   *  may be narrower in the override.)
+   *  This check is suppressed if the method is an override of a deferred member
+   *  (because the type of the receiver in the override may be a concrete type arg).
+   *
+   *  If the receiver is an opaque alias, use its upper bound if it is not also opaque.
+   *  (Member lookup would dealias, and the check must approximate an arbitrary use site.)
    *
    *  If the extension method is parameterless, it is always hidden by a member of the same name.
    *  (Either the member is parameterless, or the reference is taken as the eta-expansion of the member.)
@@ -1176,13 +1179,23 @@ object RefChecks {
             && (x frozen_<:< m)
         memberIsImplicit && !methTp.hasImplicitParams || paramsCorrespond
       def targetOfHiddenExtension: Symbol =
+        val receiver =
+          explicitInfo.firstParamTypes.head // required for extension method, the putative receiver
+            .dealiasKeepOpaques
+            .typeSymbol
         val target =
-          val target0 = explicitInfo.firstParamTypes.head // required for extension method, the putative receiver
-          target0.dealiasKeepOpaques.typeSymbol.info
-        val member = target.nonPrivateMember(sym.name)
-          .filterWithPredicate: member =>
-            member.symbol.isPublic && memberHidesMethod(member)
-        if member.exists then target.typeSymbol else NoSymbol
+          if receiver.isOpaqueAlias then
+            val hi = receiver.info.hiBound.dealiasKeepOpaques
+            if hi.typeSymbol.isOpaqueAlias then NoType
+            else hi.typeSymbol.info // use upper bound if not also opaque
+          else
+            receiver.info
+        if target.exists then
+          val member = target.nonPrivateMember(sym.name)
+            .filterWithPredicate: member =>
+              member.symbol.isPublic && memberHidesMethod(member)
+          if member.exists then receiver else NoSymbol // report the receiver not the target type where member was found
+        else NoSymbol
       if sym.is(HasDefaultParams) then
         val getterDenot =
           val receiverName = explicitInfo.firstParamNames.head

--- a/tests/warn/i22232.check
+++ b/tests/warn/i22232.check
@@ -8,21 +8,21 @@
 -- [E194] Potential Issue Warning: tests/warn/i22232.scala:9:25 --------------------------------------------------------
 9 |    extension (d: D) def equals(that: Any): Boolean = false // warn
   |                         ^
-  |                         Extension method equals will never be selected from type C
-  |                         because C already has a member with the same name and compatible parameter types.
+  |                         Extension method equals will never be selected from type D
+  |                         because D already has a member with the same name and compatible parameter types.
   |
   | longer explanation available when compiling with `-explain`
 -- [E194] Potential Issue Warning: tests/warn/i22232.scala:13:38 -------------------------------------------------------
 13 |  extension (arr: MyString[Byte]) def length: Int = 0 // warn
    |                                      ^
-   |                          Extension method length will never be selected from type String
-   |                          because String already has a member with the same name and compatible parameter types.
+   |                        Extension method length will never be selected from type MyString
+   |                        because MyString already has a member with the same name and compatible parameter types.
    |
    | longer explanation available when compiling with `-explain`
 -- [E194] Potential Issue Warning: tests/warn/i22232.scala:17:46 -------------------------------------------------------
 17 |  extension [T <: MyString[Byte]](arr: T) def length: Int = 0 // warn
    |                                              ^
-   |                          Extension method length will never be selected from type String
-   |                          because String already has a member with the same name and compatible parameter types.
+   |                        Extension method length will never be selected from type MyString
+   |                        because MyString already has a member with the same name and compatible parameter types.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/warn/i25158.scala
+++ b/tests/warn/i25158.scala
@@ -1,0 +1,57 @@
+object Math {
+  class G {
+    def print(): Unit = ???
+  }
+  class GS extends G
+
+  opaque type Geo  = G
+  opaque type GeoS <: Geo = GS
+
+  object Geo:
+    def apply(): Geo = new G
+    extension (g: Geo) def print(): Unit = println("Geo clone called")
+    extension (g: Geo) def toString(): String = "I am Geo" // warn
+
+  object GeoS:
+    def apply(): GeoS = new GS
+    extension (g: GeoS) def print(): Unit = println("GeoS clone called") // no warn
+}
+
+import Math.*
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    val g = Geo()
+    val s = GeoS()
+    g.print()
+    s.print()
+    println(g.toString())
+  }
+}
+
+object Calculus_B:
+  trait Printable:
+    def print(): Unit = ()
+
+  private class PrintableGeoS extends Printable
+
+  opaque type GeoS <: Printable = PrintableGeoS
+
+  object GeoS:
+    def apply(): GeoS = PrintableGeoS()
+    extension (g: GeoS) def print(): Unit = ??? // warn
+    extension (g: GeoS) /*override*/ def toString(): String = ??? // warn (override is also error)
+
+object Calculus_C:
+  trait Printable:
+    def print(): Unit = ()
+
+  private class PrintableGeoS extends Printable
+
+  type P = Printable
+  opaque type GeoS <: P = PrintableGeoS
+
+  object GeoS:
+    def apply(): GeoS = PrintableGeoS()
+    extension (g: GeoS) def print(): Unit = ??? // warn
+    extension (g: GeoS) /*override*/ def toString(): String = ??? // warn (override is also error)


### PR DESCRIPTION
Fixes #25158 

Do check for member in upper bound of an opaque type alias if the bound is not also opaque. (Member lookup would dealias to find it.)

Also report the receiver in the message, not where the member was found.