### PR TITLE
External Link Scaladoc Fix

### DIFF
--- a/scaladoc-testcases/src/tests/externalLocations/javadoc.scala
+++ b/scaladoc-testcases/src/tests/externalLocations/javadoc.scala
@@ -16,3 +16,12 @@ class MyArrayList[T] extends java.util.ArrayList[T]
 
 trait MyPrintStream extends java.io.PrintStream
 
+/** Test method with javadoc link */
+class MethodTest {
+  /** See [[java.lang.Float.compare]] */
+  def compareFloats(x: Float, y: Float): Int = java.lang.Float.compare(x, y)
+
+  /** See [[java.lang.Double.compare]] */
+  def compareDoubles(x: Double, y: Double): Int = java.lang.Double.compare(x, y)
+}
+

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/SymOps.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/SymOps.scala
@@ -223,7 +223,10 @@ class SymOpsWithLinkCache:
       val extension = ".html"
       val docURL = link.documentationUrl.toString
       def constructPathForJavadoc: String =
-        val l = "\\$+".r.replaceAllIn(location.mkString("/"), _ => ".")
+        // For javadoc, we need to strip trailing $ from location elements
+        // to avoid generating double dots in the URL (e.g., Float$. -> Float. -> Float..html)
+        val cleanLocation = location.map(_.stripSuffix("$"))
+        val l = "\\$+".r.replaceAllIn(cleanLocation.mkString("/"), _ => ".")
         val javadocAnchor = if anchor.isDefined then {
           val paramSigs = sym.paramSymss.flatten.map(_.tree).collect {
             case v: ValDef => v.tpt.tpe

--- a/scaladoc/test/dotty/tools/scaladoc/ExternalLocationProviderIntegrationTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/ExternalLocationProviderIntegrationTest.scala
@@ -17,7 +17,9 @@ class JavadocExternalLocationProviderIntegrationTest extends ExternalLocationPro
     "https://docs.oracle.com/javase/8/docs/api/java/util/ArrayList.html#toArray-T:A-",
     "https://docs.oracle.com/javase/8/docs/api/java/util/ArrayList.html#subList-int-int-",
     "https://docs.oracle.com/javase/8/docs/api/java/io/PrintStream.html#printf-java.lang.String-java.lang.Object...-",
-    "https://docs.oracle.com/javase/8/docs/api/java/io/PrintStream.html#write-byte:A-int-int-"
+    "https://docs.oracle.com/javase/8/docs/api/java/io/PrintStream.html#write-byte:A-int-int-",
+    "https://docs.oracle.com/javase/8/docs/api/java/lang/Float.html#compare-float-float-",
+    "https://docs.oracle.com/javase/8/docs/api/java/lang/Double.html#compare-double-double-"
   )
 )
 


### PR DESCRIPTION
Fixed extra dot '.' in generated external link, example can be found at https://www.scala-lang.org/api/3.8.1/scala/math/Equiv$$Float$$StrictEquiv.html , look for java.lang.Float.compare, which currently link to 'https://docs.oracle.com/javase/8/docs/api/java/lang/Float..html#compare-float-float-', there's extra '.' in Float..html.