### PR TITLE
Fix false unused import warning for given CanEqual in pattern matching

### DIFF
--- a/tests/warn/i25227.scala
+++ b/tests/warn/i25227.scala
@@ -1,0 +1,21 @@
+//> using options -Wunused:all
+
+import scala.language.strictEquality
+
+object Givens:
+  given CanEqual[Any, Null] = CanEqual.derived
+  given CanEqual[Null, Any] = CanEqual.derived
+
+object Test:
+  import Givens.given  // no warn: used by `case null =>`
+
+  def m(value: Any): Boolean = value match
+    case null => true
+    case _ => false
+
+object TestUnused:
+  import Givens.given  // warn: not used here
+
+  def m(value: Any): Boolean = value match
+    case _: String => true
+    case _ => false


### PR DESCRIPTION
### **Problem**
Fixes #25227

Under strict equality, `import Givens.given` (providing `CanEqual[Any, Null]`) is falsely reported as unused when the given is consumed only by pattern matching (`case null =>`), even though removing it breaks compilation. The warning does not appear when the given is consumed by `==/!=`.

```
import scala.language.strictEquality

object Givens:
  given CanEqual[Any, Null] = CanEqual.derived

object Test:
  import Givens.given  // ← falsely reported as unused

  def m(value: Any): Boolean = value match
    case null => true   // needs CanEqual[Any, Null]
    case _ => false
```
### **Root Cause**
`CheckUnused.transformApply` correctly resolves `CanEqual `for `==/!=` via `resolveScoped(caneq)`, marking the given import as used. However, `transformMatch `had no equivalent logic for pattern matching against literal/null patterns, so the import was never marked as used.

### **Fix**
Added the same `resolveScoped(caneq)` logic to `transformMatch` for Literal patterns (including null). When a Match tree has a literal pattern, we construct `CanEqual[SelectorType, PatternType]` and call `resolveScoped `to mark any given import providing it as used.


### **Testing**
New test `tests/warn/i25227.scala` with both positive (used by `case null =>`) and negative (genuinely unused) cases
All existing warn tests pass, including `unused-can-equal.scala` and `i17762.scala`
