### PR TITLE
[CI] Disable execution of requests flaky tests in the community build

### DIFF
--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -212,7 +212,7 @@ object projects:
   lazy val requests = MillCommunityProject(
     project = "requests",
     baseCommand = s"requests.jvm[$compilerVersion]",
-    executeTests = false,
+    executeTests = false, // TODO: fix this to pass consistently
   )
 
   lazy val cask = MillCommunityProject(


### PR DESCRIPTION
* Disable execution of requests tests, only perform tests compilation, fixes #25257
* Move special handling of `sourcecode` out of the main MillCommunityPojrect class to cleanup the logic