### PR TITLE
Pickle CompactAnnotations as regular annotations

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
+++ b/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
@@ -47,6 +47,7 @@ enum SourceVersion:
   def enablesBetterFors(using Context) = isAtLeast(`3.8`) || (isAtLeast(`3.7`) && isPreviewEnabled)
   /** See PR #23441 and tests/neg/i23435-min */
   def enablesDistributeAnd = !isAtLeast(`future`)
+  def enablesCompactAnnotation = isAtLeast(`3.9`)
 
   def requiresNewSyntax = isAtLeast(future)
 

--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -4,11 +4,11 @@ package core
 
 import Symbols.*, Types.*, Contexts.*, Constants.*, Phases.*
 import ast.tpd, tpd.*
-import util.Spans.Span
+import util.Spans.{Span, NoSpan}
 import printing.{Showable, Printer}
 import printing.Texts.Text
 import cc.{isRetainsLike, RetainingAnnotation}
-import config.Feature
+import config.Feature.sourceVersion
 import Decorators.*
 
 import scala.annotation.internal.sharable
@@ -141,6 +141,9 @@ object Annotations {
     assert(tpe.isInstanceOf[AppliedType | TypeRef], tpe)
 
     def tree(using Context) = TypeTree(tpe)
+
+    def oldTree(using Context): Tree =
+      New(tpe, Nil).withSpan(NoSpan)
 
     override def symbol(using Context) = tpe.typeSymbol
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -16,6 +16,7 @@ import Comments.{Comment, docCtx}
 import NameKinds.*
 import StdNames.{nme, tpnme}
 import config.Config
+import config.Feature.sourceVersion
 import collection.mutable
 import reporting.{Profile, NoProfile}
 import dotty.tools.tasty.TastyFormat.ASTsSection
@@ -286,7 +287,13 @@ class TreePickler(pickler: TastyPickler, attributes: Attributes) {
       withLength:
         pickleType(tpe.parent, richTypes)
         tpe.annot match
-          case ann: CompactAnnotation => pickleType(ann.tpe)
+          case ann: CompactAnnotation =>
+            if sourceVersion.enablesCompactAnnotation then
+              pickleType(ann.tpe)
+            else
+              val atree = ann.oldTree
+              pickleTree(atree)
+              annotatedTypeTrees += atree
           case ann =>
             pickleTree(ann.tree)
             annotatedTypeTrees += ann.tree


### PR DESCRIPTION
This is needed for forward compatibility in the 3.8 series. We phase in the more efficient encoding in 3.9.

Fixes #25210