### PR TITLE
Replace bubble sort with quicksort in emitSWITCH

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeIdiomatic.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeIdiomatic.scala
@@ -419,26 +419,45 @@ trait BCodeIdiomatic {
         return
       }
 
-      // sort `keys` by increasing key, keeping `branches` in sync. TODO FIXME use quicksort
-      var i = 1
-      while (i < keys.length) {
-        var j = 1
-        while (j <= keys.length - i) {
-          if (keys(j) < keys(j - 1)) {
-            val tmp     = keys(j)
-            keys(j)     = keys(j - 1)
-            keys(j - 1) = tmp
-            val tmpL        = branches(j)
-            branches(j)     = branches(j - 1)
-            branches(j - 1) = tmpL
+      // sort `keys` by increasing key, keeping `branches` in sync using quicksort
+      def swap(i: Int, j: Int): Unit = {
+        val tmpKey = keys(i)
+        keys(i) = keys(j)
+        keys(j) = tmpKey
+        val tmpBranch = branches(i)
+        branches(i) = branches(j)
+        branches(j) = tmpBranch
+      }
+
+      def partition(lo: Int, hi: Int): Int = {
+        val pivot = keys(hi)
+        var i = lo
+        var j = lo
+        while (j < hi) {
+          if (keys(j) < pivot) {
+            swap(i, j)
+            i += 1
           }
           j += 1
         }
-        i += 1
+        swap(i, hi)
+        i
+      }
+
+      def quicksort(lo: Int, hi: Int): Unit = {
+        if (lo < hi) {
+          val p = partition(lo, hi)
+          quicksort(lo, p - 1)
+          quicksort(p + 1, hi)
+        }
+      }
+
+      if (keys.length > 1) {
+        quicksort(0, keys.length - 1)
       }
 
       // check for duplicate keys to avoid "VerifyError: unsorted lookupswitch" (SI-6011)
-      i = 1
+      var i = 1
       while (i < keys.length) {
         if (keys(i-1) == keys(i)) {
           abort("duplicate keys in SWITCH, can't pick arbitrarily one of them to evict, see SI-6011.")


### PR DESCRIPTION
This PR addresses an old TODO/FIXME in  BCodeIdiomatic.scala that requested replacing the bubble sort with quicksort for sorting switch keys.


**Changes**

- Replace O(n²) bubble sort with O(n log n) in-place quicksort

- Add helper methods: swap(), partition(), and quicksort()

- Maintain synchronization between keys and branches arrays during sorting

**Motivation**

The emitSWITCH method sorts switch case keys before emitting either a tableswitch or lookupswitch JVM instruction. The previous implementation used bubble sort which has O(n²) worst-case complexity. While switch statements rarely have enough cases to make this a bottleneck, using quicksort provides O(n log n) average-case complexity and addresses the long-standing FIXME.
