### PR TITLE
Skip tests with no sources such as .scala-build dir

### DIFF
--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -230,7 +230,8 @@ trait ParallelTesting extends RunnerOrchestration:
       Array(dir.getPath)
   }
 
-  protected def shouldSkipTestSource(testSource: TestSource): Boolean = false
+  protected def shouldSkipTestSource(testSource: TestSource): Boolean =
+    testSource.sourceFiles.length == 0
 
   protected def shouldReRun(testSource: TestSource): Boolean =
     failedTests.forall(rerun => testSource match {

--- a/sjs-compiler-tests/test/scala/dotty/tools/dotc/ScalaJSCompilationTests.scala
+++ b/sjs-compiler-tests/test/scala/dotty/tools/dotc/ScalaJSCompilationTests.scala
@@ -54,6 +54,7 @@ object ScalaJSCompilationTests extends ParallelTesting {
 
   override protected def shouldSkipTestSource(testSource: TestSource): Boolean =
     testSource.allToolArgs.get(ToolName.ScalaJS).exists(_.contains("--skip"))
+    || super.shouldSkipTestSource(testSource)
 
   override protected def testPlatform: TestPlatform = TestPlatform.ScalaJS
 


### PR DESCRIPTION
It would be nicer to skip anything in `.gitignore`.