### PR TITLE
Drop spurious applies in unpickler and inliner

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -1512,6 +1512,7 @@ class TreeUnpickler(reader: TastyReader,
               else if fn.symbol == defn.QuotedRuntime_exprQuote then quotedExpr(fn, args) // decode pre 3.5.0 encoding
               else if fn.symbol == defn.QuotedRuntime_exprSplice then splicedExpr(fn, args) // decode pre 3.5.0 encoding
               else if fn.symbol == defn.QuotedRuntime_exprNestedSplice then nestedSpliceExpr(fn, args) // decode pre 3.5.0 encoding
+              else if isSpuriousApply(fn, args) then fn
               else tpd.Apply(fn, args)
             case TYPEAPPLY =>
               tpd.TypeApply(readTree(), until(end)(readTpt()))

--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -96,13 +96,17 @@ object Inliner:
     }
   end isElideableExpr
 
-  // InlineCopier is a more fault-tolerant copier that does not cause errors when
-  // function types in applications are undefined. This is necessary since we copy at
-  // the same time as establishing the proper context in which the copied tree should
-  // be evaluated. This matters for opaque types, see neg/i14653.scala.
+  /** InlineCopier is a more fault-tolerant copier that does not cause errors in two situations:
+   *   - Function types in applications are undefined. This is necessary since we copy at
+   *     the same time as establishing the proper context in which the copied tree should
+   *     be evaluated. This matters for opaque types, see neg/i14653.scala.
+   *   - The application is spurious (in the sense of isSpuriousTypeApply). We leave
+   *     the application around to be eliminated later by the inline typer.
+   */
   private class InlineCopier() extends TypedTreeCopier:
     override def Apply(tree: Tree)(fun: Tree, args: List[Tree])(using Context): Apply =
-      if fun.tpe.widen.exists then super.Apply(tree)(fun, args)
+      if fun.tpe.widen.exists && !isSpuriousApply(fun, args)
+      then super.Apply(tree)(fun, args)
       else untpd.cpy.Apply(tree)(fun, args).withTypeUnchecked(tree.tpe)
 
   // InlinerMap is a TreeTypeMap with special treatment for inlined arguments:
@@ -937,6 +941,9 @@ class Inliner(val call: tpd.Tree)(using Context):
     override def typedApply(tree: untpd.Apply, pt: Type)(using Context): Tree =
       val locked = ctx.typerState.ownedVars
       specializeEq(inlineIfNeeded(constToLiteral(BetaReduce(super.typedApply(tree, pt))), pt, locked))
+
+    override def isAcceptedSpuriousApply(fun: Tree, args: List[untpd.Tree])(using Context): Boolean =
+      tpd.isSpuriousApply(fun, args)
 
     override def typedTypeApply(tree: untpd.TypeApply, pt: Type)(using Context): Tree =
       val locked = ctx.typerState.ownedVars

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1198,6 +1198,12 @@ trait Applications extends Compatibility {
     if (ctx.owner.isClassConstructor && untpd.isSelfConstrCall(app)) ctx.thisCallArgContext
     else ctx
 
+  /** Overridden in InlineTyper to accept applications `fun()` of parameterless
+   *  methods `fun` that override some Java-defined method.
+   */
+  def isAcceptedSpuriousApply(fun: Tree, args: List[untpd.Tree])(using Context): Boolean =
+    false
+
   /** Typecheck application. Result could be an `Apply` node,
    *  or, if application is an operator assignment, also an `Assign` or
    *  Block node.
@@ -1263,11 +1269,14 @@ trait Applications extends Compatibility {
             val fun2 = Applications.retypeSignaturePolymorphicFn(fun1, methType)
             simpleApply(fun2, proto)
           case funRef: TermRef =>
-            val app = ApplyTo(tree, fun1, funRef, proto, pt)
-            convertNewGenericArray(
-              widenEnumCase(
-                postProcessByNameArgs(funRef, app).computeNullable(),
-                pt))
+            if isAcceptedSpuriousApply(fun1, tree.args) then
+              fun1
+            else
+              val app = ApplyTo(tree, fun1, funRef, proto, pt)
+              convertNewGenericArray(
+                widenEnumCase(
+                  postProcessByNameArgs(funRef, app).computeNullable(),
+                  pt))
           case _ =>
             handleUnexpectedFunType(tree, fun1)
         }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4457,8 +4457,10 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         else
           errorTree(tree, em"Missing arguments for $methodStr")
       case _ =>
-        tryInsertApplyOrImplicit(tree, pt, locked):
-          errorTree(tree, MethodDoesNotTakeParameters(tree))
+        if isAcceptedSpuriousApply(tree, pt.args) then tree
+        else
+          tryInsertApplyOrImplicit(tree, pt, locked):
+            errorTree(tree, MethodDoesNotTakeParameters(tree))
     }
 
     def adaptNoArgsImplicitMethod(wtp: MethodType): Tree = {

--- a/tests/pos/i25133.scala
+++ b/tests/pos/i25133.scala
@@ -1,0 +1,7 @@
+class C extends Object:
+  override def toString = "C"
+
+inline def foo(inline x: Object): String = x.toString
+
+val c = C()
+val s = foo(c)


### PR DESCRIPTION
Fixes #25133 (hopefully) by dropping spurious `Apply` nodes of parameterless methods that override some Java method.