### PR TITLE
[SUPERSEDED] Warn about missing expr after defns

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -185,9 +185,11 @@ object ErrorReporting {
         // use normalized types if that also shows an error, and both sides stripped
         // the same number of context functions. Use original types otherwise.
 
-      def missingElse = tree match
+      def missingPart = tree match
         case If(_, _, elsep @ Literal(Constant(()))) if elsep.span.isSynthetic =>
           Note("\nMaybe you are missing an else part for the conditional?") :: Nil
+        case Literal(Constant(())) if tree.span.isSynthetic && tree.hasAttachment(desugar.UnitResultAfterDef) =>
+          Note("\nMaybe you are missing an expression after a block with definitions?") :: Nil
         case _ =>
           Nil
 
@@ -201,7 +203,7 @@ object ErrorReporting {
           Note(i"\n\nThe error occurred for a synthesized $synthText") :: Nil
         else Nil
 
-      errorTree(tree, TypeMismatch(treeTp, expectedTp, Some(tree), notes ++ missingElse ++ badTreeNote))
+      errorTree(tree, TypeMismatch(treeTp, expectedTp, Some(tree), notes ++ missingPart ++ badTreeNote))
     }
 
     /** A subtype log explaining why `found` does not conform to `expected` */

--- a/tests/neg/leading-infix-miss.check
+++ b/tests/neg/leading-infix-miss.check
@@ -11,5 +11,6 @@
   |        ^
   |        Found:    Unit
   |        Required: Boolean
+  |        Maybe you are missing an expression after a block with definitions?
   |
   | longer explanation available when compiling with `-explain`

--- a/tests/neg/missing-loop.check
+++ b/tests/neg/missing-loop.check
@@ -1,0 +1,8 @@
+-- [E007] Type Mismatch Error: tests/neg/missing-loop.scala:8:63 -------------------------------------------------------
+8 |    if i == 0 then xs else loop(i - 1, (dice.next() % n) :: xs) // error
+  |                                                               ^
+  |                                               Found:    Unit
+  |                                               Required: List[Int]
+  |                                               Maybe you are missing an expression after a block with definitions?
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/missing-loop.scala
+++ b/tests/neg/missing-loop.scala
@@ -1,0 +1,13 @@
+import annotation.*
+val n = 1024
+val dice = Iterator.continually(42)
+
+// block ending in def has a type mismatch
+def make(): List[Int] =
+  @tailrec def loop(i: Int, xs: List[Int]): List[Int] =
+    if i == 0 then xs else loop(i - 1, (dice.next() % n) :: xs) // error
+
+def f(): Unit =
+  return println(loop(0, Nil))
+  @tailrec def loop(i: Int, xs: List[Int]): List[Int] =
+    if i == 0 then xs else loop(i - 1, (dice.next() % n) :: xs)


### PR DESCRIPTION
A mitigation of https://contributors.scala-lang.org/t/confusing-diagnostics-with-braceless-syntax/7372