### PR TITLE
Backport "Bump Scala CLI to v1.12.2 (was v1.11.0) & coursier to 2.1.25-M23 (was 2.1.25-M21)" to 3.8.2

### DIFF
--- a/.github/workflows/lts-backport.yaml
+++ b/.github/workflows/lts-backport.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: coursier/cache-action@v7
-      - uses: VirtusLab/scala-cli-setup@v1.11.0
+      - uses: VirtusLab/scala-cli-setup@v1.12.2
       - run: scala-cli ./project/scripts/addToBackportingProject.scala -- ${{ github.sha }}
         env:
           GRAPHQL_API_TOKEN: ${{ secrets.GRAPHQL_API_TOKEN }}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -135,9 +135,9 @@ object Build {
   val mimaPreviousDottyVersion = "3.8.0"
 
   /** Version of Scala CLI to download */
-  val scalaCliLauncherVersion = "1.11.0"
+  val scalaCliLauncherVersion = "1.12.2"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
-  val coursierJarVersion = "2.1.25-M21"
+  val coursierJarVersion = "2.1.25-M23"
 
   object CompatMode {
     final val BinaryCompatible = 0


### PR DESCRIPTION
Backports #25217 to the 3.8.2-RC2.

PR submitted by the release tooling.