### PR TITLE
Make containsOuterRefsAnywhere follow aliases

### DIFF
--- a/tests/pos/i25185.scala
+++ b/tests/pos/i25185.scala
@@ -1,0 +1,11 @@
+package example
+
+class A {
+  type B = Int
+
+  object B {
+    inline def f1(x: Int): B = x
+  }
+
+  def x1 = B.f1(2)
+}


### PR DESCRIPTION
Since dealising is not guaranteed, we need to check both orginal type and its embedded aliases for outer refs

Fixes #25185