### PR TITLE
Backport "Drop spurious applies in unpickler and inliner" to 3.8.2

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -1509,6 +1509,7 @@ class TreeUnpickler(reader: TastyReader,
               else if fn.symbol == defn.QuotedRuntime_exprQuote then quotedExpr(fn, args) // decode pre 3.5.0 encoding
               else if fn.symbol == defn.QuotedRuntime_exprSplice then splicedExpr(fn, args) // decode pre 3.5.0 encoding
               else if fn.symbol == defn.QuotedRuntime_exprNestedSplice then nestedSpliceExpr(fn, args) // decode pre 3.5.0 encoding
+              else if isSpuriousApply(fn, args) then fn
               else tpd.Apply(fn, args)
             case TYPEAPPLY =>
               tpd.TypeApply(readTree(), until(end)(readTpt()))

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1198,6 +1198,12 @@ trait Applications extends Compatibility {
     if (ctx.owner.isClassConstructor && untpd.isSelfConstrCall(app)) ctx.thisCallArgContext
     else ctx
 
+  /** Overridden in InlineTyper to accept applications `fun()` of parameterless
+   *  methods `fun` that override some Java-defined method.
+   */
+  def isAcceptedSpuriousApply(fun: Tree, args: List[untpd.Tree])(using Context): Boolean =
+    false
+
   /** Typecheck application. Result could be an `Apply` node,
    *  or, if application is an operator assignment, also an `Assign` or
    *  Block node.
@@ -1263,11 +1269,14 @@ trait Applications extends Compatibility {
             val fun2 = Applications.retypeSignaturePolymorphicFn(fun1, methType)
             simpleApply(fun2, proto)
           case funRef: TermRef =>
-            val app = ApplyTo(tree, fun1, funRef, proto, pt)
-            convertNewGenericArray(
-              widenEnumCase(
-                postProcessByNameArgs(funRef, app).computeNullable(),
-                pt))
+            if isAcceptedSpuriousApply(fun1, tree.args) then
+              fun1
+            else
+              val app = ApplyTo(tree, fun1, funRef, proto, pt)
+              convertNewGenericArray(
+                widenEnumCase(
+                  postProcessByNameArgs(funRef, app).computeNullable(),
+                  pt))
           case _ =>
             handleUnexpectedFunType(tree, fun1)
         }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4443,8 +4443,10 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         else
           errorTree(tree, em"Missing arguments for $methodStr")
       case _ =>
-        tryInsertApplyOrImplicit(tree, pt, locked):
-          errorTree(tree, MethodDoesNotTakeParameters(tree))
+        if isAcceptedSpuriousApply(tree, pt.args) then tree
+        else
+          tryInsertApplyOrImplicit(tree, pt, locked):
+            errorTree(tree, MethodDoesNotTakeParameters(tree))
     }
 
     def adaptNoArgsImplicitMethod(wtp: MethodType): Tree = {

--- a/sbt-test/scala3-compat/i25133/app/B.scala
+++ b/sbt-test/scala3-compat/i25133/app/B.scala
@@ -1,0 +1,4 @@
+object B {
+  val c = A.foo
+}
+

--- a/sbt-test/scala3-compat/i25133/build.sbt
+++ b/sbt-test/scala3-compat/i25133/build.sbt
@@ -1,0 +1,20 @@
+lazy val lib = project.in(file("lib"))
+  .settings(
+    scalaVersion := "3.3.7",
+  )
+
+// Should fail to compile
+lazy val appNeg = project.in(file("app-neg"))
+  .settings(
+    scalaVersion := "3.8.1",
+    (Compile / sources) ++= (app / Compile / sources).value
+  )
+  .dependsOn(lib)
+
+// Should compile
+lazy val app = project.in(file("app"))
+  .settings(
+    scalaVersion := sys.props("plugin.scalaVersion")
+  )
+  .dependsOn(lib)
+

--- a/sbt-test/scala3-compat/i25133/lib/A.scala
+++ b/sbt-test/scala3-compat/i25133/lib/A.scala
@@ -1,0 +1,6 @@
+object A {
+  inline def foo = {
+    val list = List[BigDecimal]()
+    val bar = list.map(_.underlying)
+  }
+}

--- a/sbt-test/scala3-compat/i25133/test
+++ b/sbt-test/scala3-compat/i25133/test
@@ -1,0 +1,3 @@
+-> appNeg/compile
+> app/compile
+

--- a/tests/pos/i25133.scala
+++ b/tests/pos/i25133.scala
@@ -1,0 +1,9 @@
+class C extends Object:
+  override def toString = "C"
+
+inline def foo(inline x: Object): String = x.toString
+inline def bar(inline x: Object): String = x.toString()
+
+val c = C()
+val s = foo(c)
+val t = bar(c)


### PR DESCRIPTION
Backports #25201 to the 3.8.2-RC2.

PR submitted by the release tooling.