### PR TITLE
Add custom version format for benchmarking

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -109,7 +109,7 @@ object Build {
         formatter.format(java.time.ZonedDateTime.now(java.time.ZoneId.of("UTC")))
       s"${baseVersion}-bin-${currentDate}-${VersionUtil.gitHash}-NIGHTLY"
     } else if (isBenchmark) {
-      s"${baseVersion}-bin-${VersionUtil.gitHash}-BENCH"
+      s"${baseVersion}-bin-${VersionUtil.gitHashFull}-BENCH"
     }
     else s"${baseVersion}-bin-SNAPSHOT"
   }

--- a/project/VersionUtil.scala
+++ b/project/VersionUtil.scala
@@ -31,6 +31,9 @@ object VersionUtil {
     new JGit(repo)
   }
 
+  /** Full SHA hash of the current commit */
+  def gitHashFull: String = git.headCommitSha
+
   /** Seven letters of the SHA hash is considered enough to uniquely identify a
    *  commit, albeit extremely large projects - such as the Linux kernel - need
    *  more letters to stay unique


### PR DESCRIPTION
When benchmarking a specific commit, I need a version string that includes the Git commit hash but excludes the current date. This ensures that the same commit yields identical version strings across different benchmark runs, regardless of when they’re executed.