### PR TITLE
Add ErrorMessageID to -Winfer-union warnings (#25073)

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -238,6 +238,7 @@ enum ErrorMessageID(val isActive: Boolean = true) extends java.lang.Enum[ErrorMe
   case EncodedPackageNameID // errorNumber: 222
   case CannotBeIncludedID // errorNumber: 223
   case OverrideClassID // errorNumber: 224
+  case InferUnionWarningID // errorNumber: 225
 
   def errorNumber = ordinal - 1
 

--- a/compiler/src/dotty/tools/dotc/reporting/Message.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Message.scala
@@ -316,7 +316,7 @@ object Message:
       super.toText(sym)
   end Printer
 
-end Message
+end Message 
 
 /** A `Message` contains all semantic information necessary to easily
   * comprehend what caused the message to be logged. Each message can be turned
@@ -517,3 +517,15 @@ object NoExplanation {
     if (m.explanation == "") Some(m)
     else None
 }
+
+final class InferUnionWarning(tp: Type)(using Context)
+  extends Message(ErrorMessageID.InferUnionWarningID):
+
+  def kind: MessageKind = MessageKind.Type
+
+  def msg(using Context): String =
+    i"""A type argument was inferred to be union type $tp
+       |This may indicate a programming error.
+       |"""
+
+  def explain(using Context): String = ""

--- a/compiler/src/dotty/tools/dotc/transform/WInferUnion.scala
+++ b/compiler/src/dotty/tools/dotc/transform/WInferUnion.scala
@@ -6,6 +6,8 @@ import dotty.tools.dotc.core.Contexts.{Context, ctx}
 import dotty.tools.dotc.core.Decorators.em
 import dotty.tools.dotc.core.Types.OrType
 import dotty.tools.dotc.report
+import dotty.tools.dotc.reporting.ErrorMessageID
+import dotty.tools.dotc.reporting.InferUnionWarning
 import dotty.tools.dotc.transform.MegaPhase.MiniPhase
 
 class WInferUnion extends MiniPhase {
@@ -21,9 +23,9 @@ class WInferUnion extends MiniPhase {
       tpt.isInstanceOf[InferredTypeTree] && tpt.tpe.stripTypeVar.isInstanceOf[OrType]
     inferredOrTypes.foreach: tpt =>
       report.warning(
-        em"""|A type argument was inferred to be union type ${tpt.tpe.stripTypeVar}
-             |This may indicate a programming error.
-             |""", tpt.srcPos)
+        InferUnionWarning(tpt.tpe.stripTypeVar),
+        tpt.srcPos
+      )
     tree
 }
 

--- a/tests/neg/infer-union-warning-id.scala
+++ b/tests/neg/infer-union-warning-id.scala
@@ -1,0 +1,5 @@
+//> using options -Winfer-union -Wconf:id=E225:error
+
+case class Pair[A](a: A, b: A)
+
+val _ = Pair(1, "") // error

--- a/tests/warn/infer-or-type.check
+++ b/tests/warn/infer-or-type.check
@@ -1,9 +1,9 @@
--- Warning: tests/warn/infer-or-type.scala:6:18 ------------------------------------------------------------------------
+-- [E225] Type Warning: tests/warn/infer-or-type.scala:6:18 ------------------------------------------------------------
 6 |  val _ = List(1).contains("") // warn
   |          ^^^^^^^^^^^^^^^^
   |          A type argument was inferred to be union type Int | String
   |          This may indicate a programming error.
--- Warning: tests/warn/infer-or-type.scala:7:10 ------------------------------------------------------------------------
+-- [E225] Type Warning: tests/warn/infer-or-type.scala:7:10 ------------------------------------------------------------
 7 |  val _ = Pair(1, "") // warn
   |          ^^^^
   |          A type argument was inferred to be union type Int | String

--- a/tests/warn/infer-union-warning-id.check
+++ b/tests/warn/infer-union-warning-id.check
@@ -1,0 +1,6 @@
+-- [E225] Type Warning: tests/warn/infer-union-warning-id.scala:3:8
+3 |val _ = Pair(1, "")
+  |        ^^^^
+  |        A type argument was inferred to be union type Int | String
+  |        This may indicate a programming error.
+1 warning found


### PR DESCRIPTION
Fixes #25073

Warnings emitted by `-Winfer-union` previously did not have an ErrorMessageID,
which meant they could not be configured using `-Wconf`.

This PR:
- Introduces `InferUnionWarningID`
- Adds structured `InferUnionWarning` message
- Updates existing warn tests to include the ID
- Adds a new warn test verifying the ID is printed
- Adds a neg test verifying `-Wconf:id=E225:error` turns the warning into an error

All tests pass.