### PR TITLE
fix: use proper import for relaxedLambdaSyntax feature in docs

### DIFF
--- a/docs/_docs/reference/experimental/relaxed-lambdas.md
+++ b/docs/_docs/reference/experimental/relaxed-lambdas.md
@@ -11,7 +11,7 @@ This experimental addition combines several small improvements to write function
 [SIP 75](https://github.com/scala/improvement-proposals/pull/118).
 They are enabled by the experimental language import
 ```scala
-import language.experimental.relaxedLambdas
+import language.experimental.relaxedLambdaSyntax
 ```
 
 ## Single Line Lambdas


### PR DESCRIPTION
The current import name in incorrect

```
[error] ./a.scala:1:30
[error] value relaxedLambdas is not a member of object language.experimental
[error] import language.experimental.relaxedLambdas
```