### PR TITLE
Fill in missing @param, @tparam, and @return tags in Scaladoc comments.

### DIFF
--- a/library-js/src/scala/Array.scala
+++ b/library-js/src/scala/Array.scala
@@ -61,7 +61,11 @@ object Array {
     val emptyObjectArray  = new Array[Object](0)
   }
 
-  /** Provides an implicit conversion from the Array object to a collection Factory. */
+  /** Provides an implicit conversion from the Array object to a collection Factory.
+   *
+   *  @tparam A the element type of the array, must have a `ClassTag`
+   *  @param dummy the `Array` companion object, used to trigger the implicit conversion
+   */
   implicit def toFactory[A : ClassTag](dummy: Array.type): Factory[A, Array[A]] = new ArrayFactory(dummy)
   @SerialVersionUID(3L)
   private class ArrayFactory[A : ClassTag](dummy: Array.type) extends Factory[A, Array[A]] with Serializable {
@@ -69,7 +73,11 @@ object Array {
     def newBuilder: mutable.Builder[A, Array[A]] = Array.newBuilder[A]
   }
 
-  /** Returns a new [[scala.collection.mutable.ArrayBuilder]]. */
+  /** Returns a new [[scala.collection.mutable.ArrayBuilder]].
+   *
+   *  @tparam T the element type of the array to build
+   *  @param t the `ClassTag` for the element type, used to create the correct array type at runtime
+   */
   def newBuilder[T](implicit t: ClassTag[T]): ArrayBuilder[T] = ArrayBuilder.make[T](using t)
 
   def from[A: ClassTag](it: IterableOnce[A]^): Array[A] = {
@@ -138,6 +146,11 @@ object Array {
    *  except that this works for primitive and object arrays in a single method.
    *
    *  @see `java.util.Arrays#copyOf`
+   *
+   *  @tparam A the element type of the array
+   *  @param original the array to be copied
+   *  @param newLength the length of the copy to be returned
+   *  @return a copy of the original array, truncated or padded with default values to obtain the specified length
    */
   def copyOf[A](original: Array[A], newLength: Int): Array[A] = (original match {
     case x: Array[BoxedUnit]  => newUnitArray(newLength).asInstanceOf[Array[A]]
@@ -164,6 +177,12 @@ object Array {
    *  in a single method.
    *
    *  @see `java.util.Arrays#copyOf`
+   *
+   *  @tparam A the element type of the destination array
+   *  @param original the array to be copied
+   *  @param newLength the length of the copy to be returned
+   *  @param ct the `ClassTag` for the target element type, used to create the correct array type at runtime
+   *  @return a copy of the original array, converted to type `Array[A]`, truncated or padded with default values to obtain the specified length
    */
   def copyAs[A](original: Array[_], newLength: Int)(implicit ct: ClassTag[A]): Array[A] = {
     val runtimeClass = ct.runtimeClass
@@ -190,7 +209,10 @@ object Array {
     result
   }
 
-  /** Returns an array of length 0. */
+  /** Returns an array of length 0.
+   *
+   *  @tparam T the element type of the empty array
+   */
   def empty[T: ClassTag]: Array[T] = new Array[T](0)
 
   /** Creates an array with given elements.
@@ -210,7 +232,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Boolean` objects. */
+  /** Creates an array of `Boolean` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Boolean, xs: Boolean*): Array[Boolean] = {
     val array = new Array[Boolean](xs.length + 1)
@@ -223,7 +249,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Byte` objects. */
+  /** Creates an array of `Byte` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Byte, xs: Byte*): Array[Byte] = {
     val array = new Array[Byte](xs.length + 1)
@@ -236,7 +266,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Short` objects. */
+  /** Creates an array of `Short` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Short, xs: Short*): Array[Short] = {
     val array = new Array[Short](xs.length + 1)
@@ -249,7 +283,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Char` objects. */
+  /** Creates an array of `Char` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Char, xs: Char*): Array[Char] = {
     val array = new Array[Char](xs.length + 1)
@@ -262,7 +300,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Int` objects. */
+  /** Creates an array of `Int` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Int, xs: Int*): Array[Int] = {
     val array = new Array[Int](xs.length + 1)
@@ -275,7 +317,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Long` objects. */
+  /** Creates an array of `Long` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Long, xs: Long*): Array[Long] = {
     val array = new Array[Long](xs.length + 1)
@@ -288,7 +334,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Float` objects. */
+  /** Creates an array of `Float` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Float, xs: Float*): Array[Float] = {
     val array = new Array[Float](xs.length + 1)
@@ -301,7 +351,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Double` objects. */
+  /** Creates an array of `Double` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Double, xs: Double*): Array[Double] = {
     val array = new Array[Double](xs.length + 1)
@@ -314,7 +368,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Unit` objects. */
+  /** Creates an array of `Unit` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   def apply(x: Unit, xs: Unit*): Array[Unit] = {
     val array = new Array[Unit](xs.length + 1)
     array(0) = x
@@ -326,28 +384,59 @@ object Array {
     array
   }
 
-  /** Creates array with given dimensions. */
+  /** Creates array with given dimensions.
+   *
+   *  @tparam T the element type of the array
+   *  @param n1 the number of elements in the 1st dimension
+   */
   def ofDim[T: ClassTag](n1: Int): Array[T] =
     new Array[T](n1)
-  /** Creates a 2-dimensional array. */
+  /** Creates a 2-dimensional array.
+   *
+   *  @tparam T the element type of the array
+   *  @param n1 the number of elements in the 1st dimension
+   *  @param n2 the number of elements in the 2nd dimension
+   */
   def ofDim[T: ClassTag](n1: Int, n2: Int): Array[Array[T]] = {
     val arr: Array[Array[T]] = (new Array[Array[T]](n1): Array[Array[T]])
     for (i <- 0 until n1) arr(i) = new Array[T](n2)
     arr
     // tabulate(n1)(_ => ofDim[T](n2))
   }
-  /** Creates a 3-dimensional array. */
+  /** Creates a 3-dimensional array.
+   *
+   *  @tparam T the element type of the array
+   *  @param n1 the number of elements in the 1st dimension
+   *  @param n2 the number of elements in the 2nd dimension
+   *  @param n3 the number of elements in the 3rd dimension
+   */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int): Array[Array[Array[T]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3))
-  /** Creates a 4-dimensional array. */
+  /** Creates a 4-dimensional array.
+   *
+   *  @tparam T the element type of the array
+   *  @param n1 the number of elements in the 1st dimension
+   *  @param n2 the number of elements in the 2nd dimension
+   *  @param n3 the number of elements in the 3rd dimension
+   *  @param n4 the number of elements in the 4th dimension
+   */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int): Array[Array[Array[Array[T]]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3, n4))
-  /** Creates a 5-dimensional array. */
+  /** Creates a 5-dimensional array.
+   *
+   *  @tparam T the element type of the array
+   *  @param n1 the number of elements in the 1st dimension
+   *  @param n2 the number of elements in the 2nd dimension
+   *  @param n3 the number of elements in the 3rd dimension
+   *  @param n4 the number of elements in the 4th dimension
+   *  @param n5 the number of elements in the 5th dimension
+   */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int): Array[Array[Array[Array[Array[T]]]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3, n4, n5))
 
   /** Concatenates all arrays into a single array.
    *
+   *  @tparam T the element type of the arrays
    *  @param xss the given arrays
    *  @return   the array created from concatenating `xss`
    */
@@ -367,6 +456,7 @@ object Array {
    *  res3: Array[Double] = Array(0.365461167592537, 1.550395944913685E-4, 0.7907242137333306)
    *  ```
    *
+   *  @tparam T the element type of the array
    *  @param   n  the number of elements desired
    *  @param   elem the element computation
    *  @return an Array of size n, where each element contains the result of computing
@@ -389,6 +479,7 @@ object Array {
   /** Returns a two-dimensional array that contains the results of some element
    *  computation a number of times.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   elem the element computation
@@ -399,6 +490,7 @@ object Array {
   /** Returns a three-dimensional array that contains the results of some element
    *  computation a number of times.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -410,6 +502,7 @@ object Array {
   /** Returns a four-dimensional array that contains the results of some element
    *  computation a number of times.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -422,6 +515,7 @@ object Array {
   /** Returns a five-dimensional array that contains the results of some element
    *  computation a number of times.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -435,9 +529,10 @@ object Array {
   /** Returns an array containing values of a given function over a range of integer
    *  values starting from 0.
    *
+   *  @tparam T the element type of the array
    *  @param  n   The number of elements in the array
    *  @param  f   The function computing element values
-   *  @return A traversable consisting of elements `f(0),f(1), ..., f(n - 1)`
+   *  @return an array consisting of elements `f(0), f(1), ..., f(n - 1)`
    */
   def tabulate[T: ClassTag](n: Int)(f: Int => T): Array[T] = {
     if (n <= 0) {
@@ -456,6 +551,7 @@ object Array {
   /** Returns a two-dimensional array containing values of a given function
    *  over ranges of integer values starting from `0`.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   f   The function computing element values
@@ -466,6 +562,7 @@ object Array {
   /** Returns a three-dimensional array containing values of a given function
    *  over ranges of integer values starting from `0`.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -477,6 +574,7 @@ object Array {
   /** Returns a four-dimensional array containing values of a given function
    *  over ranges of integer values starting from `0`.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -489,6 +587,7 @@ object Array {
   /** Returns a five-dimensional array containing values of a given function
    *  over ranges of integer values starting from `0`.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -531,6 +630,7 @@ object Array {
 
   /** Returns an array containing repeated applications of a function to a start value.
    *
+   *  @tparam T the element type of the array
    *  @param start the start value of the array
    *  @param len   the number of elements returned by the array
    *  @param f     the function that is repeatedly applied
@@ -572,8 +672,9 @@ object Array {
 
   /** Called in a pattern match like `{ case Array(x,y,z) => println('3 elements')}`.
    *
+   *  @tparam T the element type of the array
    *  @param x the selector value
-   *  @return  sequence wrapped in a [[scala.Some]], if `x` is an Array, otherwise `None`
+   *  @return  a [[UnapplySeqWrapper]] wrapping the array for pattern matching extraction
    */
   def unapplySeq[T](x: Array[T]): UnapplySeqWrapper[T] = new UnapplySeqWrapper(x)
 
@@ -657,6 +758,8 @@ object Array {
  *  @define willNotTerminateInf
  *  @define collectExample
  *  @define undefinedorder
+ *
+ *  @tparam T the type of the elements in the array
  */
 final class Array[T](_length: Int) extends java.io.Serializable with java.lang.Cloneable { self =>
 
@@ -687,7 +790,7 @@ final class Array[T](_length: Int) extends java.io.Serializable with java.lang.C
 
   /** Clones the Array.
    *
-   *  @return A clone of the Array.
+   *  @return a clone of the array
    */
   override def clone(): Array[T] = throw new Error()
 }

--- a/library-js/src/scala/Console.scala
+++ b/library-js/src/scala/Console.scala
@@ -163,6 +163,8 @@ object Console extends AnsiColor {
    *  @return the results of `thunk`
    *  @see `withOut[T](out:OutputStream)(thunk: => T)`
    *  @group io-redefinition
+   *
+   *  @tparam T the return type of `thunk`
    */
   def withOut[T](out: PrintStream)(thunk: =>T): T =
     outVar.withValue(out)(thunk)
@@ -170,6 +172,7 @@ object Console extends AnsiColor {
   /** Sets the default output stream for the duration
    *  of execution of one thunk.
    *
+   *  @tparam T the return type of `thunk`
    *  @param out the new output stream.
    *  @param thunk the code to execute with
    *               the new output stream active
@@ -192,6 +195,8 @@ object Console extends AnsiColor {
    *  @return the results of `thunk`
    *  @see `withErr[T](err:OutputStream)(thunk: =>T)`
    *  @group io-redefinition
+   *
+   *  @tparam T the return type of `thunk`
    */
   def withErr[T](err: PrintStream)(thunk: =>T): T =
     errVar.withValue(err)(thunk)
@@ -199,6 +204,7 @@ object Console extends AnsiColor {
   /** Sets the default error stream for the duration
    *  of execution of one thunk.
    *
+   *  @tparam T the return type of `thunk`
    *  @param err the new error stream.
    *  @param thunk the code to execute with
    *               the new error stream active
@@ -226,6 +232,9 @@ object Console extends AnsiColor {
    *  @return the results of `thunk`
    *  @see `withIn[T](in:InputStream)(thunk: =>T)`
    *  @group io-redefinition
+   *
+   *  @tparam T the return type of `thunk`
+   *  @param reader the new input reader
    */
   def withIn[T](reader: Reader)(thunk: =>T): T =
     inVar.withValue(new BufferedReader(reader))(thunk)
@@ -233,6 +242,7 @@ object Console extends AnsiColor {
   /** Sets the default input stream for the duration
    *  of execution of one thunk.
    *
+   *  @tparam T the return type of `thunk`
    *  @param in the new input stream.
    *  @param thunk the code to execute with
    *               the new input stream active

--- a/library-js/src/scala/Enumeration.scala
+++ b/library-js/src/scala/Enumeration.scala
@@ -148,7 +148,10 @@ abstract class Enumeration (initial: Int) extends Serializable {
    */
   final def maxId = topId
 
-  /** The value of this enumeration with given id `x` */
+  /** The value of this enumeration with given id `x`
+   *
+   *  @param x the integer id of the desired value
+   */
   final def apply(x: Int): Value = vmap(x)
 
   /** Returns a `Value` from this `Enumeration` whose name matches
@@ -224,7 +227,10 @@ abstract class Enumeration (initial: Int) extends Serializable {
     }
     override def hashCode: Int = id.##
 
-    /** Creates a ValueSet which contains this value and another one. */
+    /** Creates a ValueSet which contains this value and another one.
+     *
+     *  @param v the other value to include in the set
+     */
     def + (v: Value) = ValueSet(this, v)
   }
 
@@ -321,6 +327,8 @@ abstract class Enumeration (initial: Int) extends Serializable {
     val empty = new ValueSet(immutable.BitSet.empty)
     /** A value set containing all the values for the zero-adjusted ids
      *  corresponding to the bits in an array. 
+     *
+     *  @param elems an array of `Long` values encoding the bit mask of value ids
      */
     def fromBitMask(elems: Array[Long]): ValueSet = new ValueSet(immutable.BitSet.fromBitMask(elems))
     /** A builder object for value sets. */

--- a/library-js/src/scala/collection/immutable/NumericRange.scala
+++ b/library-js/src/scala/collection/immutable/NumericRange.scala
@@ -95,11 +95,18 @@ sealed class NumericRange[T](
 
   /** Creates a new range with the start and end values of this range and
    *  a new `step`.
+   *
+   *  @param newStep the new step value for the resulting range
    */
   def by(newStep: T): NumericRange[T] = copy(start, end, newStep)
 
 
-  /** Creates a copy of this range. */
+  /** Creates a copy of this range.
+   *
+   *  @param start the first value of the new range
+   *  @param end the upper bound of the new range (inclusive or exclusive, matching the original range)
+   *  @param step the step value between successive elements of the new range
+   */
   def copy(start: T, end: T, step: T): NumericRange[T] =
     new NumericRange(start, end, step, isInclusive)
 
@@ -350,6 +357,13 @@ object NumericRange {
   /** Calculates the number of elements in a range given start, end, step, and
    *  whether or not it is inclusive.  Throws an exception if step == 0 or
    *  the number of elements exceeds the maximum Int.
+   *
+   *  @tparam T the numeric type of the range elements, which must have an `Integral` instance
+   *  @param start the first value in the range
+   *  @param end the end boundary of the range (exclusive or inclusive depending on `isInclusive`)
+   *  @param step the increment between successive elements
+   *  @param isInclusive whether `end` is included in the range
+   *  @param num the `Integral` instance used for arithmetic on `T`
    */
   def count[T](start: T, end: T, step: T, isInclusive: Boolean)(implicit num: Integral[T]): Int = {
     val zero    = num.zero

--- a/library-js/src/scala/collection/immutable/Range.scala
+++ b/library-js/src/scala/collection/immutable/Range.scala
@@ -160,6 +160,7 @@ sealed abstract class Range(
   /** Creates a new range with the `start` and `end` values of this range and
    *  a new `step`.
    *
+   *  @param step the new step value for the range; must be non-zero
    *  @return a new range with a different step
    */
   final def by(step: Int): Range = copy(start, end, step)
@@ -258,6 +259,9 @@ sealed abstract class Range(
   /** Creates a new range consisting of the last `n` elements of the range.
    *
    *  $doesNotUseBuilders
+   *
+   *  @param n the number of elements to take from the end of this range
+   *  @return a new range consisting of the last `n` elements, or the entire range if `n` is greater than the range length
    */
   final override def takeRight(n: Int): Range = {
     if (n <= 0) newEmptyRange(start)
@@ -274,6 +278,9 @@ sealed abstract class Range(
   /** Creates a new range consisting of the initial `length - n` elements of the range.
    *
    *  $doesNotUseBuilders
+   *
+   *  @param n the number of elements to drop from the end of this range
+   *  @return a new range consisting of all elements except the last `n`, or an empty range if `n` is greater than the range length
    */
   final override def dropRight(n: Int): Range = {
     if (n <= 0) this
@@ -536,6 +543,11 @@ object Range {
    *  precondition:  step != 0
    *  If the size of the range exceeds Int.MaxValue, the
    *  result will be negative.
+   *
+   *  @param start the first element of the range
+   *  @param end the end boundary of the range (inclusive or exclusive depending on `isInclusive`)
+   *  @param step the increment between successive elements; must be non-zero
+   *  @param isInclusive whether `end` is included in the range
    */
   def count(start: Int, end: Int, step: Int, isInclusive: Boolean): Int = {
     if (step == 0)
@@ -565,18 +577,34 @@ object Range {
 
   /** Makes a range from `start` until `end` (exclusive) with given step value.
    *  @note step != 0
+   *
+   *  @param start the first element of the range
+   *  @param end the exclusive upper bound of the range
+   *  @param step the increment between successive elements; must be non-zero
    */
   def apply(start: Int, end: Int, step: Int): Range.Exclusive = new Range.Exclusive(start, end, step)
 
-  /** Makes a range from `start` until `end` (exclusive) with step value 1. */
+  /** Makes a range from `start` until `end` (exclusive) with step value 1.
+   *
+   *  @param start the first element of the range
+   *  @param end the exclusive upper bound of the range
+   */
   def apply(start: Int, end: Int): Range.Exclusive = new Range.Exclusive(start, end, 1)
 
   /** Makes an inclusive range from `start` to `end` with given step value.
    *  @note step != 0
+   *
+   *  @param start the first element of the range
+   *  @param end the inclusive upper bound of the range
+   *  @param step the increment between successive elements; must be non-zero
    */
   def inclusive(start: Int, end: Int, step: Int): Range.Inclusive = new Range.Inclusive(start, end, step)
 
-  /** Makes an inclusive range from `start` to `end` with step value 1. */
+  /** Makes an inclusive range from `start` to `end` with step value 1.
+   *
+   *  @param start the first element of the range
+   *  @param end the inclusive upper bound of the range
+   */
   def inclusive(start: Int, end: Int): Range.Inclusive = new Range.Inclusive(start, end, 1)
 
   @SerialVersionUID(3L)

--- a/library-js/src/scala/collection/mutable/ArrayBuilder.scala
+++ b/library-js/src/scala/collection/mutable/ArrayBuilder.scala
@@ -54,10 +54,18 @@ sealed abstract class ArrayBuilder[T]
 
   protected[this] def resize(size: Int): Unit
 
-  /** Adds all elements of an array. */
+  /** Adds all elements of an array.
+   *
+   *  @param xs the array from which to add elements
+   */
   def addAll(xs: Array[_ <: T]): this.type = addAll(xs, 0, xs.length)
 
-  /** Adds a slice of an array. */
+  /** Adds a slice of an array.
+   *
+   *  @param xs the array from which to add a slice of elements
+   *  @param offset the starting index in `xs` from which to copy elements
+   *  @param length the number of elements to copy from `xs`
+   */
   def addAll(xs: Array[_ <: T], offset: Int, length: Int): this.type = {
     ensureSize(this.size + length)
     Array.copy(xs, offset, elems.nn, this.size, length)
@@ -95,7 +103,10 @@ object ArrayBuilder {
     if (LinkingInfo.isWebAssembly) makeForWasm
     else makeForJS
 
-  /** Implementation of `make` for JS. */
+  /** Implementation of `make` for JS.
+   *
+   *  @tparam T the element type of the array builder, with a `ClassTag` context bound
+   */
   @inline
   private def makeForJS[T: ClassTag]: ArrayBuilder[T] =
     new ArrayBuilder.generic[T](implicitly[ClassTag[T]].runtimeClass)
@@ -103,6 +114,9 @@ object ArrayBuilder {
   /** Implementation of `make` for Wasm.
    *
    *  This is the original upstream implementation.
+   *
+   *  @tparam T the element type of the array builder, with a `ClassTag` context bound
+   *  @return a new array builder specialized for the runtime type of `T`
    */
   @inline
   private def makeForWasm[T: ClassTag]: ArrayBuilder[T] = {
@@ -146,7 +160,12 @@ object ArrayBuilder {
       this
     }
 
-    /** Adds a slice of an array. */
+    /** Adds a slice of an array.
+     *
+     *  @param xs the array from which to add a slice of elements
+     *  @param offset the starting index in `xs` from which to copy elements
+     *  @param length the number of elements to copy from `xs`
+     */
     override def addAll(xs: Array[_ <: T], offset: Int, length: Int): this.type = {
       val end = offset + length
       var i = offset

--- a/library-js/src/scala/collection/mutable/Buffer.scala
+++ b/library-js/src/scala/collection/mutable/Buffer.scala
@@ -17,7 +17,10 @@ import scala.language.`2.13`
 
 import scala.scalajs.js
 
-/** A `Buffer` is a growable and shrinkable `Seq`. */
+/** A `Buffer` is a growable and shrinkable `Seq`.
+ *
+ *  @tparam A the type of elements contained in this buffer
+ */
 trait Buffer[A]
   extends Seq[A]
     with SeqOps[A, Buffer, Buffer[A]]

--- a/library-js/src/scala/concurrent/ExecutionContext.scala
+++ b/library-js/src/scala/concurrent/ExecutionContext.scala
@@ -169,6 +169,8 @@ object ExecutionContext {
      *  The default `ExecutionContext` implementation is backed by a work-stealing thread pool. By default,
      *  the thread pool uses a target number of worker threads equal to the number of
      *  [available processors](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Runtime.html#availableProcessors()).
+     *
+     *  @return the global `ExecutionContext`
      */
     implicit final def global: ExecutionContext = ExecutionContext.global
   }

--- a/library-js/src/scala/reflect/ClassTag.scala
+++ b/library-js/src/scala/reflect/ClassTag.scala
@@ -61,7 +61,10 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
   /** Produces a `ClassTag` that knows how to instantiate an `Array[Array[T]]`. */
   def wrap: ClassTag[Array[T]] = ClassTag[Array[T]](arrayClass(runtimeClass))
 
-  /** Produces a new array with element type `T` and length `len`. */
+  /** Produces a new array with element type `T` and length `len`.
+   *
+   *  @param len the length of the new array
+   */
   def newArray(len: Int): Array[T] =
     java.lang.reflect.Array.newInstance(runtimeClass, len).asInstanceOf[Array[T]]
 
@@ -72,6 +75,9 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
    *  Type tests necessary before calling other extractors are treated similarly.
    *  `SomeExtractor(...)` is turned into `ct(SomeExtractor(...))` if `T` in `SomeExtractor.unapply(x: T)`
    *  is uncheckable, but we have an instance of `ClassTag[T]`.
+   *
+   *  @param x the value to match against the runtime class of `T`
+   *  @return `Some(x)` if `x` is an instance of `T`, `None` otherwise
    */
   def unapply(x: Any): Option[T] =
     if (runtimeClass.isInstance(x)) Some(x.asInstanceOf[T])

--- a/library-js/src/scala/runtime/ScalaRunTime.scala
+++ b/library-js/src/scala/runtime/ScalaRunTime.scala
@@ -39,7 +39,10 @@ object ScalaRunTime {
   def drop[Repr](coll: Repr, num: Int)(implicit iterable: IsIterable[Repr] { type C <: Repr }): Repr =
     iterable(coll) drop num
 
-  /** Returns the class object representing an array with element class `clazz`. */
+  /** Returns the class object representing an array with element class `clazz`.
+   *
+   *  @param clazz the element class for the resulting array type
+   */
   def arrayClass(clazz: jClass[_]): jClass[_] = {
     // newInstance throws an exception if the erasure is Void.TYPE. see scala/bug#5680
     if (clazz == java.lang.Void.TYPE) classOf[Array[Unit]]
@@ -49,11 +52,18 @@ object ScalaRunTime {
   /** Returns the class object representing an unboxed value type,
    *  e.g., classOf[int], not classOf[java.lang.Integer].  The compiler
    *  rewrites expressions like 5.getClass to come here.
+   *
+   *  @tparam T the primitive value type whose runtime class is to be retrieved
+   *  @param value the value instance (unused; the class is derived from the implicit `ClassTag`)
    */
   def anyValClass[T <: AnyVal : ClassTag](value: T): jClass[T] =
     classTag[T].runtimeClass.asInstanceOf[jClass[T]]
 
-  /** Retrieves generic array element. */
+  /** Retrieves generic array element.
+   *
+   *  @param xs the array to access, typed as `AnyRef` to support both reference and primitive arrays
+   *  @param idx the zero-based index of the element to retrieve
+   */
   def array_apply(xs: AnyRef, idx: Int): Any = {
     xs match {
       case x: Array[AnyRef]  => x(idx).asInstanceOf[Any]
@@ -69,7 +79,12 @@ object ScalaRunTime {
     }
   }
 
-  /** Updates generic array element. */
+  /** Updates generic array element.
+   *
+   *  @param xs the array to update, typed as `AnyRef` to support both reference and primitive arrays
+   *  @param idx the zero-based index of the element to update
+   *  @param value the new value to store at the given index
+   */
   def array_update(xs: AnyRef, idx: Int, value: Any): Unit = {
     xs match {
       case x: Array[AnyRef]  => x(idx) = value.asInstanceOf[AnyRef]
@@ -85,7 +100,10 @@ object ScalaRunTime {
     }
   }
 
-  /** Gets generic array length. */
+  /** Gets generic array length.
+   *
+   *  @param xs the array whose length is to be determined
+   */
   @inline def array_length(xs: AnyRef): Int = java.lang.reflect.Array.getLength(xs)
 
   // TODO: bytecode Object.clone() will in fact work here and avoids
@@ -106,6 +124,8 @@ object ScalaRunTime {
   /** Converts an array to an object array.
    *  Needed to deal with vararg arguments of primitive types that are passed
    *  to a generic Java vararg parameter T ...
+   *
+   *  @param src the source array to convert, which may be a primitive array
    */
   def toObjectArray(src: AnyRef): Array[Object] = src match {
     case x: Array[AnyRef] => x
@@ -136,7 +156,11 @@ object ScalaRunTime {
 
   def _hashCode(x: Product): Int = scala.util.hashing.MurmurHash3.productHash(x)
 
-  /** A helper for case classes. */
+  /** A helper for case classes.
+   *
+   *  @tparam T the target element type to which each product element is cast (unchecked)
+   *  @param x the product instance to iterate over
+   */
   def typedProductIterator[T](x: Product): Iterator[T] = {
     new AbstractIterator[T] {
       private[this] var c: Int = 0
@@ -245,7 +269,11 @@ object ScalaRunTime {
     }
   }
 
-  /** stringOf formatted for use in a repl result. */
+  /** stringOf formatted for use in a repl result.
+   *
+   *  @param arg the value to convert to a string representation
+   *  @param maxElements the maximum number of collection elements to include in the output
+   */
   def replStringOf(arg: Any, maxElements: Int): String =
     stringOf(arg, maxElements) match {
       case null => "null toString"

--- a/library-js/src/scala/util/DynamicVariable.scala
+++ b/library-js/src/scala/util/DynamicVariable.scala
@@ -42,6 +42,9 @@ import java.lang.InheritableThreadLocal
  *
  *  @author  Lex Spoon
  *  @since   2.6
+ *
+ *  @tparam T the type of the dynamic variable's value
+ *  @param init the initial value of the variable
  */
 class DynamicVariable[T](init: T) {
   /* Scala.js: replaced InheritableThreadLocal by a simple var.
@@ -56,6 +59,7 @@ class DynamicVariable[T](init: T) {
   /** Sets the value of the variable while executing the specified
    *  thunk.
    *
+   *  @tparam S the result type of the thunk, also the return type of this method
    *  @param newval The value to which to set the variable
    *  @param thunk The code to evaluate under the new setting
    */

--- a/library/src/scala/Array.scala
+++ b/library/src/scala/Array.scala
@@ -46,7 +46,11 @@ object Array {
   val emptyShortArray   = new Array[Short](0)
   val emptyObjectArray  = new Array[Object](0)
 
-  /** Provides an implicit conversion from the Array object to a collection Factory. */
+  /** Provides an implicit conversion from the Array object to a collection Factory.
+   *
+   *  @tparam A the element type of the array to be created
+   *  @param dummy the `Array` companion object used to trigger the implicit conversion
+   */
   implicit def toFactory[A : ClassTag](dummy: Array.type): Factory[A, Array[A]] = new ArrayFactory(dummy)
   @SerialVersionUID(3L)
   private class ArrayFactory[A : ClassTag](dummy: Array.type) extends Factory[A, Array[A]] with Serializable {
@@ -54,7 +58,11 @@ object Array {
     def newBuilder: mutable.Builder[A, Array[A]] = Array.newBuilder[A]
   }
 
-  /** Returns a new [[scala.collection.mutable.ArrayBuilder]]. */
+  /** Returns a new [[scala.collection.mutable.ArrayBuilder]].
+   *
+   *  @tparam T the element type of the array to be built
+   *  @param t the `ClassTag` providing runtime type information for `T`
+   */
   def newBuilder[T](implicit t: ClassTag[T]): ArrayBuilder[T] = ArrayBuilder.make[T](using t)
 
   /** Builds an array from the iterable collection.
@@ -67,6 +75,7 @@ object Array {
    *  val b: Array[Int] = Array(1, 2, 3, 4)
    *  ```
    *
+   *  @tparam A the element type of the array
    *  @param  it the iterable collection
    *  @return    an array consisting of elements of the iterable collection
    */
@@ -123,6 +132,11 @@ object Array {
    *  except that this works for primitive and object arrays in a single method.
    *
    *  @see `java.util.Arrays#copyOf`
+   *
+   *  @tparam A the element type of the array
+   *  @param original the array to be copied
+   *  @param newLength the length of the copy to be returned
+   *  @return a copy of the original array, truncated or padded with default values to obtain the specified length
    */
   def copyOf[A](original: Array[A], newLength: Int): Array[A] = ((original: @unchecked) match {
     case original: Array[BoxedUnit]  => newUnitArray(newLength).asInstanceOf[Array[A]]
@@ -149,6 +163,12 @@ object Array {
    *  in a single method.
    *
    *  @see `java.util.Arrays#copyOf`
+   *
+   *  @tparam A the element type of the target array
+   *  @param original the array to be copied
+   *  @param newLength the length of the copy to be returned
+   *  @param ct the `ClassTag` providing runtime type information for the target element type `A`
+   *  @return a copy of the original array, with elements converted to type `A`, truncated or padded to the specified length
    */
   def copyAs[A](original: Array[?], newLength: Int)(implicit ct: ClassTag[A]): Array[A] = {
     val runtimeClass = ct.runtimeClass
@@ -175,7 +195,10 @@ object Array {
     result
   }
 
-  /** Returns an array of length 0. */
+  /** Returns an array of length 0.
+   *
+   *  @tparam T the element type of the array
+   */
   def empty[T: ClassTag]: Array[T] = new Array[T](0)
 
   /** Creates an array with given elements.
@@ -205,7 +228,11 @@ object Array {
     }
   }
 
-  /** Creates an array of `Boolean` objects. */
+  /** Creates an array of `Boolean` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Boolean, xs: Boolean*): Array[Boolean] = {
     val array = new Array[Boolean](xs.length + 1)
@@ -218,7 +245,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Byte` objects. */
+  /** Creates an array of `Byte` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Byte, xs: Byte*): Array[Byte] = {
     val array = new Array[Byte](xs.length + 1)
@@ -231,7 +262,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Short` objects. */
+  /** Creates an array of `Short` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Short, xs: Short*): Array[Short] = {
     val array = new Array[Short](xs.length + 1)
@@ -244,7 +279,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Char` objects. */
+  /** Creates an array of `Char` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Char, xs: Char*): Array[Char] = {
     val array = new Array[Char](xs.length + 1)
@@ -257,7 +296,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Int` objects. */
+  /** Creates an array of `Int` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Int, xs: Int*): Array[Int] = {
     val array = new Array[Int](xs.length + 1)
@@ -270,7 +313,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Long` objects. */
+  /** Creates an array of `Long` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Long, xs: Long*): Array[Long] = {
     val array = new Array[Long](xs.length + 1)
@@ -283,7 +330,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Float` objects. */
+  /** Creates an array of `Float` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Float, xs: Float*): Array[Float] = {
     val array = new Array[Float](xs.length + 1)
@@ -296,7 +347,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Double` objects. */
+  /** Creates an array of `Double` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Double, xs: Double*): Array[Double] = {
     val array = new Array[Double](xs.length + 1)
@@ -309,7 +364,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Unit` objects. */
+  /** Creates an array of `Unit` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   def apply(x: Unit, xs: Unit*): Array[Unit] = {
     val array = new Array[Unit](xs.length + 1)
     array(0) = x
@@ -321,28 +380,59 @@ object Array {
     array
   }
 
-  /** Creates array with given dimensions. */
+  /** Creates array with given dimensions.
+   *
+   *  @tparam T the element type of the array
+   *  @param n1 the number of elements in the 1st dimension
+   */
   def ofDim[T: ClassTag](n1: Int): Array[T] =
     new Array[T](n1)
-  /** Creates a 2-dimensional array. */
+  /** Creates a 2-dimensional array.
+   *
+   *  @tparam T the element type of the array
+   *  @param n1 the number of elements in the 1st dimension
+   *  @param n2 the number of elements in the 2nd dimension
+   */
   def ofDim[T: ClassTag](n1: Int, n2: Int): Array[Array[T]] = {
     val arr: Array[Array[T]] = (new Array[Array[T]](n1): Array[Array[T]])
     for (i <- 0 until n1) arr(i) = new Array[T](n2)
     arr
     // tabulate(n1)(_ => ofDim[T](n2))
   }
-  /** Creates a 3-dimensional array. */
+  /** Creates a 3-dimensional array.
+   *
+   *  @tparam T the element type of the array
+   *  @param n1 the number of elements in the 1st dimension
+   *  @param n2 the number of elements in the 2nd dimension
+   *  @param n3 the number of elements in the 3rd dimension
+   */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int): Array[Array[Array[T]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3))
-  /** Creates a 4-dimensional array. */
+  /** Creates a 4-dimensional array.
+   *
+   *  @tparam T the element type of the array
+   *  @param n1 the number of elements in the 1st dimension
+   *  @param n2 the number of elements in the 2nd dimension
+   *  @param n3 the number of elements in the 3rd dimension
+   *  @param n4 the number of elements in the 4th dimension
+   */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int): Array[Array[Array[Array[T]]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3, n4))
-  /** Creates a 5-dimensional array. */
+  /** Creates a 5-dimensional array.
+   *
+   *  @tparam T the element type of the array
+   *  @param n1 the number of elements in the 1st dimension
+   *  @param n2 the number of elements in the 2nd dimension
+   *  @param n3 the number of elements in the 3rd dimension
+   *  @param n4 the number of elements in the 4th dimension
+   *  @param n5 the number of elements in the 5th dimension
+   */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int): Array[Array[Array[Array[Array[T]]]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3, n4, n5))
 
   /** Concatenates all arrays into a single array.
    *
+   *  @tparam T the element type of the arrays
    *  @param xss the given arrays
    *  @return   the array created from concatenating `xss`
    */
@@ -362,6 +452,7 @@ object Array {
    *  res3: Array[Double] = Array(0.365461167592537, 1.550395944913685E-4, 0.7907242137333306)
    *  ```
    *
+   *  @tparam T the element type of the array
    *  @param   n  the number of elements desired
    *  @param   elem the element computation
    *  @return an Array of size n, where each element contains the result of computing
@@ -384,6 +475,7 @@ object Array {
   /** Returns a two-dimensional array that contains the results of some element
    *  computation a number of times.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   elem the element computation
@@ -394,6 +486,7 @@ object Array {
   /** Returns a three-dimensional array that contains the results of some element
    *  computation a number of times.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -405,6 +498,7 @@ object Array {
   /** Returns a four-dimensional array that contains the results of some element
    *  computation a number of times.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -417,6 +511,7 @@ object Array {
   /** Returns a five-dimensional array that contains the results of some element
    *  computation a number of times.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -430,6 +525,7 @@ object Array {
   /** Returns an array containing values of a given function over a range of integer
    *  values starting from 0.
    *
+   *  @tparam T the element type of the array
    *  @param  n   The number of elements in the array
    *  @param  f   The function computing element values
    *  @return An `Array` consisting of elements `f(0),f(1), ..., f(n - 1)`
@@ -451,6 +547,7 @@ object Array {
   /** Returns a two-dimensional array containing values of a given function
    *  over ranges of integer values starting from `0`.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   f   The function computing element values
@@ -461,6 +558,7 @@ object Array {
   /** Returns a three-dimensional array containing values of a given function
    *  over ranges of integer values starting from `0`.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -472,6 +570,7 @@ object Array {
   /** Returns a four-dimensional array containing values of a given function
    *  over ranges of integer values starting from `0`.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -484,6 +583,7 @@ object Array {
   /** Returns a five-dimensional array containing values of a given function
    *  over ranges of integer values starting from `0`.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -526,6 +626,7 @@ object Array {
 
   /** Returns an array containing repeated applications of a function to a start value.
    *
+   *  @tparam T the element type of the array
    *  @param start the start value of the array
    *  @param len   the number of elements returned by the array
    *  @param f     the function that is repeatedly applied
@@ -574,8 +675,9 @@ object Array {
 
   /** Called in a pattern match like `{ case Array(x,y,z) => println('3 elements')}`.
    *
+   *  @tparam T the element type of the array
    *  @param x the selector value
-   *  @return  sequence wrapped in a [[scala.Some]], if `x` is an Array, otherwise `None`
+   *  @return  a [[UnapplySeqWrapper]] that provides sequence-like access to the array elements
    */
   def unapplySeq[T](x: Array[T]): UnapplySeqWrapper[T] = new UnapplySeqWrapper(x)
 
@@ -657,6 +759,8 @@ object Array {
  *  @define willNotTerminateInf
  *  @define collectExample
  *  @define undefinedorder
+ *
+ *  @tparam T the element type of the array
  */
 final class Array[T](_length: Int) extends java.io.Serializable with java.lang.Cloneable { self: Array[T] =>
 

--- a/library/src/scala/Boolean.scala
+++ b/library/src/scala/Boolean.scala
@@ -61,6 +61,9 @@ final abstract class Boolean private extends AnyVal {
    *  @note This method uses 'short-circuit' evaluation and
    *       behaves as if it was declared as `def ||(x: => Boolean): Boolean`.
    *       If `a` evaluates to `true`, `true` is returned without evaluating `b`.
+   *
+   *  @param x the right-hand operand, only evaluated if `this` is `false`
+   *  @return `true` if at least one operand is `true`, `false` otherwise
    */
   def ||(x: Boolean): Boolean
 
@@ -72,6 +75,9 @@ final abstract class Boolean private extends AnyVal {
    *  @note This method uses 'short-circuit' evaluation and
    *       behaves as if it was declared as `def &&(x: => Boolean): Boolean`.
    *       If `a` evaluates to `false`, `false` is returned without evaluating `b`.
+   *
+   *  @param x the right-hand operand, only evaluated if `this` is `true`
+   *  @return `true` if both operands are `true`, `false` otherwise
    */
   def &&(x: Boolean): Boolean
 
@@ -87,6 +93,9 @@ final abstract class Boolean private extends AnyVal {
    *  - `a` and `b` are `true`.
    *
    *  @note This method evaluates both `a` and `b`, even if the result is already determined after evaluating `a`.
+   *
+   *  @param x the right-hand operand, always evaluated
+   *  @return `true` if at least one operand is `true`, `false` otherwise
    */
   def |(x: Boolean): Boolean
 
@@ -96,6 +105,9 @@ final abstract class Boolean private extends AnyVal {
    *  - `a` and `b` are `true`.
    *
    *  @note This method evaluates both `a` and `b`, even if the result is already determined after evaluating `a`.
+   *
+   *  @param x the right-hand operand, always evaluated
+   *  @return `true` if both operands are `true`, `false` otherwise
    */
   def &(x: Boolean): Boolean
 
@@ -104,6 +116,9 @@ final abstract class Boolean private extends AnyVal {
    *  `a ^ b` returns `true` if and only if
    *  - `a` is `true` and `b` is `false` or
    *  - `a` is `false` and `b` is `true`.
+   *
+   *  @param x the right-hand operand
+   *  @return `true` if the operands evaluate to different values, `false` otherwise
    */
   def ^(x: Boolean): Boolean
 

--- a/library/src/scala/Byte.scala
+++ b/library/src/scala/Byte.scala
@@ -56,6 +56,8 @@ final abstract class Byte private extends AnyVal {
    *  ```
    *  6 << 3 == 48 // in binary: 0110 << 3 == 0110000
    *  ```
+   *
+   *  @param x the number of bits to shift left (only the five lowest bits are used)
    */
   def <<(x: Int): Int
   /** Returns this value bit-shifted left by the specified number of bits,
@@ -75,6 +77,8 @@ final abstract class Byte private extends AnyVal {
    *  // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
    *  //            00011111 11111111 11111111 11111101
    *  ```
+   *
+   *  @param x the number of bits to shift right (only the five lowest bits are used)
    */
   def >>>(x: Int): Int
   /** Returns this value bit-shifted right by the specified number of bits,
@@ -96,6 +100,8 @@ final abstract class Byte private extends AnyVal {
    *  // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
    *  //            11111111 11111111 11111111 11111101
    *  ```
+   *
+   *  @param x the number of bits to shift right (only the five lowest bits are used)
    */
   def >>(x: Int): Int
   /** Returns this value bit-shifted right by the specified number of bits,
@@ -140,19 +146,40 @@ final abstract class Byte private extends AnyVal {
   /** Returns `true` if this value is not equal to x, `false` otherwise. */
   def !=(x: Double): Boolean
 
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Byte): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Short): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Char): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Int): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Long): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Float): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Double): Boolean
 
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
@@ -170,19 +197,40 @@ final abstract class Byte private extends AnyVal {
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
   def <=(x: Double): Boolean
 
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Byte): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Short): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Char): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Int): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Long): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Float): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Double): Boolean
 
   /** Returns `true` if this value is greater than or equal to x, `false` otherwise. */
@@ -208,6 +256,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Byte): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -218,6 +268,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Short): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -228,6 +280,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Char): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -238,6 +292,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Int): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -248,6 +304,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Long): Long
 
@@ -259,6 +317,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Byte): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -269,6 +329,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Short): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -279,6 +341,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Char): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -289,6 +353,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Int): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -299,6 +365,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Long): Long
 
@@ -310,6 +378,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Byte): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -320,6 +390,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Short): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -330,6 +402,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Char): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -340,6 +414,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Int): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -350,82 +426,189 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Long): Long
 
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Byte): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Short): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Char): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Int): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Long): Long
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Float): Float
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Double): Double
 
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Byte): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Short): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Char): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Int): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Long): Long
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Float): Float
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Double): Double
 
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Byte): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Short): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Char): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Int): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Long): Long
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Float): Float
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Double): Double
 
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Byte): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Short): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Char): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Int): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Long): Long
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Float): Float
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Double): Double
 
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Byte): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Short): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Char): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Int): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Long): Long
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Float): Float
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Double): Double
 
   // Provide a more specific return type for Scaladoc
@@ -462,7 +645,10 @@ object Byte extends AnyValCompanion {
 
   /** The `String` representation of the `scala.Byte` companion object. */
   override def toString() = "object scala.Byte"
-  /** Language mandated coercions from `Byte` to "wider" types. */
+  /** Language mandated coercions from `Byte` to "wider" types.
+   *
+   *  @param x the `Byte` value to convert
+   */
   import scala.language.implicitConversions
   implicit def byte2short(x: Byte): Short = x.toShort
   implicit def byte2int(x: Byte): Int = x.toInt

--- a/library/src/scala/CanEqual.scala
+++ b/library/src/scala/CanEqual.scala
@@ -21,6 +21,9 @@ object CanEqual {
    *  Even though this method is not declared as given, the compiler will
    *  synthesize implicit arguments as solutions to `CanEqual[T, U]` queries if
    *  the rules of multiversal equality require it.
+   *
+   *  @tparam L the left-hand comparison type
+   *  @tparam R the right-hand comparison type
    */
   def canEqualAny[L, R]: CanEqual[L, R] = derived
 

--- a/library/src/scala/Char.scala
+++ b/library/src/scala/Char.scala
@@ -56,6 +56,8 @@ final abstract class Char private extends AnyVal {
    *  ```
    *  6 << 3 == 48 // in binary: 0110 << 3 == 0110000
    *  ```
+   *
+   *  @param x the number of bits to shift left
    */
   def <<(x: Int): Int
   /** Returns this value bit-shifted left by the specified number of bits,
@@ -75,6 +77,8 @@ final abstract class Char private extends AnyVal {
    *  // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
    *  //            00011111 11111111 11111111 11111101
    *  ```
+   *
+   *  @param x the number of bits to shift right
    */
   def >>>(x: Int): Int
   /** Returns this value bit-shifted right by the specified number of bits,
@@ -96,6 +100,8 @@ final abstract class Char private extends AnyVal {
    *  // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
    *  //            11111111 11111111 11111111 11111101
    *  ```
+   *
+   *  @param x the number of bits to shift right
    */
   def >>(x: Int): Int
   /** Returns this value bit-shifted right by the specified number of bits,
@@ -140,19 +146,40 @@ final abstract class Char private extends AnyVal {
   /** Returns `true` if this value is not equal to x, `false` otherwise. */
   def !=(x: Double): Boolean
 
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Byte): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Short): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Char): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Int): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Long): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Float): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Double): Boolean
 
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
@@ -170,19 +197,40 @@ final abstract class Char private extends AnyVal {
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
   def <=(x: Double): Boolean
 
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Byte): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Short): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Char): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Int): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Long): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Float): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Double): Boolean
 
   /** Returns `true` if this value is greater than or equal to x, `false` otherwise. */
@@ -208,6 +256,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Byte): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -218,6 +268,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Short): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -228,6 +280,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Char): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -238,6 +292,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Int): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -248,6 +304,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Long): Long
 
@@ -259,6 +317,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Byte): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -269,6 +329,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Short): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -279,6 +341,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Char): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -289,6 +353,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Int): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -299,6 +365,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Long): Long
 
@@ -310,6 +378,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Byte): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -320,6 +390,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Short): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -330,6 +402,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Char): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -340,6 +414,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Int): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -350,82 +426,189 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Long): Long
 
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Byte): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Short): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Char): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Int): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Long): Long
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Float): Float
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Double): Double
 
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Byte): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Short): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Char): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Int): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Long): Long
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Float): Float
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Double): Double
 
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Byte): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Short): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Char): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Int): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Long): Long
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Float): Float
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Double): Double
 
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Byte): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Short): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Char): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Int): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Long): Long
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Float): Float
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Double): Double
 
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Byte): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Short): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Char): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Int): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Long): Long
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Float): Float
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Double): Double
 
   // Provide a more specific return type for Scaladoc
@@ -462,7 +645,10 @@ object Char extends AnyValCompanion {
 
   /** The `String` representation of the `scala.Char` companion object. */
   override def toString() = "object scala.Char"
-  /** Language mandated coercions from `Char` to "wider" types. */
+  /** Language mandated coercions from `Char` to "wider" types.
+   *
+   *  @param x the `Char` value to convert
+   */
   import scala.language.implicitConversions
   implicit def char2int(x: Char): Int = x.toInt
   implicit def char2long(x: Char): Long = x.toLong

--- a/library/src/scala/Console.scala
+++ b/library/src/scala/Console.scala
@@ -154,6 +154,7 @@ object Console extends AnsiColor {
    *  withOut(Console.err) { println("This goes to default _error_") }
    *  ```
    *
+   *  @tparam T the return type of `thunk`
    *  @param out the new output stream.
    *  @param thunk the code to execute with
    *               the new output stream active
@@ -167,6 +168,7 @@ object Console extends AnsiColor {
   /** Sets the default output stream for the duration
    *  of execution of one thunk.
    *
+   *  @tparam T the return type of `thunk`
    *  @param out the new output stream.
    *  @param thunk the code to execute with
    *               the new output stream active
@@ -183,6 +185,7 @@ object Console extends AnsiColor {
    *  withErr(Console.out) { err.println("This goes to default _out_") }
    *  ```
    *
+   *  @tparam T the return type of `thunk`
    *  @param err the new error stream.
    *  @param thunk the code to execute with
    *               the new error stream active
@@ -196,6 +199,7 @@ object Console extends AnsiColor {
   /** Sets the default error stream for the duration
    *  of execution of one thunk.
    *
+   *  @tparam T the return type of `thunk`
    *  @param err the new error stream.
    *  @param thunk the code to execute with
    *               the new error stream active
@@ -217,9 +221,10 @@ object Console extends AnsiColor {
    *  }
    *  ```
    *
+   *  @tparam T the return type of `thunk`
+   *  @param reader the new input reader to use as the default input source
    *  @param thunk the code to execute with
    *               the new input stream active
-   *
    *  @return the results of `thunk`
    *  @see `withIn[T](in:InputStream)(thunk: => T)`
    *  @group io-redefinition
@@ -230,6 +235,7 @@ object Console extends AnsiColor {
   /** Sets the default input stream for the duration
    *  of execution of one thunk.
    *
+   *  @tparam T the return type of `thunk`
    *  @param in the new input stream.
    *  @param thunk the code to execute with
    *               the new input stream active

--- a/library/src/scala/Conversion.scala
+++ b/library/src/scala/Conversion.scala
@@ -23,11 +23,17 @@ import annotation.internal.preview
  *
  *  The `Conversion` class can also be used to convert explicitly, using
  *  the `convert` extension method.
+ *
+ *  @tparam T the input type of the conversion (contravariant)
+ *  @tparam U the output type of the conversion (covariant)
  */
 @java.lang.FunctionalInterface
 abstract class Conversion[-T, +U] extends Function1[T, U]:
   self =>
-    /** Converts value `x` of type `T` to type `U`. */
+    /** Converts value `x` of type `T` to type `U`.
+     *
+     *  @param x the value of type `T` to convert to type `U`
+     */
     def apply(x: T): U
 
     extension (x: T)

--- a/library/src/scala/Double.scala
+++ b/library/src/scala/Double.scala
@@ -72,19 +72,40 @@ final abstract class Double private extends AnyVal {
   /** Returns `true` if this value is not equal to x, `false` otherwise. */
   def !=(x: Double): Boolean
 
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def <(x: Byte): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def <(x: Short): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def <(x: Char): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def <(x: Int): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def <(x: Long): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def <(x: Float): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def <(x: Double): Boolean
 
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
@@ -102,19 +123,40 @@ final abstract class Double private extends AnyVal {
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
   def <=(x: Double): Boolean
 
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def >(x: Byte): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def >(x: Short): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def >(x: Char): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def >(x: Int): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def >(x: Long): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def >(x: Float): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def >(x: Double): Boolean
 
   /** Returns `true` if this value is greater than or equal to x, `false` otherwise. */
@@ -132,79 +174,184 @@ final abstract class Double private extends AnyVal {
   /** Returns `true` if this value is greater than or equal to x, `false` otherwise. */
   def >=(x: Double): Boolean
 
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this one
+   */
   def +(x: Byte): Double
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this one
+   */
   def +(x: Short): Double
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this one
+   */
   def +(x: Char): Double
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this one
+   */
   def +(x: Int): Double
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this one
+   */
   def +(x: Long): Double
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this one
+   */
   def +(x: Float): Double
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this one
+   */
   def +(x: Double): Double
 
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this one
+   */
   def -(x: Byte): Double
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this one
+   */
   def -(x: Short): Double
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this one
+   */
   def -(x: Char): Double
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this one
+   */
   def -(x: Int): Double
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this one
+   */
   def -(x: Long): Double
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this one
+   */
   def -(x: Float): Double
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this one
+   */
   def -(x: Double): Double
 
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this one
+   */
   def *(x: Byte): Double
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this one
+   */
   def *(x: Short): Double
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this one
+   */
   def *(x: Char): Double
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this one
+   */
   def *(x: Int): Double
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this one
+   */
   def *(x: Long): Double
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this one
+   */
   def *(x: Float): Double
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this one
+   */
   def *(x: Double): Double
 
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this one by
+   */
   def /(x: Byte): Double
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this one by
+   */
   def /(x: Short): Double
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this one by
+   */
   def /(x: Char): Double
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this one by
+   */
   def /(x: Int): Double
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this one by
+   */
   def /(x: Long): Double
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this one by
+   */
   def /(x: Float): Double
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this one by
+   */
   def /(x: Double): Double
 
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Byte): Double
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Short): Double
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Char): Double
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Int): Double
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Long): Double
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Float): Double
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Double): Double
 
   // Provide a more specific return type for Scaladoc

--- a/library/src/scala/Enumeration.scala
+++ b/library/src/scala/Enumeration.scala
@@ -152,7 +152,10 @@ abstract class Enumeration (initial: Int) extends Serializable {
    */
   final def maxId = topId
 
-  /** The value of this enumeration with given id `x`. */
+  /** The value of this enumeration with given id `x`.
+   *
+   *  @param x the integer id of the desired value; throws `NoSuchElementException` if no value with this id exists
+   */
   final def apply(x: Int): Value = vmap(x)
 
   /** Returns a `Value` from this `Enumeration` whose name matches
@@ -245,7 +248,10 @@ abstract class Enumeration (initial: Int) extends Serializable {
     }
     override def hashCode(): Int = id.##
 
-    /** Creates a ValueSet which contains this value and another one. */
+    /** Creates a ValueSet which contains this value and another one.
+     *
+     *  @param v the other value to include in the set
+     */
     def + (v: Value): ValueSet = ValueSet(this, v)
   }
 
@@ -345,6 +351,8 @@ abstract class Enumeration (initial: Int) extends Serializable {
     val empty: ValueSet = new ValueSet(immutable.BitSet.empty)
     /** A value set containing all the values for the zero-adjusted ids
      *  corresponding to the bits in an array 
+     *
+     *  @param elems an array of `Long` values encoding the bit mask of zero-adjusted value ids
      */
     def fromBitMask(elems: Array[Long]): ValueSet = new ValueSet(immutable.BitSet.fromBitMask(elems))
     /** A builder object for value sets. */

--- a/library/src/scala/Equals.scala
+++ b/library/src/scala/Equals.scala
@@ -32,6 +32,8 @@ trait Equals extends Any {
 
   /** Checks whether this instance is equal to `that`.
    *  This universal equality method is defined in `AnyRef`.
+   *
+   *  @param that the object to compare for equality with this instance
    */
   def equals(that: Any): Boolean
 }

--- a/library/src/scala/Float.scala
+++ b/library/src/scala/Float.scala
@@ -72,19 +72,40 @@ final abstract class Float private extends AnyVal {
   /** Returns `true` if this value is not equal to x, `false` otherwise. */
   def !=(x: Double): Boolean
 
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Byte): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Short): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Char): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Int): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Long): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Float): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Double): Boolean
 
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
@@ -102,19 +123,40 @@ final abstract class Float private extends AnyVal {
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
   def <=(x: Double): Boolean
 
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Byte): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Short): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Char): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Int): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Long): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Float): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Double): Boolean
 
   /** Returns `true` if this value is greater than or equal to x, `false` otherwise. */
@@ -132,79 +174,184 @@ final abstract class Float private extends AnyVal {
   /** Returns `true` if this value is greater than or equal to x, `false` otherwise. */
   def >=(x: Double): Boolean
 
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add
+   */
   def +(x: Byte): Float
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add
+   */
   def +(x: Short): Float
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add
+   */
   def +(x: Char): Float
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add
+   */
   def +(x: Int): Float
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add
+   */
   def +(x: Long): Float
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add
+   */
   def +(x: Float): Float
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add
+   */
   def +(x: Double): Double
 
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract
+   */
   def -(x: Byte): Float
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract
+   */
   def -(x: Short): Float
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract
+   */
   def -(x: Char): Float
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract
+   */
   def -(x: Int): Float
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract
+   */
   def -(x: Long): Float
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract
+   */
   def -(x: Float): Float
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract
+   */
   def -(x: Double): Double
 
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the other factor
+   */
   def *(x: Byte): Float
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the other factor
+   */
   def *(x: Short): Float
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the other factor
+   */
   def *(x: Char): Float
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the other factor
+   */
   def *(x: Int): Float
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the other factor
+   */
   def *(x: Long): Float
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the other factor
+   */
   def *(x: Float): Float
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the other factor
+   */
   def *(x: Double): Double
 
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Byte): Float
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Short): Float
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Char): Float
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Int): Float
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Long): Float
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Float): Float
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Double): Double
 
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Byte): Float
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Short): Float
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Char): Float
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Int): Float
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Long): Float
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Float): Float
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Double): Double
 
   // Provide a more specific return type for Scaladoc
@@ -253,7 +400,10 @@ object Float extends AnyValCompanion {
 
   /** The `String` representation of the `scala.Float` companion object. */
   override def toString() = "object scala.Float"
-  /** Language mandated coercions from `Float` to "wider" types. */
+  /** Language mandated coercions from `Float` to "wider" types.
+   *
+   *  @param x the `Float` value to convert
+   */
   import scala.language.implicitConversions
   implicit def float2double(x: Float): Double = x.toDouble
 }

--- a/library/src/scala/Function.scala
+++ b/library/src/scala/Function.scala
@@ -19,11 +19,18 @@ object Function {
   /** Given a sequence of functions `f,,1,,`, ..., `f,,n,,`, return the
    *  function `f,,1,, andThen ... andThen f,,n,,`.
    *
-   *  @param fs The given sequence of functions
+   *  @tparam T the common input and output type of the functions in the chain
+   *  @param fs the given sequence of functions
    */
   def chain[T](fs: scala.collection.Seq[T => T]): T => T = { x => fs.foldLeft(x)((x, f) => f(x)) }
 
-  /** The constant function. */
+  /** The constant function.
+   *
+   *  @tparam T the return type
+   *  @tparam U the type of the argument to ignore
+   *  @param x the constant value to return
+   *  @param y the argument that is ignored
+   */
   def const[T, U](x: T)(y: U): T = x
 
   /** Turns a function `A => Option[B]` into a `PartialFunction[A, B]`.
@@ -34,6 +41,8 @@ object Function {
    *  function and examine the return value.
    *  See also [[scala.PartialFunction]], method `applyOrElse`.
    *
+   *  @tparam T the input type of the function
+   *  @tparam R the result type
    *  @param   f    a function `T => Option[R]`
    *  @return       a partial function defined for those inputs where
    *                f returns `Some(_)` and undefined where `f` returns `None`.
@@ -43,22 +52,51 @@ object Function {
 
   /** Uncurrying for functions of arity 2. This transforms a unary function
    *  returning another unary function into a function of arity 2.
+   *
+   *  @tparam T1 the type of the first argument
+   *  @tparam T2 the type of the second argument
+   *  @tparam R the result type
+   *  @param f the curried function to uncurry
    */
   def uncurried[T1, T2, R](f: T1 => T2 => R): (T1, T2) => R = {
     (x1, x2) => f(x1)(x2)
   }
 
-  /** Uncurrying for functions of arity 3. */
+  /** Uncurrying for functions of arity 3.
+   *
+   *  @tparam T1 the type of the first argument
+   *  @tparam T2 the type of the second argument
+   *  @tparam T3 the type of the third argument
+   *  @tparam R the result type
+   *  @param f the curried function to uncurry
+   */
   def uncurried[T1, T2, T3, R](f: T1 => T2 => T3 => R): (T1, T2, T3) => R = {
     (x1, x2, x3) => f(x1)(x2)(x3)
   }
 
-  /** Uncurrying for functions of arity 4. */
+  /** Uncurrying for functions of arity 4.
+   *
+   *  @tparam T1 the type of the first argument
+   *  @tparam T2 the type of the second argument
+   *  @tparam T3 the type of the third argument
+   *  @tparam T4 the type of the fourth argument
+   *  @tparam R the result type
+   *  @param f the curried function to uncurry
+   */
   def uncurried[T1, T2, T3, T4, R](f: T1 => T2 => T3 => T4 => R): (T1, T2, T3, T4) => R = {
     (x1, x2, x3, x4) => f(x1)(x2)(x3)(x4)
   }
 
-  /** Uncurrying for functions of arity 5. */
+  /** Uncurrying for functions of arity 5.
+   *
+   *  @tparam T1 the type of the first argument
+   *  @tparam T2 the type of the second argument
+   *  @tparam T3 the type of the third argument
+   *  @tparam T4 the type of the fourth argument
+   *  @tparam T5 the type of the fifth argument
+   *  @tparam R the result type
+   *  @param f the curried function to uncurry
+   */
   def uncurried[T1, T2, T3, T4, T5, R](f: T1 => T2 => T3 => T4 => T5 => R): (T1, T2, T3, T4, T5) => R  =  {
     (x1, x2, x3, x4, x5) => f(x1)(x2)(x3)(x4)(x5)
   }
@@ -100,6 +138,11 @@ object Function {
 
   /** Un-tupling for functions of arity 2. This transforms a function taking
    *  a pair of arguments into a binary function which takes each argument separately.
+   *
+   *  @tparam T1 the type of the first argument
+   *  @tparam T2 the type of the second argument
+   *  @tparam R the result type
+   *  @param f the tupled function to untuple
    */
   def untupled[T1, T2, R](f: ((T1, T2)) => R): (T1, T2) => R = {
     (x1, x2) => f((x1, x2))
@@ -107,6 +150,12 @@ object Function {
 
   /** Un-tupling for functions of arity 3. This transforms a function taking
    *  a triple of arguments into a ternary function which takes each argument separately.
+   *
+   *  @tparam T1 the type of the first argument
+   *  @tparam T2 the type of the second argument
+   *  @tparam T3 the type of the third argument
+   *  @tparam R the result type
+   *  @param f the tupled function to untuple
    */
   def untupled[T1, T2, T3, R](f: ((T1, T2, T3)) => R): (T1, T2, T3) => R = {
     (x1, x2, x3) => f((x1, x2, x3))
@@ -114,6 +163,13 @@ object Function {
 
   /** Un-tupling for functions of arity 4. This transforms a function taking
    *  a 4-tuple of arguments into a function of arity 4 which takes each argument separately.
+   *
+   *  @tparam T1 the type of the first argument
+   *  @tparam T2 the type of the second argument
+   *  @tparam T3 the type of the third argument
+   *  @tparam T4 the type of the fourth argument
+   *  @tparam R the result type
+   *  @param f the tupled function to untuple
    */
   def untupled[T1, T2, T3, T4, R](f: ((T1, T2, T3, T4)) => R): (T1, T2, T3, T4) => R = {
     (x1, x2, x3, x4) => f((x1, x2, x3, x4))
@@ -121,6 +177,14 @@ object Function {
 
   /** Un-tupling for functions of arity 5. This transforms a function taking
    *  a 5-tuple of arguments into a function of arity 5 which takes each argument separately.
+   *
+   *  @tparam T1 the type of the first argument
+   *  @tparam T2 the type of the second argument
+   *  @tparam T3 the type of the third argument
+   *  @tparam T4 the type of the fourth argument
+   *  @tparam T5 the type of the fifth argument
+   *  @tparam R the result type
+   *  @param f the tupled function to untuple
    */
   def untupled[T1, T2, T3, T4, T5, R](f: ((T1, T2, T3, T4, T5)) => R): (T1, T2, T3, T4, T5) => R = {
     (x1, x2, x3, x4, x5) => f((x1, x2, x3, x4, x5))

--- a/library/src/scala/Function1.scala
+++ b/library/src/scala/Function1.scala
@@ -38,6 +38,8 @@ object Function1 {
      *              println("Not matched")
      *          }
      *          ```
+     *
+     *  @return a `PartialFunction` that is defined where `f` returns `Some` and undefined where `f` returns `None`
      */
     def unlift: PartialFunction[A, B] = Function.unlift(f)
   }
@@ -65,6 +67,8 @@ object Function1 {
 @annotation.implicitNotFound(msg = "No implicit view available from ${T1} => ${R}.")
 trait Function1[@specialized(Specializable.Arg) -T1, @specialized(Specializable.Return) +R] extends AnyRef {
   /** Applies the body of this function to the argument.
+   *
+   *  @param v1 the function argument
    *  @return   the result of function application.
    */
   def apply(v1: T1): R

--- a/library/src/scala/Function10.scala
+++ b/library/src/scala/Function10.scala
@@ -16,9 +16,33 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 10 parameters. */
+/** A function of 10 parameters.
+ *
+ *  @tparam T1 the type of the first argument
+ *  @tparam T2 the type of the second argument
+ *  @tparam T3 the type of the third argument
+ *  @tparam T4 the type of the fourth argument
+ *  @tparam T5 the type of the fifth argument
+ *  @tparam T6 the type of the sixth argument
+ *  @tparam T7 the type of the seventh argument
+ *  @tparam T8 the type of the eighth argument
+ *  @tparam T9 the type of the ninth argument
+ *  @tparam T10 the type of the tenth argument
+ *  @tparam R the return type of this function
+ */
 trait Function10[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the first argument
+   *  @param v2 the second argument
+   *  @param v3 the third argument
+   *  @param v4 the fourth argument
+   *  @param v5 the fifth argument
+   *  @param v6 the sixth argument
+   *  @param v7 the seventh argument
+   *  @param v8 the eighth argument
+   *  @param v9 the ninth argument
+   *  @param v10 the tenth argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10): R

--- a/library/src/scala/Function11.scala
+++ b/library/src/scala/Function11.scala
@@ -16,9 +16,35 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 11 parameters. */
+/** A function of 11 parameters.
+ *
+ *  @tparam T1 the type of the first parameter of this function
+ *  @tparam T2 the type of the second parameter of this function
+ *  @tparam T3 the type of the third parameter of this function
+ *  @tparam T4 the type of the fourth parameter of this function
+ *  @tparam T5 the type of the fifth parameter of this function
+ *  @tparam T6 the type of the sixth parameter of this function
+ *  @tparam T7 the type of the seventh parameter of this function
+ *  @tparam T8 the type of the eighth parameter of this function
+ *  @tparam T9 the type of the ninth parameter of this function
+ *  @tparam T10 the type of the tenth parameter of this function
+ *  @tparam T11 the type of the eleventh parameter of this function
+ *  @tparam R the return type of this function
+ */
 trait Function11[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the value of the first parameter
+   *  @param v2 the value of the second parameter
+   *  @param v3 the value of the third parameter
+   *  @param v4 the value of the fourth parameter
+   *  @param v5 the value of the fifth parameter
+   *  @param v6 the value of the sixth parameter
+   *  @param v7 the value of the seventh parameter
+   *  @param v8 the value of the eighth parameter
+   *  @param v9 the value of the ninth parameter
+   *  @param v10 the value of the tenth parameter
+   *  @param v11 the value of the eleventh parameter
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11): R

--- a/library/src/scala/Function12.scala
+++ b/library/src/scala/Function12.scala
@@ -16,9 +16,37 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 12 parameters. */
+/** A function of 12 parameters.
+ *
+ *  @tparam T1 the type of the first argument
+ *  @tparam T2 the type of the second argument
+ *  @tparam T3 the type of the third argument
+ *  @tparam T4 the type of the fourth argument
+ *  @tparam T5 the type of the fifth argument
+ *  @tparam T6 the type of the sixth argument
+ *  @tparam T7 the type of the seventh argument
+ *  @tparam T8 the type of the eighth argument
+ *  @tparam T9 the type of the ninth argument
+ *  @tparam T10 the type of the tenth argument
+ *  @tparam T11 the type of the eleventh argument
+ *  @tparam T12 the type of the twelfth argument
+ *  @tparam R the return type of this function
+ */
 trait Function12[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the value of the first argument
+   *  @param v2 the value of the second argument
+   *  @param v3 the value of the third argument
+   *  @param v4 the value of the fourth argument
+   *  @param v5 the value of the fifth argument
+   *  @param v6 the value of the sixth argument
+   *  @param v7 the value of the seventh argument
+   *  @param v8 the value of the eighth argument
+   *  @param v9 the value of the ninth argument
+   *  @param v10 the value of the tenth argument
+   *  @param v11 the value of the eleventh argument
+   *  @param v12 the value of the twelfth argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12): R

--- a/library/src/scala/Function13.scala
+++ b/library/src/scala/Function13.scala
@@ -16,9 +16,39 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 13 parameters. */
+/** A function of 13 parameters.
+ *
+ *  @tparam T1 the type of the first argument
+ *  @tparam T2 the type of the second argument
+ *  @tparam T3 the type of the third argument
+ *  @tparam T4 the type of the fourth argument
+ *  @tparam T5 the type of the fifth argument
+ *  @tparam T6 the type of the sixth argument
+ *  @tparam T7 the type of the seventh argument
+ *  @tparam T8 the type of the eighth argument
+ *  @tparam T9 the type of the ninth argument
+ *  @tparam T10 the type of the tenth argument
+ *  @tparam T11 the type of the eleventh argument
+ *  @tparam T12 the type of the twelfth argument
+ *  @tparam T13 the type of the thirteenth argument
+ *  @tparam R the return type of the function
+ */
 trait Function13[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the value of the first argument
+   *  @param v2 the value of the second argument
+   *  @param v3 the value of the third argument
+   *  @param v4 the value of the fourth argument
+   *  @param v5 the value of the fifth argument
+   *  @param v6 the value of the sixth argument
+   *  @param v7 the value of the seventh argument
+   *  @param v8 the value of the eighth argument
+   *  @param v9 the value of the ninth argument
+   *  @param v10 the value of the tenth argument
+   *  @param v11 the value of the eleventh argument
+   *  @param v12 the value of the twelfth argument
+   *  @param v13 the value of the thirteenth argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13): R

--- a/library/src/scala/Function14.scala
+++ b/library/src/scala/Function14.scala
@@ -16,9 +16,41 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 14 parameters. */
+/** A function of 14 parameters.
+ *
+ *  @tparam T1 the type of the first argument
+ *  @tparam T2 the type of the second argument
+ *  @tparam T3 the type of the third argument
+ *  @tparam T4 the type of the fourth argument
+ *  @tparam T5 the type of the fifth argument
+ *  @tparam T6 the type of the sixth argument
+ *  @tparam T7 the type of the seventh argument
+ *  @tparam T8 the type of the eighth argument
+ *  @tparam T9 the type of the ninth argument
+ *  @tparam T10 the type of the tenth argument
+ *  @tparam T11 the type of the eleventh argument
+ *  @tparam T12 the type of the twelfth argument
+ *  @tparam T13 the type of the thirteenth argument
+ *  @tparam T14 the type of the fourteenth argument
+ *  @tparam R the type of the result
+ */
 trait Function14[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the value of the first argument
+   *  @param v2 the value of the second argument
+   *  @param v3 the value of the third argument
+   *  @param v4 the value of the fourth argument
+   *  @param v5 the value of the fifth argument
+   *  @param v6 the value of the sixth argument
+   *  @param v7 the value of the seventh argument
+   *  @param v8 the value of the eighth argument
+   *  @param v9 the value of the ninth argument
+   *  @param v10 the value of the tenth argument
+   *  @param v11 the value of the eleventh argument
+   *  @param v12 the value of the twelfth argument
+   *  @param v13 the value of the thirteenth argument
+   *  @param v14 the value of the fourteenth argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14): R

--- a/library/src/scala/Function15.scala
+++ b/library/src/scala/Function15.scala
@@ -16,9 +16,43 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 15 parameters. */
+/** A function of 15 parameters.
+ *
+ *  @tparam T1 the type of the 1st argument
+ *  @tparam T2 the type of the 2nd argument
+ *  @tparam T3 the type of the 3rd argument
+ *  @tparam T4 the type of the 4th argument
+ *  @tparam T5 the type of the 5th argument
+ *  @tparam T6 the type of the 6th argument
+ *  @tparam T7 the type of the 7th argument
+ *  @tparam T8 the type of the 8th argument
+ *  @tparam T9 the type of the 9th argument
+ *  @tparam T10 the type of the 10th argument
+ *  @tparam T11 the type of the 11th argument
+ *  @tparam T12 the type of the 12th argument
+ *  @tparam T13 the type of the 13th argument
+ *  @tparam T14 the type of the 14th argument
+ *  @tparam T15 the type of the 15th argument
+ *  @tparam R the return type of the function
+ */
 trait Function15[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the value of the 1st argument
+   *  @param v2 the value of the 2nd argument
+   *  @param v3 the value of the 3rd argument
+   *  @param v4 the value of the 4th argument
+   *  @param v5 the value of the 5th argument
+   *  @param v6 the value of the 6th argument
+   *  @param v7 the value of the 7th argument
+   *  @param v8 the value of the 8th argument
+   *  @param v9 the value of the 9th argument
+   *  @param v10 the value of the 10th argument
+   *  @param v11 the value of the 11th argument
+   *  @param v12 the value of the 12th argument
+   *  @param v13 the value of the 13th argument
+   *  @param v14 the value of the 14th argument
+   *  @param v15 the value of the 15th argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15): R

--- a/library/src/scala/Function16.scala
+++ b/library/src/scala/Function16.scala
@@ -16,9 +16,45 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 16 parameters. */
+/** A function of 16 parameters.
+ *
+ *  @tparam T1 the type of the first argument
+ *  @tparam T2 the type of the second argument
+ *  @tparam T3 the type of the third argument
+ *  @tparam T4 the type of the fourth argument
+ *  @tparam T5 the type of the fifth argument
+ *  @tparam T6 the type of the sixth argument
+ *  @tparam T7 the type of the seventh argument
+ *  @tparam T8 the type of the eighth argument
+ *  @tparam T9 the type of the ninth argument
+ *  @tparam T10 the type of the tenth argument
+ *  @tparam T11 the type of the eleventh argument
+ *  @tparam T12 the type of the twelfth argument
+ *  @tparam T13 the type of the thirteenth argument
+ *  @tparam T14 the type of the fourteenth argument
+ *  @tparam T15 the type of the fifteenth argument
+ *  @tparam T16 the type of the sixteenth argument
+ *  @tparam R the result type of the function
+ */
 trait Function16[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the value of the first argument
+   *  @param v2 the value of the second argument
+   *  @param v3 the value of the third argument
+   *  @param v4 the value of the fourth argument
+   *  @param v5 the value of the fifth argument
+   *  @param v6 the value of the sixth argument
+   *  @param v7 the value of the seventh argument
+   *  @param v8 the value of the eighth argument
+   *  @param v9 the value of the ninth argument
+   *  @param v10 the value of the tenth argument
+   *  @param v11 the value of the eleventh argument
+   *  @param v12 the value of the twelfth argument
+   *  @param v13 the value of the thirteenth argument
+   *  @param v14 the value of the fourteenth argument
+   *  @param v15 the value of the fifteenth argument
+   *  @param v16 the value of the sixteenth argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16): R

--- a/library/src/scala/Function17.scala
+++ b/library/src/scala/Function17.scala
@@ -16,9 +16,47 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 17 parameters. */
+/** A function of 17 parameters.
+ *
+ *  @tparam T1 the type of the first argument
+ *  @tparam T2 the type of the second argument
+ *  @tparam T3 the type of the third argument
+ *  @tparam T4 the type of the fourth argument
+ *  @tparam T5 the type of the fifth argument
+ *  @tparam T6 the type of the sixth argument
+ *  @tparam T7 the type of the seventh argument
+ *  @tparam T8 the type of the eighth argument
+ *  @tparam T9 the type of the ninth argument
+ *  @tparam T10 the type of the tenth argument
+ *  @tparam T11 the type of the eleventh argument
+ *  @tparam T12 the type of the twelfth argument
+ *  @tparam T13 the type of the thirteenth argument
+ *  @tparam T14 the type of the fourteenth argument
+ *  @tparam T15 the type of the fifteenth argument
+ *  @tparam T16 the type of the sixteenth argument
+ *  @tparam T17 the type of the seventeenth argument
+ *  @tparam R the type of the result
+ */
 trait Function17[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the value of the first argument
+   *  @param v2 the value of the second argument
+   *  @param v3 the value of the third argument
+   *  @param v4 the value of the fourth argument
+   *  @param v5 the value of the fifth argument
+   *  @param v6 the value of the sixth argument
+   *  @param v7 the value of the seventh argument
+   *  @param v8 the value of the eighth argument
+   *  @param v9 the value of the ninth argument
+   *  @param v10 the value of the tenth argument
+   *  @param v11 the value of the eleventh argument
+   *  @param v12 the value of the twelfth argument
+   *  @param v13 the value of the thirteenth argument
+   *  @param v14 the value of the fourteenth argument
+   *  @param v15 the value of the fifteenth argument
+   *  @param v16 the value of the sixteenth argument
+   *  @param v17 the value of the seventeenth argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17): R

--- a/library/src/scala/Function18.scala
+++ b/library/src/scala/Function18.scala
@@ -16,9 +16,49 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 18 parameters. */
+/** A function of 18 parameters.
+ *
+ *  @tparam T1 the type of the first argument
+ *  @tparam T2 the type of the second argument
+ *  @tparam T3 the type of the third argument
+ *  @tparam T4 the type of the fourth argument
+ *  @tparam T5 the type of the fifth argument
+ *  @tparam T6 the type of the sixth argument
+ *  @tparam T7 the type of the seventh argument
+ *  @tparam T8 the type of the eighth argument
+ *  @tparam T9 the type of the ninth argument
+ *  @tparam T10 the type of the tenth argument
+ *  @tparam T11 the type of the eleventh argument
+ *  @tparam T12 the type of the twelfth argument
+ *  @tparam T13 the type of the thirteenth argument
+ *  @tparam T14 the type of the fourteenth argument
+ *  @tparam T15 the type of the fifteenth argument
+ *  @tparam T16 the type of the sixteenth argument
+ *  @tparam T17 the type of the seventeenth argument
+ *  @tparam T18 the type of the eighteenth argument
+ *  @tparam R the return type of the function
+ */
 trait Function18[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the value of the first argument
+   *  @param v2 the value of the second argument
+   *  @param v3 the value of the third argument
+   *  @param v4 the value of the fourth argument
+   *  @param v5 the value of the fifth argument
+   *  @param v6 the value of the sixth argument
+   *  @param v7 the value of the seventh argument
+   *  @param v8 the value of the eighth argument
+   *  @param v9 the value of the ninth argument
+   *  @param v10 the value of the tenth argument
+   *  @param v11 the value of the eleventh argument
+   *  @param v12 the value of the twelfth argument
+   *  @param v13 the value of the thirteenth argument
+   *  @param v14 the value of the fourteenth argument
+   *  @param v15 the value of the fifteenth argument
+   *  @param v16 the value of the sixteenth argument
+   *  @param v17 the value of the seventeenth argument
+   *  @param v18 the value of the eighteenth argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18): R

--- a/library/src/scala/Function19.scala
+++ b/library/src/scala/Function19.scala
@@ -16,9 +16,51 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 19 parameters. */
+/** A function of 19 parameters.
+ *
+ *  @tparam T1 the type of the first argument
+ *  @tparam T2 the type of the second argument
+ *  @tparam T3 the type of the third argument
+ *  @tparam T4 the type of the fourth argument
+ *  @tparam T5 the type of the fifth argument
+ *  @tparam T6 the type of the sixth argument
+ *  @tparam T7 the type of the seventh argument
+ *  @tparam T8 the type of the eighth argument
+ *  @tparam T9 the type of the ninth argument
+ *  @tparam T10 the type of the tenth argument
+ *  @tparam T11 the type of the eleventh argument
+ *  @tparam T12 the type of the twelfth argument
+ *  @tparam T13 the type of the thirteenth argument
+ *  @tparam T14 the type of the fourteenth argument
+ *  @tparam T15 the type of the fifteenth argument
+ *  @tparam T16 the type of the sixteenth argument
+ *  @tparam T17 the type of the seventeenth argument
+ *  @tparam T18 the type of the eighteenth argument
+ *  @tparam T19 the type of the nineteenth argument
+ *  @tparam R the result type of the function
+ */
 trait Function19[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the value of the first argument
+   *  @param v2 the value of the second argument
+   *  @param v3 the value of the third argument
+   *  @param v4 the value of the fourth argument
+   *  @param v5 the value of the fifth argument
+   *  @param v6 the value of the sixth argument
+   *  @param v7 the value of the seventh argument
+   *  @param v8 the value of the eighth argument
+   *  @param v9 the value of the ninth argument
+   *  @param v10 the value of the tenth argument
+   *  @param v11 the value of the eleventh argument
+   *  @param v12 the value of the twelfth argument
+   *  @param v13 the value of the thirteenth argument
+   *  @param v14 the value of the fourteenth argument
+   *  @param v15 the value of the fifteenth argument
+   *  @param v16 the value of the sixteenth argument
+   *  @param v17 the value of the seventeenth argument
+   *  @param v18 the value of the eighteenth argument
+   *  @param v19 the value of the nineteenth argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18, v19: T19): R

--- a/library/src/scala/Function2.scala
+++ b/library/src/scala/Function2.scala
@@ -34,6 +34,9 @@ import scala.language.`2.13`
  */
 trait Function2[@specialized(Specializable.Args) -T1, @specialized(Specializable.Args) -T2, @specialized(Specializable.Return) +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the first argument of type `T1`
+   *  @param v2 the second argument of type `T2`
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2): R

--- a/library/src/scala/Function20.scala
+++ b/library/src/scala/Function20.scala
@@ -16,9 +16,53 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 20 parameters. */
+/** A function of 20 parameters.
+ *
+ *  @tparam T1 the type of the 1st argument
+ *  @tparam T2 the type of the 2nd argument
+ *  @tparam T3 the type of the 3rd argument
+ *  @tparam T4 the type of the 4th argument
+ *  @tparam T5 the type of the 5th argument
+ *  @tparam T6 the type of the 6th argument
+ *  @tparam T7 the type of the 7th argument
+ *  @tparam T8 the type of the 8th argument
+ *  @tparam T9 the type of the 9th argument
+ *  @tparam T10 the type of the 10th argument
+ *  @tparam T11 the type of the 11th argument
+ *  @tparam T12 the type of the 12th argument
+ *  @tparam T13 the type of the 13th argument
+ *  @tparam T14 the type of the 14th argument
+ *  @tparam T15 the type of the 15th argument
+ *  @tparam T16 the type of the 16th argument
+ *  @tparam T17 the type of the 17th argument
+ *  @tparam T18 the type of the 18th argument
+ *  @tparam T19 the type of the 19th argument
+ *  @tparam T20 the type of the 20th argument
+ *  @tparam R the result type of the function
+ */
 trait Function20[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the value of the 1st argument
+   *  @param v2 the value of the 2nd argument
+   *  @param v3 the value of the 3rd argument
+   *  @param v4 the value of the 4th argument
+   *  @param v5 the value of the 5th argument
+   *  @param v6 the value of the 6th argument
+   *  @param v7 the value of the 7th argument
+   *  @param v8 the value of the 8th argument
+   *  @param v9 the value of the 9th argument
+   *  @param v10 the value of the 10th argument
+   *  @param v11 the value of the 11th argument
+   *  @param v12 the value of the 12th argument
+   *  @param v13 the value of the 13th argument
+   *  @param v14 the value of the 14th argument
+   *  @param v15 the value of the 15th argument
+   *  @param v16 the value of the 16th argument
+   *  @param v17 the value of the 17th argument
+   *  @param v18 the value of the 18th argument
+   *  @param v19 the value of the 19th argument
+   *  @param v20 the value of the 20th argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18, v19: T19, v20: T20): R

--- a/library/src/scala/Function21.scala
+++ b/library/src/scala/Function21.scala
@@ -16,9 +16,55 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 21 parameters. */
+/** A function of 21 parameters.
+ *
+ *  @tparam T1 the type of the first argument
+ *  @tparam T2 the type of the second argument
+ *  @tparam T3 the type of the third argument
+ *  @tparam T4 the type of the fourth argument
+ *  @tparam T5 the type of the fifth argument
+ *  @tparam T6 the type of the sixth argument
+ *  @tparam T7 the type of the seventh argument
+ *  @tparam T8 the type of the eighth argument
+ *  @tparam T9 the type of the ninth argument
+ *  @tparam T10 the type of the tenth argument
+ *  @tparam T11 the type of the eleventh argument
+ *  @tparam T12 the type of the twelfth argument
+ *  @tparam T13 the type of the thirteenth argument
+ *  @tparam T14 the type of the fourteenth argument
+ *  @tparam T15 the type of the fifteenth argument
+ *  @tparam T16 the type of the sixteenth argument
+ *  @tparam T17 the type of the seventeenth argument
+ *  @tparam T18 the type of the eighteenth argument
+ *  @tparam T19 the type of the nineteenth argument
+ *  @tparam T20 the type of the twentieth argument
+ *  @tparam T21 the type of the twenty-first argument
+ *  @tparam R the result type of the function
+ */
 trait Function21[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, -T21, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the first argument of type `T1`
+   *  @param v2 the second argument of type `T2`
+   *  @param v3 the third argument of type `T3`
+   *  @param v4 the fourth argument of type `T4`
+   *  @param v5 the fifth argument of type `T5`
+   *  @param v6 the sixth argument of type `T6`
+   *  @param v7 the seventh argument of type `T7`
+   *  @param v8 the eighth argument of type `T8`
+   *  @param v9 the ninth argument of type `T9`
+   *  @param v10 the tenth argument of type `T10`
+   *  @param v11 the eleventh argument of type `T11`
+   *  @param v12 the twelfth argument of type `T12`
+   *  @param v13 the thirteenth argument of type `T13`
+   *  @param v14 the fourteenth argument of type `T14`
+   *  @param v15 the fifteenth argument of type `T15`
+   *  @param v16 the sixteenth argument of type `T16`
+   *  @param v17 the seventeenth argument of type `T17`
+   *  @param v18 the eighteenth argument of type `T18`
+   *  @param v19 the nineteenth argument of type `T19`
+   *  @param v20 the twentieth argument of type `T20`
+   *  @param v21 the twenty-first argument of type `T21`
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18, v19: T19, v20: T20, v21: T21): R

--- a/library/src/scala/Function22.scala
+++ b/library/src/scala/Function22.scala
@@ -16,9 +16,57 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 22 parameters. */
+/** A function of 22 parameters.
+ *
+ *  @tparam T1 the type of the first argument
+ *  @tparam T2 the type of the second argument
+ *  @tparam T3 the type of the third argument
+ *  @tparam T4 the type of the fourth argument
+ *  @tparam T5 the type of the fifth argument
+ *  @tparam T6 the type of the sixth argument
+ *  @tparam T7 the type of the seventh argument
+ *  @tparam T8 the type of the eighth argument
+ *  @tparam T9 the type of the ninth argument
+ *  @tparam T10 the type of the tenth argument
+ *  @tparam T11 the type of the eleventh argument
+ *  @tparam T12 the type of the twelfth argument
+ *  @tparam T13 the type of the thirteenth argument
+ *  @tparam T14 the type of the fourteenth argument
+ *  @tparam T15 the type of the fifteenth argument
+ *  @tparam T16 the type of the sixteenth argument
+ *  @tparam T17 the type of the seventeenth argument
+ *  @tparam T18 the type of the eighteenth argument
+ *  @tparam T19 the type of the nineteenth argument
+ *  @tparam T20 the type of the twentieth argument
+ *  @tparam T21 the type of the twenty-first argument
+ *  @tparam T22 the type of the twenty-second argument
+ *  @tparam R the result type of the function
+ */
 trait Function22[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, -T21, -T22, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the first argument of type `T1`
+   *  @param v2 the second argument of type `T2`
+   *  @param v3 the third argument of type `T3`
+   *  @param v4 the fourth argument of type `T4`
+   *  @param v5 the fifth argument of type `T5`
+   *  @param v6 the sixth argument of type `T6`
+   *  @param v7 the seventh argument of type `T7`
+   *  @param v8 the eighth argument of type `T8`
+   *  @param v9 the ninth argument of type `T9`
+   *  @param v10 the tenth argument of type `T10`
+   *  @param v11 the eleventh argument of type `T11`
+   *  @param v12 the twelfth argument of type `T12`
+   *  @param v13 the thirteenth argument of type `T13`
+   *  @param v14 the fourteenth argument of type `T14`
+   *  @param v15 the fifteenth argument of type `T15`
+   *  @param v16 the sixteenth argument of type `T16`
+   *  @param v17 the seventeenth argument of type `T17`
+   *  @param v18 the eighteenth argument of type `T18`
+   *  @param v19 the nineteenth argument of type `T19`
+   *  @param v20 the twentieth argument of type `T20`
+   *  @param v21 the twenty-first argument of type `T21`
+   *  @param v22 the twenty-second argument of type `T22`
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18, v19: T19, v20: T20, v21: T21, v22: T22): R

--- a/library/src/scala/Function3.scala
+++ b/library/src/scala/Function3.scala
@@ -16,9 +16,19 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 3 parameters. */
+/** A function of 3 parameters.
+ *
+ *  @tparam T1 the type of the first argument
+ *  @tparam T2 the type of the second argument
+ *  @tparam T3 the type of the third argument
+ *  @tparam R the return type of the function
+ */
 trait Function3[-T1, -T2, -T3, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the first argument
+   *  @param v2 the second argument
+   *  @param v3 the third argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3): R

--- a/library/src/scala/Function4.scala
+++ b/library/src/scala/Function4.scala
@@ -16,9 +16,21 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 4 parameters. */
+/** A function of 4 parameters.
+ *
+ *  @tparam T1 the type of the first argument
+ *  @tparam T2 the type of the second argument
+ *  @tparam T3 the type of the third argument
+ *  @tparam T4 the type of the fourth argument
+ *  @tparam R the return type of the function
+ */
 trait Function4[-T1, -T2, -T3, -T4, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the first argument
+   *  @param v2 the second argument
+   *  @param v3 the third argument
+   *  @param v4 the fourth argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4): R

--- a/library/src/scala/Function5.scala
+++ b/library/src/scala/Function5.scala
@@ -16,9 +16,23 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 5 parameters. */
+/** A function of 5 parameters.
+ *
+ *  @tparam T1 the type of the first argument
+ *  @tparam T2 the type of the second argument
+ *  @tparam T3 the type of the third argument
+ *  @tparam T4 the type of the fourth argument
+ *  @tparam T5 the type of the fifth argument
+ *  @tparam R the return type of this function
+ */
 trait Function5[-T1, -T2, -T3, -T4, -T5, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the first argument
+   *  @param v2 the second argument
+   *  @param v3 the third argument
+   *  @param v4 the fourth argument
+   *  @param v5 the fifth argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5): R

--- a/library/src/scala/Function6.scala
+++ b/library/src/scala/Function6.scala
@@ -16,9 +16,25 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 6 parameters. */
+/** A function of 6 parameters.
+ *
+ *  @tparam T1 the type of the first argument
+ *  @tparam T2 the type of the second argument
+ *  @tparam T3 the type of the third argument
+ *  @tparam T4 the type of the fourth argument
+ *  @tparam T5 the type of the fifth argument
+ *  @tparam T6 the type of the sixth argument
+ *  @tparam R the return type of the function
+ */
 trait Function6[-T1, -T2, -T3, -T4, -T5, -T6, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the first argument
+   *  @param v2 the second argument
+   *  @param v3 the third argument
+   *  @param v4 the fourth argument
+   *  @param v5 the fifth argument
+   *  @param v6 the sixth argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6): R

--- a/library/src/scala/Function7.scala
+++ b/library/src/scala/Function7.scala
@@ -16,9 +16,27 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 7 parameters. */
+/** A function of 7 parameters.
+ *
+ *  @tparam T1 the type of the first argument
+ *  @tparam T2 the type of the second argument
+ *  @tparam T3 the type of the third argument
+ *  @tparam T4 the type of the fourth argument
+ *  @tparam T5 the type of the fifth argument
+ *  @tparam T6 the type of the sixth argument
+ *  @tparam T7 the type of the seventh argument
+ *  @tparam R the return type of the function
+ */
 trait Function7[-T1, -T2, -T3, -T4, -T5, -T6, -T7, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the first argument
+   *  @param v2 the second argument
+   *  @param v3 the third argument
+   *  @param v4 the fourth argument
+   *  @param v5 the fifth argument
+   *  @param v6 the sixth argument
+   *  @param v7 the seventh argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7): R

--- a/library/src/scala/Function8.scala
+++ b/library/src/scala/Function8.scala
@@ -16,9 +16,29 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 8 parameters. */
+/** A function of 8 parameters.
+ *
+ *  @tparam T1 the type of the first argument
+ *  @tparam T2 the type of the second argument
+ *  @tparam T3 the type of the third argument
+ *  @tparam T4 the type of the fourth argument
+ *  @tparam T5 the type of the fifth argument
+ *  @tparam T6 the type of the sixth argument
+ *  @tparam T7 the type of the seventh argument
+ *  @tparam T8 the type of the eighth argument
+ *  @tparam R the return type of the function
+ */
 trait Function8[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the first argument
+   *  @param v2 the second argument
+   *  @param v3 the third argument
+   *  @param v4 the fourth argument
+   *  @param v5 the fifth argument
+   *  @param v6 the sixth argument
+   *  @param v7 the seventh argument
+   *  @param v8 the eighth argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8): R

--- a/library/src/scala/Function9.scala
+++ b/library/src/scala/Function9.scala
@@ -16,9 +16,31 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 9 parameters. */
+/** A function of 9 parameters.
+ *
+ *  @tparam T1 the type of the first argument
+ *  @tparam T2 the type of the second argument
+ *  @tparam T3 the type of the third argument
+ *  @tparam T4 the type of the fourth argument
+ *  @tparam T5 the type of the fifth argument
+ *  @tparam T6 the type of the sixth argument
+ *  @tparam T7 the type of the seventh argument
+ *  @tparam T8 the type of the eighth argument
+ *  @tparam T9 the type of the ninth argument
+ *  @tparam R the return type of this function
+ */
 trait Function9[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the first argument
+   *  @param v2 the second argument
+   *  @param v3 the third argument
+   *  @param v4 the fourth argument
+   *  @param v5 the fifth argument
+   *  @param v6 the sixth argument
+   *  @param v7 the seventh argument
+   *  @param v8 the eighth argument
+   *  @param v9 the ninth argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9): R

--- a/library/src/scala/IArray.scala
+++ b/library/src/scala/IArray.scala
@@ -44,87 +44,155 @@ object IArray:
   extension [T](arr: IArray[T]) def length: Int = arr.asInstanceOf[Array[T]].length
 
 
-  /** Tests whether this array contains a given value as an element. */
+  /** Tests whether this array contains a given value as an element.
+   *
+   *  @param elem the value to test for membership
+   */
   extension [T](arr: IArray[T]) def contains(elem: T): Boolean =
     genericArrayOps(arr).contains(elem.asInstanceOf)
 
-  /** Copies elements of this array to another array. */
+  /** Copies elements of this array to another array.
+   *
+   *  @tparam U the element type of the destination array, a supertype of `T`
+   *  @param xs the destination array to copy to
+   */
   extension [T](arr: IArray[T]) def copyToArray[U >: T](xs: Array[U]): Int =
     genericArrayOps(arr).copyToArray(xs)
 
-  /** Copies elements of this array to another array. */
+  /** Copies elements of this array to another array.
+   *
+   *  @tparam U the element type of the destination array, a supertype of `T`
+   *  @param xs the destination array to copy to
+   *  @param start the index in `xs` at which to start copying
+   */
   extension [T](arr: IArray[T]) def copyToArray[U >: T](xs: Array[U], start: Int): Int =
     genericArrayOps(arr).copyToArray(xs, start)
 
-  /** Copies elements of this array to another array. */
+  /** Copies elements of this array to another array.
+   *
+   *  @tparam U the element type of the destination array, a supertype of `T`
+   *  @param xs the destination array to copy to
+   *  @param start the index in `xs` at which to start copying
+   *  @param len the maximum number of elements to copy
+   */
   extension [T](arr: IArray[T]) def copyToArray[U >: T](xs: Array[U], start: Int, len: Int): Int =
     genericArrayOps(arr).copyToArray(xs, start, len)
 
-  /** Counts the number of elements in this array which satisfy a predicate. */
+  /** Counts the number of elements in this array which satisfy a predicate.
+   *
+   *  @param p the predicate used to test elements
+   */
   extension [T](arr: IArray[T]) def count(p: T => Boolean): Int =
     genericArrayOps(arr).count(p)
 
-  /** The rest of the array without its `n` first elements. */
+  /** The rest of the array without its `n` first elements.
+   *
+   *  @param n the number of elements to drop from the front
+   */
   extension [T](arr: IArray[T]) def drop(n: Int): IArray[T] =
     genericArrayOps(arr).drop(n)
 
-  /** The rest of the array without its `n` last elements. */
+  /** The rest of the array without its `n` last elements.
+   *
+   *  @param n the number of elements to drop from the end
+   */
   extension [T](arr: IArray[T]) def dropRight(n: Int): IArray[T] =
     genericArrayOps(arr).dropRight(n)
 
-  /** Drops longest prefix of elements that satisfy a predicate. */
+  /** Drops longest prefix of elements that satisfy a predicate.
+   *
+   *  @param p the predicate used to test elements
+   */
   extension [T](arr: IArray[T]) def dropWhile(p: T => Boolean): IArray[T] =
     genericArrayOps(arr).dropWhile(p)
 
-  /** Tests whether a predicate holds for at least one element of this array. */
+  /** Tests whether a predicate holds for at least one element of this array.
+   *
+   *  @param p the predicate used to test elements
+   */
   extension [T](arr: IArray[T]) def exists(p: T => Boolean): Boolean =
     genericArrayOps(arr).exists(p)
 
-  /** Selects all elements of this array which satisfy a predicate. */
+  /** Selects all elements of this array which satisfy a predicate.
+   *
+   *  @param p the predicate used to test elements
+   */
   extension [T](arr: IArray[T]) def filter(p: T => Boolean): IArray[T] =
     genericArrayOps(arr).filter(p)
 
-  /** Selects all elements of this array which do not satisfy a predicate. */
+  /** Selects all elements of this array which do not satisfy a predicate.
+   *
+   *  @param p the predicate used to test elements
+   */
   extension [T](arr: IArray[T]) def filterNot(p: T => Boolean): IArray[T] =
     genericArrayOps(arr).filterNot(p)
 
-  /** Finds the first element of the array satisfying a predicate, if any. */
+  /** Finds the first element of the array satisfying a predicate, if any.
+   *
+   *  @param p the predicate used to test elements
+   */
   extension [T](arr: IArray[T]) def find(p: T => Boolean): Option[T] =
     genericArrayOps(arr).find(p)
 
   /** Builds a new array by applying a function to all elements of this array
    *  and using the elements of the resulting collections. 
+   *
+   *  @tparam U the element type of the returned array
+   *  @param f the function to apply to each element, returning a collection of results
    */
   extension [T](arr: IArray[T]) def flatMap[U: ClassTag](f: T => IterableOnce[U]^): IArray[U] =
     genericArrayOps(arr).flatMap(f)
 
   /** Flattens a two-dimensional array by concatenating all its rows
    *  into a single array. 
+   *
+   *  @tparam U the element type of the resulting array after flattening
+   *  @param asIterable the implicit evidence that `T` can be viewed as `Iterable[U]`
    */
   extension [T](arr: IArray[T]) def flatten[U](using asIterable: T => Iterable[U]^, ct: ClassTag[U]): IArray[U] =
     genericArrayOps(arr).flatten
 
-  /** Folds the elements of this array using the specified associative binary operator. */
+  /** Folds the elements of this array using the specified associative binary operator.
+   *
+   *  @tparam U the result type of the binary operator, a supertype of `T`
+   *  @param z the start value
+   *  @param op the associative binary operator
+   */
   extension [T](arr: IArray[T]) def fold[U >: T](z: U)(op: (U, U) => U): U =
     genericArrayOps(arr).fold(z)(op)
 
   /** Applies a binary operator to a start value and all elements of this array,
    *  going left to right. 
+   *
+   *  @tparam U the result type of the binary operator
+   *  @param z the start value
+   *  @param op the binary operator applied from left to right
    */
   extension [T](arr: IArray[T]) def foldLeft[U](z: U)(op: (U, T) => U): U =
     genericArrayOps(arr).foldLeft(z)(op)
 
   /** Applies a binary operator to all elements of this array and a start value,
    *  going right to left. 
+   *
+   *  @tparam U the result type of the binary operator
+   *  @param z the start value
+   *  @param op the binary operator applied from right to left
    */
   extension [T](arr: IArray[T]) def foldRight[U](z: U)(op: (T, U) => U): U =
     genericArrayOps(arr).foldRight(z)(op)
 
-  /** Tests whether a predicate holds for all elements of this array. */
+  /** Tests whether a predicate holds for all elements of this array.
+   *
+   *  @param p the predicate used to test elements
+   */
   extension [T](arr: IArray[T]) def forall(p: T => Boolean): Boolean =
     genericArrayOps(arr).forall(p)
 
-  /** Applies `f` to each element for its side effects. */
+  /** Applies `f` to each element for its side effects.
+   *
+   *  @tparam U the return type of `f`, discarded
+   *  @param f the function to apply to each element
+   */
   extension [T](arr: IArray[T]) def foreach[U](f: T => U): Unit =
     genericArrayOps(arr).foreach(f)
 
@@ -136,14 +204,22 @@ object IArray:
   extension [T](arr: IArray[T]) def headOption: Option[T] =
     genericArrayOps(arr).headOption
 
-  /** Finds index of first occurrence of some value in this array after or at some start index. */
+  /** Finds index of first occurrence of some value in this array after or at some start index.
+   *
+   *  @param elem the value to search for
+   *  @param from the start index where the search begins
+   */
   extension [T](arr: IArray[T]) def indexOf(elem: T, from: Int = 0): Int =
     // `asInstanceOf` needed because `elem` does not have type `arr.T`
     // We could use `arr.iterator.indexOf(elem, from)` or `arr.indexWhere(_ == elem, from)`
     // but these would incur some overhead.
     genericArrayOps(arr).indexOf(elem.asInstanceOf, from)
 
-  /** Finds index of the first element satisfying some predicate after or at some start index. */
+  /** Finds index of the first element satisfying some predicate after or at some start index.
+   *
+   *  @param p the predicate used to test elements
+   *  @param from the start index where the search begins
+   */
   extension [T](arr: IArray[T]) def indexWhere(p: T => Boolean, from: Int = 0): Int =
     genericArrayOps(arr).indexWhere(p, from)
 
@@ -171,16 +247,28 @@ object IArray:
   extension [T](arr: IArray[T]) def lastOption: Option[T] =
     genericArrayOps(arr).lastOption
 
-  /** Finds index of last occurrence of some value in this array before or at a given end index. */
+  /** Finds index of last occurrence of some value in this array before or at a given end index.
+   *
+   *  @param elem the value to search for
+   *  @param end the end index (inclusive) where the search ends
+   */
   extension [T](arr: IArray[T]) def lastIndexOf(elem: T, end: Int = arr.length - 1): Int =
     // see: same issue in `indexOf`
     genericArrayOps(arr).lastIndexOf(elem.asInstanceOf, end)
 
-  /** Finds index of last element satisfying some predicate before or at given end index. */
+  /** Finds index of last element satisfying some predicate before or at given end index.
+   *
+   *  @param p the predicate used to test elements
+   *  @param end the end index (inclusive) where the search ends
+   */
   extension [T](arr: IArray[T]) def lastIndexWhere(p: T => Boolean, end: Int = arr.length - 1): Int =
     genericArrayOps(arr).lastIndexWhere(p, end)
 
-  /** Builds a new array by applying a function to all elements of this array. */
+  /** Builds a new array by applying a function to all elements of this array.
+   *
+   *  @tparam U the element type of the returned array
+   *  @param f the function to apply to each element
+   */
   extension [T](arr: IArray[T]) def map[U: ClassTag](f: T => U): IArray[U] =
     genericArrayOps(arr).map(f)
 
@@ -188,7 +276,10 @@ object IArray:
   extension [T](arr: IArray[T]) def nonEmpty: Boolean =
     genericArrayOps(arr).nonEmpty
 
-  /** A pair of, first, all elements that satisfy predicate `p` and, second, all elements that do not. */
+  /** A pair of, first, all elements that satisfy predicate `p` and, second, all elements that do not.
+   *
+   *  @param p the predicate used to partition elements
+   */
   extension [T](arr: IArray[T]) def partition(p: T => Boolean): (IArray[T], IArray[T]) =
     genericArrayOps(arr).partition(p)
 
@@ -196,18 +287,31 @@ object IArray:
   extension [T](arr: IArray[T]) def reverse: IArray[T] =
     genericArrayOps(arr).reverse
 
-  /** Computes a prefix scan of the elements of the array. */
+  /** Computes a prefix scan of the elements of the array.
+   *
+   *  @tparam U the element type of the returned array, a supertype of `T`
+   *  @param z the initial value for the scan
+   *  @param op the associative binary operator
+   */
   extension [T](arr: IArray[T]) def scan[U >: T: ClassTag](z: U)(op: (U, U) => U): IArray[U] =
     genericArrayOps(arr).scan(z)(op)
 
   /** Produces an array containing cumulative results of applying the binary
    *  operator going left to right. 
+   *
+   *  @tparam U the element type of the returned array
+   *  @param z the initial value for the scan
+   *  @param op the binary operator applied from left to right
    */
   extension [T](arr: IArray[T]) def scanLeft[U: ClassTag](z: U)(op: (U, T) => U): IArray[U] =
     genericArrayOps(arr).scanLeft(z)(op)
 
   /** Produces an array containing cumulative results of applying the binary
    *  operator going right to left. 
+   *
+   *  @tparam U the element type of the returned array
+   *  @param z the initial value for the scan
+   *  @param op the binary operator applied from right to left
    */
   extension [T](arr: IArray[T]) def scanRight[U: ClassTag](z: U)(op: (T, U) => U): IArray[U] =
     genericArrayOps(arr).scanRight(z)(op)
@@ -216,29 +320,47 @@ object IArray:
   extension [T](arr: IArray[T]) def size: Int =
     arr.length
 
-  /** Selects the interval of elements between the given indices. */
+  /** Selects the interval of elements between the given indices.
+   *
+   *  @param from the index of the first included element
+   *  @param until the index of the first excluded element
+   */
   extension [T](arr: IArray[T]) def slice(from: Int, until: Int): IArray[T] =
     genericArrayOps(arr).slice(from, until)
 
   /** Sorts this array according to the Ordering which results from transforming
    *  an implicitly given Ordering with a transformation function. 
-   */
+   *
+   *  @tparam U the target type of the transformation function, which has an `Ordering`
+   *  @param f the transformation function mapping elements to their sort keys
+     */
   extension [T](arr: IArray[T]) def sortBy[U](f: T => U)(using math.Ordering[U]): IArray[T] =
     genericArrayOps(arr).sortBy(f)
 
-  /** Sorts this array according to a comparison function. */
+  /** Sorts this array according to a comparison function.
+   *
+   *  @param f the comparison function returning true if its first argument should come first
+   */
   extension [T](arr: IArray[T]) def sortWith(f: (T, T) => Boolean): IArray[T] =
     genericArrayOps(arr).sortWith(f)
 
-  /** Sorts this array according to an Ordering. */
+  /** Sorts this array according to an Ordering.
+   *
+     */
   extension [T](arr: IArray[T]) def sorted(using math.Ordering[T]^): IArray[T] =
     genericArrayOps(arr).sorted
 
-  /** Splits this array into a prefix/suffix pair according to a predicate. */
+  /** Splits this array into a prefix/suffix pair according to a predicate.
+   *
+   *  @param p the predicate used to test elements
+   */
   extension [T](arr: IArray[T]) def span(p: T => Boolean): (IArray[T], IArray[T]) =
     genericArrayOps(arr).span(p)
 
-  /** Splits this array into two at a given position. */
+  /** Splits this array into two at a given position.
+   *
+   *  @param n the position at which to split
+   */
   extension [T](arr: IArray[T]) def splitAt(n: Int): (IArray[T], IArray[T]) =
     genericArrayOps(arr).splitAt(n)
 
@@ -246,15 +368,24 @@ object IArray:
   extension [T](arr: IArray[T]) def tail: IArray[T] =
     genericArrayOps(arr).tail
 
-  /** An array containing the first `n` elements of this array. */
+  /** An array containing the first `n` elements of this array.
+   *
+   *  @param n the number of elements to take from the front
+   */
   extension [T](arr: IArray[T]) def take(n: Int): IArray[T] =
     genericArrayOps(arr).take(n)
 
-  /** An array containing the last `n` elements of this array. */
+  /** An array containing the last `n` elements of this array.
+   *
+   *  @param n the number of elements to take from the end
+   */
   extension [T](arr: IArray[T]) def takeRight(n: Int): IArray[T] =
     genericArrayOps(arr).takeRight(n)
 
-  /** Takes longest prefix of elements that satisfy a predicate. */
+  /** Takes longest prefix of elements that satisfy a predicate.
+   *
+   *  @param p the predicate used to test elements
+   */
   extension [T](arr: IArray[T]) def takeWhile(p: T => Boolean): IArray[T] =
     genericArrayOps(arr).takeWhile(p)
 
@@ -348,11 +479,19 @@ object IArray:
   // We intentionally keep this signature to discourage passing nulls implicitly while
   // preserving the previous behavior for backward compatibility.
 
-  /** Conversion from IArray to immutable.ArraySeq. */
+  /** Conversion from IArray to immutable.ArraySeq.
+   *
+   *  @tparam T the element type of the array
+   *  @param arr the immutable array to wrap
+   */
   implicit def genericWrapArray[T](arr: IArray[T]): ArraySeq[T] =
     mapNull(arr, ArraySeq.unsafeWrapArray(arr))
 
-  /** Conversion from IArray to immutable.ArraySeq. */
+  /** Conversion from IArray to immutable.ArraySeq.
+   *
+   *  @tparam T the element type of the array, a reference type
+   *  @param arr the immutable array to wrap
+   */
   implicit def wrapRefArray[T <: AnyRef | Null](arr: IArray[T]): ArraySeq.ofRef[T] =
     // Since the JVM thinks arrays are covariant, one 0-length Array[AnyRef | Null]
     // is as good as another for all T <: AnyRef | Null.  Instead of creating 100,000,000
@@ -362,49 +501,82 @@ object IArray:
       else ArraySeq.ofRef(arr.asInstanceOf[Array[T]])
     )
 
-  /** Conversion from IArray to immutable.ArraySeq. */
+  /** Conversion from IArray to immutable.ArraySeq.
+   *
+   *  @param arr the immutable `Int` array to wrap
+   */
   implicit def wrapIntArray(arr: IArray[Int]): ArraySeq.ofInt =
     mapNull(arr, new ArraySeq.ofInt(arr.asInstanceOf[Array[Int]]))
 
-  /** Conversion from IArray to immutable.ArraySeq. */
+  /** Conversion from IArray to immutable.ArraySeq.
+   *
+   *  @param arr the immutable `Double` array to wrap
+   */
   implicit def wrapDoubleIArray(arr: IArray[Double]): ArraySeq.ofDouble =
     mapNull(arr, new ArraySeq.ofDouble(arr.asInstanceOf[Array[Double]]))
 
-  /** Conversion from IArray to immutable.ArraySeq. */
+  /** Conversion from IArray to immutable.ArraySeq.
+   *
+   *  @param arr the immutable `Long` array to wrap
+   */
   implicit def wrapLongIArray(arr: IArray[Long]): ArraySeq.ofLong =
     mapNull(arr, new ArraySeq.ofLong(arr.asInstanceOf[Array[Long]]))
 
-  /** Conversion from IArray to immutable.ArraySeq. */
+  /** Conversion from IArray to immutable.ArraySeq.
+   *
+   *  @param arr the immutable `Float` array to wrap
+   */
   implicit def wrapFloatIArray(arr: IArray[Float]): ArraySeq.ofFloat =
     mapNull(arr, new ArraySeq.ofFloat(arr.asInstanceOf[Array[Float]]))
 
-  /** Conversion from IArray to immutable.ArraySeq. */
+  /** Conversion from IArray to immutable.ArraySeq.
+   *
+   *  @param arr the immutable `Char` array to wrap
+   */
   implicit def wrapCharIArray(arr: IArray[Char]): ArraySeq.ofChar =
     mapNull(arr, new ArraySeq.ofChar(arr.asInstanceOf[Array[Char]]))
 
-  /** Conversion from IArray to immutable.ArraySeq. */
+  /** Conversion from IArray to immutable.ArraySeq.
+   *
+   *  @param arr the immutable `Byte` array to wrap
+   */
   implicit def wrapByteIArray(arr: IArray[Byte]): ArraySeq.ofByte =
     mapNull(arr, new ArraySeq.ofByte(arr.asInstanceOf[Array[Byte]]))
 
-  /** Conversion from IArray to immutable.ArraySeq. */
+  /** Conversion from IArray to immutable.ArraySeq.
+   *
+   *  @param arr the immutable `Short` array to wrap
+   */
   implicit def wrapShortIArray(arr: IArray[Short]): ArraySeq.ofShort =
     mapNull(arr, new ArraySeq.ofShort(arr.asInstanceOf[Array[Short]]))
 
-  /** Conversion from IArray to immutable.ArraySeq. */
+  /** Conversion from IArray to immutable.ArraySeq.
+   *
+   *  @param arr the immutable `Boolean` array to wrap
+   */
   implicit def wrapBooleanIArray(arr: IArray[Boolean]): ArraySeq.ofBoolean =
     mapNull(arr, new ArraySeq.ofBoolean(arr.asInstanceOf[Array[Boolean]]))
 
-  /** Conversion from IArray to immutable.ArraySeq. */
+  /** Conversion from IArray to immutable.ArraySeq.
+   *
+   *  @param arr the immutable `Unit` array to wrap
+   */
   implicit def wrapUnitIArray(arr: IArray[Unit]): ArraySeq.ofUnit =
     mapNull(arr, new ArraySeq.ofUnit(arr.asInstanceOf[Array[Unit]]))
 
   /** Converts an array into an immutable array without copying, the original array
    *   must _not_ be mutated after this or the guaranteed immutablity of IArray will
    *   be violated.
+   *
+   *  @tparam T the element type of the array
+   *  @param s the mutable array to treat as immutable (must not be mutated afterward)
    */
   def unsafeFromArray[T](s: Array[T]): IArray[T] = s
 
-  /** An immutable array of length 0. */
+  /** An immutable array of length 0.
+   *
+   *  @tparam T the element type of the empty array
+   */
   def empty[T: ClassTag]: IArray[T] = new Array[T](0)
 
   /** An immutable boolean array of length 0. */
@@ -426,25 +598,65 @@ object IArray:
   /** An immutable object array of length 0. */
   def emptyObjectIArray: IArray[Object]  = Array.emptyObjectArray
 
-  /** An immutable array with given elements. */
+  /** An immutable array with given elements.
+   *
+   *  @tparam T the element type of the array
+   *  @param xs the elements to include in the array
+   */
   def apply[T](xs: T*)(using ct: ClassTag[T]): IArray[T] = Array(xs*)
-  /** An immutable array with given elements. */
+  /** An immutable array with given elements.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   def apply(x: Boolean, xs: Boolean*): IArray[Boolean] = Array(x, xs*)
-  /** An immutable array with given elements. */
+  /** An immutable array with given elements.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   def apply(x: Byte, xs: Byte*): IArray[Byte] = Array(x, xs*)
-  /** An immutable array with given elements. */
+  /** An immutable array with given elements.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   def apply(x: Short, xs: Short*): IArray[Short] = Array(x, xs*)
-  /** An immutable array with given elements. */
+  /** An immutable array with given elements.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   def apply(x: Char, xs: Char*): IArray[Char] = Array(x, xs*)
-  /** An immutable array with given elements. */
+  /** An immutable array with given elements.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   def apply(x: Int, xs: Int*): IArray[Int] = Array(x, xs*)
-  /** An immutable array with given elements. */
+  /** An immutable array with given elements.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   def apply(x: Long, xs: Long*): IArray[Long] = Array(x, xs*)
-  /** An immutable array with given elements. */
+  /** An immutable array with given elements.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   def apply(x: Float, xs: Float*): IArray[Float] = Array(x, xs*)
-  /** An immutable array with given elements. */
+  /** An immutable array with given elements.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   def apply(x: Double, xs: Double*): IArray[Double] = Array(x, xs*)
-  /** An immutable array with given elements. */
+  /** An immutable array with given elements.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   def apply(x: Unit, xs: Unit*): IArray[Unit] = Array(x, xs*)
 
   /** Builds an array from the iterable collection.
@@ -457,6 +669,7 @@ object IArray:
    *  val b: IArray[Int] = IArray(1, 2, 3, 4)
    *  ```
    *
+   *  @tparam A the element type of the array
    *  @param  it the iterable collection
    *  @return    an array consisting of elements of the iterable collection
    */
@@ -468,6 +681,7 @@ object IArray:
 
   /** Concatenates all arrays into a single immutable array.
    *
+   *  @tparam T the element type of the arrays
    *  @param xss the given immutable arrays
    *  @return   the array created from concatenating `xss`
    */
@@ -480,6 +694,7 @@ object IArray:
   /** Returns an immutable array that contains the results of some element computation a number
    *  of times. Each element is determined by a separate computation.
    *
+   *  @tparam T the element type of the array
    *  @param   n  the number of elements in the array
    *  @param   elem the element computation
    */
@@ -489,6 +704,7 @@ object IArray:
   /** Returns a two-dimensional immutable array that contains the results of some element computation a number
    *  of times. Each element is determined by a separate computation.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   elem the element computation
@@ -499,9 +715,10 @@ object IArray:
   /** Returns a three-dimensional immutable array that contains the results of some element computation a number
    *  of times. Each element is determined by a separate computation.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
-   *  @param   n3  the number of elements in the 3nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
    *  @param   elem the element computation
    */
   def fill[T: ClassTag](n1: Int, n2: Int, n3: Int)(elem: => T): IArray[IArray[IArray[T]]] =
@@ -510,9 +727,10 @@ object IArray:
   /** Returns a four-dimensional immutable array that contains the results of some element computation a number
    *  of times. Each element is determined by a separate computation.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
-   *  @param   n3  the number of elements in the 3nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
    *  @param   n4  the number of elements in the 4th dimension
    *  @param   elem the element computation
    */
@@ -522,9 +740,10 @@ object IArray:
   /** Returns a five-dimensional immutable array that contains the results of some element computation a number
    *  of times. Each element is determined by a separate computation.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
-   *  @param   n3  the number of elements in the 3nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
    *  @param   n4  the number of elements in the 4th dimension
    *  @param   n5  the number of elements in the 5th dimension
    *  @param   elem the element computation
@@ -535,6 +754,7 @@ object IArray:
   /** Returns an immutable array containing values of a given function over a range of integer
    *  values starting from 0.
    *
+   *  @tparam T the element type of the array
    *  @param  n   The number of elements in the array
    *  @param  f   The function computing element values
    */
@@ -544,6 +764,7 @@ object IArray:
   /** Returns a two-dimensional immutable array containing values of a given function
    *  over ranges of integer values starting from `0`.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   f   The function computing element values
@@ -554,6 +775,7 @@ object IArray:
   /** Returns a three-dimensional immutable array containing values of a given function
    *  over ranges of integer values starting from `0`.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -565,6 +787,7 @@ object IArray:
   /** Returns a four-dimensional immutable array containing values of a given function
    *  over ranges of integer values starting from `0`.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -577,6 +800,7 @@ object IArray:
   /** Returns a five-dimensional immutable array containing values of a given function
    *  over ranges of integer values starting from `0`.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -607,6 +831,7 @@ object IArray:
 
   /** Returns an immutable array containing repeated applications of a function to a start value.
    *
+   *  @tparam T the element type of the array
    *  @param start the start value of the array
    *  @param len   the number of elements returned by the array
    *  @param f     the function that is repeatedly applied
@@ -628,17 +853,26 @@ object IArray:
   /** Returns a decomposition of the array into a sequence. This supports
    *  a pattern match like `{ case IArray(x,y,z) => println('3 elements')}`.
    *
+   *  @tparam T the element type of the array
    *  @param x the selector value
    *  @return  sequence wrapped in a [[scala.Some]], if `x` is a Seq, otherwise `None`
    */
   def unapplySeq[T](x: IArray[T]): Array.UnapplySeqWrapper[? <: T] =
     Array.unapplySeq(x)
 
-  /** A lazy filtered array. No filtering is applied until one of `foreach`, `map` or `flatMap` is called. */
+  /** A lazy filtered array. No filtering is applied until one of `foreach`, `map` or `flatMap` is called.
+   *
+   *  @tparam T the element type of the array
+   *  @param p the filter predicate
+   *  @param xs the underlying immutable array
+   */
   class WithFilter[T](p: T => Boolean, xs: IArray[T]):
 
     /** Applies `f` to each element for its side effects.
      *  Note: [U] parameter needed to help scalac's type inference.
+     *
+     *  @tparam U the return type of `f`, discarded
+     *  @param f the function to apply to each element
      */
     def foreach[U](f: T => U): Unit = {
       val len = xs.length
@@ -690,7 +924,10 @@ object IArray:
     def flatMap[BS, U](f: T => BS)(using asIterable: BS => Iterable[U]^, m: ClassTag[U]): IArray[U] =
       flatMap[U](x => asIterable(f(x)))
 
-    /** Creates a new non-strict filter which combines this filter with the given predicate. */
+    /** Creates a new non-strict filter which combines this filter with the given predicate.
+     *
+     *  @param q the additional predicate to apply
+     */
     def withFilter(q: T => Boolean): WithFilter[T]^{p, q} = new WithFilter[T](a => p(a) && q(a), xs)
 
   end WithFilter

--- a/library/src/scala/Int.scala
+++ b/library/src/scala/Int.scala
@@ -56,6 +56,8 @@ final abstract class Int private extends AnyVal {
    *  ```
    *  6 << 3 == 48 // in binary: 0110 << 3 == 0110000
    *  ```
+   *
+   *  @param x the number of bits to shift left (only the 5 lowest-order bits are used)
    */
   def <<(x: Int): Int
   /** Returns this value bit-shifted left by the specified number of bits,
@@ -75,6 +77,8 @@ final abstract class Int private extends AnyVal {
    *  // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
    *  //            00011111 11111111 11111111 11111101
    *  ```
+   *
+   *  @param x the number of bits to shift right (only the 5 lowest-order bits are used)
    */
   def >>>(x: Int): Int
   /** Returns this value bit-shifted right by the specified number of bits,
@@ -96,6 +100,8 @@ final abstract class Int private extends AnyVal {
    *  // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
    *  //            11111111 11111111 11111111 11111101
    *  ```
+   *
+   *  @param x the number of bits to shift right (only the 5 lowest-order bits are used)
    */
   def >>(x: Int): Int
   /** Returns this value bit-shifted right by the specified number of bits,
@@ -140,19 +146,40 @@ final abstract class Int private extends AnyVal {
   /** Returns `true` if this value is not equal to x, `false` otherwise. */
   def !=(x: Double): Boolean
 
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Byte): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Short): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Char): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Int): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Long): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Float): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Double): Boolean
 
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
@@ -170,19 +197,40 @@ final abstract class Int private extends AnyVal {
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
   def <=(x: Double): Boolean
 
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Byte): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Short): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Char): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Int): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Long): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Float): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Double): Boolean
 
   /** Returns `true` if this value is greater than or equal to x, `false` otherwise. */
@@ -208,6 +256,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Byte): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -218,6 +268,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Short): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -228,6 +280,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Char): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -238,6 +292,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Int): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -248,6 +304,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Long): Long
 
@@ -259,6 +317,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Byte): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -269,6 +329,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Short): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -279,6 +341,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Char): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -289,6 +353,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Int): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -299,6 +365,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Long): Long
 
@@ -310,6 +378,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Byte): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -320,6 +390,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Short): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -330,6 +402,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Char): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -340,6 +414,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Int): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -350,82 +426,189 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Long): Long
 
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Byte): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Short): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Char): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Int): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Long): Long
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Float): Float
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Double): Double
 
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Byte): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Short): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Char): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Int): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Long): Long
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Float): Float
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Double): Double
 
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Byte): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Short): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Char): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Int): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Long): Long
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Float): Float
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Double): Double
 
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Byte): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Short): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Char): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Int): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Long): Long
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Float): Float
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Double): Double
 
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Byte): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Short): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Char): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Int): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Long): Long
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Float): Float
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Double): Double
 
   // Provide a more specific return type for Scaladoc

--- a/library/src/scala/Long.scala
+++ b/library/src/scala/Long.scala
@@ -56,6 +56,8 @@ final abstract class Long private extends AnyVal {
    *  ```
    *  6 << 3 == 48 // in binary: 0110 << 3 == 0110000
    *  ```
+   *
+   *  @param x the number of bits to shift left
    */
   def <<(x: Int): Long
   /** Returns this value bit-shifted left by the specified number of bits,
@@ -64,6 +66,8 @@ final abstract class Long private extends AnyVal {
    *  ```
    *  6 << 3 == 48 // in binary: 0110 << 3 == 0110000
    *  ```
+   *
+   *  @param x the number of bits to shift left
    */
   def <<(x: Long): Long
   /** Returns this value bit-shifted right by the specified number of bits,
@@ -74,6 +78,8 @@ final abstract class Long private extends AnyVal {
    *  // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
    *  //            00011111 11111111 11111111 11111101
    *  ```
+   *
+   *  @param x the number of bits to shift right
    */
   def >>>(x: Int): Long
   /** Returns this value bit-shifted right by the specified number of bits,
@@ -84,6 +90,8 @@ final abstract class Long private extends AnyVal {
    *  // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
    *  //            00011111 11111111 11111111 11111101
    *  ```
+   *
+   *  @param x the number of bits to shift right
    */
   def >>>(x: Long): Long
   /** Returns this value bit-shifted right by the specified number of bits,
@@ -94,6 +102,8 @@ final abstract class Long private extends AnyVal {
    *  // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
    *  //            11111111 11111111 11111111 11111101
    *  ```
+   *
+   *  @param x the number of bits to shift right
    */
   def >>(x: Int): Long
   /** Returns this value bit-shifted right by the specified number of bits,
@@ -104,6 +114,8 @@ final abstract class Long private extends AnyVal {
    *  // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
    *  //            11111111 11111111 11111111 11111101
    *  ```
+   *
+   *  @param x the number of bits to shift right
    */
   def >>(x: Long): Long
 
@@ -137,19 +149,40 @@ final abstract class Long private extends AnyVal {
   /** Returns `true` if this value is not equal to x, `false` otherwise. */
   def !=(x: Double): Boolean
 
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Byte): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Short): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Char): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Int): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Long): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Float): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Double): Boolean
 
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
@@ -167,19 +200,40 @@ final abstract class Long private extends AnyVal {
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
   def <=(x: Double): Boolean
 
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Byte): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Short): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Char): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Int): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Long): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Float): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Double): Boolean
 
   /** Returns `true` if this value is greater than or equal to x, `false` otherwise. */
@@ -205,6 +259,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Byte): Long
   /** Returns the bitwise OR of this value and `x`.
@@ -215,6 +271,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Short): Long
   /** Returns the bitwise OR of this value and `x`.
@@ -225,6 +283,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Char): Long
   /** Returns the bitwise OR of this value and `x`.
@@ -235,6 +295,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Int): Long
   /** Returns the bitwise OR of this value and `x`.
@@ -245,6 +307,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Long): Long
 
@@ -256,6 +320,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Byte): Long
   /** Returns the bitwise AND of this value and `x`.
@@ -266,6 +332,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Short): Long
   /** Returns the bitwise AND of this value and `x`.
@@ -276,6 +344,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Char): Long
   /** Returns the bitwise AND of this value and `x`.
@@ -286,6 +356,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Int): Long
   /** Returns the bitwise AND of this value and `x`.
@@ -296,6 +368,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Long): Long
 
@@ -307,6 +381,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Byte): Long
   /** Returns the bitwise XOR of this value and `x`.
@@ -317,6 +393,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Short): Long
   /** Returns the bitwise XOR of this value and `x`.
@@ -327,6 +405,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Char): Long
   /** Returns the bitwise XOR of this value and `x`.
@@ -337,6 +417,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Int): Long
   /** Returns the bitwise XOR of this value and `x`.
@@ -347,82 +429,189 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Long): Long
 
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Byte): Long
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Short): Long
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Char): Long
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Int): Long
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Long): Long
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Float): Float
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Double): Double
 
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Byte): Long
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Short): Long
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Char): Long
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Int): Long
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Long): Long
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Float): Float
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Double): Double
 
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Byte): Long
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Short): Long
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Char): Long
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Int): Long
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Long): Long
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Float): Float
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Double): Double
 
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Byte): Long
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Short): Long
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Char): Long
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Int): Long
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Long): Long
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Float): Float
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Double): Double
 
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Byte): Long
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Short): Long
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Char): Long
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Int): Long
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Long): Long
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Float): Float
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Double): Double
 
   // Provide a more specific return type for Scaladoc

--- a/library/src/scala/NamedTuple.scala
+++ b/library/src/scala/NamedTuple.scala
@@ -22,6 +22,8 @@ object NamedTuple:
 
   /** A named tuple expression will desugar to a call to `build`. For instance,
    *  `(name = "Lyra", age = 23)` will desugar to `build[("name", "age")]()(("Lyra", 23))`.
+   *
+   *  @tparam N the tuple of literal string types representing the field names
    */
   inline def build[N <: Tuple]()[V <: Tuple](x: V): NamedTuple[N, V] = x
 
@@ -141,7 +143,10 @@ end NamedTuple
 object NamedTupleDecomposition:
   import NamedTuple.*
   extension [N <: Tuple, V <: Tuple](x: NamedTuple[N, V])
-      /** The value (without the name) at index `n` of this tuple. */
+    /** The value (without the name) at index `n` of this tuple.
+     *
+     *  @param n the zero-based index of the element to retrieve
+     */
     inline def apply(n: Int): Elem[NamedTuple[N, V], n.type] =
       x.toTuple.apply(n).asInstanceOf[Elem[NamedTuple[N, V], n.type]]
 
@@ -163,19 +168,30 @@ object NamedTupleDecomposition:
 
     /** The tuple consisting of the first `n` elements of this tuple, or all
      *  elements if `n` exceeds `size`.
+     *
+     *  @param n the number of elements to take from this tuple
      */
     inline def take(n: Int): Take[NamedTuple[N, V], n.type] = x.toTuple.take(n)
 
     /** The tuple consisting of all elements of this tuple except the first `n` ones,
      *  or no elements if `n` exceeds `size`.
+     *
+     *  @param n the number of elements to drop from the beginning of this tuple
      */
     inline def drop(n: Int): Drop[NamedTuple[N, V], n.type] = x.toTuple.drop(n)
 
-    /** The tuple `(x.take(n), x.drop(n))`. */
+    /** The tuple `(x.take(n), x.drop(n))`.
+     *
+     *  @param n the index at which to split this tuple
+     */
     inline def splitAt(n: Int): Split[NamedTuple[N, V], n.type] = x.toTuple.splitAt(n)
 
     /** The tuple consisting of all elements of this tuple followed by all elements
      *  of tuple `that`. The names of the two tuples must be disjoint.
+     *
+     *  @tparam N2 the tuple of name types of the other named tuple
+     *  @tparam V2 the tuple of value types of the other named tuple
+     *  @param that the named tuple to append to this one
      */
     inline def ++ [N2 <: Tuple, V2 <: Tuple](that: NamedTuple[N2, V2])(using Tuple.Disjoint[N, N2] =:= true)
       : Concat[NamedTuple[N, V], NamedTuple[N2, V2]]
@@ -184,6 +200,8 @@ object NamedTupleDecomposition:
     /** The named tuple consisting of all element values of this tuple mapped by
      *  the polymorphic mapping function `f`. The names of elements are preserved.
      *  If `x = (n1 = v1, ..., ni = vi)` then `x.map(f) = `(n1 = f(v1), ..., ni = f(vi))`.
+     *
+     *  @tparam F the type constructor applied to each element value type
      */
     inline def map[F[_]](f: [t] => t => F[t]): Map[NamedTuple[N, V], F] =
       x.toTuple.map[F](f)
@@ -197,6 +215,9 @@ object NamedTupleDecomposition:
      *  the extra elements of the larger tuple will be disregarded.
      *  The names of `x` and `that` at the same index must be the same.
      *  The result tuple keeps the same names as the operand tuples.
+     *
+     *  @tparam V2 the tuple of value types of the other named tuple
+     *  @param that the named tuple to zip with this one
      */
     inline def zip[V2 <: Tuple](that: NamedTuple[N, V2]): Zip[NamedTuple[N, V], NamedTuple[N, V2]] =
       x.toTuple.zip(that.toTuple)

--- a/library/src/scala/NotImplementedError.scala
+++ b/library/src/scala/NotImplementedError.scala
@@ -17,6 +17,8 @@ import scala.language.`2.13`
 /** Throwing this exception can be a temporary replacement for a method
  *  body that remains to be implemented. For instance, the exception is thrown by
  *  `Predef.???`.
+ *
+ *  @param msg the error message describing which implementation is missing
  */
 final class NotImplementedError(msg: String) extends Error(msg) {
   def this() = this("an implementation is missing")

--- a/library/src/scala/Predef.scala
+++ b/library/src/scala/Predef.scala
@@ -119,6 +119,8 @@ object Predef extends LowPriorityImplicits {
    *
    *  @return The runtime [[Class]] representation of type `T`.
    *  @group utilities
+   *
+   *  @tparam T the type whose runtime class representation is returned
    */
   def classOf[T]: Class[T] = null.asInstanceOf[Class[T]] // This is a stub method. The actual implementation is filled in by the compiler.
 
@@ -133,6 +135,10 @@ object Predef extends LowPriorityImplicits {
    *  // bar is 23.type = 23
    *  ```
    *  @group utilities
+   *
+   *  @tparam T the singleton type whose unique value is retrieved
+   *  @param vt the implicit `ValueOf` instance that provides the value
+   *  @return the unique inhabitant of type `T`
    */
   @inline def valueOf[T](implicit vt: ValueOf[T]): T = vt.value
 
@@ -147,6 +153,9 @@ object Predef extends LowPriorityImplicits {
    *  // bar is 23.type = 23
    *  ```
    *  @group utilities
+   *
+   *  @tparam T the singleton type whose unique value is retrieved
+   *  @return the unique inhabitant of type `T`
    */
   inline def valueOf[T]: T = summonFrom {
     case ev: ValueOf[T] => ev.value
@@ -217,9 +226,9 @@ object Predef extends LowPriorityImplicits {
   // Minor variations on identity functions
 
   /** A method that returns its input value.
-   *  @tparam A type of the input value x.
-   *  @param x the value of type `A` to be returned.
-   *  @return the value `x`.
+   *  @tparam A the type of the input value `x`
+   *  @param x the value of type `A` to be returned
+   *  @return the value `x`
    *  @group utilities
    */
   @inline def identity[A](x: A): A = x // see `$conforms` for the implicit version
@@ -227,6 +236,7 @@ object Predef extends LowPriorityImplicits {
   /** Summon an implicit value of type `T`. Usually, the argument is not passed explicitly.
    *
    *  @tparam T the type of the value to be summoned
+   *  @param e the implicit value of type `T`
    *  @return the implicit value of type `T`
    *  @group utilities
    */
@@ -235,7 +245,8 @@ object Predef extends LowPriorityImplicits {
   /** Summon a given value of type `T`. Usually, the argument is not passed explicitly.
    *
    *  @tparam T the type of the value to be summoned
-   *  @return the given value typed: the provided type parameter
+   *  @param x the given value of type `T`
+   *  @return the given value with its singleton type preserved
    */
   transparent inline def summon[T](using x: T): x.type = x
 
@@ -267,6 +278,8 @@ object Predef extends LowPriorityImplicits {
    *             // locally guards the block and helps communicate intent
    *           ```
    *  @group utilities
+   *
+   *  @tparam T the type of the expression being guarded
    */
   @inline def locally[T](@deprecatedName("x") x: T): T = x
 
@@ -384,14 +397,24 @@ object Predef extends LowPriorityImplicits {
 
   // implicit classes -----------------------------------------------------
 
-  /** @group implicit-classes-any */
+  /**
+   *  @group implicit-classes-any
+   *
+   *  @tparam A the type of the left-hand side of the arrow association
+   *  @param self the value to use as the first element of the resulting tuple
+   */
   implicit final class ArrowAssoc[A](private val self: A) extends AnyVal {
     @inline def -> [B](y: B): (A, B) = (self, y)
     @deprecated("Use `->` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code.", "2.13.0")
     def →[B](y: B): (A, B) = ->(y)
   }
 
-  /** @group implicit-classes-any */
+  /**
+   *  @group implicit-classes-any
+   *
+   *  @tparam A the type of the value being checked with `ensuring`
+   *  @param self the value to check postconditions against
+   */
   implicit final class Ensuring[A](private val self: A) extends AnyVal {
     def ensuring(cond: Boolean): A = { assert(cond); self }
     def ensuring(cond: Boolean, msg: => Any): A = { assert(cond, msg); self }
@@ -399,7 +422,12 @@ object Predef extends LowPriorityImplicits {
     def ensuring(cond: A => Boolean, msg: => Any): A = { assert(cond(self), msg); self }
   }
 
-  /** @group implicit-classes-any */
+  /**
+   *  @group implicit-classes-any
+   *
+   *  @tparam A the type of the value to be formatted as a string
+   *  @param self the value to format
+   */
   implicit final class StringFormat[A](private val self: A) extends AnyVal {
     /** Returns string formatted according to given `format` string.
      *  Format strings are as for `String.format`
@@ -419,7 +447,11 @@ object Predef extends LowPriorityImplicits {
     def +(other: String): String = String.valueOf(self) + other
   }
 
-  /** @group char-sequence-wrappers */
+  /**
+   *  @group char-sequence-wrappers
+   *
+   *  @param sequenceOfChars the indexed sequence of characters to wrap as a `CharSequence`
+   */
   final class SeqCharSequence(sequenceOfChars: scala.collection.IndexedSeq[Char]) extends CharSequence {
     def length: Int                                     = sequenceOfChars.length
     def charAt(index: Int): Char                        = sequenceOfChars(index)
@@ -427,10 +459,18 @@ object Predef extends LowPriorityImplicits {
     override def toString()                             = sequenceOfChars.mkString
   }
 
-  /** @group char-sequence-wrappers */
+  /**
+   *  @group char-sequence-wrappers
+   *
+   *  @param sequenceOfChars the indexed sequence of characters to wrap as a `CharSequence`
+   */
   def SeqCharSequence(sequenceOfChars: scala.collection.IndexedSeq[Char]): SeqCharSequence = new SeqCharSequence(sequenceOfChars)
 
-  /** @group char-sequence-wrappers */
+  /**
+   *  @group char-sequence-wrappers
+   *
+   *  @param arrayOfChars the array of characters to wrap as a `CharSequence`
+   */
   final class ArrayCharSequence(arrayOfChars: Array[Char]) extends CharSequence {
     def length: Int                                     = arrayOfChars.length
     def charAt(index: Int): Char                        = arrayOfChars(index)
@@ -438,10 +478,18 @@ object Predef extends LowPriorityImplicits {
     override def toString()                             = arrayOfChars.mkString
   }
 
-  /** @group char-sequence-wrappers */
+  /**
+   *  @group char-sequence-wrappers
+   *
+   *  @param arrayOfChars the array of characters to wrap as a `CharSequence`
+   */
   def ArrayCharSequence(arrayOfChars: Array[Char]): ArrayCharSequence = new ArrayCharSequence(arrayOfChars)
 
-  /** @group conversions-string */
+  /**
+   *  @group conversions-string
+   *
+   *  @param x the string to enrich with `StringOps` methods
+   */
   @inline implicit def augmentString(x: String): StringOps = new StringOps(x)
 
   // printing -----------------------------------------------------------
@@ -508,38 +556,102 @@ object Predef extends LowPriorityImplicits {
 
   // "Autoboxing" and "Autounboxing" ---------------------------------------------------
 
-  /** @group conversions-anyval-to-java */
+  /**
+   *  @group conversions-anyval-to-java
+   *
+   *  @param x the Scala `Byte` value to convert
+   */
   implicit def byte2Byte(x: Byte): java.lang.Byte             = x.asInstanceOf[java.lang.Byte]
-  /** @group conversions-anyval-to-java */
+  /**
+   *  @group conversions-anyval-to-java
+   *
+   *  @param x the Scala `Short` value to convert
+   */
   implicit def short2Short(x: Short): java.lang.Short         = x.asInstanceOf[java.lang.Short]
-  /** @group conversions-anyval-to-java */
+  /**
+   *  @group conversions-anyval-to-java
+   *
+   *  @param x the Scala `Char` value to convert
+   */
   implicit def char2Character(x: Char): java.lang.Character   = x.asInstanceOf[java.lang.Character]
-  /** @group conversions-anyval-to-java */
+  /**
+   *  @group conversions-anyval-to-java
+   *
+   *  @param x the Scala `Int` value to convert
+   */
   implicit def int2Integer(x: Int): java.lang.Integer         = x.asInstanceOf[java.lang.Integer]
-  /** @group conversions-anyval-to-java */
+  /**
+   *  @group conversions-anyval-to-java
+   *
+   *  @param x the Scala `Long` value to convert
+   */
   implicit def long2Long(x: Long): java.lang.Long             = x.asInstanceOf[java.lang.Long]
-  /** @group conversions-anyval-to-java */
+  /**
+   *  @group conversions-anyval-to-java
+   *
+   *  @param x the Scala `Float` value to convert
+   */
   implicit def float2Float(x: Float): java.lang.Float         = x.asInstanceOf[java.lang.Float]
-  /** @group conversions-anyval-to-java */
+  /**
+   *  @group conversions-anyval-to-java
+   *
+   *  @param x the Scala `Double` value to convert
+   */
   implicit def double2Double(x: Double): java.lang.Double     = x.asInstanceOf[java.lang.Double]
-  /** @group conversions-anyval-to-java */
+  /**
+   *  @group conversions-anyval-to-java
+   *
+   *  @param x the Scala `Boolean` value to convert
+   */
   implicit def boolean2Boolean(x: Boolean): java.lang.Boolean = x.asInstanceOf[java.lang.Boolean]
 
-  /** @group conversions-java-to-anyval */
+  /**
+   *  @group conversions-java-to-anyval
+   *
+   *  @param x the `java.lang.Byte` value to unbox
+   */
   implicit def Byte2byte(x: java.lang.Byte): Byte             = x.asInstanceOf[Byte]
-  /** @group conversions-java-to-anyval */
+  /**
+   *  @group conversions-java-to-anyval
+   *
+   *  @param x the `java.lang.Short` value to unbox
+   */
   implicit def Short2short(x: java.lang.Short): Short         = x.asInstanceOf[Short]
-  /** @group conversions-java-to-anyval */
+  /**
+   *  @group conversions-java-to-anyval
+   *
+   *  @param x the `java.lang.Character` value to unbox
+   */
   implicit def Character2char(x: java.lang.Character): Char   = x.asInstanceOf[Char]
-  /** @group conversions-java-to-anyval */
+  /**
+   *  @group conversions-java-to-anyval
+   *
+   *  @param x the `java.lang.Integer` value to unbox
+   */
   implicit def Integer2int(x: java.lang.Integer): Int         = x.asInstanceOf[Int]
-  /** @group conversions-java-to-anyval */
+  /**
+   *  @group conversions-java-to-anyval
+   *
+   *  @param x the `java.lang.Long` value to unbox
+   */
   implicit def Long2long(x: java.lang.Long): Long             = x.asInstanceOf[Long]
-  /** @group conversions-java-to-anyval */
+  /**
+   *  @group conversions-java-to-anyval
+   *
+   *  @param x the `java.lang.Float` value to unbox
+   */
   implicit def Float2float(x: java.lang.Float): Float         = x.asInstanceOf[Float]
-  /** @group conversions-java-to-anyval */
+  /**
+   *  @group conversions-java-to-anyval
+   *
+   *  @param x the `java.lang.Double` value to unbox
+   */
   implicit def Double2double(x: java.lang.Double): Double     = x.asInstanceOf[Double]
-  /** @group conversions-java-to-anyval */
+  /**
+   *  @group conversions-java-to-anyval
+   *
+   *  @param x the `java.lang.Boolean` value to unbox
+   */
   implicit def Boolean2boolean(x: java.lang.Boolean): Boolean = x.asInstanceOf[Boolean]
 
   /** An implicit of type `A => A` is available for all `A` because it can always
@@ -561,6 +673,8 @@ object Predef extends LowPriorityImplicits {
    *  val s3: String | Null = null
    *  val s4: String = s3.nn // throw NullPointerException
    *  ```
+   *
+   *  @return the value cast to its non-nullable type `x.type & T`
    */
   extension [T](x: T | Null) inline def nn: x.type & T =
     if x.asInstanceOf[Any] == null then scala.runtime.Scala3RunTime.nnFail()
@@ -570,12 +684,16 @@ object Predef extends LowPriorityImplicits {
     /** Enables an expression of type `T|Null`, where `T` is a subtype of `AnyRef`, to be checked for `null`
      *  using `eq` rather than only `==`. This is needed because `Null` no longer has
      *  `eq` or `ne` methods, only `==` and `!=` inherited from `Any`. 
+     *
+     *  @param inline y the reference to compare against for reference equality
      */
     inline infix def eq(inline y: AnyRef | Null): Boolean =
       x.asInstanceOf[AnyRef] eq y.asInstanceOf[AnyRef]
     /** Enables an expression of type `T|Null`, where `T` is a subtype of `AnyRef`, to be checked for `null`
      *  using `ne` rather than only `!=`. This is needed because `Null` no longer has
      *  `eq` or `ne` methods, only `==` and `!=` inherited from `Any`. 
+     *
+     *  @param inline y the reference to compare against for reference non-equality
      */
     inline infix def ne(inline y: AnyRef | Null): Boolean =
       !(x eq y)
@@ -629,6 +747,9 @@ private[scala] abstract class LowPriorityImplicits extends LowPriorityImplicits2
    *  the call to xxxWrapper is not eliminated even though it does nothing.
    *  Even inlined, every call site does a no-op retrieval of Predef's MODULE$
    *  because maybe loading Predef has side effects!
+   *
+   *  @param x the primitive value to wrap
+   *  @return a rich wrapper providing additional methods on the primitive value
    */
   @inline implicit def byteWrapper(x: Byte): runtime.RichByte          = new runtime.RichByte(x)
   @inline implicit def shortWrapper(x: Short): runtime.RichShort       = new runtime.RichShort(x)
@@ -639,39 +760,89 @@ private[scala] abstract class LowPriorityImplicits extends LowPriorityImplicits2
   @inline implicit def doubleWrapper(x: Double): runtime.RichDouble    = new runtime.RichDouble(x)
   @inline implicit def booleanWrapper(x: Boolean): runtime.RichBoolean = new runtime.RichBoolean(x)
 
-  /** @group conversions-array-to-wrapped-array */
+  /**
+   *  @group conversions-array-to-wrapped-array
+   *
+   *  @tparam T the element type of the array
+   *  @param xs the array to wrap as an `ArraySeq`
+   */
   implicit def genericWrapArray[T](xs: Array[T]): ArraySeq[T] =
     mapNull(xs, ArraySeq.make(xs))
 
   // Since the JVM thinks arrays are covariant, one 0-length Array[AnyRef]
   // is as good as another for all T <: AnyRef.  Instead of creating 100,000,000
   // unique ones by way of this implicit, let's share one.
-  /** @group conversions-array-to-wrapped-array */
+  /**
+   *  @group conversions-array-to-wrapped-array
+   *
+   *  @tparam T the element type of the array, must be a reference type
+   *  @param xs the array of reference-typed elements to wrap as an `ArraySeq`
+   */
   implicit def wrapRefArray[T <: AnyRef | Null](xs: Array[T]): ArraySeq.ofRef[T] =
     mapNull(xs,
       if (xs.length == 0) ArraySeq.empty[AnyRef].asInstanceOf[ArraySeq.ofRef[T]]
       else new ArraySeq.ofRef[T](xs))
 
-  /** @group conversions-array-to-wrapped-array */
+  /**
+   *  @group conversions-array-to-wrapped-array
+   *
+   *  @param xs the array to wrap as an `ArraySeq`
+   */
   implicit def wrapIntArray(xs: Array[Int]): ArraySeq.ofInt = mapNull(xs, new ArraySeq.ofInt(xs))
-  /** @group conversions-array-to-wrapped-array */
+  /**
+   *  @group conversions-array-to-wrapped-array
+   *
+   *  @param xs the array to wrap as an `ArraySeq`
+   */
   implicit def wrapDoubleArray(xs: Array[Double]): ArraySeq.ofDouble = mapNull(xs, new ArraySeq.ofDouble(xs))
-  /** @group conversions-array-to-wrapped-array */
+  /**
+   *  @group conversions-array-to-wrapped-array
+   *
+   *  @param xs the array to wrap as an `ArraySeq`
+   */
   implicit def wrapLongArray(xs: Array[Long]): ArraySeq.ofLong = mapNull(xs, new ArraySeq.ofLong(xs))
-  /** @group conversions-array-to-wrapped-array */
+  /**
+   *  @group conversions-array-to-wrapped-array
+   *
+   *  @param xs the array to wrap as an `ArraySeq`
+   */
   implicit def wrapFloatArray(xs: Array[Float]): ArraySeq.ofFloat = mapNull(xs, new ArraySeq.ofFloat(xs))
-  /** @group conversions-array-to-wrapped-array */
+  /**
+   *  @group conversions-array-to-wrapped-array
+   *
+   *  @param xs the array to wrap as an `ArraySeq`
+   */
   implicit def wrapCharArray(xs: Array[Char]): ArraySeq.ofChar = mapNull(xs, new ArraySeq.ofChar(xs))
-  /** @group conversions-array-to-wrapped-array */
+  /**
+   *  @group conversions-array-to-wrapped-array
+   *
+   *  @param xs the array to wrap as an `ArraySeq`
+   */
   implicit def wrapByteArray(xs: Array[Byte]): ArraySeq.ofByte = mapNull(xs, new ArraySeq.ofByte(xs))
-  /** @group conversions-array-to-wrapped-array */
+  /**
+   *  @group conversions-array-to-wrapped-array
+   *
+   *  @param xs the array to wrap as an `ArraySeq`
+   */
   implicit def wrapShortArray(xs: Array[Short]): ArraySeq.ofShort = mapNull(xs, new ArraySeq.ofShort(xs))
-  /** @group conversions-array-to-wrapped-array */
+  /**
+   *  @group conversions-array-to-wrapped-array
+   *
+   *  @param xs the array to wrap as an `ArraySeq`
+   */
   implicit def wrapBooleanArray(xs: Array[Boolean]): ArraySeq.ofBoolean = mapNull(xs, new ArraySeq.ofBoolean(xs))
-  /** @group conversions-array-to-wrapped-array */
+  /**
+   *  @group conversions-array-to-wrapped-array
+   *
+   *  @param xs the array to wrap as an `ArraySeq`
+   */
   implicit def wrapUnitArray(xs: Array[Unit]): ArraySeq.ofUnit = mapNull(xs, new ArraySeq.ofUnit(xs))
 
-  /** @group conversions-string */
+  /**
+   *  @group conversions-string
+   *
+   *  @param s the string to wrap as a `WrappedString`
+   */
   implicit def wrapString(s: String): WrappedString = mapNull(s, new WrappedString(s))
 }
 

--- a/library/src/scala/Product10.scala
+++ b/library/src/scala/Product10.scala
@@ -21,7 +21,19 @@ object Product10 {
     Some(x)
 }
 
-/** Product10 is a Cartesian product of 10 components. */
+/** Product10 is a Cartesian product of 10 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ */
 trait Product10[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10] extends Any with Product {
   /** The arity of this product.
    *  @return 10

--- a/library/src/scala/Product11.scala
+++ b/library/src/scala/Product11.scala
@@ -21,7 +21,20 @@ object Product11 {
     Some(x)
 }
 
-/** Product11 is a Cartesian product of 11 components. */
+/** Product11 is a Cartesian product of 11 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ */
 trait Product11[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11] extends Any with Product {
   /** The arity of this product.
    *  @return 11

--- a/library/src/scala/Product12.scala
+++ b/library/src/scala/Product12.scala
@@ -21,7 +21,21 @@ object Product12 {
     Some(x)
 }
 
-/** Product12 is a Cartesian product of 12 components. */
+/** Product12 is a Cartesian product of 12 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ */
 trait Product12[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12] extends Any with Product {
   /** The arity of this product.
    *  @return 12
@@ -32,8 +46,8 @@ trait Product12[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12] e
   /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
-   *  @param n number of the projection to be returned
-   *  @return  same as `._(n+1)`, for example `productElement(0)` is the same as `._1`.
+   *  @param n the zero-based index of the projection to be returned
+   *  @return  the element at the given zero-based index, equivalent to `._(n+1)` (e.g., `productElement(0)` returns `._1`)
    *  @throws  IndexOutOfBoundsException if the `n` is out of range(n < 0 || n >= 12).
    */
 

--- a/library/src/scala/Product13.scala
+++ b/library/src/scala/Product13.scala
@@ -21,7 +21,22 @@ object Product13 {
     Some(x)
 }
 
-/** Product13 is a Cartesian product of 13 components. */
+/** Product13 is a Cartesian product of 13 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ */
 trait Product13[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13] extends Any with Product {
   /** The arity of this product.
    *  @return 13

--- a/library/src/scala/Product14.scala
+++ b/library/src/scala/Product14.scala
@@ -21,7 +21,23 @@ object Product14 {
     Some(x)
 }
 
-/** Product14 is a Cartesian product of 14 components. */
+/** Product14 is a Cartesian product of 14 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ */
 trait Product14[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14] extends Any with Product {
   /** The arity of this product.
    *  @return 14

--- a/library/src/scala/Product15.scala
+++ b/library/src/scala/Product15.scala
@@ -21,7 +21,24 @@ object Product15 {
     Some(x)
 }
 
-/** Product15 is a Cartesian product of 15 components. */
+/** Product15 is a Cartesian product of 15 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ */
 trait Product15[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15] extends Any with Product {
   /** The arity of this product.
    *  @return 15

--- a/library/src/scala/Product16.scala
+++ b/library/src/scala/Product16.scala
@@ -21,7 +21,25 @@ object Product16 {
     Some(x)
 }
 
-/** Product16 is a Cartesian product of 16 components. */
+/** Product16 is a Cartesian product of 16 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ */
 trait Product16[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16] extends Any with Product {
   /** The arity of this product.
    *  @return 16

--- a/library/src/scala/Product17.scala
+++ b/library/src/scala/Product17.scala
@@ -21,7 +21,26 @@ object Product17 {
     Some(x)
 }
 
-/** Product17 is a Cartesian product of 17 components. */
+/** Product17 is a Cartesian product of 17 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ *  @tparam T17 the type of the 17th element
+ */
 trait Product17[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17] extends Any with Product {
   /** The arity of this product.
    *  @return 17

--- a/library/src/scala/Product18.scala
+++ b/library/src/scala/Product18.scala
@@ -21,7 +21,27 @@ object Product18 {
     Some(x)
 }
 
-/** Product18 is a Cartesian product of 18 components. */
+/** Product18 is a Cartesian product of 18 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ *  @tparam T17 the type of the 17th element
+ *  @tparam T18 the type of the 18th element
+ */
 trait Product18[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18] extends Any with Product {
   /** The arity of this product.
    *  @return 18

--- a/library/src/scala/Product19.scala
+++ b/library/src/scala/Product19.scala
@@ -21,7 +21,28 @@ object Product19 {
     Some(x)
 }
 
-/** Product19 is a Cartesian product of 19 components. */
+/** Product19 is a Cartesian product of 19 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ *  @tparam T17 the type of the 17th element
+ *  @tparam T18 the type of the 18th element
+ *  @tparam T19 the type of the 19th element
+ */
 trait Product19[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18, +T19] extends Any with Product {
   /** The arity of this product.
    *  @return 19

--- a/library/src/scala/Product20.scala
+++ b/library/src/scala/Product20.scala
@@ -21,7 +21,29 @@ object Product20 {
     Some(x)
 }
 
-/** Product20 is a Cartesian product of 20 components. */
+/** Product20 is a Cartesian product of 20 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ *  @tparam T17 the type of the 17th element
+ *  @tparam T18 the type of the 18th element
+ *  @tparam T19 the type of the 19th element
+ *  @tparam T20 the type of the 20th element
+ */
 trait Product20[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18, +T19, +T20] extends Any with Product {
   /** The arity of this product.
    *  @return 20

--- a/library/src/scala/Product21.scala
+++ b/library/src/scala/Product21.scala
@@ -21,7 +21,30 @@ object Product21 {
     Some(x)
 }
 
-/** Product21 is a Cartesian product of 21 components. */
+/** Product21 is a Cartesian product of 21 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ *  @tparam T17 the type of the 17th element
+ *  @tparam T18 the type of the 18th element
+ *  @tparam T19 the type of the 19th element
+ *  @tparam T20 the type of the 20th element
+ *  @tparam T21 the type of the 21st element
+ */
 trait Product21[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18, +T19, +T20, +T21] extends Any with Product {
   /** The arity of this product.
    *  @return 21

--- a/library/src/scala/Product22.scala
+++ b/library/src/scala/Product22.scala
@@ -21,7 +21,31 @@ object Product22 {
     Some(x)
 }
 
-/** Product22 is a Cartesian product of 22 components. */
+/** Product22 is a Cartesian product of 22 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ *  @tparam T17 the type of the 17th element
+ *  @tparam T18 the type of the 18th element
+ *  @tparam T19 the type of the 19th element
+ *  @tparam T20 the type of the 20th element
+ *  @tparam T21 the type of the 21st element
+ *  @tparam T22 the type of the 22nd element
+ */
 trait Product22[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18, +T19, +T20, +T21, +T22] extends Any with Product {
   /** The arity of this product.
    *  @return 22

--- a/library/src/scala/Product3.scala
+++ b/library/src/scala/Product3.scala
@@ -21,7 +21,12 @@ object Product3 {
     Some(x)
 }
 
-/** Product3 is a Cartesian product of 3 components. */
+/** Product3 is a Cartesian product of 3 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ */
 trait Product3[+T1, +T2, +T3] extends Any with Product {
   /** The arity of this product.
    *  @return 3

--- a/library/src/scala/Product4.scala
+++ b/library/src/scala/Product4.scala
@@ -21,7 +21,13 @@ object Product4 {
     Some(x)
 }
 
-/** Product4 is a Cartesian product of 4 components. */
+/** Product4 is a Cartesian product of 4 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ */
 trait Product4[+T1, +T2, +T3, +T4] extends Any with Product {
   /** The arity of this product.
    *  @return 4

--- a/library/src/scala/Product5.scala
+++ b/library/src/scala/Product5.scala
@@ -21,7 +21,14 @@ object Product5 {
     Some(x)
 }
 
-/** Product5 is a Cartesian product of 5 components. */
+/** Product5 is a Cartesian product of 5 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ */
 trait Product5[+T1, +T2, +T3, +T4, +T5] extends Any with Product {
   /** The arity of this product.
    *  @return 5

--- a/library/src/scala/Product6.scala
+++ b/library/src/scala/Product6.scala
@@ -21,7 +21,15 @@ object Product6 {
     Some(x)
 }
 
-/** Product6 is a Cartesian product of 6 components. */
+/** Product6 is a Cartesian product of 6 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ */
 trait Product6[+T1, +T2, +T3, +T4, +T5, +T6] extends Any with Product {
   /** The arity of this product.
    *  @return 6

--- a/library/src/scala/Product7.scala
+++ b/library/src/scala/Product7.scala
@@ -21,7 +21,16 @@ object Product7 {
     Some(x)
 }
 
-/** Product7 is a Cartesian product of 7 components. */
+/** Product7 is a Cartesian product of 7 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ */
 trait Product7[+T1, +T2, +T3, +T4, +T5, +T6, +T7] extends Any with Product {
   /** The arity of this product.
    *  @return 7

--- a/library/src/scala/Product8.scala
+++ b/library/src/scala/Product8.scala
@@ -21,7 +21,17 @@ object Product8 {
     Some(x)
 }
 
-/** Product8 is a Cartesian product of 8 components. */
+/** Product8 is a Cartesian product of 8 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ */
 trait Product8[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8] extends Any with Product {
   /** The arity of this product.
    *  @return 8

--- a/library/src/scala/Product9.scala
+++ b/library/src/scala/Product9.scala
@@ -21,7 +21,18 @@ object Product9 {
     Some(x)
 }
 
-/** Product9 is a Cartesian product of 9 components. */
+/** Product9 is a Cartesian product of 9 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ */
 trait Product9[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9] extends Any with Product {
   /** The arity of this product.
    *  @return 9

--- a/library/src/scala/ScalaReflectionException.scala
+++ b/library/src/scala/ScalaReflectionException.scala
@@ -2,7 +2,10 @@ package scala
 
 import scala.language.`2.13`
 
-/** An exception that indicates an error during Scala reflection. */
+/** An exception that indicates an error during Scala reflection.
+ *
+ *  @param msg the detail message describing the reflection error
+ */
 case class ScalaReflectionException(msg: String) extends Exception(msg)
 
 object ScalaReflectionException extends scala.runtime.AbstractFunction1[String, ScalaReflectionException]:

--- a/library/src/scala/Short.scala
+++ b/library/src/scala/Short.scala
@@ -56,6 +56,8 @@ final abstract class Short private extends AnyVal {
    *  ```
    *  6 << 3 == 48 // in binary: 0110 << 3 == 0110000
    *  ```
+   *
+   *  @param x the number of bits to shift left
    */
   def <<(x: Int): Int
   /** Returns this value bit-shifted left by the specified number of bits,
@@ -75,6 +77,8 @@ final abstract class Short private extends AnyVal {
    *  // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
    *  //            00011111 11111111 11111111 11111101
    *  ```
+   *
+   *  @param x the number of bits to shift right
    */
   def >>>(x: Int): Int
   /** Returns this value bit-shifted right by the specified number of bits,
@@ -96,6 +100,8 @@ final abstract class Short private extends AnyVal {
    *  // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
    *  //            11111111 11111111 11111111 11111101
    *  ```
+   *
+   *  @param x the number of bits to shift right
    */
   def >>(x: Int): Int
   /** Returns this value bit-shifted right by the specified number of bits,
@@ -140,19 +146,40 @@ final abstract class Short private extends AnyVal {
   /** Returns `true` if this value is not equal to x, `false` otherwise. */
   def !=(x: Double): Boolean
 
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Byte): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Short): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Char): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Int): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Long): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Float): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Double): Boolean
 
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
@@ -170,19 +197,40 @@ final abstract class Short private extends AnyVal {
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
   def <=(x: Double): Boolean
 
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Byte): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Short): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Char): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Int): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Long): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Float): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Double): Boolean
 
   /** Returns `true` if this value is greater than or equal to x, `false` otherwise. */
@@ -208,6 +256,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Byte): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -218,6 +268,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Short): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -228,6 +280,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Char): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -238,6 +292,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Int): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -248,6 +304,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Long): Long
 
@@ -259,6 +317,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Byte): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -269,6 +329,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Short): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -279,6 +341,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Char): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -289,6 +353,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Int): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -299,6 +365,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Long): Long
 
@@ -310,6 +378,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Byte): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -320,6 +390,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Short): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -330,6 +402,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Char): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -340,6 +414,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Int): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -350,82 +426,189 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Long): Long
 
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Byte): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Short): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Char): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Int): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Long): Long
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Float): Float
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Double): Double
 
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Byte): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Short): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Char): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Int): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Long): Long
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Float): Float
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Double): Double
 
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Byte): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Short): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Char): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Int): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Long): Long
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Float): Float
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Double): Double
 
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Byte): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Short): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Char): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Int): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Long): Long
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Float): Float
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Double): Double
 
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Byte): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Short): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Char): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Int): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Long): Long
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Float): Float
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Double): Double
 
   // Provide a more specific return type for Scaladoc
@@ -462,7 +645,10 @@ object Short extends AnyValCompanion {
 
   /** The `String` representation of the `scala.Short` companion object. */
   override def toString() = "object scala.Short"
-  /** Language mandated coercions from `Short` to "wider" types. */
+  /** Language mandated coercions from `Short` to "wider" types.
+   *
+   *  @param x the `Short` value to be implicitly converted
+   */
   import scala.language.implicitConversions
   implicit def short2int(x: Short): Int = x.toInt
   implicit def short2long(x: Short): Long = x.toLong

--- a/library/src/scala/StringContext.scala
+++ b/library/src/scala/StringContext.scala
@@ -81,7 +81,8 @@ case class StringContext(parts: String*) {
    *  ```
    *  will print the string `1 + 1 = 2`.
    *
-   *  @param `args` The arguments to be inserted into the resulting string.
+   *  @param args the values to be interpolated into the string
+   *  @return the interpolated string with arguments converted via `toString` and escape sequences expanded
    *  @throws IllegalArgumentException
    *          if the number of `parts` in the enclosing `StringContext` does not exceed
    *          the number of arguments `arg` by exactly 1.
@@ -127,6 +128,9 @@ case class StringContext(parts: String*) {
      *
      *  Here, we use the `TimeSplitter` regex within the `s` matcher, further splitting the
      *  matched string "10.50" into its constituent parts
+     *
+     *  @param s the string to match against the pattern
+     *  @return `Some` containing the sequence of matched substrings, or `None` if the input does not match
      */
     def unapplySeq(s: String): Option[Seq[String]] = glob(parts.map(processEscapes), s)
   }
@@ -147,7 +151,8 @@ case class StringContext(parts: String*) {
    *    res0: String = #
    *  ```
    *
-   *  @param `args` The arguments to be inserted into the resulting string.
+   *  @param args the values to be interpolated into the string
+   *  @return the interpolated string without expanding escape sequences
    *  @throws IllegalArgumentException
    *          if the number of `parts` in the enclosing `StringContext` does not exceed
    *          the number of arguments `arg` by exactly 1.
@@ -175,7 +180,9 @@ case class StringContext(parts: String*) {
    *    println(f"\$name%s is \$height%2.2f meters tall")  // James is 1.90 meters tall
    *  ```
    *
-   *  @param `args` The arguments to be inserted into the resulting string.
+   *  @tparam A the type of the arguments (effectively unconstrained; the lower bound `>: Any` ensures `A` resolves to `Any`)
+   *  @param args the values to be formatted and interpolated into the string
+   *  @return the interpolated and formatted string
    *  @throws IllegalArgumentException
    *          if the number of `parts` in the enclosing `StringContext` does not exceed
    *          the number of arguments `arg` by exactly 1.
@@ -421,6 +428,10 @@ object StringContext {
    *  backwards compatibility is also retained.
    *  Otherwise, the backslash is not taken to introduce an escape and the
    *  backslash is taken to be literal
+   *
+   *  @param str the string potentially containing Unicode escape sequences
+   *  @param backslash the index of the first `\\u` escape sequence in `str`
+   *  @return the string with Unicode escape sequences replaced by their corresponding characters
    */
   private def replaceU(str: String, backslash: Int): String = {
     val len = str.length()
@@ -466,6 +477,8 @@ object StringContext {
   /** Checks that the length of the given argument `args` is one less than the number
    *  of `parts` supplied to the `StringContext`.
    *
+   *  @param args the interpolated argument values
+   *  @param parts the literal parts of the interpolated string
    *  @throws IllegalArgumentException  if this is not the case.
    */
   def checkLengths(args: scala.collection.Seq[Any], parts: Seq[String]): Unit =

--- a/library/src/scala/Symbol.scala
+++ b/library/src/scala/Symbol.scala
@@ -35,6 +35,9 @@ object Symbol extends UniquenessCache[String, Symbol] {
 
 /** This is private so it won't appear in the library API, but
  *  abstracted to offer some hope of reusability.  
+ *
+ *  @tparam K the type of keys used for cache lookup, held via weak references
+ *  @tparam V the type of cached values, weakly referenced and constructed from keys via `valueFromKey`
  */
 private[scala] abstract class UniquenessCache[K, V] {
   import java.lang.ref.WeakReference

--- a/library/src/scala/Tuple.scala
+++ b/library/src/scala/Tuple.scala
@@ -34,35 +34,55 @@ sealed trait Tuple extends Product {
 
   /** Gets the i-th element of this tuple.
    *  Equivalent to productElement but with a precise return type.
+   *
+   *  @tparam This the exact type of this tuple
+   *  @param n the zero-based index of the element to retrieve
    */
   inline def apply[This >: this.type <: Tuple](n: Int): Elem[This, n.type] =
     runtime.Tuples.apply(this, n).asInstanceOf[Elem[This, n.type]]
 
-  /** Gets the head of this tuple. */
+  /** Gets the head of this tuple.
+   *
+   *  @tparam This the exact type of this tuple
+   */
   inline def head[This >: this.type <: Tuple]: Head[This] =
     runtime.Tuples.apply(this, 0).asInstanceOf[Head[This]]
 
-  /** Gets the initial part of the tuple without its last element. */
+  /** Gets the initial part of the tuple without its last element.
+   *
+   *  @tparam This the exact type of this tuple
+   */
   inline def init[This >: this.type <: Tuple]: Init[This] =
     runtime.Tuples.init(this).asInstanceOf[Init[This]]
 
-  /** Gets the last of this tuple. */
+  /** Gets the last of this tuple.
+   *
+   *  @tparam This the exact type of this tuple
+   */
   inline def last[This >: this.type <: Tuple]: Last[This] =
     runtime.Tuples.last(this).asInstanceOf[Last[This]]
 
   /** Gets the tail of this tuple.
    *  This operation is O(this.size)
+   *
+   *  @tparam This the exact type of this tuple
    */
   inline def tail[This >: this.type <: Tuple]: Tail[This] =
     runtime.Tuples.tail(this).asInstanceOf[Tail[This]]
 
   /** Returns a new tuple by concatenating `this` tuple with `that` tuple.
    *  This operation is O(this.size + that.size)
+   *
+   *  @tparam This the exact type of this tuple
+   *  @param that the tuple to append to this tuple
    */
   inline def ++ [This >: this.type <: Tuple](that: Tuple): This ++ that.type =
     runtime.Tuples.concat(this, that).asInstanceOf[This ++ that.type]
 
-  /** Returns the size (or arity) of the tuple. */
+  /** Returns the size (or arity) of the tuple.
+   *
+   *  @tparam This the exact type of this tuple
+   */
   inline def size[This >: this.type <: Tuple]: Size[This] =
     runtime.Tuples.size(this).asInstanceOf[Size[This]]
 
@@ -72,6 +92,10 @@ sealed trait Tuple extends Product {
    *  The result is typed as `((A1, B1), ..., (An, Bn))` if at least one of the
    *  tuple types has a `EmptyTuple` tail. Otherwise the result type is
    *  `(A1, B1) *: ... *: (Ai, Bi) *: Tuple`
+   *
+   *  @tparam This the exact type of this tuple
+   *  @tparam T2 the type of the other tuple to zip with
+   *  @param t2 the tuple to zip with this tuple
    */
   inline def zip[This >: this.type <: Tuple, T2 <: Tuple](t2: T2): Zip[This, T2] =
     runtime.Tuples.zip(this, t2).asInstanceOf[Zip[This, T2]]
@@ -80,12 +104,17 @@ sealed trait Tuple extends Product {
    *  The result is typed as `(F[A1], ..., F[An])` if the tuple type is fully known.
    *  If the tuple is of the form `a1 *: ... *: Tuple` (that is, the tail is not known
    *  to be the cons type.
+   *
+   *  @tparam F the type constructor applied to each element type
    */
   inline def map[F[_]](f: [t] => t => F[t]): Map[this.type, F] =
     runtime.Tuples.map(this, f).asInstanceOf[Map[this.type, F]]
 
   /** Given a tuple `(a1, ..., am)`, returns the tuple `(a1, ..., an)` consisting
    *  of its first n elements.
+   *
+   *  @tparam This the exact type of this tuple
+   *  @param n the number of elements to take from the beginning
    */
   inline def take[This >: this.type <: Tuple](n: Int): Take[This, n.type] =
     runtime.Tuples.take(this, n).asInstanceOf[Take[This, n.type]]
@@ -93,6 +122,9 @@ sealed trait Tuple extends Product {
 
   /** Given a tuple `(a1, ..., am)`, returns the tuple `(an+1, ..., am)` consisting
    *  all its elements except the first n ones.
+   *
+   *  @tparam This the exact type of this tuple
+   *  @param n the number of elements to drop from the beginning
    */
   inline def drop[This >: this.type <: Tuple](n: Int): Drop[This, n.type] =
     runtime.Tuples.drop(this, n).asInstanceOf[Drop[This, n.type]]
@@ -100,12 +132,17 @@ sealed trait Tuple extends Product {
   /** Given a tuple `(a1, ..., am)`, returns a pair of the tuple `(a1, ..., an)`
    *  consisting of the first n elements, and the tuple `(an+1, ..., am)` consisting
    *  of the remaining elements.
+   *
+   *  @tparam This the exact type of this tuple
+   *  @param n the number of elements in the first part of the split
    */
   inline def splitAt[This >: this.type <: Tuple](n: Int): Split[This, n.type] =
     runtime.Tuples.splitAt(this, n).asInstanceOf[Split[This, n.type]]
 
   /** Given a tuple `(a1, ..., am)`, returns the reversed tuple `(am, ..., a1)`
    *  consisting all its elements.
+   *
+   *  @tparam This the exact type of this tuple
    */
   inline def reverse[This >: this.type <: Tuple]: Reverse[This] =
     runtime.Tuples.reverse(this).asInstanceOf[Reverse[This]]
@@ -285,13 +322,24 @@ object Tuple {
   /** Empty tuple. */
   def apply(): EmptyTuple = EmptyTuple
 
-  /** Tuple with one element. */
+  /** Tuple with one element.
+   *
+   *  @tparam T the type of the element
+   *  @param x the single element of the tuple
+   */
   def apply[T](x: T): T *: EmptyTuple = Tuple1(x)
 
-  /** Matches an empty tuple. */
+  /** Matches an empty tuple.
+   *
+   *  @param x the empty tuple to match
+   */
   def unapply(x: EmptyTuple): true = true
 
-  /** Converts an array into a tuple of unknown arity and types. */
+  /** Converts an array into a tuple of unknown arity and types.
+   *
+   *  @tparam T the element type of the array
+   *  @param xs the array to convert into a tuple
+   */
   def fromArray[T](xs: Array[T]): Tuple = {
     val xs2 = xs match {
       case xs: Array[Object] => xs
@@ -300,7 +348,11 @@ object Tuple {
     runtime.Tuples.fromArray(xs2)
   }
 
-  /** Converts an immutable array into a tuple of unknown arity and types. */
+  /** Converts an immutable array into a tuple of unknown arity and types.
+   *
+   *  @tparam T the element type of the immutable array
+   *  @param xs the immutable array to convert into a tuple
+   */
   def fromIArray[T](xs: IArray[T]): Tuple = {
     val xs2: IArray[Object] = xs match {
       case xs: IArray[Object] @unchecked => xs
@@ -310,7 +362,10 @@ object Tuple {
     runtime.Tuples.fromIArray(xs2)
   }
 
-  /** Converts a Product into a tuple of unknown arity and types. */
+  /** Converts a Product into a tuple of unknown arity and types.
+   *
+   *  @param product the product to convert into a tuple
+   */
   def fromProduct(product: Product): Tuple =
     runtime.Tuples.fromProduct(product)
 

--- a/library/src/scala/Tuple10.scala
+++ b/library/src/scala/Tuple10.scala
@@ -19,16 +19,26 @@ import scala.language.`2.13`
 /** A tuple of 10 elements; the canonical representation of a [[scala.Product10]].
  *
  *  @constructor  Create a new tuple with 10 elements. Note that it is more idiomatic to create a Tuple10 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)`
- *  @param  _1   Element 1 of this Tuple10
- *  @param  _2   Element 2 of this Tuple10
- *  @param  _3   Element 3 of this Tuple10
- *  @param  _4   Element 4 of this Tuple10
- *  @param  _5   Element 5 of this Tuple10
- *  @param  _6   Element 6 of this Tuple10
- *  @param  _7   Element 7 of this Tuple10
- *  @param  _8   Element 8 of this Tuple10
- *  @param  _9   Element 9 of this Tuple10
- *  @param  _10   Element 10 of this Tuple10
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @param  _1   element 1 of this Tuple10
+ *  @param  _2   element 2 of this Tuple10
+ *  @param  _3   element 3 of this Tuple10
+ *  @param  _4   element 4 of this Tuple10
+ *  @param  _5   element 5 of this Tuple10
+ *  @param  _6   element 6 of this Tuple10
+ *  @param  _7   element 7 of this Tuple10
+ *  @param  _8   element 8 of this Tuple10
+ *  @param  _9   element 9 of this Tuple10
+ *  @param  _10   element 10 of this Tuple10
  */
 final case class Tuple10[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10)
   extends Product10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]

--- a/library/src/scala/Tuple11.scala
+++ b/library/src/scala/Tuple11.scala
@@ -19,6 +19,17 @@ import scala.language.`2.13`
 /** A tuple of 11 elements; the canonical representation of a [[scala.Product11]].
  *
  *  @constructor  Create a new tuple with 11 elements. Note that it is more idiomatic to create a Tuple11 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)`
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
  *  @param  _1   Element 1 of this Tuple11
  *  @param  _2   Element 2 of this Tuple11
  *  @param  _3   Element 3 of this Tuple11

--- a/library/src/scala/Tuple12.scala
+++ b/library/src/scala/Tuple12.scala
@@ -19,6 +19,18 @@ import scala.language.`2.13`
 /** A tuple of 12 elements; the canonical representation of a [[scala.Product12]].
  *
  *  @constructor  Create a new tuple with 12 elements. Note that it is more idiomatic to create a Tuple12 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)`
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
  *  @param  _1   Element 1 of this Tuple12
  *  @param  _2   Element 2 of this Tuple12
  *  @param  _3   Element 3 of this Tuple12

--- a/library/src/scala/Tuple13.scala
+++ b/library/src/scala/Tuple13.scala
@@ -19,6 +19,19 @@ import scala.language.`2.13`
 /** A tuple of 13 elements; the canonical representation of a [[scala.Product13]].
  *
  *  @constructor  Create a new tuple with 13 elements. Note that it is more idiomatic to create a Tuple13 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)`
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
  *  @param  _1   Element 1 of this Tuple13
  *  @param  _2   Element 2 of this Tuple13
  *  @param  _3   Element 3 of this Tuple13

--- a/library/src/scala/Tuple14.scala
+++ b/library/src/scala/Tuple14.scala
@@ -19,20 +19,34 @@ import scala.language.`2.13`
 /** A tuple of 14 elements; the canonical representation of a [[scala.Product14]].
  *
  *  @constructor  Create a new tuple with 14 elements. Note that it is more idiomatic to create a Tuple14 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)`
- *  @param  _1   Element 1 of this Tuple14
- *  @param  _2   Element 2 of this Tuple14
- *  @param  _3   Element 3 of this Tuple14
- *  @param  _4   Element 4 of this Tuple14
- *  @param  _5   Element 5 of this Tuple14
- *  @param  _6   Element 6 of this Tuple14
- *  @param  _7   Element 7 of this Tuple14
- *  @param  _8   Element 8 of this Tuple14
- *  @param  _9   Element 9 of this Tuple14
- *  @param  _10   Element 10 of this Tuple14
- *  @param  _11   Element 11 of this Tuple14
- *  @param  _12   Element 12 of this Tuple14
- *  @param  _13   Element 13 of this Tuple14
- *  @param  _14   Element 14 of this Tuple14
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @param  _1   element 1 of this Tuple14
+ *  @param  _2   element 2 of this Tuple14
+ *  @param  _3   element 3 of this Tuple14
+ *  @param  _4   element 4 of this Tuple14
+ *  @param  _5   element 5 of this Tuple14
+ *  @param  _6   element 6 of this Tuple14
+ *  @param  _7   element 7 of this Tuple14
+ *  @param  _8   element 8 of this Tuple14
+ *  @param  _9   element 9 of this Tuple14
+ *  @param  _10   element 10 of this Tuple14
+ *  @param  _11   element 11 of this Tuple14
+ *  @param  _12   element 12 of this Tuple14
+ *  @param  _13   element 13 of this Tuple14
+ *  @param  _14   element 14 of this Tuple14
  */
 final case class Tuple14[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10, _11: T11, _12: T12, _13: T13, _14: T14)
   extends Product14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]

--- a/library/src/scala/Tuple15.scala
+++ b/library/src/scala/Tuple15.scala
@@ -19,6 +19,21 @@ import scala.language.`2.13`
 /** A tuple of 15 elements; the canonical representation of a [[scala.Product15]].
  *
  *  @constructor  Create a new tuple with 15 elements. Note that it is more idiomatic to create a Tuple15 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)`
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
  *  @param  _1   Element 1 of this Tuple15
  *  @param  _2   Element 2 of this Tuple15
  *  @param  _3   Element 3 of this Tuple15

--- a/library/src/scala/Tuple16.scala
+++ b/library/src/scala/Tuple16.scala
@@ -19,6 +19,22 @@ import scala.language.`2.13`
 /** A tuple of 16 elements; the canonical representation of a [[scala.Product16]].
  *
  *  @constructor  Create a new tuple with 16 elements. Note that it is more idiomatic to create a Tuple16 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16)`
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
  *  @param  _1   Element 1 of this Tuple16
  *  @param  _2   Element 2 of this Tuple16
  *  @param  _3   Element 3 of this Tuple16

--- a/library/src/scala/Tuple17.scala
+++ b/library/src/scala/Tuple17.scala
@@ -19,23 +19,40 @@ import scala.language.`2.13`
 /** A tuple of 17 elements; the canonical representation of a [[scala.Product17]].
  *
  *  @constructor  Create a new tuple with 17 elements. Note that it is more idiomatic to create a Tuple17 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17)`
- *  @param  _1   Element 1 of this Tuple17
- *  @param  _2   Element 2 of this Tuple17
- *  @param  _3   Element 3 of this Tuple17
- *  @param  _4   Element 4 of this Tuple17
- *  @param  _5   Element 5 of this Tuple17
- *  @param  _6   Element 6 of this Tuple17
- *  @param  _7   Element 7 of this Tuple17
- *  @param  _8   Element 8 of this Tuple17
- *  @param  _9   Element 9 of this Tuple17
- *  @param  _10   Element 10 of this Tuple17
- *  @param  _11   Element 11 of this Tuple17
- *  @param  _12   Element 12 of this Tuple17
- *  @param  _13   Element 13 of this Tuple17
- *  @param  _14   Element 14 of this Tuple17
- *  @param  _15   Element 15 of this Tuple17
- *  @param  _16   Element 16 of this Tuple17
- *  @param  _17   Element 17 of this Tuple17
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ *  @tparam T17 the type of the 17th element
+ *  @param  _1   element 1 of this Tuple17
+ *  @param  _2   element 2 of this Tuple17
+ *  @param  _3   element 3 of this Tuple17
+ *  @param  _4   element 4 of this Tuple17
+ *  @param  _5   element 5 of this Tuple17
+ *  @param  _6   element 6 of this Tuple17
+ *  @param  _7   element 7 of this Tuple17
+ *  @param  _8   element 8 of this Tuple17
+ *  @param  _9   element 9 of this Tuple17
+ *  @param  _10   element 10 of this Tuple17
+ *  @param  _11   element 11 of this Tuple17
+ *  @param  _12   element 12 of this Tuple17
+ *  @param  _13   element 13 of this Tuple17
+ *  @param  _14   element 14 of this Tuple17
+ *  @param  _15   element 15 of this Tuple17
+ *  @param  _16   element 16 of this Tuple17
+ *  @param  _17   element 17 of this Tuple17
  */
 final case class Tuple17[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10, _11: T11, _12: T12, _13: T13, _14: T14, _15: T15, _16: T16, _17: T17)
   extends Product17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]

--- a/library/src/scala/Tuple18.scala
+++ b/library/src/scala/Tuple18.scala
@@ -19,24 +19,42 @@ import scala.language.`2.13`
 /** A tuple of 18 elements; the canonical representation of a [[scala.Product18]].
  *
  *  @constructor  Create a new tuple with 18 elements. Note that it is more idiomatic to create a Tuple18 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18)`
- *  @param  _1   Element 1 of this Tuple18
- *  @param  _2   Element 2 of this Tuple18
- *  @param  _3   Element 3 of this Tuple18
- *  @param  _4   Element 4 of this Tuple18
- *  @param  _5   Element 5 of this Tuple18
- *  @param  _6   Element 6 of this Tuple18
- *  @param  _7   Element 7 of this Tuple18
- *  @param  _8   Element 8 of this Tuple18
- *  @param  _9   Element 9 of this Tuple18
- *  @param  _10   Element 10 of this Tuple18
- *  @param  _11   Element 11 of this Tuple18
- *  @param  _12   Element 12 of this Tuple18
- *  @param  _13   Element 13 of this Tuple18
- *  @param  _14   Element 14 of this Tuple18
- *  @param  _15   Element 15 of this Tuple18
- *  @param  _16   Element 16 of this Tuple18
- *  @param  _17   Element 17 of this Tuple18
- *  @param  _18   Element 18 of this Tuple18
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ *  @tparam T17 the type of the 17th element
+ *  @tparam T18 the type of the 18th element
+ *  @param  _1   element 1 of this Tuple18
+ *  @param  _2   element 2 of this Tuple18
+ *  @param  _3   element 3 of this Tuple18
+ *  @param  _4   element 4 of this Tuple18
+ *  @param  _5   element 5 of this Tuple18
+ *  @param  _6   element 6 of this Tuple18
+ *  @param  _7   element 7 of this Tuple18
+ *  @param  _8   element 8 of this Tuple18
+ *  @param  _9   element 9 of this Tuple18
+ *  @param  _10   element 10 of this Tuple18
+ *  @param  _11   element 11 of this Tuple18
+ *  @param  _12   element 12 of this Tuple18
+ *  @param  _13   element 13 of this Tuple18
+ *  @param  _14   element 14 of this Tuple18
+ *  @param  _15   element 15 of this Tuple18
+ *  @param  _16   element 16 of this Tuple18
+ *  @param  _17   element 17 of this Tuple18
+ *  @param  _18   element 18 of this Tuple18
  */
 final case class Tuple18[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10, _11: T11, _12: T12, _13: T13, _14: T14, _15: T15, _16: T16, _17: T17, _18: T18)
   extends Product18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]

--- a/library/src/scala/Tuple19.scala
+++ b/library/src/scala/Tuple19.scala
@@ -19,6 +19,25 @@ import scala.language.`2.13`
 /** A tuple of 19 elements; the canonical representation of a [[scala.Product19]].
  *
  *  @constructor  Create a new tuple with 19 elements. Note that it is more idiomatic to create a Tuple19 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19)`
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ *  @tparam T17 the type of the 17th element
+ *  @tparam T18 the type of the 18th element
+ *  @tparam T19 the type of the 19th element
  *  @param  _1   Element 1 of this Tuple19
  *  @param  _2   Element 2 of this Tuple19
  *  @param  _3   Element 3 of this Tuple19

--- a/library/src/scala/Tuple20.scala
+++ b/library/src/scala/Tuple20.scala
@@ -19,26 +19,46 @@ import scala.language.`2.13`
 /** A tuple of 20 elements; the canonical representation of a [[scala.Product20]].
  *
  *  @constructor  Create a new tuple with 20 elements. Note that it is more idiomatic to create a Tuple20 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20)`
- *  @param  _1   Element 1 of this Tuple20
- *  @param  _2   Element 2 of this Tuple20
- *  @param  _3   Element 3 of this Tuple20
- *  @param  _4   Element 4 of this Tuple20
- *  @param  _5   Element 5 of this Tuple20
- *  @param  _6   Element 6 of this Tuple20
- *  @param  _7   Element 7 of this Tuple20
- *  @param  _8   Element 8 of this Tuple20
- *  @param  _9   Element 9 of this Tuple20
- *  @param  _10   Element 10 of this Tuple20
- *  @param  _11   Element 11 of this Tuple20
- *  @param  _12   Element 12 of this Tuple20
- *  @param  _13   Element 13 of this Tuple20
- *  @param  _14   Element 14 of this Tuple20
- *  @param  _15   Element 15 of this Tuple20
- *  @param  _16   Element 16 of this Tuple20
- *  @param  _17   Element 17 of this Tuple20
- *  @param  _18   Element 18 of this Tuple20
- *  @param  _19   Element 19 of this Tuple20
- *  @param  _20   Element 20 of this Tuple20
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ *  @tparam T17 the type of the 17th element
+ *  @tparam T18 the type of the 18th element
+ *  @tparam T19 the type of the 19th element
+ *  @tparam T20 the type of the 20th element
+ *  @param  _1   the 1st element of this Tuple20
+ *  @param  _2   the 2nd element of this Tuple20
+ *  @param  _3   the 3rd element of this Tuple20
+ *  @param  _4   the 4th element of this Tuple20
+ *  @param  _5   the 5th element of this Tuple20
+ *  @param  _6   the 6th element of this Tuple20
+ *  @param  _7   the 7th element of this Tuple20
+ *  @param  _8   the 8th element of this Tuple20
+ *  @param  _9   the 9th element of this Tuple20
+ *  @param  _10   the 10th element of this Tuple20
+ *  @param  _11   the 11th element of this Tuple20
+ *  @param  _12   the 12th element of this Tuple20
+ *  @param  _13   the 13th element of this Tuple20
+ *  @param  _14   the 14th element of this Tuple20
+ *  @param  _15   the 15th element of this Tuple20
+ *  @param  _16   the 16th element of this Tuple20
+ *  @param  _17   the 17th element of this Tuple20
+ *  @param  _18   the 18th element of this Tuple20
+ *  @param  _19   the 19th element of this Tuple20
+ *  @param  _20   the 20th element of this Tuple20
  */
 final case class Tuple20[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18, +T19, +T20](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10, _11: T11, _12: T12, _13: T13, _14: T14, _15: T15, _16: T16, _17: T17, _18: T18, _19: T19, _20: T20)
   extends Product20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]

--- a/library/src/scala/Tuple21.scala
+++ b/library/src/scala/Tuple21.scala
@@ -19,6 +19,27 @@ import scala.language.`2.13`
 /** A tuple of 21 elements; the canonical representation of a [[scala.Product21]].
  *
  *  @constructor  Create a new tuple with 21 elements. Note that it is more idiomatic to create a Tuple21 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20, t21)`
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ *  @tparam T17 the type of the 17th element
+ *  @tparam T18 the type of the 18th element
+ *  @tparam T19 the type of the 19th element
+ *  @tparam T20 the type of the 20th element
+ *  @tparam T21 the type of the 21st element
  *  @param  _1   Element 1 of this Tuple21
  *  @param  _2   Element 2 of this Tuple21
  *  @param  _3   Element 3 of this Tuple21

--- a/library/src/scala/Tuple22.scala
+++ b/library/src/scala/Tuple22.scala
@@ -19,28 +19,50 @@ import scala.language.`2.13`
 /** A tuple of 22 elements; the canonical representation of a [[scala.Product22]].
  *
  *  @constructor  Create a new tuple with 22 elements. Note that it is more idiomatic to create a Tuple22 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20, t21, t22)`
- *  @param  _1   Element 1 of this Tuple22
- *  @param  _2   Element 2 of this Tuple22
- *  @param  _3   Element 3 of this Tuple22
- *  @param  _4   Element 4 of this Tuple22
- *  @param  _5   Element 5 of this Tuple22
- *  @param  _6   Element 6 of this Tuple22
- *  @param  _7   Element 7 of this Tuple22
- *  @param  _8   Element 8 of this Tuple22
- *  @param  _9   Element 9 of this Tuple22
- *  @param  _10   Element 10 of this Tuple22
- *  @param  _11   Element 11 of this Tuple22
- *  @param  _12   Element 12 of this Tuple22
- *  @param  _13   Element 13 of this Tuple22
- *  @param  _14   Element 14 of this Tuple22
- *  @param  _15   Element 15 of this Tuple22
- *  @param  _16   Element 16 of this Tuple22
- *  @param  _17   Element 17 of this Tuple22
- *  @param  _18   Element 18 of this Tuple22
- *  @param  _19   Element 19 of this Tuple22
- *  @param  _20   Element 20 of this Tuple22
- *  @param  _21   Element 21 of this Tuple22
- *  @param  _22   Element 22 of this Tuple22
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ *  @tparam T17 the type of the 17th element
+ *  @tparam T18 the type of the 18th element
+ *  @tparam T19 the type of the 19th element
+ *  @tparam T20 the type of the 20th element
+ *  @tparam T21 the type of the 21st element
+ *  @tparam T22 the type of the 22nd element
+ *  @param  _1   the 1st element of this Tuple22
+ *  @param  _2   the 2nd element of this Tuple22
+ *  @param  _3   the 3rd element of this Tuple22
+ *  @param  _4   the 4th element of this Tuple22
+ *  @param  _5   the 5th element of this Tuple22
+ *  @param  _6   the 6th element of this Tuple22
+ *  @param  _7   the 7th element of this Tuple22
+ *  @param  _8   the 8th element of this Tuple22
+ *  @param  _9   the 9th element of this Tuple22
+ *  @param  _10   the 10th element of this Tuple22
+ *  @param  _11   the 11th element of this Tuple22
+ *  @param  _12   the 12th element of this Tuple22
+ *  @param  _13   the 13th element of this Tuple22
+ *  @param  _14   the 14th element of this Tuple22
+ *  @param  _15   the 15th element of this Tuple22
+ *  @param  _16   the 16th element of this Tuple22
+ *  @param  _17   the 17th element of this Tuple22
+ *  @param  _18   the 18th element of this Tuple22
+ *  @param  _19   the 19th element of this Tuple22
+ *  @param  _20   the 20th element of this Tuple22
+ *  @param  _21   the 21st element of this Tuple22
+ *  @param  _22   the 22nd element of this Tuple22
  */
 final case class Tuple22[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18, +T19, +T20, +T21, +T22](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10, _11: T11, _12: T12, _13: T13, _14: T14, _15: T15, _16: T16, _17: T17, _18: T18, _19: T19, _20: T20, _21: T21, _22: T22)
   extends Product22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]

--- a/library/src/scala/Tuple3.scala
+++ b/library/src/scala/Tuple3.scala
@@ -19,6 +19,9 @@ import scala.language.`2.13`
 /** A tuple of 3 elements; the canonical representation of a [[scala.Product3]].
  *
  *  @constructor  Create a new tuple with 3 elements. Note that it is more idiomatic to create a Tuple3 via `(t1, t2, t3)`
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
  *  @param  _1   Element 1 of this Tuple3
  *  @param  _2   Element 2 of this Tuple3
  *  @param  _3   Element 3 of this Tuple3

--- a/library/src/scala/Tuple4.scala
+++ b/library/src/scala/Tuple4.scala
@@ -19,10 +19,14 @@ import scala.language.`2.13`
 /** A tuple of 4 elements; the canonical representation of a [[scala.Product4]].
  *
  *  @constructor  Create a new tuple with 4 elements. Note that it is more idiomatic to create a Tuple4 via `(t1, t2, t3, t4)`
- *  @param  _1   Element 1 of this Tuple4
- *  @param  _2   Element 2 of this Tuple4
- *  @param  _3   Element 3 of this Tuple4
- *  @param  _4   Element 4 of this Tuple4
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @param  _1   element 1 of this Tuple4
+ *  @param  _2   element 2 of this Tuple4
+ *  @param  _3   element 3 of this Tuple4
+ *  @param  _4   element 4 of this Tuple4
  */
 final case class Tuple4[+T1, +T2, +T3, +T4](_1: T1, _2: T2, _3: T3, _4: T4)
   extends Product4[T1, T2, T3, T4]

--- a/library/src/scala/Tuple5.scala
+++ b/library/src/scala/Tuple5.scala
@@ -19,11 +19,16 @@ import scala.language.`2.13`
 /** A tuple of 5 elements; the canonical representation of a [[scala.Product5]].
  *
  *  @constructor  Create a new tuple with 5 elements. Note that it is more idiomatic to create a Tuple5 via `(t1, t2, t3, t4, t5)`
- *  @param  _1   Element 1 of this Tuple5
- *  @param  _2   Element 2 of this Tuple5
- *  @param  _3   Element 3 of this Tuple5
- *  @param  _4   Element 4 of this Tuple5
- *  @param  _5   Element 5 of this Tuple5
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @param  _1   the 1st element of this Tuple5
+ *  @param  _2   the 2nd element of this Tuple5
+ *  @param  _3   the 3rd element of this Tuple5
+ *  @param  _4   the 4th element of this Tuple5
+ *  @param  _5   the 5th element of this Tuple5
  */
 final case class Tuple5[+T1, +T2, +T3, +T4, +T5](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5)
   extends Product5[T1, T2, T3, T4, T5]

--- a/library/src/scala/Tuple6.scala
+++ b/library/src/scala/Tuple6.scala
@@ -19,12 +19,18 @@ import scala.language.`2.13`
 /** A tuple of 6 elements; the canonical representation of a [[scala.Product6]].
  *
  *  @constructor  Create a new tuple with 6 elements. Note that it is more idiomatic to create a Tuple6 via `(t1, t2, t3, t4, t5, t6)`
- *  @param  _1   Element 1 of this Tuple6
- *  @param  _2   Element 2 of this Tuple6
- *  @param  _3   Element 3 of this Tuple6
- *  @param  _4   Element 4 of this Tuple6
- *  @param  _5   Element 5 of this Tuple6
- *  @param  _6   Element 6 of this Tuple6
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @param  _1   the 1st element of this Tuple6
+ *  @param  _2   the 2nd element of this Tuple6
+ *  @param  _3   the 3rd element of this Tuple6
+ *  @param  _4   the 4th element of this Tuple6
+ *  @param  _5   the 5th element of this Tuple6
+ *  @param  _6   the 6th element of this Tuple6
  */
 final case class Tuple6[+T1, +T2, +T3, +T4, +T5, +T6](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6)
   extends Product6[T1, T2, T3, T4, T5, T6]

--- a/library/src/scala/Tuple7.scala
+++ b/library/src/scala/Tuple7.scala
@@ -19,13 +19,20 @@ import scala.language.`2.13`
 /** A tuple of 7 elements; the canonical representation of a [[scala.Product7]].
  *
  *  @constructor  Create a new tuple with 7 elements. Note that it is more idiomatic to create a Tuple7 via `(t1, t2, t3, t4, t5, t6, t7)`
- *  @param  _1   Element 1 of this Tuple7
- *  @param  _2   Element 2 of this Tuple7
- *  @param  _3   Element 3 of this Tuple7
- *  @param  _4   Element 4 of this Tuple7
- *  @param  _5   Element 5 of this Tuple7
- *  @param  _6   Element 6 of this Tuple7
- *  @param  _7   Element 7 of this Tuple7
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @param  _1   the 1st element of this Tuple7
+ *  @param  _2   the 2nd element of this Tuple7
+ *  @param  _3   the 3rd element of this Tuple7
+ *  @param  _4   the 4th element of this Tuple7
+ *  @param  _5   the 5th element of this Tuple7
+ *  @param  _6   the 6th element of this Tuple7
+ *  @param  _7   the 7th element of this Tuple7
  */
 final case class Tuple7[+T1, +T2, +T3, +T4, +T5, +T6, +T7](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7)
   extends Product7[T1, T2, T3, T4, T5, T6, T7]

--- a/library/src/scala/Tuple8.scala
+++ b/library/src/scala/Tuple8.scala
@@ -19,6 +19,14 @@ import scala.language.`2.13`
 /** A tuple of 8 elements; the canonical representation of a [[scala.Product8]].
  *
  *  @constructor  Create a new tuple with 8 elements. Note that it is more idiomatic to create a Tuple8 via `(t1, t2, t3, t4, t5, t6, t7, t8)`
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
  *  @param  _1   Element 1 of this Tuple8
  *  @param  _2   Element 2 of this Tuple8
  *  @param  _3   Element 3 of this Tuple8

--- a/library/src/scala/Tuple9.scala
+++ b/library/src/scala/Tuple9.scala
@@ -19,6 +19,15 @@ import scala.language.`2.13`
 /** A tuple of 9 elements; the canonical representation of a [[scala.Product9]].
  *
  *  @constructor  Create a new tuple with 9 elements. Note that it is more idiomatic to create a Tuple9 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9)`
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
  *  @param  _1   Element 1 of this Tuple9
  *  @param  _2   Element 2 of this Tuple9
  *  @param  _3   Element 3 of this Tuple9

--- a/library/src/scala/UninitializedFieldError.scala
+++ b/library/src/scala/UninitializedFieldError.scala
@@ -19,6 +19,8 @@ import scala.language.`2.13`
  *
  *  Such runtime checks are not emitted by default.
  *  They can be enabled by the `-Xcheckinit` compiler option.
+ *
+ *  @param msg the error message describing which field was accessed before initialization
  */
 final case class UninitializedFieldError(msg: String) extends RuntimeException(msg) {
   def this(obj: Any) = this("" + obj)

--- a/library/src/scala/annotation/MacroAnnotation.scala
+++ b/library/src/scala/annotation/MacroAnnotation.scala
@@ -214,9 +214,10 @@ trait MacroAnnotation extends StaticAnnotation:
    *    override def hashCode(): Int = hash$macro$1
    *  ```
    *
-   *  @param Quotes     Implicit instance of Quotes used for tree reflection
-   *  @param definition Tree that will be transformed
-   *  @param companion  Tree for the companion class or module if the definition is respectively a module or a class
+   *  @param Quotes     the implicit `Quotes` context providing access to the reflection API
+   *  @param definition the annotated definition to be transformed
+   *  @param companion  the companion object definition if `definition` is a class, or the companion class definition if `definition` is an object; `None` if no companion exists
+   *  @return a non-empty list of definitions: the transformed `definition` (which must reuse the original symbol) followed by any additional new definitions
    *
    *  @syntax markdown
    */

--- a/library/src/scala/annotation/experimental.scala
+++ b/library/src/scala/annotation/experimental.scala
@@ -6,6 +6,8 @@ import language.experimental.captureChecking
  *
  *  @see [[https://nightly.scala-lang.org/docs/reference/other-new-features/experimental-defs]]
  *  @syntax markdown
+ *
+ *  @param message a description explaining the experimental status, or an empty string if no message is needed
  */
 final class experimental(message: String) extends StaticAnnotation:
   def this() = this("")

--- a/library/src/scala/annotation/implicitAmbiguous.scala
+++ b/library/src/scala/annotation/implicitAmbiguous.scala
@@ -38,6 +38,8 @@ import scala.language.`2.13`
  *
  *  implicitly[Int =!= Int]
  *  ```
+ *
+ *  @param msg the error message template, with `\${Xi}` placeholders for type parameters
  */
 @meta.getter
 final class implicitAmbiguous(msg: String) extends scala.annotation.ConstantAnnotation

--- a/library/src/scala/annotation/implicitNotFound.scala
+++ b/library/src/scala/annotation/implicitNotFound.scala
@@ -53,5 +53,7 @@ import scala.language.`2.13`
  *   k.n[String]
  *      ^
  *  </pre>
+ *
+ *  @param msg the error message template, with `\${Xi}` placeholders for type parameters
  */
 final class implicitNotFound(msg: String) extends scala.annotation.ConstantAnnotation

--- a/library/src/scala/annotation/init.scala
+++ b/library/src/scala/annotation/init.scala
@@ -29,6 +29,8 @@ object init:
    *  `C(a = Cold)` for the argument `c` of the method `build`. Consequently,
    *  the checker will issue a warning for the method call `c.a.square()` because
    *  it is forbidden to call methods or access fields on cold values.
+   *
+   *  @param height the maximum height (depth of the abstract object tree) to which the argument value is widened
    */
   @experimental
   final class widen(height: Int) extends StaticAnnotation
@@ -55,6 +57,10 @@ object init:
    *  Therefore, the field `box1.value` and `box2.value` points to both instances of `C` and `D`. Consequently,
    *  the method call `box1.value.foo()` will be invalid, because it reaches `A.m`, which is not yet initialized.
    *  The explicit context annotation solves the problem.
+   *
+   *  @tparam T the type of the value computed within the region
+   *  @param v the expression to evaluate within a fresh region context
+   *  @return the value `v` unchanged at runtime; at the checker level, mutable fields within this region receive distinct abstract representations
    */
   @experimental
   def region[T](v: T): T = v

--- a/library/src/scala/annotation/internal/Child.scala
+++ b/library/src/scala/annotation/internal/Child.scala
@@ -19,5 +19,7 @@ import language.experimental.captureChecking
  *  appears before the one for `B`.
  *
  *  TODO: This should be `Child[T <: AnyKind]`
+ *
+ *  @tparam T a reference to the child class or object that extends the annotated sealed class, typically a `TypeRef` to the child's class symbol
  */
 class Child[T] extends Annotation

--- a/library/src/scala/annotation/internal/ContextResultCount.scala
+++ b/library/src/scala/annotation/internal/ContextResultCount.scala
@@ -7,5 +7,7 @@ import language.experimental.captureChecking
  *  that have one or more nested context closures as their right hand side.
  *  The parameter `n` is an Int Literal that tells how many nested closures
  *  there are.
+ *
+ *  @param n the number of nested context closures in the method's right-hand side
  */
 class ContextResultCount(n: Int) extends StaticAnnotation

--- a/library/src/scala/annotation/internal/SourceFile.scala
+++ b/library/src/scala/annotation/internal/SourceFile.scala
@@ -4,8 +4,9 @@ import language.experimental.captureChecking
 
 import scala.annotation.Annotation
 
-/** An annotation to record a Scala2 pickled alias.
- *  @param aliased  A TermRef pointing to the aliased field.
+/** An annotation to record the source file path of a definition.
+ *
+ *  @param path the path of the source file in which the annotated definition appears
  */
 class SourceFile(path: String) extends Annotation {
 

--- a/library/src/scala/annotation/internal/WitnessNames.scala
+++ b/library/src/scala/annotation/internal/WitnessNames.scala
@@ -49,6 +49,8 @@ import language.experimental.captureChecking
  *  select the `map` method of `Functor`.
  *
  *  4. At PostTyper, issue an error when encountering any reference to a CB companion.
+ *
+ *  @param names the string names (n_1, ..., n_k) of the witness values generated for the context bounds of the annotated type
  */
 @experimental
 class WitnessNames(names: String*) extends StaticAnnotation

--- a/library/src/scala/annotation/internal/onlyCapability.scala
+++ b/library/src/scala/annotation/internal/onlyCapability.scala
@@ -3,6 +3,8 @@ package internal
 
 /** An annotation that represents a capability  `c.only[T]`,
  *  encoded as `x.type @onlyCapability[T]`
+ *
+ *  @tparam T the capability type that `c` is restricted to via `c.only[T]`
  */
 class onlyCapability[T] extends StaticAnnotation
 

--- a/library/src/scala/annotation/internal/preview.scala
+++ b/library/src/scala/annotation/internal/preview.scala
@@ -7,6 +7,8 @@ import language.experimental.captureChecking
  *
  *  @see [[https://nightly.scala-lang.org/docs/reference/other-new-features/preview-defs]]
  *  @syntax markdown
+ *
+ *  @param message an optional explanation of the preview status or migration guidance
  */
 private[scala] final class preview(message: String) extends StaticAnnotation:
   def this() = this("")

--- a/library/src/scala/annotation/internal/requiresCapability.scala
+++ b/library/src/scala/annotation/internal/requiresCapability.scala
@@ -3,6 +3,9 @@ import annotation.StaticAnnotation
 
 import language.experimental.captureChecking
 
-/** An annotation to record a required capaility in the type of a throws */
+/** An annotation to record a required capaility in the type of a throws
+ *
+ *  @param capability the capture checking capability required by the annotated throws type
+ */
 class requiresCapability(capability: Any) extends StaticAnnotation
 

--- a/library/src/scala/annotation/meta/defaultArg.scala
+++ b/library/src/scala/annotation/meta/defaultArg.scala
@@ -25,6 +25,8 @@ import scala.language.`2.13`
  *  `AnnotationInfo`.
  *
  *  For details, see `scala.reflect.internal.AnnotationInfos.AnnotationInfo`.
+ *
+ *  @param arg the default expression for the annotation parameter, stored as a syntax tree in the classfile
  */
 @meta.param class defaultArg(arg: Any) extends StaticAnnotation {
   def this() = this(null)

--- a/library/src/scala/annotation/meta/languageFeature.scala
+++ b/library/src/scala/annotation/meta/languageFeature.scala
@@ -14,5 +14,9 @@ package scala.annotation.meta
 
 import scala.language.`2.13`
 
-/** An annotation giving particulars for a language feature in object `scala.language`. */
+/** An annotation giving particulars for a language feature in object `scala.language`.
+ *
+ *  @param feature the name of the language feature being described
+ *  @param enableRequired whether an explicit import of the feature is required to suppress the compiler warning about its usage
+ */
 final class languageFeature(feature: String, enableRequired: Boolean) extends scala.annotation.StaticAnnotation

--- a/library/src/scala/annotation/meta/superArg.scala
+++ b/library/src/scala/annotation/meta/superArg.scala
@@ -21,6 +21,9 @@ import scala.language.`2.13`
  *   class a(x: Int) extends Annotation
  *   class b extends a(42) // the compiler adds `@superArg("x", 42)` to class b
  *  ```
+ *
+ *  @param p the name of the parameter in the superclass annotation
+ *  @param v the value passed to the superclass annotation parameter
  */
 class superArg(p: String, v: Any) extends StaticAnnotation
 
@@ -30,5 +33,8 @@ class superArg(p: String, v: Any) extends StaticAnnotation
  *   class a(x: Int) extends Annotation
  *   class b(y: Int) extends a(y) // the compiler adds `@superFwdArg("x", "y")` to class b
  *  ```
+ *
+ *  @param p the name of the parameter in the superclass annotation
+ *  @param n the name of the subclass parameter whose value is forwarded
  */
 class superFwdArg(p: String, n: String) extends StaticAnnotation

--- a/library/src/scala/annotation/nowarn.scala
+++ b/library/src/scala/annotation/nowarn.scala
@@ -40,5 +40,7 @@ import scala.language.`2.13`
  *  To ensure that a `@nowarn` annotation actually suppresses a warning, enable `-Xlint:unused` or `-Wunused:nowarn`.
  *  The unused annotation warning is emitted in category `unused-nowarn` and can be selectively managed
  *  using `-Wconf:cat=unused-nowarn:s`.
+ *
+ *  @param value a message filter expression for selectively suppressing warnings, or `""` to suppress all warnings
  */
 class nowarn(value: String = "") extends ConstantAnnotation

--- a/library/src/scala/annotation/retains.scala
+++ b/library/src/scala/annotation/retains.scala
@@ -12,6 +12,8 @@ import language.experimental.captureChecking
  *
  *  The annotation can also be written explicitly if one wants to avoid the
  *  non-standard capturing type syntax.
+ *
+ *  @tparam Elems a union of singleton `.type` references representing the captured capabilities (e.g., `x.type | y.type | z.type`)
  */
 @experimental
 class retains[Elems] extends annotation.StaticAnnotation

--- a/library/src/scala/annotation/retainsByName.scala
+++ b/library/src/scala/annotation/retainsByName.scala
@@ -2,6 +2,9 @@ package scala.annotation
 
 import language.experimental.captureChecking
 
-/** An annotation that indicates capture of an enclosing by-name type */
+/** An annotation that indicates capture of an enclosing by-name type
+ *
+ *  @tparam Elems the capture set elements retained by the enclosing by-name type
+ */
 @experimental class retainsByName[Elems] extends annotation.StaticAnnotation
 

--- a/library/src/scala/annotation/targetName.scala
+++ b/library/src/scala/annotation/targetName.scala
@@ -6,5 +6,7 @@ import language.experimental.captureChecking
  *  If an `targetName(extname)` annotation is given for a method or some other
  *  definition, its implementation will use the name `extname` instead of
  *  the regular name.
+ *
+ *  @param name the external name to use for the annotated definition
  */
 final class targetName(name: String) extends StaticAnnotation

--- a/library/src/scala/annotation/unused.scala
+++ b/library/src/scala/annotation/unused.scala
@@ -21,6 +21,8 @@ import scala.language.`2.13`
  *  For example, a method parameter may be marked `@unused`
  *  because the method is designed to be overridden by
  *  an implementation that does use the parameter.
+ *
+ *  @param message a description of why the element is unused
  */
 @meta.getter @meta.setter
 class unused(message: String) extends StaticAnnotation {

--- a/library/src/scala/caps/package.scala
+++ b/library/src/scala/caps/package.scala
@@ -117,6 +117,9 @@ trait CapSet extends Any
 
 /** A type constraint expressing that the capture set `C` needs to contain
  *  the capability `R`
+ *
+ *  @tparam C the capture set that must contain the capability `R`
+ *  @tparam R the singleton type of the capability that must be present in `C`
  */
 @experimental
 sealed trait Contains[+C >: CapSet <: CapSet @retainsCap, R <: Singleton]
@@ -196,10 +199,15 @@ object internal:
    *  user-accessible compiletime.erasedValue, this version is assumed
    *  to be a pure expression, hence capability safe. The compiler generates this
    *  version only where it is known that a value can be generated.
+   *
+   *  @tparam T the type of the erased value to produce
    */
   def erasedValue[T]: T = ???
 
-  /** A trait for capabilities representing usage of mutable vars in capture sets. */
+  /** A trait for capabilities representing usage of mutable vars in capture sets.
+   *
+   *  @tparam T the type of the mutable variable's value
+   */
   trait Var[T] extends Mutable:
     def get: T
     update def set(x: T): Unit
@@ -250,16 +258,24 @@ object unsafe:
      */
     def unsafeAssumePure: T = x
 
-  /** A wrapper around code for which separation checks are suppressed. */
+  /** A wrapper around code for which separation checks are suppressed.
+   *
+   *  @param op the code block to execute without separation checking; returned as-is
+   */
   def unsafeAssumeSeparate(op: Any): op.type = op
 
-  /** A wrapper around code for which uses go unrecorded. */
+  /** A wrapper around code for which uses go unrecorded.
+   *
+   *  @param op the code block to execute without recording capability uses; returned as-is
+   */
   def unsafeDiscardUses(op: Any): op.type = op
 
   /** An unsafe variant of erasedValue that can be used as an escape hatch. Unlike the
    *  user-accessible compiletime.erasedValue, this version is assumed
    *  to be a pure expression, hence capability safe. But there is no proof
    *  of realizability, hence it is unsafe.
+   *
+   *  @tparam T the type of the erased value to produce (no realizability guarantee, hence unsafe)
    */
   def unsafeErasedValue[T]: T = ???
 

--- a/library/src/scala/collection/BitSet.scala
+++ b/library/src/scala/collection/BitSet.scala
@@ -84,7 +84,10 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
   }
 }
 
-/** Base implementation type of bitsets. */
+/** Base implementation type of bitsets.
+ *
+ *  @tparam C the type of the bitset itself, used for return types of operations
+ */
 transparent trait BitSetOps[+C <: BitSet & BitSetOps[C]]
   extends SortedSetOps[Int, SortedSet, C] { self =>
   import BitSetOps._
@@ -100,10 +103,15 @@ transparent trait BitSetOps[+C <: BitSet & BitSetOps[C]]
 
   /** The words at index `idx`, or 0L if outside the range of the set
    *  **Note:** requires `idx >= 0`
+   *
+   *  @param idx the index of the word to retrieve, must be non-negative
    */
   protected[collection] def word(idx: Int): Long
 
-  /** Creates a new set of this kind from an array of longs */
+  /** Creates a new set of this kind from an array of longs
+   *
+   *  @param elems the array of 64-bit words representing the bit mask for the new set
+   */
   protected[collection] def fromBitMaskNoCopy(elems: Array[Long]): C
 
   def contains(elem: Int): Boolean =

--- a/library/src/scala/collection/BufferedIterator.scala
+++ b/library/src/scala/collection/BufferedIterator.scala
@@ -17,6 +17,8 @@ import language.experimental.captureChecking
 
 /** Buffered iterators are iterators which provide a method `head`
  *  that inspects the next element without discarding it.
+ *
+ *  @tparam A the type of elements returned by this iterator
  */
 trait BufferedIterator[+A] extends Iterator[A] {
 

--- a/library/src/scala/collection/BuildFrom.scala
+++ b/library/src/scala/collection/BuildFrom.scala
@@ -33,13 +33,18 @@ trait BuildFrom[-From, -A, +C] extends Any { self =>
 
   /** Gets a Builder for the collection. For non-strict collection types this will use an intermediate buffer.
    *  Building collections with `fromSpecific` is preferred because it can be lazy for lazy collections. 
+   *
+   *  @param from the source collection providing the factory for creating the builder
    */
   def newBuilder(from: From): Builder[A, C]
 
   @deprecated("Use newBuilder() instead of apply()", "2.13.0")
   @`inline` def apply(from: From): Builder[A, C] = newBuilder(from)
 
-  /** Partially apply a BuildFrom to a Factory. */
+  /** Partially apply a BuildFrom to a Factory.
+   *
+   *  @param from the source collection to partially apply, producing a `Factory` bound to it
+   */
   def toFactory(from: From): Factory[A, C] = new Factory[A, C] {
     def fromSpecific(it: IterableOnce[A]^): C^{it} = self.fromSpecific(from)(it)
     def newBuilder: Builder[A, C] = self.newBuilder(from)
@@ -48,14 +53,20 @@ trait BuildFrom[-From, -A, +C] extends Any { self =>
 
 object BuildFrom extends BuildFromLowPriority1 {
 
-  /** Builds the source collection type from a MapOps. */
+  /** Builds the source collection type from a MapOps.
+   *
+   *  @tparam CC the higher-kinded type constructor of the map collection (e.g. `HashMap`)
+   */
   implicit def buildFromMapOps[CC[X, Y] <: Map[X, Y] & MapOps[X, Y, CC, ?], K0, V0, K, V]: BuildFrom[CC[K0, V0] & Map[K0, V0], (K, V), CC[K, V] & Map[K, V]] = new BuildFrom[CC[K0, V0], (K, V), CC[K, V]] {
     //TODO: Reuse a prototype instance
     def newBuilder(from: CC[K0, V0]): Builder[(K, V), CC[K, V]] = (from: MapOps[K0, V0, CC, ?]).mapFactory.newBuilder[K, V]
     def fromSpecific(from: CC[K0, V0])(it: IterableOnce[(K, V)]^): CC[K, V] = (from: MapOps[K0, V0, CC, ?]).mapFactory.from(it)
   }
 
-  /** Builds the source collection type from a SortedMapOps. */
+  /** Builds the source collection type from a SortedMapOps.
+   *
+   *  @tparam CC the higher-kinded type constructor of the sorted map collection (e.g. `TreeMap`)
+   */
   implicit def buildFromSortedMapOps[CC[X, Y] <: SortedMap[X, Y] & SortedMapOps[X, Y, CC, ?], K0, V0, K : Ordering, V]: BuildFrom[CC[K0, V0] & SortedMap[K0, V0], (K, V), CC[K, V] & SortedMap[K, V]] = new BuildFrom[CC[K0, V0], (K, V), CC[K, V]] {
     def newBuilder(from: CC[K0, V0]): Builder[(K, V), CC[K, V]] = (from: SortedMapOps[K0, V0, CC, ?]).sortedMapFactory.newBuilder[K, V]
     def fromSpecific(from: CC[K0, V0])(it: IterableOnce[(K, V)]^): CC[K, V] = (from: SortedMapOps[K0, V0, CC, ?]).sortedMapFactory.from(it)
@@ -95,7 +106,10 @@ object BuildFrom extends BuildFromLowPriority1 {
 
 trait BuildFromLowPriority1 extends BuildFromLowPriority2 {
 
-  /** Builds the source collection type from an Iterable with SortedOps. */
+  /** Builds the source collection type from an Iterable with SortedOps.
+   *
+   *  @tparam CC the higher-kinded type constructor of the sorted set collection (e.g. `TreeSet`)
+   */
   // Restating the upper bound of CC in the result type seems redundant, but it serves to prune the
   // implicit search space for faster compilation and reduced change of divergence. See the compilation
   // test in test/junit/scala/collection/BuildFromTest.scala and discussion in https://github.com/scala/scala/pull/10209
@@ -112,7 +126,10 @@ trait BuildFromLowPriority1 extends BuildFromLowPriority2 {
 }
 
 trait BuildFromLowPriority2 {
-  /** Builds the source collection type from an IterableOps. */
+  /** Builds the source collection type from an IterableOps.
+   *
+   *  @tparam CC the higher-kinded type constructor of the iterable collection (e.g. `List`, `Vector`)
+   */
   implicit def buildFromIterableOps[CC[X] <: Iterable[X] & IterableOps[X, CC, ?], A0, A]: BuildFrom[CC[A0], A, CC[A]] = new BuildFrom[CC[A0], A, CC[A]] {
     //TODO: Reuse a prototype instance
     def newBuilder(from: CC[A0]): Builder[A, CC[A]] = (from: IterableOps[A0, CC, ?]).iterableFactory.newBuilder[A]

--- a/library/src/scala/collection/Factory.scala
+++ b/library/src/scala/collection/Factory.scala
@@ -34,9 +34,8 @@ import scala.reflect.ClassTag
 trait Factory[-A, +C] extends Any { self =>
 
   /**
-   *  @param it Source collection
-   *  @return A collection of type `C` containing the same elements
-   *         as the source collection `it`.
+   *  @param it the source of elements to include in the collection
+   *  @return a collection of type `C` containing the elements from `it`
    */
   def fromSpecific(it: IterableOnce[A]^): C^{it}
 
@@ -107,6 +106,7 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
 
   /** Produces a $coll containing repeated applications of a function to a start value.
    *
+   *  @tparam A the element type of the $coll
    *  @param start the start value of the $coll
    *  @param len   the number of elements contained in the $coll
    *  @param f     the function that's repeatedly applied
@@ -128,6 +128,7 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
 
   /** Produces a $coll containing a sequence of increasing of integers.
    *
+   *  @tparam A the element type of the $coll, which must have an `Integral` instance
    *  @param start the first element of the $coll
    *  @param end   the end value of the $coll (the first value NOT contained)
    *  @return  a $coll with values `start, start + 1, ..., end - 1`
@@ -135,6 +136,8 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
   def range[A : Integral](start: A, end: A): CC[A] = from(NumericRange(start, end, implicitly[Integral[A]].one))
 
   /** Produces a $coll containing equally spaced values in some integer interval.
+   *
+   *  @tparam A the element type of the $coll, which must have an `Integral` instance
    *  @param start the start value of the $coll
    *  @param end   the end value of the $coll (the first value NOT contained)
    *  @param step  the difference between successive elements of the $coll (must be positive or negative)
@@ -144,11 +147,13 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
 
   /**
    *  @tparam A the type of the ${coll}’s elements
-   *  @return A builder for $Coll objects.
+   *  @return a builder for $Coll objects.
    */
   def newBuilder[A]: Builder[A, CC[A]]
 
   /** Produces a $coll containing the results of some element computation a number of times.
+   *
+   *  @tparam A the element type of the $coll
    *  @param   n  the number of elements contained in the $coll.
    *  @param   elem the element computation
    *  @return  A $coll that contains the results of `n` evaluations of `elem`.
@@ -156,6 +161,8 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
   def fill[A](n: Int)(elem: => A): CC[A]^{elem} = from(new View.Fill(n)(elem))
 
   /** Produces a two-dimensional $coll containing the results of some element computation a number of times.
+   *
+   *  @tparam A the element type of the $coll
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   elem the element computation
@@ -164,6 +171,8 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
   def fill[A](n1: Int, n2: Int)(elem: => A): CC[(CC[A]^{elem}) @uncheckedVariance]^{elem} = fill(n1)(fill(n2)(elem))
 
   /** Produces a three-dimensional $coll containing the results of some element computation a number of times.
+   *
+   *  @tparam A the element type of the $coll
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -173,6 +182,8 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
   def fill[A](n1: Int, n2: Int, n3: Int)(elem: => A): CC[(CC[CC[A]^{elem}]^{elem}) @uncheckedVariance]^{elem} = fill(n1)(fill(n2, n3)(elem))
 
   /** Produces a four-dimensional $coll containing the results of some element computation a number of times.
+   *
+   *  @tparam A the element type of the $coll
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -184,6 +195,8 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
     fill(n1)(fill(n2, n3, n4)(elem))
 
   /** Produces a five-dimensional $coll containing the results of some element computation a number of times.
+   *
+   *  @tparam A the element type of the $coll
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -196,6 +209,8 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
     fill(n1)(fill(n2, n3, n4, n5)(elem))
 
   /** Produces a $coll containing values of a given function over a range of integer values starting from 0.
+   *
+   *  @tparam A the element type of the $coll
    *  @param  n   The number of elements in the $coll
    *  @param  f   The function computing element values
    *  @return A $coll consisting of elements `f(0), ..., f(n -1)`
@@ -203,6 +218,8 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
   def tabulate[A](n: Int)(f: Int => A): CC[A]^{f} = from(new View.Tabulate(n)(f))
 
   /** Produces a two-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
+   *
+   *  @tparam A the element type of the $coll
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   f   The function computing element values
@@ -213,6 +230,8 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
     tabulate(n1)(i1 => tabulate(n2)(f(i1, _)))
 
   /** Produces a three-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
+   *
+   *  @tparam A the element type of the $coll
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -224,6 +243,8 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
     tabulate(n1)(i1 => tabulate(n2, n3)(f(i1, _, _)))
 
   /** Produces a four-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
+   *
+   *  @tparam A the element type of the $coll
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -236,6 +257,8 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
     tabulate(n1)(i1 => tabulate(n2, n3, n4)(f(i1, _, _, _)))
 
   /** Produces a five-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
+   *
+   *  @tparam A the element type of the $coll
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -250,6 +273,7 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
 
   /** Concatenates all argument collections into a single $coll.
    *
+   *  @tparam A the element type of the $coll
    *  @param xss the collections that are to be concatenated.
    *  @return the concatenation of all the collections.
    */
@@ -382,22 +406,46 @@ trait SpecificIterableFactory[-A, +C] extends Factory[A, C] {
  *
  *  @define coll collection
  *  @define Coll `Iterable`
+ *
+ *  @tparam CC Collection type constructor for the map (e.g. `Map`, `HashMap`)
  */
 trait MapFactory[+CC[_, _]] extends Serializable { self =>
 
-  /** An empty Map. */
+  /** An empty Map.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   */
   def empty[K, V]: CC[K, V]
 
-  /** A collection of type Map generated from given iterable object. */
+  /** A collection of type Map generated from given iterable object.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @param it the source collection of key-value pairs
+   */
   def from[K, V](it: IterableOnce[(K, V)]^): CC[K, V]^{it}
 
-  /** A collection of type Map that contains given key/value bindings. */
+  /** A collection of type Map that contains given key/value bindings.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @param elems the key-value pairs to include in the map
+   */
   def apply[K, V](elems: (K, V)*): CC[K, V] = from(elems)
 
-  /** The default builder for Map objects. */
+  /** The default builder for Map objects.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   */
   def newBuilder[K, V]: Builder[(K, V), CC[K, V]]
 
-  /** The default Factory instance for maps. */
+  /** The default Factory instance for maps.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   */
   implicit def mapFactory[K, V]: Factory[(K, V), CC[K, V]] = MapFactory.toFactory(this)
 }
 
@@ -454,6 +502,8 @@ trait EvidenceIterableFactory[+CC[_], Ev[_]] extends Serializable, caps.Pure {
   def apply[A : Ev](xs: A*): CC[A] = from(xs)
 
   /** Produces a $coll containing the results of some element computation a number of times.
+   *
+   *  @tparam A the element type of the $coll, for which an implicit `Ev` instance must exist
    *  @param   n  the number of elements contained in the $coll.
    *  @param   elem the element computation
    *  @return  A $coll that contains the results of `n` evaluations of `elem`.
@@ -461,6 +511,8 @@ trait EvidenceIterableFactory[+CC[_], Ev[_]] extends Serializable, caps.Pure {
   def fill[A : Ev](n: Int)(elem: => A): CC[A] = from(new View.Fill(n)(elem))
 
   /** Produces a $coll containing values of a given function over a range of integer values starting from 0.
+   *
+   *  @tparam A the element type of the $coll, for which an implicit `Ev` instance must exist
    *  @param  n   The number of elements in the $coll
    *  @param  f   The function computing element values
    *  @return A $coll consisting of elements `f(0), ..., f(n -1)`
@@ -469,6 +521,7 @@ trait EvidenceIterableFactory[+CC[_], Ev[_]] extends Serializable, caps.Pure {
 
   /** Produces a $coll containing repeated applications of a function to a start value.
    *
+   *  @tparam A the element type of the $coll, for which an implicit `Ev` instance must exist
    *  @param start the start value of the $coll
    *  @param len   the number of elements contained in the $coll
    *  @param f     the function that's repeatedly applied
@@ -547,6 +600,7 @@ trait ClassTagIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, ClassT
 
   /** Produces a $coll containing a sequence of increasing of integers.
    *
+   *  @tparam A the element type of the $coll, which must have `Integral` and `ClassTag` instances
    *  @param start the first element of the $coll
    *  @param end   the end value of the $coll (the first value NOT contained)
    *  @return  a $coll with values `start, start + 1, ..., end - 1`
@@ -554,6 +608,8 @@ trait ClassTagIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, ClassT
   def range[A : Integral : ClassTag](start: A, end: A): CC[A] = from(NumericRange(start, end, implicitly[Integral[A]].one))
 
   /** Produces a $coll containing equally spaced values in some integer interval.
+   *
+   *  @tparam A the element type of the $coll, which must have `Integral` and `ClassTag` instances
    *  @param start the start value of the $coll
    *  @param end   the end value of the $coll (the first value NOT contained)
    *  @param step  the difference between successive elements of the $coll (must be positive or negative)
@@ -562,6 +618,8 @@ trait ClassTagIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, ClassT
   def range[A : Integral : ClassTag](start: A, end: A, step: A): CC[A] = from(NumericRange(start, end, step))
 
   /** Produces a two-dimensional $coll containing the results of some element computation a number of times.
+   *
+   *  @tparam A the element type of the $coll, which must have a `ClassTag`
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   elem the element computation
@@ -570,6 +628,8 @@ trait ClassTagIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, ClassT
   def fill[A : ClassTag](n1: Int, n2: Int)(elem: => A): CC[CC[A] @uncheckedVariance] = fill(n1)(fill(n2)(elem))
 
   /** Produces a three-dimensional $coll containing the results of some element computation a number of times.
+   *
+   *  @tparam A the element type of the $coll, which must have a `ClassTag`
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -579,6 +639,8 @@ trait ClassTagIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, ClassT
   def fill[A : ClassTag](n1: Int, n2: Int, n3: Int)(elem: => A): CC[CC[CC[A]] @uncheckedVariance] = fill(n1)(fill(n2, n3)(elem))
 
   /** Produces a four-dimensional $coll containing the results of some element computation a number of times.
+   *
+   *  @tparam A the element type of the $coll, which must have a `ClassTag`
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -590,6 +652,8 @@ trait ClassTagIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, ClassT
     fill(n1)(fill(n2, n3, n4)(elem))
 
   /** Produces a five-dimensional $coll containing the results of some element computation a number of times.
+   *
+   *  @tparam A the element type of the $coll, which must have a `ClassTag`
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -602,6 +666,8 @@ trait ClassTagIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, ClassT
     fill(n1)(fill(n2, n3, n4, n5)(elem))
 
   /** Produces a two-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
+   *
+   *  @tparam A the element type of the $coll, which must have a `ClassTag`
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   f   The function computing element values
@@ -612,6 +678,8 @@ trait ClassTagIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, ClassT
     tabulate(n1)(i1 => tabulate(n2)(f(i1, _)))
 
   /** Produces a three-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
+   *
+   *  @tparam A the element type of the $coll, which must have a `ClassTag`
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -623,6 +691,8 @@ trait ClassTagIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, ClassT
     tabulate(n1)(i1 => tabulate(n2, n3)(f(i1, _, _)))
 
   /** Produces a four-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
+   *
+   *  @tparam A the element type of the $coll, which must have a `ClassTag`
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -635,6 +705,8 @@ trait ClassTagIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, ClassT
     tabulate(n1)(i1 => tabulate(n2, n3, n4)(f(i1, _, _, _)))
 
   /** Produces a five-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
+   *
+   *  @tparam A the element type of the $coll, which must have a `ClassTag`
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -724,6 +796,8 @@ trait StrictOptimizedClassTagSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]]] extend
  *
  *  @define coll collection
  *  @define Coll `Iterable`
+ *
+ *  @tparam CC Collection type constructor for the sorted map (e.g. `TreeMap`)
  */
 trait SortedMapFactory[+CC[_, _]] extends Serializable { this: SortedMapFactory[CC] =>
 

--- a/library/src/scala/collection/IndexedSeq.scala
+++ b/library/src/scala/collection/IndexedSeq.scala
@@ -21,7 +21,10 @@ import scala.collection.Searching.{Found, InsertionPoint, SearchResult}
 import scala.collection.Stepper.EfficientSplit
 import scala.math.Ordering
 
-/** Base trait for indexed sequences that have efficient `apply` and `length`. */
+/** Base trait for indexed sequences that have efficient `apply` and `length`.
+ *
+ *  @tparam A the element type of the indexed sequence
+ */
 trait IndexedSeq[+A] extends Seq[A]
   with IndexedSeqOps[A, IndexedSeq, IndexedSeq[A]]
   with IterableFactoryDefaults[A, IndexedSeq] {
@@ -34,7 +37,12 @@ trait IndexedSeq[+A] extends Seq[A]
 @SerialVersionUID(3L)
 object IndexedSeq extends SeqFactory.Delegate[IndexedSeq](immutable.IndexedSeq)
 
-/** Base trait for indexed Seq operations. */
+/** Base trait for indexed Seq operations.
+ *
+ *  @tparam A the element type of the sequence
+ *  @tparam CC the type constructor for the resulting collection (e.g., `IndexedSeq`)
+ *  @tparam C the type of the concrete collection
+ */
 transparent trait IndexedSeqOps[+A, +CC[_], +C] extends Any with SeqOps[A, CC, C] { self: IndexedSeqOps[A, CC, C]^ =>
 
   def iterator: Iterator[A]^{this} = view.iterator
@@ -155,7 +163,11 @@ transparent trait IndexedSeqOps[+A, +CC[_], +C] extends Any with SeqOps[A, CC, C
   }
 }
 
-/** A fast sliding iterator for IndexedSeqs which uses the underlying `slice` operation. */
+/** A fast sliding iterator for IndexedSeqs which uses the underlying `slice` operation.
+ *
+ *  @tparam A the element type of the sequence
+ *  @tparam CC the type constructor for the resulting collection (e.g., `IndexedSeq`)
+ */
 private final class IndexedSeqSlidingIterator[A, CC[_], C](s: IndexedSeqOps[A, CC, C]^, size: Int, step: Int)
   extends AbstractIterator[C^{s}] {
   // CC note: seems like the compiler cannot figure out that this class <: Iterator[C^{s}],

--- a/library/src/scala/collection/IndexedSeqView.scala
+++ b/library/src/scala/collection/IndexedSeqView.scala
@@ -19,7 +19,10 @@ import language.experimental.captureChecking
 import scala.annotation.nowarn
 
 
-/** View defined in terms of indexing a range. */
+/** View defined in terms of indexing a range.
+ *
+ *  @tparam A the element type of the view
+ */
 trait IndexedSeqView[+A] extends IndexedSeqOps[A, View, View[A]] with SeqView[A] {
 
   override def view: IndexedSeqView[A]^{this} = this

--- a/library/src/scala/collection/JavaConverters.scala
+++ b/library/src/scala/collection/JavaConverters.scala
@@ -145,78 +145,121 @@ object JavaConverters extends AsJavaConverters with AsScalaConverters {
 
   /** Adds an `asJava` method that implicitly converts a Scala `Iterator` to a Java `Iterator`.
    *  @see [[asJavaIterator]]
+   *
+   *  @tparam A the element type of the iterator
+   *  @param i the Scala `Iterator` to be converted
    */
   implicit def asJavaIteratorConverter[A](i : Iterator[A]): AsJava[ju.Iterator[A]] =
     new AsJava(asJavaIterator(i))
 
   /** Adds an `asJavaEnumeration` method that implicitly converts a Scala `Iterator` to a Java `Enumeration`.
    *  @see [[asJavaEnumeration]]
+   *
+   *  @tparam A the element type of the iterator
+   *  @param i the Scala `Iterator` to be converted
    */
   implicit def asJavaEnumerationConverter[A](i : Iterator[A]): AsJavaEnumeration[A] =
     new AsJavaEnumeration(i)
 
   /** Adds an `asJava` method that implicitly converts a Scala `Iterable` to a Java `Iterable`.
    *  @see [[asJavaIterable]]
+   *
+   *  @tparam A the element type of the iterable
+   *  @param i the Scala `Iterable` to be converted
    */
   implicit def asJavaIterableConverter[A](i : Iterable[A]): AsJava[jl.Iterable[A]] =
     new AsJava(asJavaIterable(i))
 
   /** Adds an `asJavaCollection` method that implicitly converts a Scala `Iterable` to an immutable Java `Collection`.
    *  @see [[asJavaCollection]]
+   *
+   *  @tparam A the element type of the iterable
+   *  @param i the Scala `Iterable` to be converted
    */
   implicit def asJavaCollectionConverter[A](i : Iterable[A]): AsJavaCollection[A] =
     new AsJavaCollection(i)
 
   /** Adds an `asJava` method that implicitly converts a Scala mutable `Buffer` to a Java `List`.
    *  @see [[bufferAsJavaList]]
+   *
+   *  @tparam A the element type of the buffer
+   *  @param b the Scala mutable `Buffer` to be converted
    */
   implicit def bufferAsJavaListConverter[A](b : mutable.Buffer[A]): AsJava[ju.List[A]] =
     new AsJava(bufferAsJavaList(b))
 
   /** Adds an `asJava` method that implicitly converts a Scala mutable `Seq` to a Java `List`.
    *  @see [[mutableSeqAsJavaList]]
+   *
+   *  @tparam A the element type of the sequence
+   *  @param b the Scala mutable `Seq` to be converted
    */
   implicit def mutableSeqAsJavaListConverter[A](b : mutable.Seq[A]): AsJava[ju.List[A]] =
     new AsJava(mutableSeqAsJavaList(b))
 
   /** Adds an `asJava` method that implicitly converts a Scala `Seq` to a Java `List`.
    *  @see [[seqAsJavaList]]
+   *
+   *  @tparam A the element type of the sequence
+   *  @param b the Scala `Seq` to be converted
    */
   implicit def seqAsJavaListConverter[A](b : Seq[A]): AsJava[ju.List[A]] =
     new AsJava(seqAsJavaList(b))
 
   /** Adds an `asJava` method that implicitly converts a Scala mutable `Set` to a Java `Set`.
    *  @see [[mutableSetAsJavaSet]]
+   *
+   *  @tparam A the element type of the set
+   *  @param s the Scala mutable `Set` to be converted
    */
   implicit def mutableSetAsJavaSetConverter[A](s : mutable.Set[A]): AsJava[ju.Set[A]] =
     new AsJava(mutableSetAsJavaSet(s))
 
   /** Adds an `asJava` method that implicitly converts a Scala `Set` to a Java `Set`.
    *  @see [[setAsJavaSet]]
+   *
+   *  @tparam A the element type of the set
+   *  @param s the Scala `Set` to be converted
    */
   implicit def setAsJavaSetConverter[A](s : Set[A]): AsJava[ju.Set[A]] =
     new AsJava(setAsJavaSet(s))
 
   /** Adds an `asJava` method that implicitly converts a Scala mutable `Map` to a Java `Map`.
    *  @see [[mutableMapAsJavaMap]]
+   *
+   *  @tparam K the type of the map keys
+   *  @tparam V the type of the map values
+   *  @param m the Scala mutable `Map` to be converted
    */
   implicit def mutableMapAsJavaMapConverter[K, V](m : mutable.Map[K, V]): AsJava[ju.Map[K, V]] =
     new AsJava(mutableMapAsJavaMap(m))
 
   /** Adds an `asJavaDictionary` method that implicitly converts a Scala mutable `Map` to a Java `Dictionary`.
    *  @see [[asJavaDictionary]]
+   *
+   *  @tparam K the type of the map keys
+   *  @tparam V the type of the map values
+   *  @param m the Scala mutable `Map` to be converted
    */
   implicit def asJavaDictionaryConverter[K, V](m : mutable.Map[K, V]): AsJavaDictionary[K, V] =
     new AsJavaDictionary(m)
 
   /** Adds an `asJava` method that implicitly converts a Scala `Map` to a Java `Map`.
    *  @see [[mapAsJavaMap]]
+   *
+   *  @tparam K the type of the map keys
+   *  @tparam V the type of the map values
+   *  @param m the Scala `Map` to be converted
    */
   implicit def mapAsJavaMapConverter[K, V](m : Map[K, V]): AsJava[ju.Map[K, V]] =
     new AsJava(mapAsJavaMap(m))
 
   /** Adds an `asJava` method that implicitly converts a Scala mutable `concurrent.Map` to a Java `ConcurrentMap`.
    *  @see [[mapAsJavaConcurrentMap]].
+   *
+   *  @tparam K the type of the map keys
+   *  @tparam V the type of the map values
+   *  @param m the Scala `concurrent.Map` to be converted
    */
   implicit def mapAsJavaConcurrentMapConverter[K, V](m: concurrent.Map[K, V]): AsJava[juc.ConcurrentMap[K, V]] =
     new AsJava(mapAsJavaConcurrentMap(m))
@@ -224,90 +267,143 @@ object JavaConverters extends AsJavaConverters with AsScalaConverters {
 
   /** Adds an `asScala` method that implicitly converts a Java `Iterator` to a Scala `Iterator`.
    *  @see [[asScalaIterator]]
+   *
+   *  @tparam A the element type of the iterator
+   *  @param i the Java `Iterator` to be converted
    */
   implicit def asScalaIteratorConverter[A](i : ju.Iterator[A]): AsScala[Iterator[A]] =
     new AsScala(asScalaIterator(i))
 
   /** Adds an `asScala` method that implicitly converts a Java `Enumeration` to a Scala `Iterator`.
    *  @see [[enumerationAsScalaIterator]]
+   *
+   *  @tparam A the element type of the enumeration
+   *  @param i the Java `Enumeration` to be converted
    */
   implicit def enumerationAsScalaIteratorConverter[A](i : ju.Enumeration[A]): AsScala[Iterator[A]] =
     new AsScala(enumerationAsScalaIterator(i))
 
   /** Adds an `asScala` method that implicitly converts a Java `Iterable` to a Scala `Iterable`.
    *  @see [[iterableAsScalaIterable]]
+   *
+   *  @tparam A the element type of the iterable
+   *  @param i the Java `Iterable` to be converted
    */
   implicit def iterableAsScalaIterableConverter[A](i : jl.Iterable[A]): AsScala[Iterable[A]] =
     new AsScala(iterableAsScalaIterable(i))
 
   /** Adds an `asScala` method that implicitly converts a Java `Collection` to an Scala `Iterable`.
    *  @see [[collectionAsScalaIterable]]
+   *
+   *  @tparam A the element type of the collection
+   *  @param i the Java `Collection` to be converted
    */
   implicit def collectionAsScalaIterableConverter[A](i : ju.Collection[A]): AsScala[Iterable[A]] =
     new AsScala(collectionAsScalaIterable(i))
 
   /** Adds an `asScala` method that implicitly converts a Java `List` to a Scala mutable `Buffer`.
    *  @see [[asScalaBuffer]]
+   *
+   *  @tparam A the element type of the list
+   *  @param l the Java `List` to be converted
    */
   implicit def asScalaBufferConverter[A](l : ju.List[A]): AsScala[mutable.Buffer[A]] =
     new AsScala(asScalaBuffer(l))
 
   /** Adds an `asScala` method that implicitly converts a Java `Set` to a Scala mutable `Set`.
    *  @see [[asScalaSet]]
+   *
+   *  @tparam A the element type of the set
+   *  @param s the Java `Set` to be converted
    */
   implicit def asScalaSetConverter[A](s : ju.Set[A]): AsScala[mutable.Set[A]] =
     new AsScala(asScalaSet(s))
 
   /** Adds an `asScala` method that implicitly converts a Java `Map` to a Scala mutable `Map`.
    *  @see [[mapAsScalaMap]]
+   *
+   *  @tparam K the type of the map keys
+   *  @tparam V the type of the map values
+   *  @param m the Java `Map` to be converted
    */
   implicit def mapAsScalaMapConverter[K, V](m : ju.Map[K, V]): AsScala[mutable.Map[K, V]] =
     new AsScala(mapAsScalaMap(m))
 
   /** Adds an `asScala` method that implicitly converts a Java `ConcurrentMap` to a Scala mutable `concurrent.Map`.
    *  @see [[mapAsScalaConcurrentMap]]
+   *
+   *  @tparam K the type of the map keys
+   *  @tparam V the type of the map values
+   *  @param m the Java `ConcurrentMap` to be converted
    */
   implicit def mapAsScalaConcurrentMapConverter[K, V](m: juc.ConcurrentMap[K, V]): AsScala[concurrent.Map[K, V]] =
     new AsScala(mapAsScalaConcurrentMap(m))
 
   /** Adds an `asScala` method that implicitly converts a Java `Dictionary` to a Scala mutable `Map`.
    *  @see [[dictionaryAsScalaMap]]
+   *
+   *  @tparam K the type of the dictionary keys
+   *  @tparam V the type of the dictionary values
+   *  @param p the Java `Dictionary` to be converted
    */
   implicit def dictionaryAsScalaMapConverter[K, V](p: ju.Dictionary[K, V]): AsScala[mutable.Map[K, V]] =
     new AsScala(dictionaryAsScalaMap(p))
 
   /** Adds an `asScala` method that implicitly converts a Java `Properties` to a Scala mutable `Map[String, String]`.
    *  @see [[propertiesAsScalaMap]]
+   *
+   *  @param p the Java `Properties` to be converted
    */
   implicit def propertiesAsScalaMapConverter(p: ju.Properties): AsScala[mutable.Map[String, String]] =
     new AsScala(propertiesAsScalaMap(p))
 
 
-  /** Generic class containing the `asJava` converter method. */
+  /** Generic class containing the `asJava` converter method.
+   *
+   *  @tparam A the target type of the conversion result
+   *  @param op the conversion operation, evaluated lazily
+   */
   class AsJava[A](op: => A) {
     /** Converts a Scala collection to the corresponding Java collection. */
     def asJava: A = op
   }
 
-  /** Generic class containing the `asScala` converter method. */
+  /** Generic class containing the `asScala` converter method.
+   *
+   *  @tparam A the target type of the conversion result
+   *  @param op the conversion operation, evaluated lazily
+   */
   class AsScala[A](op: => A) {
     /** Converts a Java collection to the corresponding Scala collection. */
     def asScala: A = op
   }
 
-  /** Generic class containing the `asJavaCollection` converter method. */
+  /** Generic class containing the `asJavaCollection` converter method.
+   *
+   *  @tparam A the element type of the collection
+   *  @param i the Scala `Iterable` to be converted
+   */
   class AsJavaCollection[A](i: Iterable[A]) {
     /** Converts a Scala `Iterable` to a Java `Collection`. */
     def asJavaCollection: ju.Collection[A] = JavaConverters.asJavaCollection(i)
   }
 
-  /** Generic class containing the `asJavaEnumeration` converter method. */
+  /** Generic class containing the `asJavaEnumeration` converter method.
+   *
+   *  @tparam A the element type of the enumeration
+   *  @param i the Scala `Iterator` to be converted
+   */
   class AsJavaEnumeration[A](i: Iterator[A]) {
     /** Converts a Scala `Iterator` to a Java `Enumeration`. */
     def asJavaEnumeration: ju.Enumeration[A] = JavaConverters.asJavaEnumeration(i)
   }
 
-  /** Generic class containing the `asJavaDictionary` converter method. */
+  /** Generic class containing the `asJavaDictionary` converter method.
+   *
+   *  @tparam K the type of the dictionary keys
+   *  @tparam V the type of the dictionary values
+   *  @param m the Scala mutable `Map` to be converted
+   */
   class AsJavaDictionary[K, V](m : mutable.Map[K, V]) {
     /** Converts a Scala `Map` to a Java `Dictionary`. */
     def asJavaDictionary: ju.Dictionary[K, V] = JavaConverters.asJavaDictionary(m)

--- a/library/src/scala/collection/LazyZipOps.scala
+++ b/library/src/scala/collection/LazyZipOps.scala
@@ -22,6 +22,10 @@ import language.experimental.captureChecking
  *  @define willNotTerminateInf
  *
  *              Note: will not terminate for infinite-sized collections.
+ *
+ *  @tparam El1 the element type of the first collection
+ *  @tparam El2 the element type of the second collection
+ *  @tparam C1 the type of the source collection, used to determine the result type of strict operations
  */
 final class LazyZip2[+El1, +El2, C1] private[collection](src: C1, coll1: Iterable[El1]^, coll2: Iterable[El2]^) {
 
@@ -147,6 +151,11 @@ object LazyZip2 {
  *  @define willNotTerminateInf
  *
  *              Note: will not terminate for infinite-sized collections.
+ *
+ *  @tparam El1 the element type of the first collection
+ *  @tparam El2 the element type of the second collection
+ *  @tparam El3 the element type of the third collection
+ *  @tparam C1 the type of the source collection, used to determine the result type of strict operations
  */
 final class LazyZip3[+El1, +El2, +El3, C1] private[collection](src: C1,
                                                                coll1: Iterable[El1]^,
@@ -288,6 +297,12 @@ object LazyZip3 {
  *  @define willNotTerminateInf
  *
  *              Note: will not terminate for infinite-sized collections.
+ *
+ *  @tparam El1 the element type of the first collection
+ *  @tparam El2 the element type of the second collection
+ *  @tparam El3 the element type of the third collection
+ *  @tparam El4 the element type of the fourth collection
+ *  @tparam C1 the type of the source collection, used to determine the result type of strict operations
  */
 final class LazyZip4[+El1, +El2, +El3, +El4, C1] private[collection](src: C1,
                                                                      coll1: Iterable[El1]^,

--- a/library/src/scala/collection/LinearSeq.scala
+++ b/library/src/scala/collection/LinearSeq.scala
@@ -21,6 +21,8 @@ import scala.annotation.{nowarn, tailrec}
 /** Base trait for linearly accessed sequences that have efficient `head` and
  *  `tail` operations.
  *  Known subclasses: List, LazyList
+ *
+ *  @tparam A the element type of the sequence
  */
 trait LinearSeq[+A] extends Seq[A]
   with LinearSeqOps[A, LinearSeq, LinearSeq[A]]
@@ -34,7 +36,12 @@ trait LinearSeq[+A] extends Seq[A]
 @SerialVersionUID(3L)
 object LinearSeq extends SeqFactory.Delegate[LinearSeq](immutable.LinearSeq)
 
-/** Base trait for linear Seq operations. */
+/** Base trait for linear Seq operations.
+ *
+ *  @tparam A the element type of the sequence
+ *  @tparam CC the type constructor for the collection (e.g., `List`, `LazyList`)
+ *  @tparam C the concrete collection type
+ */
 transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & LinearSeqOps[A, CC, C]] extends Any with SeqOps[A, CC, C] with caps.Pure { self =>
 
   /** @inheritdoc
@@ -288,6 +295,9 @@ transparent trait StrictOptimizedLinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: 
 
 /** A specialized Iterator for LinearSeqs that is lazy enough for Stream and LazyList. This is accomplished by not
  *  evaluating the tail after returning the current head.
+ *
+ *  @tparam A the element type of the linear sequence being iterated
+ *  @param coll the linear sequence to iterate over
  */
 private[collection] final class LinearSeqIterator[A](coll: LinearSeqOps[A, LinearSeq, LinearSeq[A]]) extends AbstractIterator[A] {
   // A call-by-need cell

--- a/library/src/scala/collection/MapView.scala
+++ b/library/src/scala/collection/MapView.scala
@@ -48,6 +48,8 @@ trait MapView[K, +V]
   override def filterKeys(p: K => Boolean): MapView[K, V]^{this, p} = new MapView.FilterKeys(this, p)
 
   /** Transforms this map by applying a function to every retrieved value.
+   *
+   *  @tparam W the type of the transformed values
    *  @param  f   the function used to transform values of this map.
    *  @return a map view which maps every key of this map
    *          to `f(this(key))`. The resulting map wraps the original map without copying any elements.

--- a/library/src/scala/collection/Seq.scala
+++ b/library/src/scala/collection/Seq.scala
@@ -84,6 +84,8 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
 
   /** Gets the element at the specified index. This operation is provided for convenience in `Seq`. It should
    *  not be assumed to be efficient unless you have an `IndexedSeq`. 
+   *
+   *  @param i the index of the element to retrieve, zero-based
    */
   @throws[IndexOutOfBoundsException]
   def apply(i: Int): A
@@ -110,7 +112,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *  @tparam B      the element type of the returned $coll.
    *  @param  elem   the prepended element
    *
-   *  @return a new $coll consisting of `value` followed
+   *  @return a new $coll consisting of `elem` followed
    *            by all elements of this $coll.
    */
   def prepended[B >: A](elem: B): CC[B]^{this} = iterableFactory.from(new View.Prepended(elem, this))
@@ -119,6 +121,8 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *
    *  Note that :-ending operators are right associative (see example).
    *  A mnemonic for `+:` vs. `:+` is: the COLon goes on the COLlection side.
+   *
+   *  @return a new $coll consisting of `elem` followed by all elements of this $coll
    */
   @`inline` final def +: [B >: A](elem: B): CC[B]^{this} = prepended(elem)
 
@@ -141,7 +145,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *  @tparam B      the element type of the returned $coll.
    *  @param  elem   the appended element
    *  @return a new $coll consisting of
-   *         all elements of this $coll followed by `value`.
+   *         all elements of this $coll followed by `elem`.
    */
   def appended[B >: A](elem: B): CC[B]^{this} = iterableFactory.from(new View.Appended(this, elem))
 
@@ -242,6 +246,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *  **Note**: If the both the receiver object `this` and the argument
    *  `that` are infinite sequences this method may not terminate.
    *
+   *  @tparam B the element type used for comparison (a supertype of `A`)
    *  @param  that    the sequence to test
    *  @param  offset  the index where the sequence is searched.
    *  @return `true` if the sequence `that` is contained in this $coll at
@@ -259,6 +264,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
 
   /** Tests whether this $coll ends with the given sequence.
    *  $willNotTerminateInf
+   *  @tparam B the element type used for comparison (a supertype of `A`)
    *  @param  that    the sequence to test
    *  @return `true` if this $coll has `that` as a suffix, `false` otherwise.
    */
@@ -395,6 +401,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *  $willNotTerminateInf
    *
    *  @param   p     the predicate used to test elements.
+   *  @param end the maximum index to consider (inclusive)
    *  @return  the index `<= end` of the last element of this $coll that satisfies the predicate `p`,
    *           or `-1`, if none exists.
    */
@@ -423,6 +430,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
 
   /** Finds first index after or at a start index where this $coll contains a given sequence as a slice.
    *  $mayNotTerminateInf
+   *  @tparam B the element type used for comparison (a supertype of `A`)
    *  @param  that    the sequence to test
    *  @param  from    the start index
    *  @return  the first index `>= from` such that the elements of this $coll starting at this index
@@ -468,6 +476,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *
    *  $willNotTerminateInf
    *
+   *  @tparam B the element type used for comparison (a supertype of `A`)
    *  @param  that    the sequence to test
    *  @param  end     the end index
    *  @return  the last index `<= end` such that the elements of this $coll starting at this index
@@ -514,6 +523,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
 
   /** Tests whether this $coll contains a given sequence as a slice.
    *  $mayNotTerminateInf
+   *  @tparam B the element type used for comparison (a supertype of `A`)
    *  @param  that    the sequence to test
    *  @return  `true` if this $coll contains a slice with the same elements
    *           as `that`, otherwise `false`.
@@ -523,6 +533,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
   /** Tests whether this $coll contains a given value as an element.
    *  $mayNotTerminateInf
    *
+   *  @tparam A1 the type of the element to test (a supertype of `A`)
    *  @param elem  the element to test.
    *  @return     `true` if this $coll has an element that is equal (as
    *              determined by `==`) to `elem`, `false` otherwise.
@@ -573,6 +584,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *
    *  $willForceEvaluation
    *
+   *  @param n the number of elements in each combination
    *  @return   An Iterator which traverses the n-element combinations of this $coll.
    *  @example ```
    *    Seq('a', 'b', 'b', 'b', 'c').combinations(2).foreach(println)
@@ -716,6 +728,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *
    *  $willForceEvaluation
    *
+   *  @tparam B the element type used for ordering (a supertype of `A`)
    *  @param  ord the ordering to be used to compare elements.
    *  @return     a $coll consisting of the elements of this $coll
    *              sorted according to the ordering `ord`.
@@ -842,6 +855,8 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *  this.lengthIs >= len    // this.lengthCompare(len) >= 0
    *  this.lengthIs > len     // this.lengthCompare(len) > 0
    *  ```
+   *
+   *  @return an object providing `<`, `<=`, `==`, `!=`, `>=`, and `>` operations for comparing the length
    */
   @inline final def lengthIs: IterableOps.SizeCompareOps^{this} = new IterableOps.SizeCompareOps(caps.unsafe.unsafeAssumePure(this) /* see comment in SizeCompareOps*/)
 
@@ -887,6 +902,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
 
   /** Computes the multiset difference between this $coll and another sequence.
    *
+   *  @tparam B the element type used for comparison (a supertype of `A`)
    *  @param that   the sequence of elements to remove
    *  @return       a new $coll which contains all elements of this $coll
    *                except some of the occurrences of elements that also appear in `that`.
@@ -912,6 +928,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
 
   /** Computes the multiset intersection between this $coll and another sequence.
    *
+   *  @tparam B the element type used for comparison (a supertype of `A`)
    *  @param that   the sequence of elements to intersect with.
    *  @return       a new $coll which contains all elements of this $coll
    *                which also appear in `that`.
@@ -987,9 +1004,10 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *  @see [[scala.math.Ordering]]
    *  @see [[scala.collection.SeqOps]], method `sorted`
    *
+   *  @tparam B the element type used for searching and ordering (a supertype of `A`)
    *  @param elem the element to find.
-   *  @param ord  the ordering to be used to compare elements.
    *
+   *  @param ord  the ordering to be used to compare elements.
    *  @return a `Found` value containing the index corresponding to the element in the
    *         sequence, or the `InsertionPoint` where the element would be inserted if
    *         the element is not in the sequence.
@@ -1008,11 +1026,12 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *  @see [[scala.math.Ordering]]
    *  @see [[scala.collection.SeqOps]], method `sorted`
    *
+   *  @tparam B the element type used for searching and ordering (a supertype of `A`)
    *  @param elem the element to find.
    *  @param from the index where the search starts.
    *  @param to   the index following where the search ends.
-   *  @param ord  the ordering to be used to compare elements.
    *
+   *  @param ord  the ordering to be used to compare elements.
    *  @return a `Found` value containing the index corresponding to the element in the
    *         sequence, or the `InsertionPoint` where the element would be inserted if
    *         the element is not in the sequence.
@@ -1044,6 +1063,7 @@ object SeqOps {
  /** A KMP implementation, based on the undoubtedly reliable wikipedia entry.
   *  Note: I made this private to keep it from entering the API.  That can be reviewed.
   *
+  *  @tparam B the element type of the sequences being searched
   *  @param  S       Sequence that may contain target
   *  @param  m0      First index of S to consider
   *  @param  m1      Last index of S to consider (exclusive)
@@ -1131,9 +1151,11 @@ object SeqOps {
 
   /** Makes sure a target sequence has fast, correctly-ordered indexing for KMP.
    *
+   *  @tparam B the element type of the target sequence
    *  @param  W    The target sequence
    *  @param  n0   The first element in the target sequence that we should use
    *  @param  n1   The far end of the target sequence that we should use (exclusive)
+   *  @param forward `true` to index in forward order, `false` to index in reverse order
    *  @return Target packed in an IndexedSeq (taken from iterator unless W already is an IndexedSeq)
    */
   private def kmpOptimizeWord[B](W: scala.collection.Seq[B], n0: Int, n1: Int, forward: Boolean): IndexedSeqView[B] = W match {
@@ -1169,6 +1191,7 @@ object SeqOps {
 
  /** Makes a jump table for KMP search.
   *
+  *  @tparam B the element type of the target sequence
   *  @param  Wopt The target sequence
   *  @param  wlen Just in case we're only IndexedSeq and not IndexedSeqOptimized
   *  @return KMP jump table for target sequence
@@ -1197,5 +1220,8 @@ object SeqOps {
   }
 }
 
-/** Explicit instantiation of the `Seq` trait to reduce class file size in subclasses. */
+/** Explicit instantiation of the `Seq` trait to reduce class file size in subclasses.
+ *
+ *  @tparam A the element type of the collection
+ */
 abstract class AbstractSeq[+A] extends AbstractIterable[A] with Seq[A]

--- a/library/src/scala/collection/Set.scala
+++ b/library/src/scala/collection/Set.scala
@@ -21,7 +21,10 @@ import java.lang.String
 
 import scala.annotation.nowarn
 
-/** Base trait for set collections. */
+/** Base trait for set collections.
+ *
+ *  @tparam A the element type of the set
+ */
 trait Set[A]
   extends Iterable[A]
     with SetOps[A, Set, Set[A]]
@@ -86,6 +89,9 @@ trait Set[A]
  *
  *  @define coll set
  *  @define Coll `Set`
+ *
+ *  @tparam A the element type of the set
+ *  @tparam CC the type constructor for the set's collection type
  */
 transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   extends IterableOps[A, CC, C]
@@ -149,6 +155,9 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
    *  ListSet(1,2,3).subsets => {{1},{2},{3},{1,2},{1,3},{2,3},{1,2,3}}
    *
    *  $willForceEvaluation
+   *
+   *  @param elms the elements of the set as an indexed sequence
+   *  @param len the size of each subset to generate
    */
   private class SubsetsItr(elms: IndexedSeq[A], len: Int) extends AbstractIterator[C] {
     private val idxs = Array.range(0, len+1)
@@ -186,7 +195,10 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
    */
   def intersect(that: Set[A]): C = this.filter(that)
 
-  /** Alias for `intersect`. */
+  /** Alias for `intersect`.
+   *
+   *  @param that the set to intersect with
+   */
   @`inline` final def & (that: Set[A]): C = intersect(that)
 
   /** Computes the difference of this set and another set.
@@ -197,7 +209,10 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
    */
   def diff(that: Set[A]): C
 
-  /** Alias for `diff`. */
+  /** Alias for `diff`.
+   *
+   *  @param that the set of elements to exclude
+   */
   @`inline` final def &~ (that: Set[A]): C = this diff that
 
   @deprecated("Consider requiring an immutable Set", "2.13.0")
@@ -242,7 +257,10 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
   def + (elem1: A, elem2: A, elems: A*): C = fromSpecific(new View.Concat(new View.Appended(new View.Appended(this, elem1), elem2), elems))
 
-  /** Alias for `concat`. */
+  /** Alias for `concat`.
+   *
+   *  @param that the collection containing the elements to add
+   */
   @`inline` final def ++ (that: collection.IterableOnce[A]^): C = concat(that)
 
   /** Computes the union between of set and another set.
@@ -253,7 +271,10 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
    */
   @`inline` final def union(that: Set[A]): C = concat(that)
 
-  /** Alias for `union`. */
+  /** Alias for `union`.
+   *
+   *  @param that the set to form the union with
+   */
   @`inline` final def | (that: Set[A]): C = concat(that)
 }
 
@@ -264,5 +285,8 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
 @SerialVersionUID(3L)
 object Set extends IterableFactory.Delegate[Set](immutable.Set)
 
-/** Explicit instantiation of the `Set` trait to reduce class file size in subclasses. */
+/** Explicit instantiation of the `Set` trait to reduce class file size in subclasses.
+ *
+ *  @tparam A the element type of the set
+ */
 abstract class AbstractSet[A] extends AbstractIterable[A] with Set[A]

--- a/library/src/scala/collection/SortedOps.scala
+++ b/library/src/scala/collection/SortedOps.scala
@@ -15,7 +15,11 @@ package scala.collection
 import scala.language.`2.13`
 import language.experimental.captureChecking
 
-/** Base trait for sorted collections. */
+/** Base trait for sorted collections.
+ *
+ *  @tparam A the element type of this sorted collection
+ *  @tparam C the type of the sorted collection itself
+ */
 transparent trait SortedOps[A, +C] {
 
   def ordering: Ordering[A]
@@ -42,6 +46,7 @@ transparent trait SortedOps[A, +C] {
    *               `None` if there is no lower bound.
    *  @param until The upper-bound (exclusive) of the ranged projection.
    *               `None` if there is no upper bound.
+   *  @return a ranged projection of this collection containing only elements within the specified range
    */
   def rangeImpl(from: Option[A], until: Option[A]): C
 

--- a/library/src/scala/collection/SortedSet.scala
+++ b/library/src/scala/collection/SortedSet.scala
@@ -18,7 +18,10 @@ import language.experimental.captureChecking
 import scala.annotation.{implicitNotFound, nowarn}
 import scala.annotation.unchecked.uncheckedVariance
 
-/** Base type of sorted sets. */
+/** Base type of sorted sets.
+ *
+ *  @tparam A the element type of the set
+ */
 trait SortedSet[A] extends Set[A]
     with SortedSetOps[A, SortedSet, SortedSet[A]]
     with SortedSetFactoryDefaults[A, SortedSet, Set] {
@@ -57,6 +60,8 @@ transparent trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, 
    *  @note When implementing a custom collection type and refining `CC` to the new type, this
    *       method needs to be overridden to return a factory for the new type (the compiler will
    *       issue an error otherwise).
+   *
+   *  @return a factory for creating new sorted collections of the same type
    */
   def sortedIterableFactory: SortedIterableFactory[CC]
 
@@ -169,6 +174,9 @@ object SortedSetOps {
   /** Specialize `WithFilter` for sorted collections
    *
    *  @define coll sorted collection
+   *
+   *  @tparam A the element type of the sorted collection
+   *  @tparam IterableCC the type constructor for the unsorted collection type
    */
   class WithFilter[+A, +IterableCC[_], +CC[X] <: SortedSet[X]](
     self: SortedSetOps[A, CC, ?] & IterableOps[A, IterableCC, ?],

--- a/library/src/scala/collection/Stepper.scala
+++ b/library/src/scala/collection/Stepper.scala
@@ -53,6 +53,8 @@ trait Stepper[@specialized(Double, Int, Long) +A] {
    *  May return `null`, in which case the current Stepper yields the same elements as before.
    *
    *  See method `trySplit` in [[java.util.Spliterator]].
+   *
+   *  @return a new `Stepper` containing a portion of the elements, or `null` if this stepper cannot be split
    */
   def trySplit(): Stepper[A]^{this} | Null
 
@@ -71,6 +73,9 @@ trait Stepper[@specialized(Double, Int, Long) +A] {
    *  Note that the return type is `Spliterator[_]` instead of `Spliterator[A]` to allow returning
    *  a [[java.util.Spliterator.OfInt]] (which is a `Spliterator[Integer]`) in the subclass [[IntStepper]]
    *  (which is a `Stepper[Int]`).
+   *
+   *  @tparam B a supertype of the element type `A`
+   *  @return a `Spliterator` over the remaining elements of this stepper
    */
   def spliterator[B >: A]: Spliterator[?]^{this}
 
@@ -79,6 +84,9 @@ trait Stepper[@specialized(Double, Int, Long) +A] {
    *  Note that the return type is `Iterator[_]` instead of `Iterator[A]` to allow returning
    *  a [[java.util.PrimitiveIterator.OfInt]] (which is a `Iterator[Integer]`) in the subclass
    *  [[IntStepper]] (which is a `Stepper[Int]`).
+   *
+   *  @tparam B a supertype of the element type `A`
+   *  @return a Java `Iterator` over the remaining elements of this stepper
    */
   def javaIterator[B >: A]: JIterator[?]^{this}
 
@@ -184,7 +192,10 @@ object Stepper {
   }
 }
 
-/** A `Stepper` for arbitrary element types. See [[Stepper]]. */
+/** A `Stepper` for arbitrary element types. See [[Stepper]].
+ *
+ *  @tparam A the element type of the stepper
+ */
 trait AnyStepper[+A] extends Stepper[A] {
   def trySplit(): AnyStepper[A]^{this} | Null
 

--- a/library/src/scala/collection/StepperShape.scala
+++ b/library/src/scala/collection/StepperShape.scala
@@ -21,6 +21,9 @@ import scala.collection.Stepper.EfficientSplit
 
 /** An implicit StepperShape instance is used in the [[IterableOnce.stepper]] to return a possibly
  *  specialized Stepper `S` according to the element type `T`.
+ *
+ *  @tparam T the element type of the collection (may be a primitive or reference type)
+ *  @tparam S the type of `Stepper` to use, possibly specialized for primitive types
  */
 sealed trait StepperShape[-T, S <: Stepper[?]] { self =>
   /** Returns the Int constant (as defined in the `StepperShape` companion object) for this `StepperShape`. */
@@ -28,11 +31,15 @@ sealed trait StepperShape[-T, S <: Stepper[?]] { self =>
 
   /** Creates an unboxing primitive sequential Stepper from a boxed `AnyStepper`.
    *  This is an identity operation for reference shapes. 
+   *
+   *  @param st the boxed `AnyStepper` to convert into a possibly specialized stepper
    */
   def seqUnbox(st: AnyStepper[T]^): S^{st}
 
   /** Creates an unboxing primitive parallel (i.e. `with EfficientSplit`) Stepper from a boxed `AnyStepper`.
    *  This is an identity operation for reference shapes. 
+   *
+   *  @param st the boxed `AnyStepper` with `EfficientSplit` capability to convert into a possibly specialized stepper
    */
   def parUnbox(st: (AnyStepper[T] & EfficientSplit)^): (S & EfficientSplit)^{st}
 }

--- a/library/src/scala/collection/StrictOptimizedIterableOps.scala
+++ b/library/src/scala/collection/StrictOptimizedIterableOps.scala
@@ -254,6 +254,8 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
 
   /** A collection containing the last `n` elements of this collection.
    *  $willForceEvaluation
+   *
+   *  @param n the number of elements to take from the end of this collection
    */
   override def takeRight(n: Int): C = {
     val b = newSpecificBuilder
@@ -271,6 +273,8 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
   /** The rest of the collection without its `n` last elements. For
    *  linear, immutable collections this should avoid making a copy.
    *  $willForceEvaluation
+   *
+   *  @param n the number of elements to drop from the end of this collection
    */
   override def dropRight(n: Int): C = {
     val b = newSpecificBuilder

--- a/library/src/scala/collection/StrictOptimizedSeqOps.scala
+++ b/library/src/scala/collection/StrictOptimizedSeqOps.scala
@@ -17,6 +17,9 @@ import language.experimental.captureChecking
 
 /** Trait that overrides operations on sequences in order
  *  to take advantage of strict builders.
+ *
+ *  @tparam A the element type of the sequence
+ *  @tparam CC the type constructor of the collection
  */
 transparent trait StrictOptimizedSeqOps [+A, +CC[_] <: caps.Pure, +C]
   extends Any with SeqOps[A, CC, C] with StrictOptimizedIterableOps[A, CC, C] with caps.Pure {

--- a/library/src/scala/collection/StringOps.scala
+++ b/library/src/scala/collection/StringOps.scala
@@ -64,11 +64,18 @@ object StringOps {
     }
   }
 
-  /** A lazy filtered string. No filtering is applied until one of `foreach`, `map` or `flatMap` is called. */
+  /** A lazy filtered string. No filtering is applied until one of `foreach`, `map` or `flatMap` is called.
+   *
+   *  @param p the predicate used to filter characters
+   *  @param s the underlying string to filter
+   */
   class WithFilter(p: Char => Boolean, s: String) {
 
     /** Applies `f` to each element for its side effects.
      *  Note: [U] parameter needed to help scalac's type inference.
+     *
+     *  @tparam U the return type of the function `f`, used only for side effects
+     *  @param f the function to apply to each char
      */
     def foreach[U](f: Char => U): Unit = {
       val len = s.length
@@ -82,6 +89,7 @@ object StringOps {
 
     /** Builds a new collection by applying a function to all chars of this filtered string.
      *
+     *  @tparam B the element type of the returned collection
      *  @param f      the function to apply to each char.
      *  @return       a new collection resulting from applying the given function
      *                `f` to each char of this string and collecting the results.
@@ -120,6 +128,7 @@ object StringOps {
     /** Builds a new collection by applying a function to all chars of this filtered string
      *  and using the elements of the resulting collections.
      *
+     *  @tparam B the element type of the returned collection
      *  @param f      the function to apply to each char.
      *  @return       a new collection resulting from applying the given collection-valued function
      *                `f` to each char of this string and concatenating the results.
@@ -155,7 +164,10 @@ object StringOps {
       sb.toString
     }
 
-    /** Creates a new non-strict filter which combines this filter with the given predicate. */
+    /** Creates a new non-strict filter which combines this filter with the given predicate.
+     *
+     *  @param q the additional predicate to apply to each char
+     */
     def withFilter(q: Char => Boolean): WithFilter^{this, q} = new WithFilter(a => p(a) && q(a), s)
   }
 
@@ -177,6 +189,8 @@ object StringOps {
  *                        The user is responsible for making sure such cases
  *                        are handled correctly. Failing to do so may result in
  *                        an invalid Unicode string.
+ *
+ *  @param s the underlying string being wrapped
  */
 final class StringOps(private val s: String) extends AnyVal { self =>
   import StringOps._
@@ -187,7 +201,10 @@ final class StringOps(private val s: String) extends AnyVal { self =>
 
   @inline def knownSize: Int = s.length
 
-  /** Gets the char at the specified index. */
+  /** Gets the char at the specified index.
+   *
+   *  @param i the zero-based index of the char to retrieve
+   */
   @inline def apply(i: Int): Char = s.charAt(i)
 
   def sizeCompare(otherSize: Int): Int = Integer.compare(s.length, otherSize)
@@ -200,6 +217,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
 
   /** Builds a new collection by applying a function to all chars of this string.
    *
+   *  @tparam B the element type of the returned collection
    *  @param f      the function to apply to each char.
    *  @return       a new collection resulting from applying the given function
    *                `f` to each char of this string and collecting the results.
@@ -235,6 +253,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   /** Builds a new collection by applying a function to all chars of this string
    *  and using the elements of the resulting collections.
    *
+   *  @tparam B the element type of the returned collection
    *  @param f      the function to apply to each char.
    *  @return       a new collection resulting from applying the given collection-valued function
    *                `f` to each char of this string and concatenating the results.
@@ -310,6 +329,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   /** Returns a new collection containing the chars from this string followed by the elements from the
    *  right hand operand.
    *
+   *  @tparam B the element type of the returned collection, a supertype of `Char`
    *  @param suffix the collection to append.
    *  @return       a new collection which contains all chars
    *                of this string followed by all elements of `suffix`.
@@ -347,17 +367,28 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    */
   @inline def concat(suffix: String): String = s + suffix
 
-  /** Alias for `concat`. */
+  /** Alias for `concat`.
+   *
+   *  @tparam B the element type of the returned collection, a supertype of `Char`
+   *  @param suffix the collection to append
+   */
   @inline def ++[B >: Char](suffix: Iterable[B]^): immutable.IndexedSeq[B] = concat(suffix)
 
-  /** Alias for `concat`. */
+  /** Alias for `concat`.
+   *
+   *  @param suffix the collection of chars to append
+   */
   @inline def ++(suffix: IterableOnce[Char]^): String = concat(suffix)
 
-  /** Alias for `concat`. */
+  /** Alias for `concat`.
+   *
+   *  @param xs the string to append
+   */
   def ++(xs: String): String = concat(xs)
 
   /** Returns a collection with an element appended until a given target length is reached.
    *
+   *  @tparam B the element type of the returned collection, a supertype of `Char`
    *  @param  len   the target length
    *  @param  elem  the padding value
    *  @return a collection consisting of
@@ -397,7 +428,11 @@ final class StringOps(private val s: String) extends AnyVal { self =>
     }
   }
 
-  /** A copy of the string with an element prepended. */
+  /** A copy of the string with an element prepended.
+   *
+   *  @tparam B the element type of the returned collection, a supertype of `Char`
+   *  @param elem the element to prepend
+   */
   def prepended[B >: Char](elem: B): immutable.IndexedSeq[B] = {
     val b = immutable.IndexedSeq.newBuilder[B]
     b.sizeHint(s.length + 1)
@@ -409,14 +444,21 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   /** Alias for `prepended`. */
   @inline def +: [B >: Char] (elem: B): immutable.IndexedSeq[B] = prepended(elem)
 
-  /** A copy of the string with an char prepended. */
+  /** A copy of the string with an char prepended.
+   *
+   *  @param c the char to prepend
+   */
   def prepended(c: Char): String =
     new JStringBuilder(s.length + 1).append(c).append(s).toString
 
   /** Alias for `prepended`. */
   @inline def +: (c: Char): String = prepended(c)
 
-  /** A copy of the string with all elements from a collection prepended. */
+  /** A copy of the string with all elements from a collection prepended.
+   *
+   *  @tparam B the element type of the returned collection, a supertype of `Char`
+   *  @param prefix the collection to prepend
+   */
   def prependedAll[B >: Char](prefix: IterableOnce[B]^): immutable.IndexedSeq[B] = {
     val b = immutable.IndexedSeq.newBuilder[B]
     val k = prefix.knownSize
@@ -429,13 +471,20 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   /** Alias for `prependedAll`. */
   @inline def ++: [B >: Char] (prefix: IterableOnce[B]^): immutable.IndexedSeq[B] = prependedAll(prefix)
 
-  /** A copy of the string with another string prepended. */
+  /** A copy of the string with another string prepended.
+   *
+   *  @param prefix the string to prepend
+   */
   def prependedAll(prefix: String): String = prefix + s
 
   /** Alias for `prependedAll`. */
   @inline def ++: (prefix: String): String = prependedAll(prefix)
 
-  /** A copy of the string with an element appended. */
+  /** A copy of the string with an element appended.
+   *
+   *  @tparam B the element type of the returned collection, a supertype of `Char`
+   *  @param elem the element to append
+   */
   def appended[B >: Char](elem: B): immutable.IndexedSeq[B] = {
     val b = immutable.IndexedSeq.newBuilder[B]
     b.sizeHint(s.length + 1)
@@ -447,14 +496,21 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   /** Alias for `appended`. */
   @inline def :+ [B >: Char](elem: B): immutable.IndexedSeq[B] = appended(elem)
 
-  /** A copy of the string with an element appended. */
+  /** A copy of the string with an element appended.
+   *
+   *  @param c the char to append
+   */
   def appended(c: Char): String =
     new JStringBuilder(s.length + 1).append(s).append(c).toString
 
   /** Alias for `appended`. */
   @inline def :+ (c: Char): String = appended(c)
 
-  /** A copy of the string with all elements from a collection appended. */
+  /** A copy of the string with all elements from a collection appended.
+   *
+   *  @tparam B the element type of the returned collection, a supertype of `Char`
+   *  @param suffix the collection to append
+   */
   @inline def appendedAll[B >: Char](suffix: IterableOnce[B]^): immutable.IndexedSeq[B] =
     concat(suffix)
 
@@ -462,7 +518,10 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   @inline def :++ [B >: Char](suffix: IterableOnce[B]^): immutable.IndexedSeq[B] =
     concat(suffix)
 
-  /** A copy of the string with another string appended. */
+  /** A copy of the string with another string appended.
+   *
+   *  @param suffix the string to append
+   */
   @inline def appendedAll(suffix: String): String = s + suffix
 
   /** Alias for `appendedAll`. */
@@ -474,6 +533,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *  Patching at indices at or larger than the length of the original string appends the patch to the end.
    *  If more values are replaced than actually exist, the excess is ignored.
    *
+   *  @tparam B the element type of the returned collection, a supertype of `Char`
    *  @param  from     the index of the first replaced char
    *  @param  other    the replacement collection
    *  @param  replaced the number of chars to drop in the original string
@@ -588,14 +648,27 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   /** Returns this string. */
   @inline final def mkString: String = s
 
-  /** Appends this string to a string builder. */
+  /** Appends this string to a string builder.
+   *
+   *  @param b the string builder to append to
+   */
   @inline final def addString(b: StringBuilder): b.type = b.append(s)
 
-  /** Appends this string to a string builder using a separator string. */
+  /** Appends this string to a string builder using a separator string.
+   *
+   *  @param b the string builder to append to
+   *  @param sep the separator string inserted between chars
+   */
   @inline final def addString(b: StringBuilder, sep: String): b.type =
     addString(b, "", sep, "")
 
-  /** Appends this string to a string builder using start, end and separator strings. */
+  /** Appends this string to a string builder using start, end and separator strings.
+   *
+   *  @param b the string builder to append to
+   *  @param start the string to prepend before all chars
+   *  @param sep the separator string inserted between chars
+   *  @param end the string to append after all chars
+   */
   final def addString(b: StringBuilder, start: String, sep: String, end: String): b.type = {
     val jsb = b.underlying
     if (start.length != 0) jsb.append(start)
@@ -638,7 +711,10 @@ final class StringOps(private val s: String) extends AnyVal { self =>
     else s.substring(start, end)
   }
 
-  /** Returns the current string concatenated `n` times. */
+  /** Returns the current string concatenated `n` times.
+   *
+   *  @param n the number of times to repeat this string
+   */
   def *(n: Int): String =
     if (n <= 0) {
       ""
@@ -668,6 +744,8 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *  including trailing line separator characters.
    *
    *  The empty string yields an empty iterator.
+   *
+   *  @return an iterator over the lines in this string, including line separator characters
    */
   def linesWithSeparators: Iterator[String] = linesSeparated(stripped = false)
 
@@ -716,6 +794,8 @@ final class StringOps(private val s: String) extends AnyVal { self =>
 
   /** Returns this string with the given `prefix` stripped. If this string does not
    *  start with `prefix`, it is returned unchanged.
+   *
+   *  @param prefix the prefix to strip from this string
    */
   def stripPrefix(prefix: String): String =
     if (s.startsWith(prefix)) s.substring(prefix.length)
@@ -723,6 +803,8 @@ final class StringOps(private val s: String) extends AnyVal { self =>
 
   /** Returns this string with the given `suffix` stripped. If this string does not
    *  end with `suffix`, it is returned unchanged.
+   *
+   *  @param suffix the suffix to strip from this string
    */
   def stripSuffix(suffix: String): String =
     if (s.endsWith(suffix)) s.substring(0, s.length - suffix.length)
@@ -742,6 +824,9 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *
    *  Strip a leading prefix consisting of blanks or control characters
    *  followed by `marginChar` from the line.
+   *
+   *  @param marginChar the character used as a margin delimiter
+   *  @return the string with leading margin characters and preceding whitespace removed from each line
    */
   def stripMargin(marginChar: Char): String = {
     val sb = new JStringBuilder(s.length)
@@ -761,6 +846,8 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *
    *  Strip a leading prefix consisting of blanks or control characters
    *  followed by `|` from the line.
+   *
+   *  @return the string with leading `|` margin characters and preceding whitespace removed from each line
    */
   def stripMargin: String = stripMargin('|')
 
@@ -818,6 +905,8 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *  ```
    *
    *  @param separator the character used as a delimiter
+   *
+   *  @return an array of strings computed by splitting this string around occurrences of the separator character
    */
   def split(separator: Char): Array[String] = s.split(escape(separator))
 
@@ -834,6 +923,8 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *  `"""(?<month>\d\d)-(?<day>\d\d)-(?<year>\d\d\d\d)""".r` matches dates
    *  and provides its subcomponents through groups named "month", "day" and
    *  "year".
+   *
+   *  @return a `Regex` with this string as the pattern
    */
   def r: Regex = new Regex(s)
 
@@ -958,6 +1049,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *  checks the format string at compilation.
    *
    *  @param args the arguments used to instantiating the pattern.
+   *  @return the string with format placeholders replaced by the formatted arguments
    *  @throws java.util.IllegalFormatException if the format contains syntax or conversion errors
    */
   def format(args: Any*): String =
@@ -974,6 +1066,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *
    *  @param l    an instance of `java.util.Locale`
    *  @param args the arguments used to instantiating the pattern.
+   *  @return the string with format placeholders replaced by the formatted arguments using the given locale
    *  @throws java.util.IllegalFormatException if the format contains syntax or conversion errors
    */
   def formatLocal(l: java.util.Locale, args: Any*): String =
@@ -981,10 +1074,16 @@ final class StringOps(private val s: String) extends AnyVal { self =>
 
   def compare(that: String): Int = s.compareTo(that)
 
-  /** Returns true if `this` is less than `that`. */
+  /** Returns true if `this` is less than `that`.
+   *
+   *  @param that the string to compare against
+   */
   def < (that: String): Boolean = compare(that) <  0
 
-  /** Returns true if `this` is greater than `that`. */
+  /** Returns true if `this` is greater than `that`.
+   *
+   *  @param that the string to compare against
+   */
   def > (that: String): Boolean = compare(that) >  0
 
   /** Returns true if `this` is less than or equal to `that`. */
@@ -993,7 +1092,10 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   /** Returns true if `this` is greater than or equal to `that`. */
   def >= (that: String): Boolean = compare(that) >= 0
 
-  /** Counts the number of chars in this string which satisfy a predicate. */
+  /** Counts the number of chars in this string which satisfy a predicate.
+   *
+   *  @param p the predicate used to test chars
+   */
   def count(p: (Char) => Boolean): Int = {
     var i, res = 0
     val len = s.length
@@ -1006,6 +1108,9 @@ final class StringOps(private val s: String) extends AnyVal { self =>
 
   /** Applies `f` to each element for its side effects.
    *  Note: [U] parameter needed to help scalac's type inference.
+   *
+   *  @tparam U the return type of the function `f`, used only for side effects
+   *  @param f the function to apply to each char
    */
   def foreach[U](f: Char => U): Unit = {
     val len = s.length
@@ -1186,21 +1291,29 @@ final class StringOps(private val s: String) extends AnyVal { self =>
 
   /** A string containing the first `n` chars of this string.
    *  @note $unicodeunaware
+   *
+   *  @param n the number of chars to take from the beginning of this string
    */
   def take(n: Int): String = slice(0, min(n, s.length))
 
   /** The rest of the string without its `n` first chars.
    *  @note $unicodeunaware
+   *
+   *  @param n the number of chars to drop from the beginning of this string
    */
   def drop(n: Int): String = slice(min(n, s.length), s.length)
 
   /** A string containing the last `n` chars of this string.
    *  @note $unicodeunaware
+   *
+   *  @param n the number of chars to take from the end of this string
    */
   def takeRight(n: Int): String = drop(s.length - max(n, 0))
 
   /** The rest of the string without its `n` last chars.
    *  @note $unicodeunaware
+   *
+   *  @param n the number of chars to drop from the end of this string
    */
   def dropRight(n: Int): String = take(s.length - max(n, 0))
 
@@ -1226,7 +1339,10 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   private def iterateUntilEmpty(f: String => String): Iterator[String]^{f} =
     Iterator.iterate(s)(f).takeWhile(x => !x.isEmpty) ++ Iterator.single("")
 
-  /** Selects all chars of this string which satisfy a predicate. */
+  /** Selects all chars of this string which satisfy a predicate.
+   *
+   *  @param pred the predicate used to test chars
+   */
   def filter(pred: Char => Boolean): String = {
     val len = s.length
     val sb = new JStringBuilder(len)
@@ -1239,7 +1355,10 @@ final class StringOps(private val s: String) extends AnyVal { self =>
     if(len == sb.length()) s else sb.toString
   }
 
-  /** Selects all chars of this string which do not satisfy a predicate. */
+  /** Selects all chars of this string which do not satisfy a predicate.
+   *
+   *  @param pred the predicate used to test chars
+   */
   @inline def filterNot(pred: Char => Boolean): String = filter(c => !pred(c))
 
   /** Copies chars of this string to an array.
@@ -1314,7 +1433,10 @@ final class StringOps(private val s: String) extends AnyVal { self =>
     -1
   }
 
-  /** Tests whether a predicate holds for at least one char of this string. */
+  /** Tests whether a predicate holds for at least one char of this string.
+   *
+   *  @param p the predicate used to test chars
+   */
   def exists(p: Char => Boolean): Boolean = indexWhere(p) != -1
 
   /** Finds the first char of the string satisfying a predicate, if any.
@@ -1339,7 +1461,10 @@ final class StringOps(private val s: String) extends AnyVal { self =>
     case i => s.substring(i)
   }
 
-  /** Takes longest prefix of chars that satisfy a predicate. */
+  /** Takes longest prefix of chars that satisfy a predicate.
+   *
+   *  @param p the predicate used to test chars
+   */
   def takeWhile(p: Char => Boolean): String = indexWhere(c => !p(c)) match {
     case -1 => s
     case i => s.substring(0, i)
@@ -1380,7 +1505,10 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    */
   def grouped(size: Int): Iterator[String] = new StringOps.GroupedIterator(s, size)
 
-  /** A pair of, first, all chars that satisfy predicate `p` and, second, all chars that do not. */
+  /** A pair of, first, all chars that satisfy predicate `p` and, second, all chars that do not.
+   *
+   *  @param p the predicate used to partition chars
+   */
   def partition(p: Char => Boolean): (String, String) = {
     val res1, res2 = new JStringBuilder
     var i = 0
@@ -1453,6 +1581,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
 
   /** Computes the multiset difference between this string and another sequence.
    *
+   *  @tparam B the element type of the other sequence, a supertype of `Char`
    *  @param that   the sequence of chars to remove
    *  @return       a new string which contains all chars of this string
    *                except some of occurrences of elements that also appear in `that`.
@@ -1465,6 +1594,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
 
   /** Computes the multiset intersection between this string and another sequence.
    *
+   *  @tparam B the element type of the other sequence, a supertype of `Char`
    *  @param that   the sequence of chars to intersect with.
    *  @return       a new string which contains all chars of this string
    *                which also appear in `that`.
@@ -1498,6 +1628,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *
    *  @see [[scala.math.Ordering]]
    *
+   *  @tparam B the type over which the ordering is defined, a supertype of `Char`
    *  @param  ord the ordering to be used to compare elements.
    *  @return     a string consisting of the chars of this string
    *              sorted according to the ordering `ord`.
@@ -1588,6 +1719,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *  of the original sequence, but the order in which elements were selected, by "first index";
    *  the order of each `x` element is also arbitrary.
    *
+   *  @param n the number of elements per combination
    *  @return   An Iterator which traverses the n-element combinations of this string.
    *  @example ```
    *    "abbbc".combinations(2).foreach(println)

--- a/library/src/scala/collection/View.scala
+++ b/library/src/scala/collection/View.scala
@@ -26,6 +26,8 @@ import caps.unsafe.unsafeAssumePure
  *  or when the view is converted to a strict collection type (using the `to` operation).
  *  @define coll view
  *  @define Coll `View`
+ *
+ *  @tparam A the element type of the view
  */
 trait View[+A] extends Iterable[A] with IterableOps[A, View, View[A]] with IterableFactoryDefaults[A, View] with Serializable {
 

--- a/library/src/scala/collection/convert/AsJavaConverters.scala
+++ b/library/src/scala/collection/convert/AsJavaConverters.scala
@@ -41,6 +41,7 @@ trait AsJavaConverters {
    *  If the Scala `Iterator` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `Iterator` will be returned.
    *
+   *  @tparam A the element type of the iterator
    *  @param i The Scala `Iterator` to be converted.
    *  @return  A Java `Iterator` view of the argument.
    */
@@ -58,6 +59,7 @@ trait AsJavaConverters {
    *  If the Scala `Iterator` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `Enumeration` will be returned.
    *
+   *  @tparam A the element type of the iterator
    *  @param i The Scala `Iterator` to be converted.
    *  @return  A Java `Enumeration` view of the argument.
    */
@@ -75,6 +77,7 @@ trait AsJavaConverters {
    *  If the Scala `Iterable` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `Iterable` will be returned.
    *
+   *  @tparam A the element type of the iterable
    *  @param i The Scala `Iterable` to be converted.
    *  @return  A Java `Iterable` view of the argument.
    */
@@ -89,6 +92,7 @@ trait AsJavaConverters {
    *  If the Scala `Iterable` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `Collection` will be returned.
    *
+   *  @tparam A the element type of the iterable
    *  @param i The Scala `Iterable` to be converted.
    *  @return  A Java `Collection` view of the argument.
    */
@@ -106,6 +110,7 @@ trait AsJavaConverters {
    *  If the Scala `Buffer` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `List` will be returned.
    *
+   *  @tparam A the element type of the buffer
    *  @param b The Scala `Buffer` to be converted.
    *  @return A Java `List` view of the argument.
    */
@@ -123,6 +128,7 @@ trait AsJavaConverters {
    *  If the Scala `Seq` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `List` will be returned.
    *
+   *  @tparam A the element type of the sequence
    *  @param s The Scala `Seq` to be converted.
    *  @return  A Java `List` view of the argument.
    */
@@ -140,6 +146,7 @@ trait AsJavaConverters {
    *  If the Scala `Seq` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `List` will be returned.
    *
+   *  @tparam A the element type of the sequence
    *  @param s The Scala `Seq` to be converted.
    *  @return  A Java `List` view of the argument.
    */
@@ -157,6 +164,7 @@ trait AsJavaConverters {
    *  If the Scala `Set` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `Set` will be returned.
    *
+   *  @tparam A the element type of the set
    *  @param s The Scala mutable `Set` to be converted.
    *  @return  A Java `Set` view of the argument.
    */
@@ -174,6 +182,7 @@ trait AsJavaConverters {
    *  If the Scala `Set` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `Set` will be returned.
    *
+   *  @tparam A the element type of the set
    *  @param s The Scala `Set` to be converted.
    *  @return  A Java `Set` view of the argument.
    */
@@ -191,6 +200,8 @@ trait AsJavaConverters {
    *  If the Scala `Map` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `Map` will be returned.
    *
+   *  @tparam K the key type of the map
+   *  @tparam V the value type of the map
    *  @param m The Scala mutable `Map` to be converted.
    *  @return  A Java `Map` view of the argument.
    */
@@ -209,7 +220,9 @@ trait AsJavaConverters {
    *  If the Scala `Map` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `Dictionary` will be returned.
    *
-   *  @param m The Scala `Map` to be converted.
+   *  @tparam K the key type of the map
+   *  @tparam V the value type of the map
+   *  @param m The Scala mutable `Map` to be converted.
    *  @return  A Java `Dictionary` view of the argument.
    */
   def asJavaDictionary[K, V](m: mutable.Map[K, V]): ju.Dictionary[K, V] = (m: mutable.Map[K, V] | Null) match {
@@ -226,6 +239,8 @@ trait AsJavaConverters {
    *  If the Scala `Map` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `Map` will be returned.
    *
+   *  @tparam K the key type of the map
+   *  @tparam V the value type of the map
    *  @param m The Scala `Map` to be converted.
    *  @return  A Java `Map` view of the argument.
    */
@@ -244,6 +259,8 @@ trait AsJavaConverters {
    *  If the Scala `concurrent.Map` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `ConcurrentMap` will be returned.
    *
+   *  @tparam K the key type of the map
+   *  @tparam V the value type of the map
    *  @param m The Scala `concurrent.Map` to be converted.
    *  @return  A Java `ConcurrentMap` view of the argument.
    */

--- a/library/src/scala/collection/convert/AsScalaConverters.scala
+++ b/library/src/scala/collection/convert/AsScalaConverters.scala
@@ -42,6 +42,7 @@ trait AsScalaConverters {
    *  If the Java `Iterator` was previously obtained from an implicit or explicit call of
    *  `asJava` then the original Scala `Iterator` will be returned.
    *
+   *  @tparam A the element type of the iterator
    *  @param i The Java `Iterator` to be converted.
    *  @return  A Scala `Iterator` view of the argument.
    */
@@ -59,6 +60,7 @@ trait AsScalaConverters {
    *  If the Java `Enumeration` was previously obtained from an implicit or explicit call of
    *  `asJavaEnumeration` then the original Scala `Iterator` will be returned.
    *
+   *  @tparam A the element type of the enumeration
    *  @param e The Java `Enumeration` to be converted.
    *  @return  A Scala `Iterator` view of the argument.
    */
@@ -76,6 +78,7 @@ trait AsScalaConverters {
    *  If the Java `Iterable` was previously obtained from an implicit or explicit call of
    *  `asJava` then the original Scala `Iterable` will be returned.
    *
+   *  @tparam A the element type of the iterable
    *  @param i The Java `Iterable` to be converted.
    *  @return  A Scala `Iterable` view of the argument.
    */
@@ -90,6 +93,7 @@ trait AsScalaConverters {
    *  If the Java `Collection` was previously obtained from an implicit or explicit call of
    *  `asJavaCollection` then the original Scala `Iterable` will be returned.
    *
+   *  @tparam A the element type of the collection
    *  @param c The Java `Collection` to be converted.
    *  @return  A Scala `Iterable` view of the argument.
    */
@@ -107,6 +111,7 @@ trait AsScalaConverters {
    *  If the Java `List` was previously obtained from an implicit or explicit call of
    *  `asJava` then the original Scala `Buffer` will be returned.
    *
+   *  @tparam A the element type of the list
    *  @param l The Java `List` to be converted.
    *  @return A Scala mutable `Buffer` view of the argument.
    */
@@ -124,6 +129,7 @@ trait AsScalaConverters {
    *  If the Java `Set` was previously obtained from an implicit or explicit call of
    *  `asJava` then the original Scala `Set` will be returned.
    *
+   *  @tparam A the element type of the set
    *  @param s The Java `Set` to be converted.
    *  @return  A Scala mutable `Set` view of the argument.
    */
@@ -146,6 +152,8 @@ trait AsScalaConverters {
    *  This includes `get`, as `java.util.Map`'s API does not allow for an atomic `get` when `null`
    *  values may be present.
    *
+   *  @tparam K the type of keys in the map
+   *  @tparam V the type of values in the map
    *  @param m The Java `Map` to be converted.
    *  @return  A Scala mutable `Map` view of the argument.
    */
@@ -164,6 +172,8 @@ trait AsScalaConverters {
    *  If the Java `ConcurrentMap` was previously obtained from an implicit or explicit call of
    *  `asJava` then the original Scala `ConcurrentMap` will be returned.
    *
+   *  @tparam K the type of keys in the map
+   *  @tparam V the type of values in the map
    *  @param m The Java `ConcurrentMap` to be converted.
    *  @return  A Scala mutable `ConcurrentMap` view of the argument.
    */
@@ -181,6 +191,8 @@ trait AsScalaConverters {
    *  If the Java `Dictionary` was previously obtained from an implicit or explicit call of
    *  `asJavaDictionary` then the original Scala `Map` will be returned.
    *
+   *  @tparam K the type of keys in the dictionary
+   *  @tparam V the type of values in the dictionary
    *  @param d The Java `Dictionary` to be converted.
    *  @return  A Scala mutable `Map` view of the argument.
    */

--- a/library/src/scala/collection/convert/StreamExtensions.scala
+++ b/library/src/scala/collection/convert/StreamExtensions.scala
@@ -37,6 +37,8 @@ trait StreamExtensions {
     /** Creates a sequential [[java.util.stream.Stream Java Stream]] for this collection. If the
      *  collection contains primitive values, a corresponding specialized Stream is returned (e.g.,
      *  [[java.util.stream.IntStream `IntStream`]]).
+     *
+     *  @tparam S the type of Java Stream to create, determined by the element type `A`
      */
     def asJavaSeqStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit s: StreamShape[A, S, St], st: StepperShape[A, St]): S =
       s.fromStepper(cc.stepper, par = false)
@@ -51,6 +53,8 @@ trait StreamExtensions {
     /** Creates a parallel [[java.util.stream.Stream Java Stream]] for this collection. If the
      *  collection contains primitive values, a corresponding specialized Stream is returned (e.g.,
      *  [[java.util.stream.IntStream `IntStream`]]).
+     *
+     *  @tparam S the type of Java Stream to create, determined by the element type `A`
      */
     def asJavaParStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit
         s: StreamShape[A, S, St],
@@ -66,6 +70,8 @@ trait StreamExtensions {
     /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the keys of this map. If
      *  the keys are primitive values, a corresponding specialized Stream is returned (e.g.,
      *  [[java.util.stream.IntStream `IntStream`]]).
+     *
+     *  @tparam S the type of Java Stream to create, determined by the key type `K`
      */
     def asJavaSeqKeyStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit s: StreamShape[K, S, St], st: StepperShape[K, St]): S =
       s.fromStepper(cc.keyStepper, par = false)
@@ -73,6 +79,8 @@ trait StreamExtensions {
     /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the values of this map. If
      *  the values are primitives, a corresponding specialized Stream is returned (e.g.,
      *  [[java.util.stream.IntStream `IntStream`]]).
+     *
+     *  @tparam S the type of Java Stream to create, determined by the value type `V`
      */
     def asJavaSeqValueStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit s: StreamShape[V, S, St], st: StepperShape[V, St]): S =
       s.fromStepper(cc.valueStepper, par = false)
@@ -80,6 +88,8 @@ trait StreamExtensions {
     // The asJavaSeqStream extension method for IterableOnce doesn't apply because its `CC` takes a single type parameter, whereas the one here takes two
     /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the `(key, value)` pairs of
      *  this map.
+     *
+     *  @tparam S the type of Java Stream to create, determined by the pair type `(K, V)`
      */
     def asJavaSeqStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit s: StreamShape[(K, V), S, St], st: StepperShape[(K, V), St]): S =
       s.fromStepper(cc.stepper, par = false)
@@ -94,6 +104,8 @@ trait StreamExtensions {
     /** Creates a parallel [[java.util.stream.Stream Java Stream]] for the keys of this map. If
      *  the keys are primitive values, a corresponding specialized Stream is returned (e.g.,
      *  [[java.util.stream.IntStream `IntStream`]]).
+     *
+     *  @tparam S the type of Java Stream to create, determined by the key type `K`
      */
     def asJavaParKeyStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit
         s: StreamShape[K, S, St],
@@ -105,6 +117,8 @@ trait StreamExtensions {
     /** Creates a parallel [[java.util.stream.Stream Java Stream]] for the values of this map. If
      *  the values are primitives, a corresponding specialized Stream is returned (e.g.,
      *  [[java.util.stream.IntStream `IntStream`]]).
+     *
+     *  @tparam S the type of Java Stream to create, determined by the value type `V`
      */
     def asJavaParValueStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit
         s: StreamShape[V, S, St],
@@ -116,6 +130,8 @@ trait StreamExtensions {
     // The asJavaParStream extension method for IterableOnce doesn't apply because its `CC` takes a single type parameter, whereas the one here takes two
     /** Creates a parallel [[java.util.stream.Stream Java Stream]] for the `(key, value)` pairs of
      *  this map.
+     *
+     *  @tparam S the type of Java Stream to create, determined by the pair type `(K, V)`
      */
     def asJavaParStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit
         s: StreamShape[(K, V), S, St],
@@ -131,6 +147,8 @@ trait StreamExtensions {
     /** Creates a sequential [[java.util.stream.Stream Java Stream]] for this stepper. If the
      *  stepper yields primitive values, a corresponding specialized Stream is returned (e.g.,
      *  [[java.util.stream.IntStream `IntStream`]]).
+     *
+     *  @tparam S the type of Java Stream to create, determined by the element type `A`
      */
     def asJavaSeqStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit s: StreamShape[A, S, St], st: StepperShape[A, St]): S = {
       val sStepper = stepper match {
@@ -145,6 +163,8 @@ trait StreamExtensions {
     /** Creates a parallel [[java.util.stream.Stream Java Stream]] for this stepper. If the
      *  stepper yields primitive values, a corresponding specialized Stream is returned (e.g.,
      *  [[java.util.stream.IntStream `IntStream`]]).
+     *
+     *  @tparam S the type of Java Stream to create, determined by the element type `A`
      */
     def asJavaParStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit s: StreamShape[A, S, St], st: StepperShape[A, St]): S = {
       val sStepper = (stepper: @unchecked) match {
@@ -260,6 +280,11 @@ trait StreamExtensions {
      *
      *  Sequential streams are directly converted to the target collection. If the target collection
      *  is lazy, the conversion is lazy as well.
+     *
+     *  @tparam C1 the type of the target Scala collection
+     *  @param factory the factory used to build the target collection
+     *  @param info implicit evidence connecting the element type to a specialized `Accumulator`, or a generic fallback (resolved automatically)
+     *  @return the elements of this stream collected into a Scala collection of type `C1`
      */
     def toScala[C1](factory: collection.Factory[A, C1])(implicit info: AccumulatorFactoryInfo[A, C1]): C1 = {
 
@@ -274,6 +299,9 @@ trait StreamExtensions {
 
     /** Converts a generic Java Stream wrapping a primitive type to a corresponding primitive
      *  Stream.
+     *
+     *  @tparam S the resulting primitive stream type (e.g., `IntStream`, `LongStream`, `DoubleStream`)
+     *  @param unboxer implicit conversion from boxed `Stream[A]` to primitive stream `S`
      */
     def asJavaPrimitiveStream[S](implicit unboxer: StreamUnboxer[A, S]): S = unboxer(stream)
   }
@@ -294,6 +322,11 @@ trait StreamExtensions {
      *
      *  Sequential streams are directly converted to the target collection. If the target collection
      *  is lazy, the conversion is lazy as well.
+     *
+     *  @tparam C1 the type of the target Scala collection
+     *  @param factory the factory used to build the target collection
+     *  @param info implicit evidence connecting `Int` to a specialized `IntAccumulator`, or a generic fallback
+     *  @return the elements of this stream collected into a Scala collection of type `C1`
      */
     def toScala[C1](factory: collection.Factory[Int, C1])(implicit info: AccumulatorFactoryInfo[Int, C1]): C1 = {
       def intAcc = stream.collect(IntAccumulator.supplier, IntAccumulator.adder, IntAccumulator.merger)
@@ -320,6 +353,11 @@ trait StreamExtensions {
      *
      *  Sequential streams are directly converted to the target collection. If the target collection
      *  is lazy, the conversion is lazy as well.
+     *
+     *  @tparam C1 the type of the target Scala collection
+     *  @param factory the factory used to build the target collection
+     *  @param info implicit evidence connecting `Long` to a specialized `LongAccumulator`, or a generic fallback
+     *  @return the elements of this stream collected into a Scala collection of type `C1`
      */
     def toScala[C1](factory: collection.Factory[Long, C1])(implicit info: AccumulatorFactoryInfo[Long, C1]): C1 = {
       def longAcc = stream.collect(LongAccumulator.supplier, LongAccumulator.adder, LongAccumulator.merger)
@@ -346,6 +384,11 @@ trait StreamExtensions {
      *
      *  Sequential streams are directly converted to the target collection. If the target collection
      *  is lazy, the conversion is lazy as well.
+     *
+     *  @tparam C1 the type of the target Scala collection
+     *  @param factory the factory used to build the target collection
+     *  @param info implicit evidence connecting `Double` to a specialized `DoubleAccumulator`, or a generic fallback
+     *  @return the elements of this stream collected into a Scala collection of type `C1`
      */
     def toScala[C1](factory: collection.Factory[Double, C1])(implicit info: AccumulatorFactoryInfo[Double, C1]): C1 = {
       def doubleAcc = stream.collect(DoubleAccumulator.supplier, DoubleAccumulator.adder, DoubleAccumulator.merger)
@@ -361,6 +404,10 @@ object StreamExtensions {
   /** An implicit StreamShape instance connects element types with the corresponding specialized
    *  Stream and Stepper types. This is used in `asJavaStream` extension methods to create
    *  generic or primitive streams according to the element type.
+   *
+   *  @tparam T the element type of the collection
+   *  @tparam S the type of Java Stream (e.g., `Stream[T]`, `IntStream`, `LongStream`, `DoubleStream`)
+   *  @tparam St the type of `Stepper` used to traverse elements
    */
   sealed trait StreamShape[T, S <: BaseStream[?, ?], St <: Stepper[?]] {
     final def fromStepper(st: St, par: Boolean): S = mkStream(st, par)
@@ -413,6 +460,9 @@ object StreamExtensions {
 
   /** Connects a stream element type `A` to the corresponding, potentially specialized, Stream type.
    *  Used in the `stream.asJavaPrimitiveStream` extension method.
+   *
+   *  @tparam A the boxed element type of the stream
+   *  @tparam S the target primitive stream type (e.g., `IntStream`, `LongStream`, `DoubleStream`)
    */
   sealed trait StreamUnboxer[A, S] {
     def apply(s: Stream[A]): S
@@ -442,6 +492,9 @@ object StreamExtensions {
    *
    *  When converting to a collection other than `Accumulator`, the generic
    *  `noAccumulatorFactoryInfo` is passed.
+   *
+   *  @tparam A the element type of the stream
+   *  @tparam C the target collection type, potentially a specialized `Accumulator`
    */
   trait AccumulatorFactoryInfo[A, C] {
     val companion: AnyRef | Null

--- a/library/src/scala/collection/convert/impl/BinaryTreeStepper.scala
+++ b/library/src/scala/collection/convert/impl/BinaryTreeStepper.scala
@@ -45,6 +45,11 @@ private[collection] object BinaryTreeStepper {
  *
  *  Subclasses should allow this class to do all the work of maintaining state; `next` should simply
  *  reduce `maxLength` by one, and consume `myCurrent` and set it to `null` if `hasNext` is true.
+ *
+ *  @tparam A the element type produced by this stepper
+ *  @tparam T the type of tree nodes being traversed, must be a reference type
+ *  @tparam Sub the public stepper type returned by `trySplit`
+ *  @tparam Semi the self type of the concrete stepper subclass, which must extend both `Sub` and `BinaryTreeStepperBase`
  */
 private[collection] abstract class BinaryTreeStepperBase[A, T <: AnyRef, Sub, Semi <: Sub & BinaryTreeStepperBase[A, T, ?, ?]](
   protected var maxLength: Int, protected var myCurrent: T | Null, protected var stack: Array[AnyRef | Null], protected var index: Int,
@@ -54,6 +59,8 @@ extends EfficientSplit {
   /** Unrolls a subtree onto the stack starting from a particular node, returning
    *  the last node found.  This final node is _not_ placed on the stack, and
    *  may have things to its right.
+   *
+   *  @param from the tree node from which to begin unrolling leftward
    */
   @tailrec protected final def unroll(from: T): T = {
     val l = left(from)
@@ -71,6 +78,8 @@ extends EfficientSplit {
    *  the subtree from the stack entirely (so it is ready to use).  It returns
    *  the node that is being detached. Note that the node must _not_ already be
    *  on the stack.
+   *
+   *  @param node the tree node to detach, whose left subtree has already been visited
    */
   protected final def detach(node: T): node.type = {
     val r = right(node)
@@ -88,6 +97,9 @@ extends EfficientSplit {
    *  tree is not already empty.
    *
    *  Right now overwrites everything so could allow reuse, but isn't used for it.
+   *
+   *  @param root the root node of the tree to traverse, or `null` for an empty tree
+   *  @param size the total number of elements in the tree
    */
   private[impl] final def initialize(root: T | Null, size: Int): Unit =
     if (root eq null) {
@@ -122,6 +134,8 @@ extends EfficientSplit {
    *  detaching the root, and leaving the right-hand side of the root unrolled.
    *
    *  If the tree is empty or only has one element left, it returns `null` instead of splitting.
+   *
+   *  @return a new stepper covering the left portion of the remaining elements, or `null` if the stepper cannot be split
    */
   def trySplit(): Sub | Null =
     if (!hasStep || index < 0) null

--- a/library/src/scala/collection/convert/impl/ChampStepper.scala
+++ b/library/src/scala/collection/convert/impl/ChampStepper.scala
@@ -21,6 +21,9 @@ import scala.collection.immutable.Node
 /** A stepper that is a slightly elaborated version of the ChampBaseIterator;
  *  the main difference is that it knows when it should stop instead of running
  *  to the end of all trees.
+ *
+ *  @tparam A the element type produced by this stepper
+ *  @tparam T the CHAMP trie node type, with recursive bound `T <: Node[T]`
  */
 private[collection] abstract class ChampStepperBase[
   A, T <: Node[T], Sub, Semi <: Sub & ChampStepperBase[A, T, ?, ?]

--- a/library/src/scala/collection/convert/impl/InOrderStepperBase.scala
+++ b/library/src/scala/collection/convert/impl/InOrderStepperBase.scala
@@ -22,6 +22,11 @@ import scala.collection.Stepper.EfficientSplit
  *  that has an indexable ordering but may have gaps.
  *
  *  For collections that are guaranteed to not have gaps, use `IndexedStepperBase` instead.
+ *
+ *  @tparam Sub the concrete stepper subtype, used as the self-type and return type of `trySplit`
+ *  @tparam Semi the concrete type of the split-off stepper half, constrained to be a subtype of `Sub`
+ *  @param i0 the starting index (inclusive) of the range to step over
+ *  @param iN the ending index (exclusive) of the range to step over
  */
 private[convert] abstract class InOrderStepperBase[Sub, Semi <: Sub](protected var i0: Int, protected var iN: Int)
 extends EfficientSplit {

--- a/library/src/scala/collection/convert/impl/IndexedStepperBase.scala
+++ b/library/src/scala/collection/convert/impl/IndexedStepperBase.scala
@@ -18,7 +18,13 @@ import java.util.Spliterator
 
 import scala.collection.Stepper.EfficientSplit
 
-/** Abstracts all the generic operations of stepping over an indexable collection. */
+/** Abstracts all the generic operations of stepping over an indexable collection.
+ *
+ *  @tparam Sub the concrete stepper subtype
+ *  @tparam Semi the type returned by splitting, a subtype of `Sub`
+ *  @param i0 the starting index (inclusive) into the underlying collection
+ *  @param iN the ending index (exclusive) into the underlying collection
+ */
 private[convert] abstract class IndexedStepperBase[Sub, Semi <: Sub](protected var i0: Int, protected var iN: Int)
   extends EfficientSplit {
   protected def semiclone(half: Int): Semi

--- a/library/src/scala/collection/convert/impl/IteratorStepper.scala
+++ b/library/src/scala/collection/convert/impl/IteratorStepper.scala
@@ -119,7 +119,12 @@ private[collection] class LongIteratorStepper(_underlying: Iterator[Long] | Null
   }
 }
 
-/** Common functionality for Steppers that step through an Iterator, caching the results as needed when a split is requested. */
+/** Common functionality for Steppers that step through an Iterator, caching the results as needed when a split is requested.
+ *
+ *  @tparam A the element type of the iterator being stepped through
+ *  @tparam SP the specific `Stepper` subtype, bounded by `Stepper[A]`, used for proxied delegation and split results
+ *  @tparam Semi the concrete stepper subtype returned by `semiclone()`, must extend `SP`
+ */
 private[convert] abstract class IteratorStepperBase[A, SP <: Stepper[A], Semi <: SP](final protected val underlying: Iterator[A] | Null) {
   final protected var nextChunkSize = 16
   @annotation.stableNull

--- a/library/src/scala/collection/convert/impl/RangeStepper.scala
+++ b/library/src/scala/collection/convert/impl/RangeStepper.scala
@@ -19,6 +19,9 @@ import scala.collection.{IntStepper, Stepper}
 /** Implements Stepper on an integer Range.  You don't actually need the Range to do this,
  *  so only the relevant parts are included.  Because the arguments are protected, they are
  *  not error-checked; `Range` is required to provide valid arguments.
+ *
+ *  @param myNext the next integer value to be produced by this stepper
+ *  @param myStep the increment between consecutive elements of the range
  */
 private[collection] final class RangeStepper(protected var myNext: Int, myStep: Int, _i0: Int, _iN: Int)
 extends IndexedStepperBase[IntStepper, RangeStepper](_i0, _iN)

--- a/library/src/scala/collection/convert/impl/StringStepper.scala
+++ b/library/src/scala/collection/convert/impl/StringStepper.scala
@@ -20,7 +20,10 @@ import java.util.Spliterator
 import scala.collection.Stepper.EfficientSplit
 import scala.collection.{IntStepper, Stepper}
 
-/** Implements `Stepper` on a `String` where you step through chars packed into `Int`. */
+/** Implements `Stepper` on a `String` where you step through chars packed into `Int`.
+ *
+ *  @param underlying the `String` to step through
+ */
 private[collection] final class CharStringStepper(underlying: String, _i0: Int, _iN: Int)
 extends IndexedStepperBase[IntStepper, CharStringStepper](_i0, _iN)
 with IntStepper {
@@ -31,7 +34,12 @@ with IntStepper {
   def semiclone(half: Int): CharStringStepper = new CharStringStepper(underlying, i0, half)
 }
 
-/** Implements `Stepper` on a `String` where you step through code points. */
+/** Implements `Stepper` on a `String` where you step through code points.
+ *
+ *  @param underlying the `String` to step through by code point
+ *  @param i0 the starting char index (inclusive) into the string
+ *  @param iN the ending char index (exclusive) into the string
+ */
 private[collection] final class CodePointStringStepper(underlying: String, private var i0: Int, private var iN: Int)
 extends IntStepper with EfficientSplit {
   def characteristics: Int = Spliterator.IMMUTABLE | Spliterator.NONNULL | Spliterator.ORDERED

--- a/library/src/scala/collection/generic/CommonErrors.scala
+++ b/library/src/scala/collection/generic/CommonErrors.scala
@@ -18,12 +18,19 @@ import language.experimental.captureChecking
 
 /** Some precomputed common errors to reduce the generated code size. */
 private[collection] object CommonErrors {
-  /** IndexOutOfBounds exception with a known max index. */
+  /** IndexOutOfBounds exception with a known max index.
+   *
+   *  @param index the index that was out of bounds
+   *  @param max the upper bound of the valid index range
+   */
   @noinline
   def indexOutOfBounds(index: Int, max: Int): IndexOutOfBoundsException = 
     new IndexOutOfBoundsException(s"$index is out of bounds (min 0, max ${max})")
 
-  /** IndexOutOfBounds exception with an unknown max index. */
+  /** IndexOutOfBounds exception with an unknown max index.
+   *
+   *  @param index the index that was out of bounds
+   */
   @noinline
   def indexOutOfBounds(index: Int): IndexOutOfBoundsException = 
     new IndexOutOfBoundsException(s"$index is out of bounds (min 0, max unknown)")

--- a/library/src/scala/collection/generic/IsIterable.scala
+++ b/library/src/scala/collection/generic/IsIterable.scala
@@ -87,6 +87,11 @@ import caps.unsafe.untrackedCaptures
  *     def apply(coll: Range): IterableOps[Int, IndexedSeq, IndexedSeq[Int]] = coll
  *   }
  *  ```
+ *
+ *  (Note that in practice the `IsIterable[Range]` instance is already provided by
+ *  the standard library, and it is defined as an `IsSeq[Range]` instance)
+ *
+ *  @tparam Repr the representation type (e.g. `String`, `Array[Int]`) that can be converted to an `Iterable`
  */
 transparent trait IsIterable[Repr] extends IsIterableOnce[Repr] {
 
@@ -102,7 +107,10 @@ transparent trait IsIterable[Repr] extends IsIterableOnce[Repr] {
   @untrackedCaptures
   override val conversion: Repr => IterableOps[A, Iterable, C] = apply(_)
 
-  /** A conversion from the type `Repr` to `IterableOps[A, Iterable, C]`. */
+  /** A conversion from the type `Repr` to `IterableOps[A, Iterable, C]`.
+   *
+   *  @param coll the collection or value to convert to `IterableOps[A, Iterable, C]`
+   */
   def apply(coll: Repr): IterableOps[A, Iterable, C]
 
 }

--- a/library/src/scala/collection/generic/IsIterableOnce.scala
+++ b/library/src/scala/collection/generic/IsIterableOnce.scala
@@ -38,6 +38,8 @@ import caps.unsafe.untrackedCaptures
  *    List(1, 2, 3, 4, 5).filterMap(i => if(i % 2 == 0) Some(i) else None)
  *    // == List(2, 4)
  *  ```
+ *
+ *  @tparam Repr the collection representation type that can be converted to `IterableOnce`
  */
 transparent trait IsIterableOnce[Repr] {
 
@@ -48,7 +50,10 @@ transparent trait IsIterableOnce[Repr] {
   @untrackedCaptures
   val conversion: Repr => IterableOnce[A] = apply(_)
 
-  /** A conversion from the representation type `Repr` to a `IterableOnce[A]`. */
+  /** A conversion from the representation type `Repr` to an `IterableOnce[A]`.
+   *
+   *  @param coll the representation type instance to view as an `IterableOnce[A]`
+   */
   def apply(coll: Repr): IterableOnce[A]
 
 }

--- a/library/src/scala/collection/generic/IsMap.scala
+++ b/library/src/scala/collection/generic/IsMap.scala
@@ -43,6 +43,9 @@ transparent trait IsMap[Repr] extends IsIterable[Repr] {
    *  @note The third type parameter of the returned `MapOps` value is
    *       still `Iterable` (and not `Map`) because `MapView[K, V]` only
    *       extends `MapOps[K, V, View, View[A]]`.
+   *
+   *  @param c the collection to convert to `MapOps`
+   *  @return a `MapOps[K, V, Iterable, C]` view of the collection
    */
   override def apply(c: Repr): MapOps[K, V, Tupled[Iterable]#Ap, C]
 

--- a/library/src/scala/collection/generic/IsSeq.scala
+++ b/library/src/scala/collection/generic/IsSeq.scala
@@ -28,6 +28,8 @@ import scala.reflect.ClassTag
  *  their implementation.
  *
  *  @see [[scala.collection.generic.IsIterable]]
+ *
+ *  @tparam Repr the collection representation type that is witnessed to have sequence-like operations
  */
 transparent trait IsSeq[Repr] extends IsIterable[Repr] {
 
@@ -40,6 +42,9 @@ transparent trait IsSeq[Repr] extends IsIterable[Repr] {
    *  @note The second type parameter of the returned `SeqOps` value is
    *       still `Iterable` (and not `Seq`) because `SeqView[A]` only
    *       extends `SeqOps[A, View, View[A]]`.
+   *
+   *  @param coll the collection to convert
+   *  @return a `SeqOps` instance that provides sequence operations on `coll`
    */
   def apply(coll: Repr): SeqOps[A, Iterable, C]
 }

--- a/library/src/scala/collection/immutable/ArraySeq.scala
+++ b/library/src/scala/collection/immutable/ArraySeq.scala
@@ -33,6 +33,8 @@ import scala.util.hashing.MurmurHash3
  *
  *  @define coll immutable array
  *  @define Coll `ArraySeq`
+ *
+ *  @tparam A the element type of the immutable array
  */
 sealed abstract class ArraySeq[+A]
   extends AbstractSeq[A]
@@ -90,7 +92,9 @@ sealed abstract class ArraySeq[+A]
 
   /** Fast concatenation of two [[ArraySeq]]s.
    *
-   *  @return null if optimisation not possible.
+   *  @tparam B the element type of the resulting sequence, a supertype of `A`
+   *  @param that the `ArraySeq` to append to this sequence
+   *  @return the concatenated `ArraySeq`, or `null` if optimization is not possible
    */
   private def appendedAllArraySeq[B >: A](that: ArraySeq[B]): ArraySeq[B] | Null = {
     // Optimise concatenation of two ArraySeqs
@@ -310,6 +314,10 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
    *  boxed, the resulting instance is an [[ArraySeq.ofRef]]. Writing
    *  `ArraySeq.unsafeWrapArray(a.asInstanceOf[Array[Int]])` does not work, it throws a
    *  `ClassCastException` at runtime.
+   *
+   *  @tparam T the element type of the array to wrap
+   *  @param x the array to wrap, which must not be modified after wrapping
+   *  @return an `ArraySeq` backed by the given array, using the appropriate primitive specialization
    */
   def unsafeWrapArray[T](x: Array[T]): ArraySeq[T] = ((x: @unchecked) match {
     case null              => null

--- a/library/src/scala/collection/immutable/BitSet.scala
+++ b/library/src/scala/collection/immutable/BitSet.scala
@@ -65,7 +65,11 @@ sealed abstract class BitSet
     } else this
   }
 
-  /** Updates word at index `idx`; enlarges set if `idx` outside range of set. */
+  /** Updates word at index `idx`; enlarges set if `idx` outside range of set.
+   *
+   *  @param idx the index of the word to update
+   *  @param w the new value for the word at index `idx`
+   */
   protected def updateWord(idx: Int, w: Long): BitSet
 
   override def map(f: Int => Int): BitSet = strictOptimizedMap(newSpecificBuilder, f)
@@ -108,7 +112,10 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
 
   private def createSmall(a: Long, b: Long): BitSet = if (b == 0L) new BitSet1(a) else new BitSet2(a, b)
 
-  /** A bitset containing all the bits in an array. */
+  /** A bitset containing all the bits in an array.
+   *
+   *  @param elems the array of `Long` words representing the bits; the array is defensively copied
+   */
   def fromBitMask(elems: Array[Long]): BitSet = {
     val len = elems.length
     if (len == 0) empty
@@ -122,6 +129,8 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
 
   /** A bitset containing all the bits in an array, wrapping the existing
    *  array without copying.
+   *
+   *  @param elems the array of `Long` words representing the bits; the caller must not modify the array after this call
    */
   def fromBitMaskNoCopy(elems: Array[Long]): BitSet = {
     val len = elems.length

--- a/library/src/scala/collection/immutable/ChampCommon.scala
+++ b/library/src/scala/collection/immutable/ChampCommon.scala
@@ -105,6 +105,7 @@ private[collection] abstract class Node[T <: Node[T]] {
  *  node before traversing sub-nodes (left to right).
  *
  *  @tparam T the trie node type we are iterating over
+ *  @tparam A the element type produced by the iterator
  */
 private[immutable] abstract class ChampBaseIterator[A, T <: Node[T]] extends AbstractIterator[A] {
 
@@ -191,6 +192,7 @@ private[immutable] abstract class ChampBaseIterator[A, T <: Node[T]] extends Abs
  *  iterator performs a depth-first post-order traversal, traversing sub-nodes (right to left).
  *
  *  @tparam T the trie node type we are iterating over
+ *  @tparam A the element type produced by the iterator
  */
 private[immutable] abstract class ChampBaseReverseIterator[A, T <: Node[T]] extends AbstractIterator[A] {
 

--- a/library/src/scala/collection/immutable/IntMap.scala
+++ b/library/src/scala/collection/immutable/IntMap.scala
@@ -126,7 +126,10 @@ private[immutable] abstract class IntMapIterator[V, T](it: IntMap[V]) extends Ab
   }
   push(it)
 
-  /** What value do we assign to a tip? */
+  /** What value do we assign to a tip?
+   *
+   *  @param tip the leaf node to extract a value from
+   */
   def valueOf(tip: IntMap.Tip[V]): T
 
   def hasNext = index != 0
@@ -210,7 +213,11 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case _ => new IntMapEntryIterator(this)
   }
 
-  /** Loops over the key, value pairs of the map in unsigned order of the keys. */
+  /** Loops over the key, value pairs of the map in unsigned order of the keys.
+   *
+   *  @tparam U the return type of the function `f`, used only for side effects
+   *  @param f the function applied to each key-value pair in the map
+   */
   override final def foreach[U](f: ((Int, T)) => U): Unit = this match {
     case IntMap.Bin(_, _, left, right) => { left.foreach(f); right.foreach(f) }
     case IntMap.Tip(key, value) => f((key, value))
@@ -231,6 +238,7 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
   /** Loop over the keys of the map. The same as `keys.foreach(f)`, but may
    *  be more efficient.
    *
+   *  @tparam U the return type of the function `f`, used only for side effects
    *  @param f The loop body
    */
   final def foreachKey[U](f: Int => U): Unit = this match {
@@ -247,6 +255,7 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
   /** Loop over the values of the map. The same as `values.foreach(f)`, but may
    *  be more efficient.
    *
+   *  @tparam U the return type of the function `f`, used only for side effects
    *  @param f The loop body
    */
   final def foreachValue[U](f: T => U): Unit = this match {
@@ -340,7 +349,7 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
    *   }
    *  ```
    *
-   *  @tparam S     The supertype of values in this `LongMap`.
+   *  @tparam S     the supertype of values in this `IntMap`.
    *  @param key    The key to update
    *  @param value  The value to use if there is no conflict
    *  @param f      The function used to resolve conflicts.
@@ -372,7 +381,7 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
    *  for each `(key, value)` mapping in this map, if `f(key, value) == None`
    *  the map contains no mapping for key, and if `f(key, value)`.
    *
-   *  @tparam S  The type of the values in the resulting `LongMap`.
+   *  @tparam S  the type of the values in the resulting `IntMap`.
    *  @param f   The transforming function.
    *  @return    The modified map.
    */
@@ -427,7 +436,7 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
    *  values produced from the original mappings by combining them with `f`.
    *
    *  @tparam S      The type of values in `that`.
-   *  @tparam R      The type of values in the resulting `LongMap`.
+   *  @tparam R      the type of values in the resulting `IntMap`.
    *  @param that    The map to intersect with.
    *  @param f       The combining function.
    *  @return        Intersection of `this` and `that`, with values for identical keys produced by function `f`.

--- a/library/src/scala/collection/immutable/LazyListIterable.scala
+++ b/library/src/scala/collection/immutable/LazyListIterable.scala
@@ -426,6 +426,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** Applies the given function `f` to each element of this linear sequence
    *  (while respecting the order of the elements).
    *
+   *  @tparam U the return type of the function `f`
    *  @param f The treatment to apply to each element.
    *  @note  Overridden here as final to trigger tail-call optimization, which
    *  replaces 'this' with 'tail' at each iteration. This is absolutely
@@ -467,6 +468,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  $appendStackSafety
    *
+   *  @tparam B the element type of the returned lazy list, a supertype of `A`
    *  @param suffix The collection that gets appended to this lazy list
    *  @return The lazy list containing elements of this lazy list and the iterable object.
    */
@@ -485,6 +487,10 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *  $preservesLaziness
    *
    *  $appendStackSafety
+   *
+   *  @tparam B the element type of the returned lazy list, a supertype of `A`
+   *  @param suffix the collection to append
+   *  @return a new lazy list containing elements of this lazy list followed by elements of `suffix`
    */
   override def appendedAll[B >: A](suffix: IterableOnce[B]^): LazyListIterable[B]^{this, suffix} =
     if (knownIsEmpty) LazyListIterable.from(suffix)
@@ -495,6 +501,10 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *  $preservesLaziness
    *
    *  $appendStackSafety
+   *
+   *  @tparam B the element type of the returned lazy list, a supertype of `A`
+   *  @param elem the element to append
+   *  @return a new lazy list containing all elements of this lazy list followed by `elem`
    */
   override def appended[B >: A](elem: B): LazyListIterable[B]^{this} =
     if (knownIsEmpty) eagerCons(elem, Empty)
@@ -503,6 +513,10 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam B the result type of the binary operator and the type of the initial value
+   *  @param z the initial value
+   *  @param op the binary operator applied to the intermediate result and the element
    */
   override def scanLeft[B](z: B)(op: (B, A) => B): LazyListIterable[B]^{this, op} =
     if (knownIsEmpty) eagerCons(z, Empty)
@@ -540,12 +554,18 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @param p the predicate used to test elements
    */
   override def partition(p: A => Boolean): (LazyListIterable[A]^{this, p}, LazyListIterable[A]^{this, p}) = (filter(p), filterNot(p))
 
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam A1 the element type of the first resulting collection
+   *  @tparam A2 the element type of the second resulting collection
+   *  @param f the function applied to each element that returns `Left` or `Right`
    */
   override def partitionMap[A1, A2](f: A => Either[A1, A2]): (LazyListIterable[A1]^{this, f}, LazyListIterable[A2]^{this, f}) = {
     val p: (LazyListIterable[Either[A1, A2]]^{this, f}, LazyListIterable[Either[A1, A2]]^{this, f}) = map(f).partition(_.isLeft)
@@ -555,6 +575,8 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @param pred the predicate used to test elements
    */
   override def filter(pred: A => Boolean): LazyListIterable[A]^{this, pred} =
     if (knownIsEmpty) Empty
@@ -563,6 +585,8 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @param pred the predicate used to test elements
    */
   override def filterNot(pred: A => Boolean): LazyListIterable[A]^{this, pred} =
     if (knownIsEmpty) Empty
@@ -575,6 +599,9 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  The `collection.WithFilter` returned by this method preserves laziness; elements are
    *  only evaluated individually as needed.
+   *
+   *  @param p the predicate used to test elements
+   *  @return an object of class `WithFilter`, which supports `map`, `flatMap`, `foreach`, and `withFilter` operations
    */
   override def withFilter(p: A => Boolean): collection.WithFilter[A, LazyListIterable]^{this, p} =
     new LazyListIterable.WithFilter(coll, p)
@@ -582,12 +609,18 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam B the element type of the returned lazy list, a supertype of `A`
+   *  @param elem the element to prepend
    */
   override def prepended[B >: A](elem: B): LazyListIterable[B]^{this} = eagerCons(elem, this)
 
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam B the element type of the returned lazy list, a supertype of `A`
+   *  @param prefix the collection to prepend
    */
   override def prependedAll[B >: A](prefix: collection.IterableOnce[B]^): LazyListIterable[B]^{this, prefix} =
     if (knownIsEmpty) LazyListIterable.from(prefix)
@@ -597,6 +630,9 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam B the element type of the returned lazy list
+   *  @param f the function to apply to each element
    */
   override def map[B](f: A => B): LazyListIterable[B]^{this, f} =
     if (knownIsEmpty) Empty
@@ -605,6 +641,9 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam U the return type of the function `f`
+   *  @param f the function to apply to each element for its side effect
    */
   override def tapEach[U](f: A => U): LazyListIterable[A]^{this, f} = map { a => f(a); a }
 
@@ -617,6 +656,9 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam B the element type of the returned lazy list
+   *  @param pf the partial function which filters and maps elements
    */
   override def collect[B](pf: PartialFunction[A, B]^): LazyListIterable[B]^{this, pf} =
     if (knownIsEmpty) Empty
@@ -626,6 +668,9 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  This method does not evaluate any elements further than
    *  the first element for which the partial function is defined.
+   *
+   *  @tparam B the element type of the returned option
+   *  @param pf the partial function which filters and maps elements
    */
   @tailrec
   override def collectFirst[B](pf: PartialFunction[A, B]^): Option[B] =
@@ -640,6 +685,8 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  This method does not evaluate any elements further than
    *  the first element matching the predicate.
+   *
+   *  @param p the predicate used to test elements
    */
   @tailrec
   override def find(p: A => Boolean): Option[A] =
@@ -663,12 +710,18 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam B the element type of the returned lazy list
+   *  @param asIterable an implicit conversion which asserts that the element type of this lazy list is an `IterableOnce`
    */
   override def flatten[B](implicit asIterable: A -> IterableOnce[B]): LazyListIterable[B]^{this} = flatMap(asIterable)
 
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam B the element type of the second half of the returned pairs
+   *  @param that the iterable providing the second half of each result pair
    */
   override def zip[B](that: collection.IterableOnce[B]^): LazyListIterable[(A, B)]^{this, that} =
     if (knownIsEmpty || that.knownSize == 0) Empty
@@ -687,6 +740,12 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam A1 the type of the first half of the returned pairs, a supertype of `A`
+   *  @tparam B the type of the second half of the returned pairs
+   *  @param that the iterable providing the second half of each result pair
+   *  @param thisElem the element to use if this lazy list is shorter than `that`
+   *  @param thatElem the element to use if `that` is shorter than this lazy list
    */
   override def zipAll[A1 >: A, B](that: collection.Iterable[B]^, thisElem: A1, thatElem: B): LazyListIterable[(A1, B)]^{this, that} = {
     if (knownIsEmpty) {
@@ -715,6 +774,10 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  The `collection.LazyZip2` returned by this method preserves laziness; elements are
    *  only evaluated individually as needed.
+   *
+   *  @tparam B the element type of the second collection
+   *  @param that the collection providing the second element of each pair
+   *  @return a `LazyZip2` decorator for lazy pairing with `that`
    */
   // just in case it can be meaningfully overridden at some point
   override def lazyZip[B](that: collection.Iterable[B]^): LazyZip2[A, B, this.type]^{this, that} =
@@ -723,6 +786,10 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam A1 the type of the first element in each pair
+   *  @tparam A2 the type of the second element in each pair
+   *  @param asPair an implicit conversion which asserts that the element type of this lazy list is a pair
    */
   override def unzip[A1, A2](implicit asPair: A -> (A1, A2)): (LazyListIterable[A1]^{this}, LazyListIterable[A2]^{this}) =
     (map(asPair(_)._1), map(asPair(_)._2))
@@ -730,6 +797,11 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam A1 the type of the first element in each triple
+   *  @tparam A2 the type of the second element in each triple
+   *  @tparam A3 the type of the third element in each triple
+   *  @param asTriple an implicit conversion which asserts that the element type of this lazy list is a triple
    */
   override def unzip3[A1, A2, A3](implicit asTriple: A -> (A1, A2, A3)): (LazyListIterable[A1]^{this}, LazyListIterable[A2]^{this}, LazyListIterable[A3]^{this}) =
     (map(asTriple(_)._1), map(asTriple(_)._2), map(asTriple(_)._3))
@@ -738,6 +810,8 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  $initiallyLazy
    *  Additionally, it preserves laziness for all except the first `n` elements.
+   *
+   *  @param n the number of elements to drop from this lazy list
    */
   override def drop(n: Int): LazyListIterable[A]^{this} =
     if (n <= 0) this
@@ -748,6 +822,8 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  $initiallyLazy
    *  Additionally, it preserves laziness for all elements after the predicate returns `false`.
+   *
+   *  @param p the predicate used to test elements
    */
   override def dropWhile(p: A => Boolean): LazyListIterable[A]^{this, p} =
     if (knownIsEmpty) Empty
@@ -756,6 +832,8 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $initiallyLazy
+   *
+   *  @param n the number of elements to drop from the right end
    */
   override def dropRight(n: Int): LazyListIterable[A]^{this} = {
     if (n <= 0) this
@@ -779,6 +857,8 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @param n the number of elements to take from this lazy list
    */
   override def take(n: Int): LazyListIterable[A]^{this} =
     if (knownIsEmpty) Empty
@@ -795,6 +875,8 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @param p the predicate used to test elements
    */
   override def takeWhile(p: A => Boolean): LazyListIterable[A]^{this, p} =
     if (knownIsEmpty) Empty
@@ -809,6 +891,8 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $initiallyLazy
+   *
+   *  @param n the number of elements to take from the right end
    */
   override def takeRight(n: Int): LazyListIterable[A]^{this} =
     if (n <= 0 || knownIsEmpty) Empty
@@ -818,6 +902,9 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  $initiallyLazy
    *  Additionally, it preserves laziness for all but the first `from` elements.
+   *
+   *  @param from the index of the first element in the slice
+   *  @param until the index of the element following the slice
    */
   override def slice(from: Int, until: Int): LazyListIterable[A]^{this} = take(until).drop(from)
 
@@ -836,6 +923,9 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam B the element type of the returned lazy list, a supertype of `A`
+   *  @param that the sequence of elements to subtract (by multiplicity)
    */
   override def diff[B >: A](that: collection.Seq[B]): LazyListIterable[A]^{this}  =
     if (knownIsEmpty) Empty
@@ -844,6 +934,9 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam B the element type of the returned lazy list, a supertype of `A`
+   *  @param that the sequence of elements to intersect with
    */
   override def intersect[B >: A](that: collection.Seq[B]): LazyListIterable[A]^{this} =
     if (knownIsEmpty) Empty
@@ -859,6 +952,8 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  The iterator returned by this method mostly preserves laziness;
    *  a single element ahead of the iterator is evaluated.
+   *
+   *  @param size the number of elements per group, must be positive
    */
   override def grouped(size: Int): Iterator[LazyListIterable[A]^{this}]^{this} = {
     require(size > 0, "size must be positive, but was " + size)
@@ -869,6 +964,9 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  The iterator returned by this method mostly preserves laziness;
    *  `size - step max 1` elements ahead of the iterator are evaluated.
+   *
+   *  @param size the number of elements per window, must be positive
+   *  @param step the number of elements to advance per window, must be positive
    */
   override def sliding(size: Int, step: Int): Iterator[LazyListIterable[A]^{this}]^{this} = {
     require(size > 0 && step > 0, s"size=$size and step=$step, but both must be positive")
@@ -884,6 +982,10 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam B the element type of the returned lazy list, a supertype of `A`
+   *  @param len the length to which this lazy list should be padded
+   *  @param elem the padding element
    */
   override def padTo[B >: A](len: Int, elem: B): LazyListIterable[B]^{this} =
     if (len <= 0) this
@@ -895,6 +997,11 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam B the element type of the returned lazy list, a supertype of `A`
+   *  @param from the index of the first replaced element
+   *  @param other the collection of replacement elements
+   *  @param replaced the number of elements to replace starting from index `from`
    */
   override def patch[B >: A](from: Int, other: IterableOnce[B]^, replaced: Int): LazyListIterable[B]^{this, other} =
     if (knownIsEmpty) LazyListIterable from other
@@ -910,6 +1017,9 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $evaluatesAllElements
+   *
+   *  @tparam B the element type of each nested iterable
+   *  @param asIterable an implicit conversion which asserts that the element type of this lazy list is an `Iterable`
    */
   // overridden just in case a lazy implementation is developed at some point
   override def transpose[B](implicit asIterable: A -> collection.Iterable[B]): LazyListIterable[LazyListIterable[B]^{this}]^{this} = super.transpose
@@ -917,6 +1027,10 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam B the element type of the returned lazy list, a supertype of `A`
+   *  @param index the zero-based index of the element to replace
+   *  @param elem the replacing element
    */
   override def updated[B >: A](index: Int, elem: B): LazyListIterable[B]^{this} =
     if (index < 0) throw new IndexOutOfBoundsException(s"$index")
@@ -1074,10 +1188,19 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
 
   private val Empty: LazyListIterable[Nothing] = new LazyListIterable(EmptyMarker)
 
-  /** Creates a new LazyListIterable. */
+  /** Creates a new LazyListIterable.
+   *
+   *  @tparam A the element type of the lazy list
+   *  @param state the by-name expression that computes the lazy list state when forced
+   */
   @inline private def newLL[A](state: => LazyListIterable[A]^): LazyListIterable[A]^{state} = new LazyListIterable[A](() => state)
 
-  /** Creates a new LazyListIterable with evaluated `head` and `tail`. */
+  /** Creates a new LazyListIterable with evaluated `head` and `tail`.
+   *
+   *  @tparam A the element type of the lazy list
+   *  @param hd the head element of the cons cell
+   *  @param tl the tail lazy list of the cons cell
+   */
   @inline private def eagerCons[A](hd: A, tl: LazyListIterable[A]^): LazyListIterable[A]^{tl} = new LazyListIterable[A](hd, tl)
 
   private val anyToMarker: Any -> Any = _ => Statics.pfMarker
@@ -1211,12 +1334,18 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
   /** An alternative way of building and matching lazy lists using LazyListIterable.cons(hd, tl). */
   object cons {
     /** A lazy list consisting of a given first element and remaining elements.
+     *
+     *  @tparam A the element type of the lazy list
      *  @param hd   The first element of the result lazy list
      *  @param tl   The remaining elements of the result lazy list
      */
     def apply[A](hd: => A, tl: => LazyListIterable[A]): LazyListIterable[A]^{hd, tl} = newLL(eagerCons(hd, newLL(tl)))
 
-    /** Maps a lazy list to its head and tail. */
+    /** Maps a lazy list to its head and tail.
+     *
+     *  @tparam A the element type of the lazy list
+     *  @param xs the lazy list to decompose
+     */
     def unapply[A](xs: LazyListIterable[A]^): Option[(A, LazyListIterable[A]^{xs})] = #::.unapply(xs)
   }
 
@@ -1248,12 +1377,20 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
 
   /** Creates a LazyListIterable with the elements of an iterator followed by a LazyListIterable suffix.
    *  Eagerly evaluates the first element.
+   *
+   *  @tparam A the element type of the lazy list
+   *  @param it the iterator whose elements are prepended
+   *  @param suffix the lazy list to append after the iterator elements are exhausted
    */
   private def eagerHeadPrependIterator[A](it: Iterator[A]^)(suffix: => LazyListIterable[A]^): LazyListIterable[A]^{it, suffix} =
     if (it.hasNext) eagerCons(it.next(), newLL(eagerHeadPrependIterator(it)(suffix)))
     else suffix
 
-  /** Creates a LazyListIterable from an Iterator. Eagerly evaluates the first element. */
+  /** Creates a LazyListIterable from an Iterator. Eagerly evaluates the first element.
+   *
+   *  @tparam A the element type of the lazy list
+   *  @param it the iterator to convert into a lazy list
+   */
   private def eagerHeadFromIterator[A](it: Iterator[A]^): LazyListIterable[A]^{it} =
     if (it.hasNext) eagerCons(it.next(), newLL(eagerHeadFromIterator(it)))
     else Empty
@@ -1281,6 +1418,7 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
 
   /** An infinite LazyListIterable that repeatedly applies a given function to a start value.
    *
+   *  @tparam A the element type of the lazy list
    *  @param start the start value of the LazyListIterable
    *  @param f     the function that's repeatedly applied
    *  @return      the LazyListIterable returning the infinite sequence of values `start, f(start), f(f(start)), ...`
@@ -1311,6 +1449,7 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
   /** Creates an infinite LazyListIterable containing the given element expression (which
    *  is computed for each occurrence).
    *
+   *  @tparam A the element type of the lazy list
    *  @param elem the element composing the resulting LazyListIterable
    *  @return the LazyListIterable containing an infinite number of elem
    */

--- a/library/src/scala/collection/immutable/ListMap.scala
+++ b/library/src/scala/collection/immutable/ListMap.scala
@@ -128,7 +128,14 @@ sealed class ListMap[K, +V]
  */
 @SerialVersionUID(3L)
 object ListMap extends MapFactory[ListMap] {
-  /** Represents an entry in the `ListMap`. */
+  /** Represents an entry in the `ListMap`.
+   *
+   *  @tparam K the type of the keys in this map entry
+   *  @tparam V the type of the values in this map entry
+   *  @param private[immutable] val key the key for this map entry
+   *  @param private[immutable] var _value the value associated with the key
+   *  @param private[immutable] var _init the rest of the list map (tail), or `null` during construction
+   */
   private[immutable] final class Node[K, V](
     override private[immutable] val key: K,
     private[immutable] var _value: V,
@@ -271,6 +278,7 @@ object ListMap extends MapFactory[ListMap] {
    *
    *  @tparam K the map key type
    *  @tparam V the map value type
+   *  @return a new `ReusableBuilder` for creating `ListMap` instances
    */
   def newBuilder[K, V]: ReusableBuilder[(K, V), ListMap[K, V]] = new ListMapBuilder[K, V]
 
@@ -282,6 +290,9 @@ object ListMap extends MapFactory[ListMap] {
 
 /** Builder for ListMap.
  *  $multipleResults
+ *
+ *  @tparam K the type of the keys in the list map being built
+ *  @tparam V the type of the values in the list map being built
  */
 private[immutable] final class ListMapBuilder[K, V] extends mutable.ReusableBuilder[(K, V), ListMap[K, V]] {
   private var isAliased: Boolean = false

--- a/library/src/scala/collection/immutable/ListSet.scala
+++ b/library/src/scala/collection/immutable/ListSet.scala
@@ -71,7 +71,10 @@ sealed class ListSet[A]
 
   override def iterableFactory: IterableFactory[ListSet] = ListSet
 
-  /** Represents an entry in the `ListSet`. */
+  /** Represents an entry in the `ListSet`.
+   *
+   *  @param elem the element contained in this node of the list set
+   */
   protected class Node(override protected val elem: A) extends ListSet[A] {
 
     override def size = sizeInternal(this, 0)

--- a/library/src/scala/collection/immutable/LongMap.scala
+++ b/library/src/scala/collection/immutable/LongMap.scala
@@ -123,7 +123,10 @@ private[immutable] abstract class LongMapIterator[V, T](it: LongMap[V]) extends 
   }
   push(it)
 
-  /** What value do we assign to a tip? */
+  /** What value do we assign to a tip?
+   *
+   *  @param tip the leaf node to extract a value from
+   */
   def valueOf(tip: LongMap.Tip[V]): T
 
   def hasNext = index != 0
@@ -204,7 +207,11 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     case _ => new LongMapEntryIterator(this)
   }
 
-  /** Loops over the key, value pairs of the map in unsigned order of the keys. */
+  /** Loops over the key, value pairs of the map in unsigned order of the keys.
+   *
+   *  @tparam U the return type of the function `f`, used only for side effects
+   *  @param f the function applied to each key-value pair in the map
+   */
   override final def foreach[U](f: ((Long, T)) => U): Unit = this match {
     case LongMap.Bin(_, _, left, right) => { left.foreach(f); right.foreach(f) }
     case LongMap.Tip(key, value) => f((key, value))
@@ -225,6 +232,7 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
   /** Loop over the keys of the map. The same as keys.foreach(f), but may
    *  be more efficient.
    *
+   *  @tparam U the return type of the function `f`, used only for side effects
    *  @param f The loop body
    */
   final def foreachKey[U](f: Long => U): Unit = this match {
@@ -241,6 +249,7 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
   /** Loop over the values of the map. The same as values.foreach(f), but may
    *  be more efficient.
    *
+   *  @tparam U the return type of the function `f`, used only for side effects
    *  @param f The loop body
    */
   final def foreachValue[U](f: T => U): Unit = this match {

--- a/library/src/scala/collection/immutable/Map.scala
+++ b/library/src/scala/collection/immutable/Map.scala
@@ -23,7 +23,11 @@ import scala.collection.immutable.Map.Map4
 import scala.collection.mutable.{Builder, ReusableBuilder}
 import SeqMap.{SeqMap1, SeqMap2, SeqMap3, SeqMap4}
 
-/** Base type of immutable Maps. */
+/** Base type of immutable Maps.
+ *
+ *  @tparam K the type of the keys in this map
+ *  @tparam V the type of the values associated with the keys
+ */
 trait Map[K, +V]
   extends Iterable[(K, V)]
      with collection.Map[K, V]
@@ -40,6 +44,7 @@ trait Map[K, +V]
    *
    *  Invoking transformer methods (e.g. `map`) will not preserve the default value.
    *
+   *  @tparam V1 the type of the values returned by the default function, which must be a supertype of `V`
    *  @param d     the function mapping keys to values, used for non-present keys
    *  @return      a wrapper of the map with a default value
    */
@@ -51,6 +56,7 @@ trait Map[K, +V]
    *
    *  Invoking transformer methods (e.g. `map`) will not preserve the default value.
    *
+   *  @tparam V1 the type of the default value, which must be a supertype of `V`
    *  @param d     default value used for non-present keys
    *  @return      a wrapper of the map with a default value
    */
@@ -61,6 +67,10 @@ trait Map[K, +V]
  *
  *  @define coll immutable map
  *  @define Coll `immutable.Map`
+ *
+ *  @tparam K the type of the keys in this map
+ *  @tparam V the type of the values associated with the keys
+ *  @tparam CC the type constructor of the resulting map (e.g., `Map`, `HashMap`)
  */
 transparent trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[K, V, CC, C]]
   extends IterableOps[(K, V), Iterable, C]
@@ -76,7 +86,10 @@ transparent trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[
    */
   def removed(key: K): C
 
-  /** Alias for `removed`. */
+  /** Alias for `removed`.
+   *
+   *  @param key the key to remove from this map
+   */
   @`inline` final def - (key: K): C = removed(key)
 
   @deprecated("Use -- with an explicit collection", "2.13.0")
@@ -93,7 +106,10 @@ transparent trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[
    */
   def removedAll(keys: IterableOnce[K]^): C = keys.iterator.foldLeft[C](coll)(_ - _)
 
-  /** Alias for `removedAll`. */
+  /** Alias for `removedAll`.
+   *
+   *  @param keys the collection of keys to remove from this map
+   */
   @`inline` final override def -- (keys: IterableOnce[K]^): C = removedAll(keys)
 
   /** Creates a new map obtained by updating this map with a given key/value pair.
@@ -111,6 +127,7 @@ transparent trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[
    *  If the remapping function returns `None`, the mapping is removed (or remains absent if initially absent).
    *  If the function itself throws an exception, the exception is rethrown, and the current mapping is left unchanged.
    *
+   *  @tparam V1 the type of the values in the returned map, which must be a supertype of `V`
    *  @param key the key value
    *  @param remappingFunction a function that receives current optionally mapped value and returns a new mapping
    *  @return A new map with the updated mapping with the key
@@ -136,6 +153,7 @@ transparent trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[
   /** This function transforms all the values of mappings contained
    *  in this map with function `f`.
    *
+   *  @tparam W the type of the transformed values
    *  @param f A function over keys and values
    *  @return  the updated map
    */
@@ -664,7 +682,11 @@ object Map extends MapFactory[Map] {
   }
 }
 
-/** Explicit instantiation of the `Map` trait to reduce class file size in subclasses. */
+/** Explicit instantiation of the `Map` trait to reduce class file size in subclasses.
+ *
+ *  @tparam K the type of the keys in this map
+ *  @tparam V the type of the values associated with the keys
+ */
 abstract class AbstractMap[K, +V] extends scala.collection.AbstractMap[K, V] with Map[K, V]
 
 private[immutable] final class MapBuilderImpl[K, V] extends ReusableBuilder[(K, V), Map[K, V]] {

--- a/library/src/scala/collection/immutable/NumericRange.scala
+++ b/library/src/scala/collection/immutable/NumericRange.scala
@@ -98,11 +98,18 @@ sealed class NumericRange[T](
 
   /** Creates a new range with the start and end values of this range and
    *  a new `step`.
+   *
+   *  @param newStep the new step value for the range
    */
   def by(newStep: T): NumericRange[T] = copy(start, end, newStep)
 
 
-  /** Creates a copy of this range. */
+  /** Creates a copy of this range.
+   *
+   *  @param start the start value of the new range
+   *  @param end the end value of the new range
+   *  @param step the step value of the new range
+   */
   def copy(start: T, end: T, step: T): NumericRange[T] =
     new NumericRange(start, end, step, isInclusive)
 
@@ -407,6 +414,13 @@ object NumericRange {
   /** Calculates the number of elements in a range given start, end, step, and
    *  whether or not it is inclusive.  Throws an exception if step == 0 or
    *  the number of elements exceeds the maximum Int.
+   *
+   *  @tparam T the numeric type of the range elements, which must have an `Integral` instance
+   *  @param start the first element of the range
+   *  @param end the exclusive or inclusive upper bound, depending on `isInclusive`
+   *  @param step the increment between successive elements, must not be zero
+   *  @param isInclusive whether `end` is included in the range
+   *  @param num the `Integral` instance used for arithmetic on `T`
    */
   def count[T](start: T, end: T, step: T, isInclusive: Boolean)(implicit num: Integral[T]): Int = {
     val zero    = num.zero

--- a/library/src/scala/collection/immutable/Queue.scala
+++ b/library/src/scala/collection/immutable/Queue.scala
@@ -37,6 +37,8 @@ import scala.collection.mutable.{Builder, ListBuffer}
  *  @define coll immutable queue
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
+ *
+ *  @tparam A the type of elements contained in this queue
  */
 
 sealed class Queue[+A] protected(protected val in: List[A], protected val out: List[A])
@@ -139,6 +141,7 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
   /** Creates a new queue with element added at the end
    *  of the old queue.
    *
+   *  @tparam B the element type of the returned queue, a supertype of `A`
    *  @param  elem        the element to insert
    */
   def enqueue[B >: A](elem: B): Queue[B] = new Queue(elem :: in, out)
@@ -160,7 +163,9 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
    *  The elements are appended in the order they are given out by the
    *  iterator.
    *
+   *  @tparam B the element type of the returned queue, a supertype of `A`
    *  @param  iter        an iterable object
+   *  @return a new queue with all elements of `iter` appended at the end
    */
   def enqueueAll[B >: A](iter: scala.collection.Iterable[B]^): Queue[B] = appendedAll(iter)
 

--- a/library/src/scala/collection/immutable/Range.scala
+++ b/library/src/scala/collection/immutable/Range.scala
@@ -138,6 +138,9 @@ sealed abstract class Range(
    *
    *  If the mathematical result is not within this Range, the result won't
    *  make sense, but won't error out.
+   *
+   *  @param n the number of steps from `start`, interpreted as an unsigned integer
+   *  @return the element at position `n` in this range, i.e., `start + step * n`
    */
   @inline
   private def locationAfterN(n: Int): Int = {
@@ -222,6 +225,7 @@ sealed abstract class Range(
   /** Creates a new range with the `start` and `end` values of this range and
    *  a new `step`.
    *
+   *  @param step the new step value for the range; must be non-zero
    *  @return a new range with a different step
    */
   final def by(step: Int): Range = copy(start, end, step)
@@ -299,6 +303,9 @@ sealed abstract class Range(
    *  in this non-empty range?
    *
    *  This method returns nonsensical results if `n < 0` or if `this.isEmpty`.
+   *
+   *  @param n the non-negative value to compare against the number of elements
+   *  @return `true` if `n` is greater than or equal to the number of elements in this range
    */
   @inline private def greaterEqualNumRangeElements(n: Int): Boolean =
     (n ^ Int.MinValue) > ((numRangeElements - 1) ^ Int.MinValue) // unsigned comparison
@@ -326,6 +333,9 @@ sealed abstract class Range(
   /** Creates a new range consisting of the last `n` elements of the range.
    *
    *  $doesNotUseBuilders
+   *
+   *  @param n the number of elements to take from the right
+   *  @return a new range consisting of the last `n` elements, or an empty range if `n <= 0`, or the entire range if `n` is greater than its length
    */
   final override def takeRight(n: Int): Range = {
     if (n <= 0 || isEmpty) newEmptyRange(start)
@@ -336,6 +346,9 @@ sealed abstract class Range(
   /** Creates a new range consisting of the initial `length - n` elements of the range.
    *
    *  $doesNotUseBuilders
+   *
+   *  @param n the number of elements to drop from the right
+   *  @return a new range consisting of all elements except the last `n`, or this range unchanged if `n <= 0`, or an empty range if `n` is greater than its length
    */
   final override def dropRight(n: Int): Range = {
     if (n <= 0 || isEmpty) this
@@ -585,6 +598,11 @@ object Range {
    *  precondition:  step != 0
    *  If the size of the range exceeds Int.MaxValue, the
    *  result will be negative.
+   *
+   *  @param start the start value of the range
+   *  @param end the end value of the range (exclusive or inclusive depending on `isInclusive`)
+   *  @param step the step value between consecutive elements, must be non-zero
+   *  @param isInclusive whether `end` is included in the range
    */
   def count(start: Int, end: Int, step: Int, isInclusive: Boolean): Int = {
     if (step == 0)
@@ -617,18 +635,34 @@ object Range {
 
   /** Makes a range from `start` until `end` (exclusive) with given step value.
    *  @note step != 0
+   *
+   *  @param start the start value of the range
+   *  @param end the exclusive end value of the range
+   *  @param step the step value between consecutive elements, must be non-zero
    */
   def apply(start: Int, end: Int, step: Int): Range.Exclusive = new Range.Exclusive(start, end, step)
 
-  /** Makes a range from `start` until `end` (exclusive) with step value 1. */
+  /** Makes a range from `start` until `end` (exclusive) with step value 1.
+   *
+   *  @param start the start value of the range
+   *  @param end the exclusive end value of the range
+   */
   def apply(start: Int, end: Int): Range.Exclusive = new Range.Exclusive(start, end, 1)
 
   /** Makes an inclusive range from `start` to `end` with given step value.
    *  @note step != 0
+   *
+   *  @param start the start value of the range
+   *  @param end the inclusive end value of the range
+   *  @param step the step value between consecutive elements, must be non-zero
    */
   def inclusive(start: Int, end: Int, step: Int): Range.Inclusive = new Range.Inclusive(start, end, step)
 
-  /** Makes an inclusive range from `start` to `end` with step value 1. */
+  /** Makes an inclusive range from `start` to `end` with step value 1.
+   *
+   *  @param start the start value of the range
+   *  @param end the inclusive end value of the range
+   */
   def inclusive(start: Int, end: Int): Range.Inclusive = new Range.Inclusive(start, end, 1)
 
   @SerialVersionUID(4L)

--- a/library/src/scala/collection/immutable/RedBlackTree.scala
+++ b/library/src/scala/collection/immutable/RedBlackTree.scala
@@ -71,6 +71,12 @@ private[collection] object RedBlackTree {
     }
     /** Creates a new balanced tree where `newLeft` replaces `tree.left`.
      *  tree and newLeft are never null 
+     *
+     *  @tparam A1 the key type of the tree
+     *  @tparam B the original value type of the tree
+     *  @tparam B1 the value type of the result, a supertype of `B`
+     *  @param tree the original tree whose left child is being replaced
+     *  @param newLeft the new left subtree to substitute in
      */
     protected final def mutableBalanceLeft[A1, B, B1 >: B](tree: Tree[A1, B], newLeft: Tree[A1, B1]): Tree[A1, B1] = {
       // Parameter trees
@@ -115,6 +121,12 @@ private[collection] object RedBlackTree {
     }
     /** Creates a new balanced tree where `newRight` replaces `tree.right`.
      *  tree and newRight are never null 
+     *
+     *  @tparam A1 the key type of the tree
+     *  @tparam B the original value type of the tree
+     *  @tparam B1 the value type of the result, a supertype of `B`
+     *  @param tree the original tree whose right child is being replaced
+     *  @param newRight the new right subtree to substitute in
      */
     protected final def mutableBalanceRight[A1, B, B1 >: B](tree: Tree[A1, B], newRight: Tree[A1, B1]): Tree[A1, B1] = {
       // Parameter trees
@@ -246,7 +258,14 @@ private[collection] object RedBlackTree {
     blacken(_init(tree))
   }
 
-  /** Returns the smallest node with a key larger than or equal to `x`. Returns `null` if there is no such node. */
+  /** Returns the smallest node with a key larger than or equal to `x`. Returns `null` if there is no such node.
+   *
+   *  @tparam A the key type
+   *  @tparam B the value type
+   *  @param tree the red-black tree to search
+   *  @param x the inclusive lower bound key to search for
+   *  @param ordering the ordering used to compare keys
+   */
   def minAfter[A, B](tree: Tree[A, B] | Null, x: A)(implicit ordering: Ordering[A]): Tree[A, B] | Null = if (tree eq null) null else {
     val cmp = ordering.compare(x, tree.key)
     if (cmp == 0) tree
@@ -256,7 +275,14 @@ private[collection] object RedBlackTree {
     } else minAfter(tree.right, x)
   }
 
-  /** Returns the largest node with a key smaller than `x`. Returns `null` if there is no such node. */
+  /** Returns the largest node with a key smaller than `x`. Returns `null` if there is no such node.
+   *
+   *  @tparam A the key type
+   *  @tparam B the value type
+   *  @param tree the red-black tree to search
+   *  @param x the exclusive upper bound key
+   *  @param ordering the ordering used to compare keys
+   */
   def maxBefore[A, B](tree: Tree[A, B] | Null, x: A)(implicit ordering: Ordering[A]): Tree[A, B] | Null = if (tree eq null) null else {
     val cmp = ordering.compare(x, tree.key)
     if (cmp <= 0) maxBefore(tree.left, x)
@@ -338,7 +364,13 @@ private[collection] object RedBlackTree {
     new Tree(key, value.asInstanceOf[AnyRef], left, right, sizeAndColour)
   }
 
-  /** Creates a new balanced tree where `newLeft` replaces `tree.left`. */
+  /** Creates a new balanced tree where `newLeft` replaces `tree.left`.
+   *
+   *  @tparam A the key type
+   *  @tparam B1 the value type
+   *  @param tree the original tree whose left child is being replaced
+   *  @param newLeft the new left subtree to substitute in
+   */
   private def balanceLeft[A, B1](tree: Tree[A, B1], newLeft: Tree[A, B1]): Tree[A, B1] = {
     // Parameter trees
     //            tree              |                   newLeft
@@ -379,7 +411,13 @@ private[collection] object RedBlackTree {
       }
     }
   }
-  /** Creates a new balanced tree where `newRight` replaces `tree.right`. */
+  /** Creates a new balanced tree where `newRight` replaces `tree.right`.
+   *
+   *  @tparam A the key type
+   *  @tparam B1 the value type
+   *  @param tree the original tree whose right child is being replaced
+   *  @param newRight the new right subtree to substitute in
+   */
   private def balanceRight[A, B1](tree: Tree[A, B1], newRight: Tree[A, B1]): Tree[A, B1] = {
     // Parameter trees
     //            tree                |                             newRight
@@ -785,6 +823,13 @@ private[collection] object RedBlackTree {
 
   /** Creates a new immutable red tree.
    *  left and right may be null.
+   *
+   *  @tparam A the key type
+   *  @tparam B the value type
+   *  @param key the key stored in this node
+   *  @param value the value associated with the key
+   *  @param left the left subtree, or `null` if absent
+   *  @param right the right subtree, or `null` if absent
    */
   private[immutable] def RedTree[A, B](key: A, value: B, left: Tree[A, B] | Null, right: Tree[A, B] | Null): Tree[A, B] = {
     //assertNotMutable(left)
@@ -857,6 +902,8 @@ private[collection] object RedBlackTree {
      *  the leftmost subtree with the key that would be "next" after it according
      *  to the ordering. Along the way build up the iterator's path stack so that "next"
      *  functionality works.
+     *
+     *  @param key the key from which to start iteration
      */
     private def startFrom(key: A) : Tree[A,B] | Null = if (root eq null) null else {
       @tailrec def find(tree: Tree[A, B] | Null): Tree[A, B] | Null =
@@ -936,7 +983,12 @@ private[collection] object RedBlackTree {
     override def nextResult(tree: Tree[A, B]) = tree.value
   }
 
-  /** Builds a Tree suitable for a TreeSet from an ordered sequence of keys. */
+  /** Builds a Tree suitable for a TreeSet from an ordered sequence of keys.
+   *
+   *  @tparam A the key type
+   *  @param xs an iterator yielding keys in ascending order
+   *  @param size the number of keys to consume from the iterator
+   */
   def fromOrderedKeys[A](xs: Iterator[A]^, size: Int): Tree[A, Null] | Null = {
     val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
     def f(level: Int, size: Int): Tree[A, Null] | Null = size match {
@@ -952,7 +1004,13 @@ private[collection] object RedBlackTree {
     f(1, size)
   }
 
-  /** Builds a Tree suitable for a TreeMap from an ordered sequence of key/value pairs. */
+  /** Builds a Tree suitable for a TreeMap from an ordered sequence of key/value pairs.
+   *
+   *  @tparam A the key type
+   *  @tparam B the value type
+   *  @param xs an iterator yielding key-value pairs in ascending key order
+   *  @param size the number of entries to consume from the iterator
+   */
   def fromOrderedEntries[A, B](xs: Iterator[(A, B)]^, size: Int): Tree[A, B] | Null = {
     val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
     def f(level: Int, size: Int): Tree[A, B] | Null = size match {
@@ -1089,7 +1147,13 @@ private[collection] object RedBlackTree {
          tl.nn.right.nn.redWithLeftRight(balance(tl.nn, tl.nn.left.nn.red, tl.nn.right.nn.left), tree.blackWithLeftRight(tl.nn.right.nn.right, tr))
     else sys.error("Defect: invariance violation")
 
-  /** `append` is similar to `join2` but requires that both subtrees have the same black height. */
+  /** `append` is similar to `join2` but requires that both subtrees have the same black height.
+   *
+   *  @tparam A the key type
+   *  @tparam B the value type
+   *  @param tl the left subtree to append, or `null` if empty
+   *  @param tr the right subtree to append, or `null` if empty
+   */
   private def append[A, B](tl: Tree[A, B] | Null, tr: Tree[A, B] | Null): Tree[A, B] | Null = {
     if (tl eq null) tr
     else if (tr eq null) tl
@@ -1129,7 +1193,11 @@ private[collection] object RedBlackTree {
   def difference[A, B](t1: Tree[A, B] | Null, t2: Tree[A, ?] | Null)(implicit ordering: Ordering[A]): Tree[A, B] | Null =
     blacken(_difference(t1, t2.asInstanceOf[Tree[A, B]]))
 
-  /** Computes the rank from a tree and its black height. */
+  /** Computes the rank from a tree and its black height.
+   *
+   *  @param t the tree node, or `null` for an empty subtree
+   *  @param bh the black height of `t`
+   */
   @`inline` private def rank(t: Tree[?, ?] | Null, bh: Int): Int = {
     if(t eq null) 0
     else if(t.isBlack) 2*(bh-1)

--- a/library/src/scala/collection/immutable/Seq.scala
+++ b/library/src/scala/collection/immutable/Seq.scala
@@ -30,6 +30,9 @@ trait Seq[+A] extends Iterable[A]
 /**
  *  @define coll immutable sequence
  *  @define Coll `immutable.Seq`
+ *
+ *  @tparam A the element type of the sequence
+ *  @tparam CC the type constructor for the collection type, constrained to be pure
  */
 transparent trait SeqOps[+A, +CC[B] <: caps.Pure, +C] extends Any with collection.SeqOps[A, CC, C] with caps.Pure
 
@@ -45,7 +48,10 @@ object Seq extends SeqFactory.Delegate[Seq](List) {
   }
 }
 
-/** Base trait for immutable indexed sequences that have efficient `apply` and `length`. */
+/** Base trait for immutable indexed sequences that have efficient `apply` and `length`.
+ *
+ *  @tparam A the element type of the indexed sequence
+ */
 trait IndexedSeq[+A] extends Seq[A]
                         with collection.IndexedSeq[A]
                         with IndexedSeqOps[A, IndexedSeq, IndexedSeq[A]]
@@ -94,7 +100,7 @@ trait IndexedSeq[+A] extends Seq[A]
   /** a hint to the runtime when scanning values
    *  [[apply]] is preferred for scan with a max index less than this value
    *  [[iterator]] is preferred for scans above this range
-   *  @return a hint about when to use [[apply]] or [[iterator]]
+   *  @return the maximum length below which [[apply]] is preferred over [[iterator]] for element access
    */
   protected def applyPreferredMaxLength: Int = IndexedSeqDefaults.defaultApplyPreferredMaxLength
 
@@ -118,7 +124,11 @@ object IndexedSeq extends SeqFactory.Delegate[IndexedSeq](Vector) {
   }
 }
 
-/** Base trait for immutable indexed `Seq` operations. */
+/** Base trait for immutable indexed `Seq` operations.
+ *
+ *  @tparam A the element type of the indexed sequence
+ *  @tparam CC the type constructor for the collection type, constrained to be pure
+ */
 transparent trait IndexedSeqOps[+A, +CC[B] <: caps.Pure, +C]
   extends SeqOps[A, CC, C]
     with collection.IndexedSeqOps[A, CC, C] {
@@ -131,7 +141,10 @@ transparent trait IndexedSeqOps[+A, +CC[B] <: caps.Pure, +C]
 
 }
 
-/** Base trait for immutable linear sequences that have efficient `head` and `tail`. */
+/** Base trait for immutable linear sequences that have efficient `head` and `tail`.
+ *
+ *  @tparam A the element type of the linear sequence
+ */
 trait LinearSeq[+A]
   extends Seq[A]
     with collection.LinearSeq[A]
@@ -153,5 +166,8 @@ transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & 
   extends Any with SeqOps[A, CC, C]
     with collection.LinearSeqOps[A, CC, C]
 
-/** Explicit instantiation of the `Seq` trait to reduce class file size in subclasses. */
+/** Explicit instantiation of the `Seq` trait to reduce class file size in subclasses.
+ *
+ *  @tparam A the element type of the sequence
+ */
 abstract class AbstractSeq[+A] extends scala.collection.AbstractSeq[A] with Seq[A]

--- a/library/src/scala/collection/immutable/Set.scala
+++ b/library/src/scala/collection/immutable/Set.scala
@@ -20,7 +20,10 @@ import language.experimental.captureChecking
 import scala.collection.immutable.Set.Set4
 import scala.collection.mutable.{Builder, ReusableBuilder}
 
-/** Base trait for immutable set collections. */
+/** Base trait for immutable set collections.
+ *
+ *  @tparam A the element type of the set
+ */
 trait Set[A] extends Iterable[A]
     with collection.Set[A]
     with SetOps[A, Set, Set[A]]
@@ -32,6 +35,9 @@ trait Set[A] extends Iterable[A]
  *
  *  @define coll immutable set
  *  @define Coll `immutable.Set`
+ *
+ *  @tparam A the element type of the set
+ *  @tparam CC the type constructor for the resulting set (e.g., `Set`)
  */
 transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   extends collection.SetOps[A, CC, C] {
@@ -45,7 +51,10 @@ transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
    */
   def incl(elem: A): C
 
-  /** Alias for `incl`. */
+  /** Alias for `incl`.
+   *
+   *  @param elem the element to add
+   */
   override final def + (elem: A): C = incl(elem) // like in collection.Set but not deprecated
 
   /** Creates a new set with a given element removed from this set.
@@ -56,7 +65,10 @@ transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
    */
   def excl(elem: A): C
 
-  /** Alias for `excl`. */
+  /** Alias for `excl`.
+   *
+   *  @param elem the element to remove
+   */
   @`inline` final override def - (elem: A): C = excl(elem)
 
   def diff(that: collection.Set[A]): C =
@@ -70,7 +82,10 @@ transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
    */
   def removedAll(that: IterableOnce[A]^): C = that.iterator.foldLeft[C](coll)(_ - _)
 
-  /** Alias for removedAll. */
+  /** Alias for removedAll.
+   *
+   *  @param that the collection of elements to remove
+   */
   override final def -- (that: IterableOnce[A]^): C = removedAll(that)
 }
 
@@ -355,11 +370,16 @@ object Set extends IterableFactory[Set] {
   }
 }
 
-/** Explicit instantiation of the `Set` trait to reduce class file size in subclasses. */
+/** Explicit instantiation of the `Set` trait to reduce class file size in subclasses.
+ *
+ *  @tparam A the element type of the set
+ */
 abstract class AbstractSet[A] extends scala.collection.AbstractSet[A] with Set[A]
 
 /** Builder for Set.
  *  $multipleResults
+ *
+ *  @tparam A the element type of the set being built
  */
 private final class SetBuilderImpl[A] extends ReusableBuilder[A, Set[A]] {
   private var elems: Set[A] = Set.empty

--- a/library/src/scala/collection/immutable/SortedMap.scala
+++ b/library/src/scala/collection/immutable/SortedMap.scala
@@ -69,6 +69,7 @@ trait SortedMap[K, +V]
    *
    *  Invoking transformer methods (e.g. `map`) will not preserve the default value.
    *
+   *  @tparam V1 the type of the values in the resulting map, a supertype of `V`
    *  @param d     the function mapping keys to values, used for non-present keys
    *  @return      a wrapper of the map with a default value
    */
@@ -80,6 +81,7 @@ trait SortedMap[K, +V]
    *
    *  Invoking transformer methods (e.g. `map`) will not preserve the default value.
    *
+   *  @tparam V1 the type of the values in the resulting map, a supertype of `V`
    *  @param d     default value used for non-present keys
    *  @return      a wrapper of the map with a default value
    */

--- a/library/src/scala/collection/immutable/SortedSet.scala
+++ b/library/src/scala/collection/immutable/SortedSet.scala
@@ -17,7 +17,10 @@ package immutable
 import scala.language.`2.13`
 import language.experimental.captureChecking
 
-/** Base trait for sorted sets. */
+/** Base trait for sorted sets.
+ *
+ *  @tparam A the element type of the sorted set, which must have an implicit `Ordering`
+ */
 trait SortedSet[A]
   extends Set[A]
      with collection.SortedSet[A]
@@ -32,6 +35,10 @@ trait SortedSet[A]
 /**
  *  @define coll immutable sorted set
  *  @define Coll `immutable.SortedSet`
+ *
+ *  @tparam A the element type of the sorted set
+ *  @tparam CC the type constructor for the resulting sorted set (e.g., `SortedSet`)
+ *  @tparam C the type of the concrete sorted set
  */
 transparent trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
   extends SetOps[A, Set, C]

--- a/library/src/scala/collection/immutable/Stream.scala
+++ b/library/src/scala/collection/immutable/Stream.scala
@@ -52,6 +52,7 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
   /** Applies the given function `f` to each element of this linear sequence
    *  (while respecting the order of the elements).
    *
+   *  @tparam U the result type of `f`, discarded by `foreach`
    *  @param f The treatment to apply to each element.
    *  @note  Overridden here as final to trigger tail-call optimization, which
    *  replaces 'this' with 'tail' at each iteration. This is absolutely
@@ -117,6 +118,7 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
 
   /** The stream resulting from the concatenation of this stream with the argument stream.
    *
+   *  @tparam B the element type of the returned stream, which must be a supertype of `A`
    *  @param suffix The collection that gets appended to this stream
    *  @return The stream containing elements of this stream and the iterable object.
    */
@@ -163,7 +165,10 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
     else iterableFactory.empty
   }
 
-  /** A `collection.WithFilter` which allows GC of the head of stream during processing. */
+  /** A `collection.WithFilter` which allows GC of the head of stream during processing.
+   *
+   *  @param p the predicate used to test elements
+   */
   override final def withFilter(p: A => Boolean): collection.WithFilter[A, Stream] =
     Stream.withFilter(coll, p)
 
@@ -362,12 +367,18 @@ object Stream extends SeqFactory[Stream] {
   /** An alternative way of building and matching Streams using Stream.cons(hd, tl). */
   object cons {
     /** A stream consisting of a given first element and remaining elements.
+     *
+     *  @tparam A the element type of the stream
      *  @param hd   The first element of the result stream
      *  @param tl   The remaining elements of the result stream
      */
     def apply[A](hd: A, tl: => Stream[A]): Stream[A] = new Cons(hd, tl)
 
-    /** Maps a stream to its head and tail. */
+    /** Maps a stream to its head and tail.
+     *
+     *  @tparam A the element type of the stream
+     *  @param xs the stream to decompose
+     */
     def unapply[A](xs: Stream[A]): Option[(A, Stream[A])] = #::.unapply(xs)
   }
 
@@ -487,6 +498,7 @@ object Stream extends SeqFactory[Stream] {
 
   /** An infinite Stream that repeatedly applies a given function to a start value.
    *
+   *  @tparam A the element type of the stream
    *  @param start the start value of the Stream
    *  @param f     the function that's repeatedly applied
    *  @return      the Stream returning the infinite sequence of values `start, f(start), f(f(start)), ...`
@@ -515,6 +527,7 @@ object Stream extends SeqFactory[Stream] {
   /** Creates an infinite Stream containing the given element expression (which
    *  is computed for each occurrence).
    *
+   *  @tparam A the element type of the stream
    *  @param elem the element composing the resulting Stream
    *  @return the Stream containing an infinite number of elem
    */

--- a/library/src/scala/collection/immutable/StrictOptimizedSeqOps.scala
+++ b/library/src/scala/collection/immutable/StrictOptimizedSeqOps.scala
@@ -19,7 +19,12 @@ import language.experimental.captureChecking
 
 import scala.collection.generic.CommonErrors
 
-/** Trait that overrides operations to take advantage of strict builders. */
+/** Trait that overrides operations to take advantage of strict builders.
+ *
+ *  @tparam A the element type of the collection
+ *  @tparam CC the type constructor of the collection (higher-kinded)
+ *  @tparam C the type of the collection itself
+ */
 transparent trait StrictOptimizedSeqOps[+A, +CC[B] <: caps.Pure, +C]
   extends Any
     with SeqOps[A, CC, C]

--- a/library/src/scala/collection/mutable/ArrayBuffer.scala
+++ b/library/src/scala/collection/mutable/ArrayBuffer.scala
@@ -65,7 +65,10 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
 
   override def knownSize: Int = super[IndexedSeqOps].knownSize
 
-  /** Ensures that the internal array has at least `n` cells. */
+  /** Ensures that the internal array has at least `n` cells.
+   *
+   *  @param n the minimum number of cells required in the internal array
+   */
   protected def ensureSize(n: Int): Unit = {
     array = ArrayBuffer.ensureSize(array, size0, n)
   }
@@ -77,7 +80,10 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
   def sizeHint(size: Int): Unit =
     if(size > length && size >= 1) ensureSize(size)
 
-  /** Reduces length to `n`, nulling out all dropped elements. */
+  /** Reduces length to `n`, nulling out all dropped elements.
+   *
+   *  @param n the new size of the buffer, must be less than or equal to the current size
+   */
   private def reduceToSize(n: Int): Unit = {
     mutationCount += 1
     Arrays.fill(array, n, size0, null)
@@ -95,6 +101,8 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
 
   /** Trims the `array` buffer size down to either a power of 2
    *  or Int.MaxValue while keeping first `requiredLength` elements.
+   *
+   *  @param requiredLength the number of elements to retain in the resized array
    */
   private def resize(requiredLength: Int): Unit =
     array = ArrayBuffer.downsize(array, requiredLength)
@@ -246,6 +254,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
   /** Sorts this $coll in place according to an Ordering.
    *
    *  @see [[scala.collection.mutable.IndexedSeqOps.sortInPlace]]
+   *  @tparam B a supertype of the element type `A` for which an `Ordering` is available
    *  @param  ord the ordering to be used to compare elements.
    *  @return modified input $coll sorted according to the ordering `ord`.
    */

--- a/library/src/scala/collection/mutable/ArrayBuilder.scala
+++ b/library/src/scala/collection/mutable/ArrayBuilder.scala
@@ -47,10 +47,18 @@ sealed abstract class ArrayBuilder[T]
 
   protected def resize(size: Int): Unit
 
-  /** Adds all elements of an array. */
+  /** Adds all elements of an array.
+   *
+   *  @param xs the array of elements to add
+   */
   def addAll(xs: Array[? <: T]): this.type = addAll(xs, 0, xs.length)
 
-  /** Adds a slice of an array. */
+  /** Adds a slice of an array.
+   *
+   *  @param xs the array from which a slice of elements is added
+   *  @param offset the start index within `xs` from which to copy elements (clamped to 0 if negative)
+   *  @param length the maximum number of elements to copy from `xs` (clamped to 0 if negative, and to the number of available elements)
+   */
   def addAll(xs: Array[? <: T], offset: Int, length: Int): this.type = {
     val offset1 = offset.max(0)
     val length1 = length.max(0)

--- a/library/src/scala/collection/mutable/ArraySeq.scala
+++ b/library/src/scala/collection/mutable/ArraySeq.scala
@@ -121,6 +121,10 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
    *  boxed, the resulting instance is an [[ArraySeq.ofRef]]. Writing
    *  `ArraySeq.make(a.asInstanceOf[Array[Int]])` does not work, it throws a `ClassCastException`
    *  at runtime.
+   *
+   *  @tparam T the element type of the array
+   *  @param x the array to wrap
+   *  @return an `ArraySeq` wrapping the given array using the appropriate primitive specialization, or `null` if `x` is `null`
    */
   def make[T](x: Array[T]): ArraySeq[T] = ((x: @unchecked) match {
     case null              => null

--- a/library/src/scala/collection/mutable/BitSet.scala
+++ b/library/src/scala/collection/mutable/BitSet.scala
@@ -34,6 +34,8 @@ import scala.annotation.implicitNotFound
  *  @define orderDependentFold
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
+ *
+ *  @param protected[collection] final var elems the underlying array of `Long` words storing the bits; used directly without copying, so external mutations will affect this bitset
  */
 class BitSet(protected[collection] final var elems: Array[Long])
   extends AbstractSet[Int]
@@ -368,7 +370,10 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
 
   def newBuilder: Builder[Int, BitSet] = new GrowableBuilder(empty)
 
-  /** A bitset containing all the bits in an array. */
+  /** A bitset containing all the bits in an array.
+   *
+   *  @param elems the array of `Long` words representing the bits; a defensive copy is made
+   */
   def fromBitMask(elems: Array[Long]): BitSet = {
     val len = elems.length
     if (len == 0) empty
@@ -380,6 +385,8 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
 
   /** A bitset containing all the bits in an array, wrapping the existing
    *  array without copying.
+   *
+   *  @param elems the array of `Long` words representing the bits, used directly without copying; the caller must not mutate the array afterward
    */
   def fromBitMaskNoCopy(elems: Array[Long]): BitSet = {
     val len = elems.length

--- a/library/src/scala/collection/mutable/Buffer.scala
+++ b/library/src/scala/collection/mutable/Buffer.scala
@@ -22,6 +22,8 @@ import scala.annotation.nowarn
  *
  *  @define coll buffer
  *  @define Coll `Buffer`
+ *
+ *  @tparam A the element type of the buffer
  */
 trait Buffer[A]
   extends Seq[A]
@@ -311,5 +313,8 @@ object Buffer extends SeqFactory.Delegate[Buffer](ArrayBuffer)
 @SerialVersionUID(3L)
 object IndexedBuffer extends SeqFactory.Delegate[IndexedBuffer](ArrayBuffer)
 
-/** Explicit instantiation of the `Buffer` trait to reduce class file size in subclasses. */
+/** Explicit instantiation of the `Buffer` trait to reduce class file size in subclasses.
+ *
+ *  @tparam A the element type of the buffer
+ */
 abstract class AbstractBuffer[A] extends AbstractSeq[A] with Buffer[A]

--- a/library/src/scala/collection/mutable/Builder.scala
+++ b/library/src/scala/collection/mutable/Builder.scala
@@ -22,6 +22,9 @@ import language.experimental.captureChecking
  *  Builder, in which case `result()` simply returns `this`.
  *
  *  @see [[scala.collection.mutable.ReusableBuilder]] for Builders which can be reused after calling `result()`
+ *
+ *  @tparam A the type of elements that can be added to this builder
+ *  @tparam To the type of collection produced by this builder
  */
 trait Builder[-A, +To] extends Growable[A] { self: Builder[A, To]^ =>
 
@@ -94,7 +97,11 @@ trait Builder[-A, +To] extends Growable[A] { self: Builder[A, To]^ =>
     }
   }
 
-  /** A builder resulting from this builder by mapping the result using `f`. */
+  /** A builder resulting from this builder by mapping the result using `f`.
+   *
+   *  @tparam NewTo the type of collection produced by the returned builder
+   *  @param f the function to apply to this builder's result
+   */
   def mapResult[NewTo](f: To => NewTo): Builder[A, NewTo]^{this, f} = new Builder[A, NewTo] {
     def addOne(x: A): this.type = { self += x; this }
     def clear(): Unit = self.clear()

--- a/library/src/scala/collection/mutable/CollisionProofHashMap.scala
+++ b/library/src/scala/collection/mutable/CollisionProofHashMap.scala
@@ -34,6 +34,11 @@ import scala.runtime.Statics
  *  @define coll mutable collision-proof hash map
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
+ *
+ *  @tparam K the type of the keys contained in this hash map
+ *  @tparam V the type of the values associated with the keys
+ *  @param initialCapacity the initial capacity of the internal hash table
+ *  @param loadFactor the load factor for the hash table, used to determine when to resize
  */
 final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double)(implicit ordering: Ordering[K])
   extends AbstractMap[K, V]
@@ -414,6 +419,8 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
 
   /** Builds a new `CollisionProofHashMap` by applying a function to all elements of this $coll.
    *
+   *  @tparam K2 the key type of the returned collection
+   *  @tparam V2 the value type of the returned collection
    *  @param f      the function to apply to each element.
    *  @return       a new $coll resulting from applying the given function
    *                `f` to each element of this $coll and collecting the results.
@@ -425,6 +432,8 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
   /** Builds a new `CollisionProofHashMap` by applying a function to all elements of this $coll
    *  and using the elements of the resulting collections.
    *
+   *  @tparam K2 the key type of the returned collection
+   *  @tparam V2 the value type of the returned collection
    *  @param f      the function to apply to each element.
    *  @return       a new $coll resulting from applying the given collection-valued function
    *                `f` to each element of this $coll and concatenating the results.
@@ -436,6 +445,8 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
   /** Builds a new sorted map by applying a partial function to all elements of this $coll
    *  on which the function is defined.
    *
+   *  @tparam K2 the key type of the returned collection
+   *  @tparam V2 the value type of the returned collection
    *  @param pf     the partial function which filters and maps the $coll.
    *  @return       a new $coll resulting from applying the given partial function
    *                `pf` to each element on which it is defined and collecting the results.
@@ -450,7 +461,11 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
     case _ => iterator.concat(suffix.iterator)
   })
 
-  /** Alias for `concat`. */
+  /** Alias for `concat`.
+   *
+   *  @tparam V2 the value type of the returned collection
+   *  @param xs the key-value pairs to append to this collection
+   */
   @`inline` override final def ++ [V2 >: V](xs: IterableOnce[(K, V2)]^): CollisionProofHashMap[K, V2] = concat(xs)
 
   @deprecated("Consider requiring an immutable Map or fall back to Map.concat", "2.13.0")
@@ -695,6 +710,10 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
 
   /** Transplant the node `from` to the place of node `to`. This is done by setting `from` as a child of `to`'s previous
    *  parent and setting `from`'s parent to the `to`'s previous parent. The children of `from` are left unchanged.
+   *
+   *  @param _root the root of the red-black tree
+   *  @param to the node to be replaced in the tree
+   *  @param from the node that replaces `to`
    */
   private def transplant(_root: RBNode, to: RBNode, from: RBNode): RBNode = {
     var root = _root
@@ -836,6 +855,10 @@ object CollisionProofHashMap extends SortedMapFactory[CollisionProofHashMap] {
 
   /** Returns the node that follows `node` in an in-order tree traversal. If `node` has the maximum key (and is,
    *  therefore, the last node), this method returns `null`.
+   *
+   *  @tparam A the key type of the tree nodes
+   *  @tparam B the value type of the tree nodes
+   *  @param node the node whose successor is to be found
    */
   private def successor[A, B](node: RBNode[A, B]): RBNode[A, B] | Null = {
     if (node.right ne null) minNodeNonNull(node.right)

--- a/library/src/scala/collection/mutable/Growable.scala
+++ b/library/src/scala/collection/mutable/Growable.scala
@@ -25,6 +25,8 @@ import language.experimental.captureChecking
  *  @define Coll `Growable`
  *  @define add add
  *  @define Add Add
+ *
+ *  @tparam A the type of elements that can be added to this collection
  */
 trait Growable[-A] extends Clearable {
 

--- a/library/src/scala/collection/mutable/GrowableBuilder.scala
+++ b/library/src/scala/collection/mutable/GrowableBuilder.scala
@@ -23,6 +23,9 @@ import language.experimental.captureChecking
  *
  *  @define Coll `GrowingBuilder`
  *  @define coll growing builder
+ *
+ *  @tparam Elem the type of elements that can be added to the builder
+ *  @tparam To the type of the resulting growable collection, which must be a subtype of `Growable[Elem]`
  */
 class GrowableBuilder[Elem, To <: Growable[Elem]](protected val elems: To)
   extends Builder[Elem, To] {

--- a/library/src/scala/collection/mutable/HashMap.scala
+++ b/library/src/scala/collection/mutable/HashMap.scala
@@ -62,10 +62,16 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
 
   override def size: Int = contentSize
 
-  /** Performs the inverse operation of improveHash. In this case, it happens to be identical to improveHash. */
+  /** Performs the inverse operation of improveHash. In this case, it happens to be identical to improveHash.
+   *
+   *  @param improvedHash the improved hash value to convert back to the original `any.##` hash
+   */
   @`inline` private[collection] def unimproveHash(improvedHash: Int): Int = improveHash(improvedHash)
 
-  /** Computes the improved hash of an original (`any.##`) hash. */
+  /** Computes the improved hash of an original (`any.##`) hash.
+   *
+   *  @param originalHash the original hash code from `any.##`
+   */
   @`inline` private def improveHash(originalHash: Int): Int = {
     // Improve the hash by xoring the high 16 bits into the low 16 bits just in case entropy is skewed towards the
     // high-value bits. We only use the lowest bits to determine the hash bucket. This is the same improvement
@@ -77,7 +83,10 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
     originalHash ^ (originalHash >>> 16)
   }
 
-  /** Computes the improved hash of this key. */
+  /** Computes the improved hash of this key.
+   *
+   *  @param o the key for which to compute the improved hash
+   */
   @`inline` private def computeHash(o: K): Int = improveHash(o.##)
 
   @`inline` private def index(hash: Int) = hash & (table.length - 1)

--- a/library/src/scala/collection/mutable/HashSet.scala
+++ b/library/src/scala/collection/mutable/HashSet.scala
@@ -30,6 +30,10 @@ import scala.util.hashing.MurmurHash3
  *  @define coll mutable hash set
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
+ *
+ *  @tparam A the element type of the set
+ *  @param initialCapacity the initial capacity of the internal hash table
+ *  @param loadFactor the load factor for the hash table (ratio of size to capacity that triggers resizing)
  */
 final class HashSet[A](initialCapacity: Int, loadFactor: Double)
   extends AbstractSet[A]
@@ -57,10 +61,16 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
 
   override def size: Int = contentSize
 
-  /** Performs the inverse operation of improveHash. In this case, it happens to be identical to improveHash. */
+  /** Performs the inverse operation of improveHash. In this case, it happens to be identical to improveHash.
+   *
+   *  @param improvedHash the improved hash value to convert back to a standard hash index
+   */
   @`inline` private[collection] def unimproveHash(improvedHash: Int): Int = improveHash(improvedHash)
 
-  /** Computes the improved hash of an original (`any.##`) hash. */
+  /** Computes the improved hash of an original (`any.##`) hash.
+   *
+   *  @param originalHash the original hash code obtained from `##`
+   */
   private def improveHash(originalHash: Int): Int = {
     // Improve the hash by xoring the high 16 bits into the low 16 bits just in case entropy is skewed towards the
     // high-value bits. We only use the lowest bits to determine the hash bucket. This is the same improvement
@@ -68,7 +78,10 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
     originalHash ^ (originalHash >>> 16)
   }
 
-  /** Computes the improved hash of this element. */
+  /** Computes the improved hash of this element.
+   *
+   *  @param o the element whose hash to compute
+   */
   @`inline` private def computeHash(o: A): Int = improveHash(o.##)
 
   @`inline` private def index(hash: Int) = hash & (table.length - 1)

--- a/library/src/scala/collection/mutable/ImmutableBuilder.scala
+++ b/library/src/scala/collection/mutable/ImmutableBuilder.scala
@@ -17,7 +17,11 @@ package mutable
 import scala.language.`2.13`
 import language.experimental.captureChecking
 
-/** Reusable builder for immutable collections */
+/** Reusable builder for immutable collections
+ *
+ *  @tparam A the element type of the collection being built
+ *  @tparam C the type of the immutable collection to build (must be a subtype of `IterableOnce[?]`)
+ */
 abstract class ImmutableBuilder[-A, C <: IterableOnce[?]](empty: C)
   extends ReusableBuilder[A, C] {
 

--- a/library/src/scala/collection/mutable/IndexedSeq.scala
+++ b/library/src/scala/collection/mutable/IndexedSeq.scala
@@ -48,6 +48,7 @@ transparent trait IndexedSeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
   /** Sorts this $coll in place according to an Ordering.
    *
    *  @see [[scala.collection.SeqOps.sorted]]
+   *  @tparam B a supertype of the element type `A` for which an `Ordering` is available
    *  @param  ord the ordering to be used to compare elements.
    *  @return modified input $coll sorted according to the ordering `ord`.
    */
@@ -73,6 +74,8 @@ transparent trait IndexedSeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
   /** Sorts this $coll in place according to a comparison function.
    *
    *  @see [[scala.collection.SeqOps.sortWith]]
+   *
+   *  @param lt the less-than comparison function; should return `true` if the first argument strictly precedes the second in the desired ordering
    */
   def sortInPlaceWith(lt: (A, A) => Boolean): this.type = sortInPlace()(using Ordering.fromLessThan(lt))
 
@@ -80,6 +83,10 @@ transparent trait IndexedSeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
    *  an implicitly given Ordering with a transformation function.
    *
    *  @see [[scala.collection.SeqOps.sortBy]]
+   *
+   *  @tparam B the target type of the transformation function `f`, for which an `Ordering` must exist
+   *  @param f the transformation function that extracts a sort key of type `B` from each element
+   *  @param ord the implicit ordering on type `B` used to compare transformed elements
    */
   def sortInPlaceBy[B](f: A => B)(implicit ord: Ordering[B]): this.type = sortInPlace()(using ord.on(f))
 

--- a/library/src/scala/collection/mutable/Iterable.scala
+++ b/library/src/scala/collection/mutable/Iterable.scala
@@ -31,5 +31,8 @@ trait Iterable[A]
 @SerialVersionUID(3L)
 object Iterable extends IterableFactory.Delegate[Iterable](ArrayBuffer)
 
-/** Explicit instantiation of the `Iterable` trait to reduce class file size in subclasses. */
+/** Explicit instantiation of the `Iterable` trait to reduce class file size in subclasses.
+ *
+ *  @tparam A the element type of the collection
+ */
 abstract class AbstractIterable[A] extends scala.collection.AbstractIterable[A] with Iterable[A]

--- a/library/src/scala/collection/mutable/LinkedHashMap.scala
+++ b/library/src/scala/collection/mutable/LinkedHashMap.scala
@@ -159,8 +159,8 @@ class LinkedHashMap[K, V]
   /** Removes a key from this map if it exists
    *
    *  @param elem the element to remove
-   *  @param hash the **improved** hashcode of `element` (see computeHash)
-   *  @return the node that contained element if it was present, otherwise null
+   *  @param hash the **improved** hash code of `elem` (see `computeHash`)
+   *  @return the node that contained `elem` if it was present, otherwise `null`
    */
   private def removeEntry0(elem: K, hash: Int): Entry | Null = {
     val idx = index(hash)
@@ -190,13 +190,19 @@ class LinkedHashMap[K, V]
     }
   }
 
-  /** Computes the improved hash of an original (`any.##`) hash. */
+  /** Computes the improved hash of an original (`any.##`) hash.
+   *
+   *  @param originalHash the original hash code obtained from `any.##`
+   */
   @`inline` private def improveHash(originalHash: Int): Int = {
     originalHash ^ (originalHash >>> 16)
   }
   @`inline` private[collection] def unimproveHash(improvedHash: Int): Int = improveHash(improvedHash)
 
-  /** Computes the improved hash of this key. */
+  /** Computes the improved hash of this key.
+   *
+   *  @param o the key whose improved hash to compute
+   */
   @`inline` private def computeHash(o: K): Int = improveHash(o.##)
 
   @`inline` private def index(hash: Int) = hash & (table.length - 1)
@@ -365,7 +371,10 @@ class LinkedHashMap[K, V]
     e
   }
 
-  /** Deletes the entry from the LinkedHashMap, set the `earlier` and `later` pointers correctly. */
+  /** Deletes the entry from the LinkedHashMap, set the `earlier` and `later` pointers correctly.
+   *
+   *  @param e the entry to remove from the linked list
+   */
   private def deleteEntry(e: Entry): Unit = {
     if (e.earlier eq null) firstEntry = e.later
     else e.earlier.nn.later = e.later
@@ -495,7 +504,14 @@ object LinkedHashMap extends MapFactory[LinkedHashMap] {
 
   def newBuilder[K, V]: GrowableBuilder[(K, V), LinkedHashMap[K, V]] = new GrowableBuilder(empty[K, V])
 
-  /** Class for the linked hash map entry, used internally. */
+  /** Class for the linked hash map entry, used internally.
+   *
+   *  @tparam K the type of keys stored in this entry
+   *  @tparam V the type of values stored in this entry
+   *  @param key the key for this map entry
+   *  @param hash the improved hash code of `key` (see `improveHash`)
+   *  @param value the value associated with `key`
+   */
   private[mutable] final class LinkedEntry[K, V](val key: K, val hash: Int, var value: V) {
     var earlier: LinkedEntry[K, V] | Null = null
     var later: LinkedEntry[K, V] | Null = null

--- a/library/src/scala/collection/mutable/LinkedHashSet.scala
+++ b/library/src/scala/collection/mutable/LinkedHashSet.scala
@@ -152,7 +152,10 @@ class LinkedHashSet[A]
 
   @`inline` private[collection] def unimproveHash(improvedHash: Int): Int = improveHash(improvedHash)
 
-  /** Computes the improved hash of this key. */
+  /** Computes the improved hash of this key.
+   *
+   *  @param o the key whose hash to compute
+   */
   @`inline` private def computeHash(o: A): Int = improveHash(o.##)
 
   @`inline` private def index(hash: Int) = hash & (table.length - 1)
@@ -180,7 +183,10 @@ class LinkedHashSet[A]
     e
   }
 
-  /** Deletes the entry from the LinkedHashSet, set the `earlier` and `later` pointers correctly. */
+  /** Deletes the entry from the LinkedHashSet, set the `earlier` and `later` pointers correctly.
+   *
+   *  @param e the entry to remove from the insertion-order linked list
+   */
   private def deleteEntry(e: Entry): Unit = {
     if (e.earlier eq null) firstEntry = e.later
     else e.earlier.later = e.later
@@ -329,7 +335,12 @@ object LinkedHashSet extends IterableFactory[LinkedHashSet] {
 
   def newBuilder[A]: GrowableBuilder[A, LinkedHashSet[A]] = new GrowableBuilder(empty[A])
 
-  /** Class for the linked hash set entry, used internally. */
+  /** Class for the linked hash set entry, used internally.
+   *
+   *  @tparam A the type of the elements contained in the linked hash set
+   *  @param key the element stored in this entry
+   *  @param hash the improved hash value of `key`
+   */
   private[mutable] final class Entry[A](val key: A, val hash: Int) {
     @annotation.stableNull var earlier: Entry[A] | Null = null
     @annotation.stableNull var later: Entry[A] | Null = null

--- a/library/src/scala/collection/mutable/ListBuffer.scala
+++ b/library/src/scala/collection/mutable/ListBuffer.scala
@@ -182,6 +182,8 @@ class ListBuffer[A]
 
   /** Reduces the length of the buffer, and nulls out last0
    *  if this reduces the length to 0.
+   *
+   *  @param num the number of elements by which to reduce the length
    */
   private def reduceLengthBy(num: Int): Unit = {
     len -= num
@@ -393,7 +395,7 @@ class ListBuffer[A]
    *
    *  Runs in constant time.
    *
-   *  @return The last element of this $coll.
+   *  @return the last element of this $coll.
    *  @throws NoSuchElementException If the $coll is empty.
    */
   override def last: A = if (last0 eq null) throw new NoSuchElementException("last of empty ListBuffer") else last0.head
@@ -402,7 +404,7 @@ class ListBuffer[A]
    *
    *  Runs in constant time.
    *
-   *  @return the last element of this $coll$ if it is nonempty, `None` if it is empty.
+   *  @return the last element of this $coll if it is nonempty, `None` if it is empty.
    */
   override def lastOption: Option[A] = if (last0 eq null) None else Some(last0.head)
 

--- a/library/src/scala/collection/mutable/LongMap.scala
+++ b/library/src/scala/collection/mutable/LongMap.scala
@@ -36,6 +36,8 @@ import scala.language.implicitConversions
  *  This map is not intended to contain more than 2^29 entries (approximately
  *  500 million).  The maximum capacity is 2^30, but performance will degrade
  *  rapidly as 2^30 is approached.
+ *
+ *  @tparam V the type of the values stored in this map
  */
 final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBufferSize: Int, initBlank: Boolean)
   extends AbstractMap[Long, V]
@@ -56,17 +58,26 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
   }
   override protected def newSpecificBuilder: Builder[(Long, V),LongMap[V]] = new GrowableBuilder(LongMap.empty[V])
 
-  /** Creates a new `LongMap` that returns default values according to a supplied key-value mapping. */
+  /** Creates a new `LongMap` that returns default values according to a supplied key-value mapping.
+   *
+   *  @param defaultEntry the function mapping keys to default values
+   */
   def this(defaultEntry: Long -> V) = this(defaultEntry, 16, initBlank = true)
 
   /** Creates a new `LongMap` with an initial buffer of specified size.
    *
    *  A LongMap can typically contain half as many elements as its buffer size
    *  before it requires resizing.
+   *
+   *  @param initialBufferSize the initial size of the internal buffer; the map can hold about half this many elements before resizing
    */
   def this(initialBufferSize: Int) = this(LongMap.exceptionDefault, initialBufferSize, initBlank = true)
 
-  /** Creates a new `LongMap` with specified default values and initial buffer size. */
+  /** Creates a new `LongMap` with specified default values and initial buffer size.
+   *
+   *  @param defaultEntry the function mapping keys to default values
+   *  @param initialBufferSize the initial size of the internal buffer; the map can hold about half this many elements before resizing
+   */
   def this(defaultEntry: Long -> V,  initialBufferSize: Int) = this(defaultEntry,  initialBufferSize,  initBlank = true)
 
   private var mask = 0
@@ -220,6 +231,9 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
    *  Note: this is the fastest way to retrieve a value that may or
    *  may not exist, if the default null/zero is acceptable.  For key/value
    *  pairs that do exist,  `apply` (i.e. `map(key)`) is equally fast.
+   *
+   *  @param key the key to look up
+   *  @return the value associated with `key`, or `null` if not present
    */
   def getOrNull(key: Long): V | Null = {
     if (key == -key) {
@@ -236,6 +250,8 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
   /** Retrieves the value associated with a key.
    *  If the key does not exist in the map, the `defaultEntry` for that key
    *  will be returned instead.
+   *
+   *  @param key the key to look up
    */
   override def apply(key: Long): V = {
     if (key == -key) {
@@ -251,6 +267,8 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
 
   /** The user-supplied default value for the key.  Throws an exception
    *  if no other default behavior was specified.
+   *
+   *  @param key the key whose default value is requested
    */
   override def default(key: Long) = defaultEntry(key)
 
@@ -321,6 +339,9 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
   /** Updates the map to include a new key-value pair.
    *
    *  This is the fastest way to add an entry to a `LongMap`.
+   *
+   *  @param key the key to update
+   *  @param value the new value to associate with `key`
    */
   override def update(key: Long, value: V): Unit = {
     if (key == -key) {
@@ -354,7 +375,11 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
   @deprecated("Use `addOne` or `update` instead; infix operations with an operand of multiple args will be deprecated", "2.13.3")
   def +=(key: Long, value: V): this.type = { update(key, value); this }
 
-  /** Adds a new key/value pair to this map and returns the map. */
+  /** Adds a new key/value pair to this map and returns the map.
+   *
+   *  @param key the key to add
+   *  @param value the value to associate with `key`
+   */
   @inline final def addOne(key: Long, value: V): this.type = { update(key, value); this }
 
   @inline override final def addOne(kv: (Long, V)): this.type = { update(kv._1, kv._2); this }
@@ -486,7 +511,11 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
   override def updated[V1 >: V](key: Long, value: V1): LongMap[V1] =
     clone().asInstanceOf[LongMap[V1]].addOne(key, value)
 
-  /** Applies a function to all keys of this map. */
+  /** Applies a function to all keys of this map.
+   *
+   *  @tparam A the result type of the function
+   *  @param f the function to apply to each key
+   */
   def foreachKey[A](f: Long => A): Unit = {
     if ((extraKeys & 1) == 1) f(0L)
     if ((extraKeys & 2) == 2) f(Long.MinValue)
@@ -501,7 +530,11 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
     }
   }
 
-  /** Applies a function to all values of this map. */
+  /** Applies a function to all values of this map.
+   *
+   *  @tparam A the result type of the function
+   *  @param f the function to apply to each value
+   */
   def foreachValue[A](f: V => A): Unit = {
     if ((extraKeys & 1) == 1) f(zeroValue.asInstanceOf[V])
     if ((extraKeys & 2) == 2) f(minValue.asInstanceOf[V])
@@ -519,6 +552,9 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
   /** Creates a new `LongMap` with different values.
    *  Unlike `mapValues`, this method generates a new
    *  collection immediately.
+   *
+   *  @tparam V1 the type of the values in the resulting map
+   *  @param f the transformation function applied to each value
    */
   def mapValuesNow[V1](f: V => V1): LongMap[V1] = {
     val zv = if ((extraKeys & 1) == 1) f(zeroValue.asInstanceOf[V]).asInstanceOf[AnyRef | Null] else null
@@ -547,6 +583,8 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
 
   /** Applies a transformation function to all values stored in this map.
    *  Note: the default, if any,  is not transformed.
+   *
+   *  @param f the transformation function applied to each value
    */
   def transformValuesInPlace(f: V => V): this.type = {
     if ((extraKeys & 1) == 1) zeroValue = f(zeroValue.asInstanceOf[V]).asInstanceOf[AnyRef | Null]
@@ -565,19 +603,22 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
 
   /** An overload of `map` which produces a `LongMap`.
    *
+   *  @tparam V2 the value type of the resulting map
    *  @param f the mapping function
    */
   def map[V2](f: ((Long, V)) => (Long, V2)): LongMap[V2] = LongMap.from(new View.Map(coll, f))
 
   /** An overload of `flatMap` which produces a `LongMap`.
    *
+   *  @tparam V2 the value type of the resulting map
    *  @param f the mapping function
    */
   def flatMap[V2](f: ((Long, V)) => IterableOnce[(Long, V2)]^): LongMap[V2] = LongMap.from(new View.FlatMap(coll, f))
 
   /** An overload of `collect` which produces a `LongMap`.
    *
-   *  @param pf the mapping function
+   *  @tparam V2 the value type of the resulting map
+   *  @param pf the partial function to apply to matching elements
    */
   def collect[V2](pf: PartialFunction[(Long, V), (Long, V2)]): LongMap[V2] =
     strictOptimizedCollect(LongMap.newBuilder[V2], pf)
@@ -598,6 +639,8 @@ object LongMap {
   /** A builder for instances of `LongMap`.
    *
    *  This builder can be reused to create multiple instances.
+   *
+   *  @tparam V the type of the values in the map being built
    */
   final class LongMapBuilder[V] extends ReusableBuilder[(Long, V), LongMap[V]] {
     private[collection] var elems: LongMap[V] = new LongMap[V]
@@ -610,7 +653,11 @@ object LongMap {
     override def knownSize: Int = elems.knownSize
   }
 
-  /** Creates a new `LongMap` with zero or more key/value pairs. */
+  /** Creates a new `LongMap` with zero or more key/value pairs.
+   *
+   *  @tparam V the type of the values
+   *  @param elems the key/value pairs to initialize the map with
+   */
   def apply[V](elems: (Long, V)*): LongMap[V] = buildFromIterableOnce(elems)
 
   private def buildFromIterableOnce[V](elems: IterableOnce[(Long, V)]^): LongMap[V] = {
@@ -622,18 +669,25 @@ object LongMap {
     lm
   }
 
-  /** Creates a new empty `LongMap`. */
+  /** Creates a new empty `LongMap`.
+   *
+   *  @tparam V the type of the values
+   */
   def empty[V]: LongMap[V] = new LongMap[V]
 
-  /** Creates a new empty `LongMap` with the supplied default. */
+  /** Creates a new empty `LongMap` with the supplied default.
+   *
+   *  @tparam V the type of the values
+   *  @param default the function mapping keys to default values
+   */
   def withDefault[V](default: Long -> V): LongMap[V] = new LongMap[V](default)
 
   /** Creates a new `LongMap` from an existing source collection. A source collection
    *  which is already a `LongMap` gets cloned.
    *
-   *  @tparam V the type of the collection’s elements
-   *  @param source Source collection
-   *  @return a new `LongMap` with the elements of `source`
+   *  @tparam V the type of the values
+   *  @param source the source collection to create the map from
+   *  @return a new `LongMap` with the elements of `source`; if `source` is already a `LongMap`, it is cloned
    */
   def from[V](source: IterableOnce[(Long, V)]^): LongMap[V] = source match {
     case source: LongMap[?] => source.clone().asInstanceOf[LongMap[V]]
@@ -644,6 +698,10 @@ object LongMap {
 
   /** Creates a new `LongMap` from arrays of keys and values.
    *  Equivalent to but more efficient than `LongMap((keys zip values): _*)`.
+   *
+   *  @tparam V the type of the values
+   *  @param keys the array of `Long` keys
+   *  @param values the array of values corresponding to each key
    */
   def fromZip[V](keys: Array[Long], values: Array[V]): LongMap[V] = {
     val sz = math.min(keys.length, values.length)
@@ -656,6 +714,10 @@ object LongMap {
 
   /** Creates a new `LongMap` from keys and values.
    *  Equivalent to but more efficient than `LongMap((keys zip values): _*)`.
+   *
+   *  @tparam V the type of the values
+   *  @param keys the iterable of `Long` keys
+   *  @param values the iterable of values corresponding to each key
    */
   def fromZip[V](keys: scala.collection.Iterable[Long], values: scala.collection.Iterable[V]): LongMap[V] = {
     val sz = math.min(keys.size, values.size)

--- a/library/src/scala/collection/mutable/Map.scala
+++ b/library/src/scala/collection/mutable/Map.scala
@@ -18,7 +18,11 @@ import language.experimental.captureChecking
 
 import scala.language.`2.13`
 
-/** Base type of mutable Maps. */
+/** Base type of mutable Maps.
+ *
+ *  @tparam K the type of keys in the map
+ *  @tparam V the type of values associated with keys
+ */
 trait Map[K, V]
   extends Iterable[(K, V)]
     with collection.Map[K, V]
@@ -65,6 +69,11 @@ trait Map[K, V]
 /**
  *  @define coll mutable map
  *  @define Coll `mutable.Map`
+ *
+ *  @tparam K the type of keys in the map
+ *  @tparam V the type of values associated with keys
+ *  @tparam CC the higher-kinded type constructor for map operations returning the same collection type
+ *  @tparam C the concrete type of the map collection
  */
 transparent trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[K, V, CC, C]]
   extends IterableOps[(K, V), Iterable, C]
@@ -267,5 +276,9 @@ object Map extends MapFactory.Delegate[Map](HashMap) {
 
 }
 
-/** Explicit instantiation of the `Map` trait to reduce class file size in subclasses. */
+/** Explicit instantiation of the `Map` trait to reduce class file size in subclasses.
+ *
+ *  @tparam K the type of keys in the map
+ *  @tparam V the type of values associated with keys
+ */
 abstract class AbstractMap[K, V] extends scala.collection.AbstractMap[K, V] with Map[K, V]

--- a/library/src/scala/collection/mutable/OpenHashMap.scala
+++ b/library/src/scala/collection/mutable/OpenHashMap.scala
@@ -41,6 +41,12 @@ object OpenHashMap extends MapFactory[OpenHashMap] {
    *  deleted if and only if its `value` is `None`.
    *  If its `key` is not the default value of type `Key`, the entry is occupied.
    *  If the entry is occupied, `hash` contains the hash value of `key`.
+   *
+   *  @tparam Key the type of keys stored in this entry
+   *  @tparam Value the type of values stored in this entry
+   *  @param key the key associated with this entry
+   *  @param hash the cached hash code of `key`
+   *  @param value `Some(v)` if the entry is occupied, `None` if deleted
    */
   final private class OpenEntry[Key, Value](var key: Key,
                                             var hash: Int,
@@ -101,7 +107,10 @@ class OpenHashMap[Key, Value](initialSize : Int)
   override def knownSize: Int = size
   private def size_=(s : Int): Unit = _size = s
   override def isEmpty: Boolean = _size == 0
-  /** Returns a mangled hash code of the provided key. */
+  /** Returns a mangled hash code of the provided key.
+   *
+   *  @param key the key to compute the hash for
+   */
   protected def hashOf(key: Key) = {
     var h = key.##
     h ^= ((h >>> 20) ^ (h >>> 12))
@@ -126,7 +135,8 @@ class OpenHashMap[Key, Value](initialSize : Int)
   /** Returns the index of the first slot in the hash table (in probe order)
    *  that is, in order of preference, either occupied by the given key, deleted, or empty.
    *
-   *  @param hash hash value for `key`
+   *  @param hash the hash code of `key`
+   *  @param key the key to search for in the hash table
    */
   private def findIndex(key: Key, hash: Int): Int = {
     var index = hash & mask
@@ -186,7 +196,10 @@ class OpenHashMap[Key, Value](initialSize : Int)
     }
   }
 
-  /** Deletes the hash table slot contained in the given entry. */
+  /** Deletes the hash table slot contained in the given entry.
+   *
+   *  @param entry the hash table entry to mark as deleted
+   */
   @`inline`
   private def deleteSlot(entry: Entry) = {
     entry.key = null.asInstanceOf[Key]

--- a/library/src/scala/collection/mutable/PriorityQueue.scala
+++ b/library/src/scala/collection/mutable/PriorityQueue.scala
@@ -264,7 +264,10 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
     } else
       throw new NoSuchElementException("no element to remove from heap")
 
-  /** Dequeues all elements and returns them in a sequence, in priority order. */
+  /** Dequeues all elements and returns them in a sequence, in priority order.
+   *
+   *  @tparam A1 a supertype of the element type `A`, allowing the result to be typed more broadly
+   */
   def dequeueAll[A1 >: A]: immutable.Seq[A1] = {
     val b = ArrayBuilder.make[Any]
     b.sizeHint(size)
@@ -347,6 +350,8 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
   /** Returns a regular queue containing the same elements.
    *
    *  Note: the order of elements is undefined.
+   *
+   *  @return a mutable `Queue` containing all elements of this priority queue
    */
   def toQueue: Queue[A] = new Queue[A] ++= this.iterator
 

--- a/library/src/scala/collection/mutable/Queue.scala
+++ b/library/src/scala/collection/mutable/Queue.scala
@@ -28,6 +28,8 @@ import scala.collection.generic.DefaultSerializable
  *  @define orderDependentFold
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
+ *
+ *  @tparam A the element type stored in this queue
  */
 class Queue[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
   extends ArrayDeque[A](array, start, end)
@@ -48,21 +50,23 @@ class Queue[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
 
   /** Adds elements to the end of this queue
    *
-   *  @param elem
-   *  @return this
+   *  @param elem the element to enqueue
+   *  @return this queue
    */
   def enqueue(elem: A): this.type = this += elem
 
   /** Enqueue two or more elements at the end of the queue. The last element
    *  of the sequence will be on end of the queue.
    *
-   *  @param   elems      the element sequence.
+   *  @param   elems      the remaining elements to enqueue
+   *  @param elem1 the first element to enqueue
+   *  @param elem2 the second element to enqueue
    *  @return this
    */
   def enqueue(elem1: A, elem2: A, elems: A*): this.type = enqueue(elem1).enqueue(elem2).enqueueAll(elems)
 
   /** Enqueues all elements in the given iterable object into the queue. The
-   *  last element in the iterable object will be on front of the new queue.
+   *  last element in the iterable object will be at the end of the queue.
    *
    *  @param elems the iterable object.
    *  @return this
@@ -71,7 +75,7 @@ class Queue[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
 
   /** Removes the first element from this queue and returns it.
    *
-   *  @return
+   *  @return the first element of the queue
    *  @throws NoSuchElementException when queue is empty
    */
   def dequeue(): A = removeHead()
@@ -97,8 +101,8 @@ class Queue[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
 
   /** Returns and dequeues all elements from the queue which satisfy the given predicate.
    *
-   *  @param f   the predicate used for choosing elements
-   *  @return The removed elements
+   *  @param f   the predicate that must hold true for elements to be dequeued from the front
+   *  @return the removed elements, in order from front of the queue
    */
   def dequeueWhile(f: A => Boolean): scala.collection.Seq[A] = removeHeadWhile(f)
 

--- a/library/src/scala/collection/mutable/RedBlackTree.scala
+++ b/library/src/scala/collection/mutable/RedBlackTree.scala
@@ -128,6 +128,12 @@ private[collection] object RedBlackTree {
 
   /** Returns the first (lowest) map entry with a key equal or greater than `key`. Returns `None` if there is no such
    *  node.
+   *
+   *  @tparam A the key type of the tree entries
+   *  @tparam B the value type of the tree entries
+   *  @param tree the red-black tree to search
+   *  @param key the lower bound (inclusive) for the key lookup
+   *  @param ord the ordering used to compare keys
    */
   def minAfter[A, B](tree: Tree[A, B], key: A)(implicit ord: Ordering[A]): Option[(A, B)] =
     minNodeAfter(tree.root, key) match {
@@ -157,7 +163,14 @@ private[collection] object RedBlackTree {
     }
   }
 
-  /** Returns the last (highest) map entry with a key smaller than `key`. Returns `None` if there is no such node. */
+  /** Returns the last (highest) map entry with a key smaller than `key`. Returns `None` if there is no such node.
+   *
+   *  @tparam A the key type of the tree entries
+   *  @tparam B the value type of the tree entries
+   *  @param tree the red-black tree to search
+   *  @param key the upper bound (exclusive) for the key lookup
+   *  @param ord the ordering used to compare keys
+   */
   def maxBefore[A, B](tree: Tree[A, B], key: A)(implicit ord: Ordering[A]): Option[(A, B)] =
     maxNodeBefore(tree.root, key) match {
       case null => None
@@ -360,6 +373,10 @@ private[collection] object RedBlackTree {
 
   /** Returns the node that follows `node` in an in-order tree traversal. If `node` has the maximum key (and is,
    *  therefore, the last node), this method returns `null`.
+   *
+   *  @tparam A the key type of the tree entries
+   *  @tparam B the value type of the tree entries
+   *  @param node the node whose in-order successor is to be found
    */
   private def successor[A, B](node: Node[A, B]): Node[A, B] | Null = {
     if (node.right ne null) minNodeNonNull(node.right)
@@ -376,6 +393,10 @@ private[collection] object RedBlackTree {
 
   /** Returns the node that precedes `node` in an in-order tree traversal. If `node` has the minimum key (and is,
    *  therefore, the first node), this method returns `null`.
+   *
+   *  @tparam A the key type of the tree entries
+   *  @tparam B the value type of the tree entries
+   *  @param node the node whose in-order predecessor is to be found
    */
   private def predecessor[A, B](node: Node[A, B]): Node[A, B] | Null = {
     if (node.left ne null) maxNodeNonNull(node.left)
@@ -424,6 +445,12 @@ private[collection] object RedBlackTree {
 
   /** Transplant the node `from` to the place of node `to`. This is done by setting `from` as a child of `to`'s previous
    *  parent and setting `from`'s parent to the `to`'s previous parent. The children of `from` are left unchanged.
+   *
+   *  @tparam A the key type of the tree entries
+   *  @tparam B the value type of the tree entries
+   *  @param tree the red-black tree being modified
+   *  @param to the node to be replaced
+   *  @param from the node to put in `to`'s position, or `null` to leave the position empty
    */
   private def transplant[A, B](tree: Tree[A, B], to: Node[A, B], from: Node[A, B] | Null): Unit = {
     if (to.parent eq null) tree.root = from
@@ -542,11 +569,20 @@ private[collection] object RedBlackTree {
    *  - All red-black properties are satisfied;
    *  - All non-null nodes have their `parent` reference correct;
    *  - The size variable in `tree` corresponds to the actual size of the tree.
+   *
+   *  @tparam A the key type of the tree entries
+   *  @tparam B the value type of the tree entries
+   *  @param tree the red-black tree to validate
    */
   def isValid[A: Ordering, B](tree: Tree[A, B]): Boolean =
     isValidBST(tree.root) && hasProperParentRefs(tree) && isValidRedBlackTree(tree) && size(tree.root) == tree.size
 
-  /** Returns true if all non-null nodes have their `parent` reference correct. */
+  /** Returns true if all non-null nodes have their `parent` reference correct.
+   *
+   *  @tparam A the key type of the tree entries
+   *  @tparam B the value type of the tree entries
+   *  @param tree the red-black tree to check
+   */
   private def hasProperParentRefs[A, B](tree: Tree[A, B]): Boolean = {
 
     def hasProperParentRefs(node: Node[A, B] | Null): Boolean = {
@@ -562,7 +598,13 @@ private[collection] object RedBlackTree {
     else (tree.root.nn.parent eq null) && hasProperParentRefs(tree.root)
   }
 
-  /** Returns true if this node follows the properties of a binary search tree. */
+  /** Returns true if this node follows the properties of a binary search tree.
+   *
+   *  @tparam A the key type of the tree entries
+   *  @tparam B the value type of the tree entries
+   *  @param node the root node of the subtree to validate
+   *  @param ord the ordering used to compare keys
+   */
   private def isValidBST[A, B](node: Node[A, B] | Null)(implicit ord: Ordering[A]): Boolean = {
     if (node eq null) true
     else {
@@ -574,6 +616,10 @@ private[collection] object RedBlackTree {
 
   /** Returns true if the tree has all the red-black tree properties: if the root node is black, if all children of red
    *  nodes are black and if the path from any node to any of its null children has the same number of black nodes.
+   *
+   *  @tparam A the key type of the tree entries
+   *  @tparam B the value type of the tree entries
+   *  @param tree the red-black tree to validate
    */
   private def isValidRedBlackTree[A, B](tree: Tree[A, B]): Boolean = {
 
@@ -600,7 +646,12 @@ private[collection] object RedBlackTree {
 
   // building
 
-  /** Builds a Tree suitable for a TreeSet from an ordered sequence of keys. */
+  /** Builds a Tree suitable for a TreeSet from an ordered sequence of keys.
+   *
+   *  @tparam A the key type of the set entries
+   *  @param xs an iterator over keys in ascending order
+   *  @param size the number of keys in the iterator
+   */
   def fromOrderedKeys[A](xs: Iterator[A]^, size: Int): Tree[A, Null] = {
     val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
     def f(level: Int, size: Int): Node[A, Null] | Null = size match {
@@ -619,7 +670,13 @@ private[collection] object RedBlackTree {
     new Tree(f(1, size), size)
   }
 
-  /** Builds a Tree suitable for a TreeMap from an ordered sequence of key/value pairs. */
+  /** Builds a Tree suitable for a TreeMap from an ordered sequence of key/value pairs.
+   *
+   *  @tparam A the key type of the map entries
+   *  @tparam B the value type of the map entries
+   *  @param xs an iterator over key-value pairs in ascending key order
+   *  @param size the number of key-value pairs in the iterator
+   */
   def fromOrderedEntries[A, B](xs: Iterator[(A, B)]^, size: Int): Tree[A, B] = {
     val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
     def f(level: Int, size: Int): Node[A, B] | Null = size match {

--- a/library/src/scala/collection/mutable/Seq.scala
+++ b/library/src/scala/collection/mutable/Seq.scala
@@ -35,6 +35,9 @@ object Seq extends SeqFactory.Delegate[Seq](ArrayBuffer)
 /**
  *  @define coll mutable sequence
  *  @define Coll `mutable.Seq`
+ *
+ *  @tparam A the element type of the sequence
+ *  @tparam CC the type constructor for the resulting collection
  */
 transparent trait SeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
   extends collection.SeqOps[A, CC, C]
@@ -65,5 +68,8 @@ transparent trait SeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
   }
 }
 
-/** Explicit instantiation of the `Seq` trait to reduce class file size in subclasses. */
+/** Explicit instantiation of the `Seq` trait to reduce class file size in subclasses.
+ *
+ *  @tparam A the element type of the sequence
+ */
 abstract class AbstractSeq[A] extends scala.collection.AbstractSeq[A] with Seq[A]

--- a/library/src/scala/collection/mutable/Set.scala
+++ b/library/src/scala/collection/mutable/Set.scala
@@ -16,7 +16,10 @@ import scala.language.`2.13`
 import language.experimental.captureChecking
 import scala.collection.{IterableFactory, IterableFactoryDefaults, IterableOps}
 
-/** Base trait for mutable sets. */
+/** Base trait for mutable sets.
+ *
+ *  @tparam A the element type of the set
+ */
 trait Set[A]
   extends Iterable[A]
     with collection.Set[A]
@@ -29,6 +32,10 @@ trait Set[A]
 /**
  *  @define coll mutable set
  *  @define Coll `mutable.Set`
+ *
+ *  @tparam A the element type of the set
+ *  @tparam CC the type constructor for the collection (e.g., `Set`)
+ *  @tparam C the concrete collection type
  */
 transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   extends collection.SetOps[A, CC, C]
@@ -119,5 +126,8 @@ transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
 object Set extends IterableFactory.Delegate[Set](HashSet)
 
 
-/** Explicit instantiation of the `Set` trait to reduce class file size in subclasses. */
+/** Explicit instantiation of the `Set` trait to reduce class file size in subclasses.
+ *
+ *  @tparam A the element type of the set
+ */
 abstract class AbstractSet[A] extends scala.collection.AbstractSet[A] with Set[A]

--- a/library/src/scala/collection/mutable/Shrinkable.scala
+++ b/library/src/scala/collection/mutable/Shrinkable.scala
@@ -22,6 +22,8 @@ import scala.annotation.tailrec
  *
  *  @define coll shrinkable collection
  *  @define Coll `Shrinkable`
+ *
+ *  @tparam A the type of elements that can be removed from this collection
  */
 trait Shrinkable[-A] {
 

--- a/library/src/scala/collection/mutable/SortedMap.scala
+++ b/library/src/scala/collection/mutable/SortedMap.scala
@@ -17,7 +17,11 @@ import scala.language.`2.13`
 import language.experimental.captureChecking
 import scala.collection.{SortedMapFactory, SortedMapFactoryDefaults}
 
-/** Base type for mutable sorted map collections */
+/** Base type for mutable sorted map collections
+ *
+ *  @tparam K the type of the keys in this sorted map; an implicit `Ordering[K]` is required for most operations
+ *  @tparam V the type of the values associated with the keys
+ */
 trait SortedMap[K, V]
   extends collection.SortedMap[K, V]
     with Map[K, V]

--- a/library/src/scala/collection/mutable/SortedSet.scala
+++ b/library/src/scala/collection/mutable/SortedSet.scala
@@ -17,7 +17,10 @@ package mutable
 import scala.language.`2.13`
 import language.experimental.captureChecking
 
-/** Base type for mutable sorted set collections */
+/** Base type for mutable sorted set collections
+ *
+ *  @tparam A the element type of the set, which must have an implicit `Ordering`
+ */
 trait SortedSet[A]
   extends Set[A]
     with collection.SortedSet[A]
@@ -32,6 +35,9 @@ trait SortedSet[A]
 /**
  *  @define coll mutable sorted set
  *  @define Coll `mutable.SortedSet`
+ *
+ *  @tparam A the element type of the set
+ *  @tparam CC the type constructor for the sorted set collection
  */
 transparent trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
   extends SetOps[A, Set, C]

--- a/library/src/scala/collection/mutable/Stack.scala
+++ b/library/src/scala/collection/mutable/Stack.scala
@@ -54,15 +54,17 @@ class Stack[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
 
   /** Adds elements to the top of this stack
    *
-   *  @param elem
-   *  @return
+   *  @param elem the element to push onto the stack
+   *  @return this stack
    */
   def push(elem: A): this.type = prepend(elem)
 
   /** Pushes two or more elements onto the stack. The last element
    *  of the sequence will be on top of the new stack.
    *
-   *  @param   elems      the element sequence.
+   *  @param   elems      the remaining elements to push
+   *  @param elem1 the first element to push
+   *  @param elem2 the second element to push
    *  @return the stack with the new elements on top.
    */
   def push(elem1: A, elem2: A, elems: A*): this.type = {
@@ -85,7 +87,7 @@ class Stack[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
 
   /** Removes the top element from this stack and returns it
    *
-   *  @return
+   *  @return the element removed from the top of the stack
    *  @throws NoSuchElementException when stack is empty
    */
   def pop(): A = removeHead()

--- a/library/src/scala/collection/mutable/StringBuilder.scala
+++ b/library/src/scala/collection/mutable/StringBuilder.scala
@@ -71,11 +71,16 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
 
   /** Constructs a string builder with initial characters
    *  equal to characters of `str`.
+   *
+   *  @param str the initial string content of this builder
    */
   def this(str: String) = this(new java.lang.StringBuilder(str))
 
   /** Constructs a string builder initialized with string value `initValue`
    *  and with additional character capacity `initCapacity`.
+   *
+   *  @param initCapacity additional character capacity beyond the length of `initValue`
+   *  @param initValue the initial string content of this builder
    */
   def this(initCapacity: Int, initValue: String) =
     this(new java.lang.StringBuilder(initValue.length + initCapacity).append(initValue))
@@ -101,7 +106,10 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
 
   def clear(): Unit = underlying.setLength(0)
 
-  /** Overloaded version of `addAll` that takes a string. */
+  /** Overloaded version of `addAll` that takes a string.
+   *
+   *  @param s the string to append to this builder
+   */
   def addAll(s: String): this.type = { underlying.append(s); this }
 
   /** Alias for `addAll`. */
@@ -447,7 +455,11 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
    */
   def substring(start: Int, end: Int): String = underlying.substring(start, end)
 
-  /** For implementing CharSequence. */
+  /** For implementing CharSequence.
+   *
+   *  @param start the beginning index, inclusive
+   *  @param end the ending index, exclusive
+   */
   def subSequence(start: Int, end: Int): java.lang.CharSequence =
     underlying.substring(start, end)
 

--- a/library/src/scala/collection/mutable/TreeMap.scala
+++ b/library/src/scala/collection/mutable/TreeMap.scala
@@ -128,6 +128,7 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
    *             bound.
    *  @param until the upper bound (exclusive) of this projection wrapped in a `Some`, or `None` if there is no upper
    *              bound.
+   *  @return a new `TreeMap` that is a ranged projection of this map, sharing the same underlying data
    */
   def rangeImpl(from: Option[K], until: Option[K]): TreeMap[K, V] = new TreeMapProjection(from, until)
 
@@ -165,21 +166,30 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
    */
   private final class TreeMapProjection(from: Option[K], until: Option[K]) extends TreeMap[K, V](tree) {
 
-    /** Given a possible new lower bound, chooses and returns the most constraining one (the maximum). */
+    /** Given a possible new lower bound, chooses and returns the most constraining one (the maximum).
+     *
+     *  @param newFrom a possible new lower bound wrapped in a `Some`, or `None` if unconstrained
+     */
     private def pickLowerBound(newFrom: Option[K]): Option[K] = (from, newFrom) match {
       case (Some(fr), Some(newFr)) => Some(ordering.max(fr, newFr))
       case (None, _) => newFrom
       case _ => from
     }
 
-    /** Given a possible new upper bound, chooses and returns the most constraining one (the minimum). */
+    /** Given a possible new upper bound, chooses and returns the most constraining one (the minimum).
+     *
+     *  @param newUntil a possible new upper bound wrapped in a `Some`, or `None` if unconstrained
+     */
     private def pickUpperBound(newUntil: Option[K]): Option[K] = (until, newUntil) match {
       case (Some(unt), Some(newUnt)) => Some(ordering.min(unt, newUnt))
       case (None, _) => newUntil
       case _ => until
     }
 
-    /** Returns true if the argument is inside the view bounds (between `from` and `until`). */
+    /** Returns true if the argument is inside the view bounds (between `from` and `until`).
+     *
+     *  @param key the key to check against the view bounds
+     */
     private def isInsideViewBounds(key: K): Boolean = {
       val afterFrom = from.isEmpty || ordering.compare(from.get, key) <= 0
       val beforeUntil = until.isEmpty || ordering.compare(key, until.get) < 0

--- a/library/src/scala/collection/mutable/TreeSet.scala
+++ b/library/src/scala/collection/mutable/TreeSet.scala
@@ -115,21 +115,30 @@ sealed class TreeSet[A] private (private val tree: RB.Tree[A, Null])(implicit va
   private final class TreeSetProjection(from: Option[A], until: Option[A]) extends TreeSet[A](tree) {
     self: TreeSetProjection^{} =>
 
-    /** Given a possible new lower bound, chooses and returns the most constraining one (the maximum). */
+    /** Given a possible new lower bound, chooses and returns the most constraining one (the maximum).
+     *
+     *  @param newFrom a possible new lower bound wrapped in a `Some`, or `None` if unbounded
+     */
     private def pickLowerBound(newFrom: Option[A]): Option[A] = (from, newFrom) match {
       case (Some(fr), Some(newFr)) => Some(ordering.max(fr, newFr))
       case (None, _) => newFrom
       case _ => from
     }
 
-    /** Given a possible new upper bound, chooses and returns the most constraining one (the minimum). */
+    /** Given a possible new upper bound, chooses and returns the most constraining one (the minimum).
+     *
+     *  @param newUntil a possible new upper bound wrapped in a `Some`, or `None` if unbounded
+     */
     private def pickUpperBound(newUntil: Option[A]): Option[A] = (until, newUntil) match {
       case (Some(unt), Some(newUnt)) => Some(ordering.min(unt, newUnt))
       case (None, _) => newUntil
       case _ => until
     }
 
-    /** Returns true if the argument is inside the view bounds (between `from` and `until`). */
+    /** Returns true if the argument is inside the view bounds (between `from` and `until`).
+     *
+     *  @param key the element to check against the view bounds
+     */
     private def isInsideViewBounds(key: A): Boolean = {
       val afterFrom = from.isEmpty || ordering.compare(from.get, key) <= 0
       val beforeUntil = until.isEmpty || ordering.compare(key, until.get) < 0

--- a/library/src/scala/collection/mutable/UnrolledBuffer.scala
+++ b/library/src/scala/collection/mutable/UnrolledBuffer.scala
@@ -261,7 +261,10 @@ object UnrolledBuffer extends StrictOptimizedClassTagSeqFactory[UnrolledBuffer] 
 
   private[collection] val unrolledlength = 32
 
-  /** Unrolled buffer node. */
+  /** Unrolled buffer node.
+   *
+   *  @tparam T the element type stored in the node's array; requires an implicit `ClassTag` for array creation
+   */
   class Unrolled[T: ClassTag] private[collection] (var size: Int, var array: Array[T], var next: Unrolled[T] | Null, val buff: UnrolledBuffer[T] | Null = null) {
     this: Unrolled[T]^{} =>
     private[collection] def this() = this(0, new Array[T](unrolledlength), null, null)

--- a/library/src/scala/collection/package.scala
+++ b/library/src/scala/collection/package.scala
@@ -64,7 +64,10 @@ package object collection {
   /** An extractor used to head/tail deconstruct sequences. */
   object +: {
     /** Splits a sequence into head +: tail.
-     *  @return Some((head, tail)) if sequence is non-empty. None otherwise.
+     *
+     *  @tparam A the element type of the sequence
+     *  @tparam CC the type constructor of the sequence (e.g., `List`, `Vector`)
+     *  @return `Some((head, tail))` if the sequence is non-empty, `None` otherwise
      */
     def unapply[A, CC[_] <: Seq[?], C <: SeqOps[A, CC, C]](t: (C & SeqOps[A, CC, C])^): Option[(A, C^{t})] =
       if(t.isEmpty) None
@@ -74,7 +77,10 @@ package object collection {
   /** An extractor used to init/last deconstruct sequences. */
   object :+ {
     /** Splits a sequence into init :+ last.
-     *  @return Some((init, last)) if sequence is non-empty. None otherwise.
+     *
+     *  @tparam A the element type of the sequence
+     *  @tparam CC the type constructor of the sequence (e.g., `List`, `Vector`)
+     *  @return `Some((init, last))` if the sequence is non-empty, `None` otherwise
      */
     def unapply[A, CC[_] <: Seq[?], C <: SeqOps[A, CC, C]](t: (C & SeqOps[A, CC, C])^): Option[(C^{t}, A)] =
       if(t.isEmpty) None

--- a/library/src/scala/compiletime/package.scala
+++ b/library/src/scala/compiletime/package.scala
@@ -24,6 +24,8 @@ import annotation.{compileTimeOnly, experimental}
  *  This value can only be used in an inline match and the value cannot be used in
  *  the branches.
  *  @syntax markdown
+ *
+ *  @tparam T the type to match against in an inline match expression
  */
 def erasedValue[T]: T = erasedValue[T]
 
@@ -68,6 +70,9 @@ def deferred: Nothing = ???
  *    error("My error of this code: " + codeOf(x))
  *  ```
  *  @syntax markdown
+ *
+ *  @param msg the error message to display at compile time
+ *  @return this method never returns; it always produces a compile-time error
  */
 inline def error(inline msg: String): Nothing = ???
 
@@ -88,6 +93,9 @@ inline def error(inline msg: String): Nothing = ???
  *        Other values may display unintutively.
  *
  *  @syntax markdown
+ *
+ *  @param arg the expression whose source code representation is returned
+ *  @return the string representation of the argument's source code
  */
 transparent inline def codeOf(arg: Any): String =
   // implemented in dotty.tools.dotc.typer.Inliner.Intrinsics
@@ -107,6 +115,8 @@ transparent inline def codeOf(arg: Any): String =
  *  twice(m) // error: expected a constant value but found: m
  *  ```
  *  @syntax markdown
+ *
+ *  @param x the value that must be a compile-time constant after inlining
  */
 inline def requireConst(inline x: Boolean | Byte | Short | Int | Long | Float | Double | Char | String): Unit =
   // implemented in dotty.tools.dotc.typer.Inliner
@@ -115,6 +125,8 @@ inline def requireConst(inline x: Boolean | Byte | Short | Int | Long | Float | 
 /** Same as `constValue` but returns a `None` if a constant value
  *  cannot be constructed from the provided type. Otherwise returns
  *  that value wrapped in `Some`.
+ *
+ *  @tparam T the constant singleton type to attempt to convert to a value
  */
 transparent inline def constValueOpt[T]: Option[T] =
   // implemented in dotty.tools.dotc.typer.Inliner
@@ -122,6 +134,8 @@ transparent inline def constValueOpt[T]: Option[T] =
 
 /** Given a constant, singleton type `T`, convert it to a value
  *  of the same singleton type. For example: `assert(constValue[1] == 1)`.
+ *
+ *  @tparam T the constant singleton type to convert to a value
  */
 transparent inline def constValue[T]: T =
   // implemented in dotty.tools.dotc.typer.Inliner
@@ -129,6 +143,8 @@ transparent inline def constValue[T]: T =
 
 /** Given a tuple type `(X1, ..., Xn)`, returns a tuple value
  *  `(constValue[X1], ..., constValue[Xn])`.
+ *
+ *  @tparam T the tuple type whose element types are constant singleton types
  */
 inline def constValueTuple[T <: Tuple]: T =
   // implemented in dotty.tools.dotc.typer.Inliner
@@ -158,6 +174,10 @@ inline def constValueTuple[T <: Tuple]: T =
  *  ```
  *  the returned value would be `2`.
  *  @syntax markdown
+ *
+ *  @tparam T the result type of the match expression
+ *  @param f a match block with cases that summon givens of specified types
+ *  @return the result of the first matching case
  */
 transparent inline def summonFrom[T](f: Nothing => T): T =
   error("Compiler bug: `summonFrom` was not evaluated by the compiler")
@@ -175,13 +195,17 @@ transparent inline def summonInline[T]: T =
  *  a Tuple.
  *
  *  @tparam T the tuple containing the types of the values to be summoned
- *  @return the given values typed as elements of the tuple
+ *  @return a tuple of the summoned given instances corresponding to the element types of `T`
  */
 inline def summonAll[T <: Tuple]: T =
   // implemented in dotty.tools.dotc.typer.Inliner
   error("Compiler bug: `summonAll` was not evaluated by the compiler")
 
-/** Assertion that an argument is by-name. Used for nullability checking. */
+/** Assertion that an argument is by-name. Used for nullability checking.
+ *
+ *  @tparam T the result type of the by-name argument
+ *  @param x the by-name argument to evaluate
+ */
 def byName[T](x: => T): T = x
 
 /** Casts a value to be `Matchable`. This is needed if the value's type is an unconstrained

--- a/library/src/scala/compiletime/testing/Error.scala
+++ b/library/src/scala/compiletime/testing/Error.scala
@@ -10,5 +10,10 @@ import language.experimental.captureChecking
  *  errors. This means the format and the API may change from
  *  version to version. This API is to be used for testing purposes
  *  only.
+ *
+ *  @param message the error message produced by the compiler
+ *  @param lineContent the source line containing the error
+ *  @param column the zero-based column position within `lineContent` where the error occurred
+ *  @param kind the phase in which the error occurred, either `ErrorKind.Parser` or `ErrorKind.Typer`
  */
 final case class Error(message: String, lineContent: String, column: Int, kind: ErrorKind)

--- a/library/src/scala/compiletime/testing/package.scala
+++ b/library/src/scala/compiletime/testing/package.scala
@@ -7,9 +7,8 @@ import language.experimental.captureChecking
  *
  *  An inline definition with a call to `typeChecks` should be transparent.
  *
- *  @param code The code to be type checked
- *
- *  @return `false` if the code has syntax error or type error in the current context, `true` otherwise.
+ *  @param code a string literal containing the Scala code to type-check at compile time
+ *  @return `true` if the code type-checks successfully, `false` if the code has a syntax or type error in the current context.
  *
  *  The code should be a sequence of expressions or statements that may appear in a block.
  */
@@ -26,9 +25,8 @@ transparent inline def typeChecks(inline code: String): Boolean =
  *
  *  An inline definition with a call to `typeCheckErrors` should be transparent.
  *
- *  @param code The code to be type checked
- *
- *  @return a list of errors encountered during parsing and typechecking.
+ *  @param code a string literal containing the Scala code to type-check at compile time
+ *  @return an empty list if the code type-checks successfully, or a list of `Error` values describing the errors encountered during parsing and type-checking.
  *
  *  The code should be a sequence of expressions or statements that may appear in a block.
  */

--- a/library/src/scala/concurrent/Awaitable.scala
+++ b/library/src/scala/concurrent/Awaitable.scala
@@ -24,6 +24,8 @@ import scala.concurrent.duration.Duration
  *  The [[Await]] object provides methods that allow accessing the result of an `Awaitable`
  *  by blocking the current thread until the `Awaitable` has been completed or a timeout has
  *  occurred.
+ *
+ *  @tparam T the type of the result value
  */
 trait Awaitable[+T] {
 

--- a/library/src/scala/concurrent/BatchingExecutor.scala
+++ b/library/src/scala/concurrent/BatchingExecutor.scala
@@ -221,16 +221,22 @@ private[concurrent] trait BatchingExecutor extends Executor {
   /** MUST throw a NullPointerException when `runnable` is null
    *  When implementing a sync BatchingExecutor, it is RECOMMENDED
    *  to implement this method as `runnable.run()`
+   *
+   *  @param runnable the `Runnable` to submit for execution; must not be null
    */
   protected def submitForExecution(runnable: Runnable): Unit
 
   /** Reports that an asynchronous computation failed.
    *  See `ExecutionContext.reportFailure(throwable: Throwable)`
+   *
+   *  @param throwable the `Throwable` that caused the computation to fail
    */
   protected def reportFailure(throwable: Throwable): Unit
 
   /** WARNING: Never use both `submitAsyncBatched` and `submitSyncBatched` in the same
    *  implementation of `BatchingExecutor`
+   *
+   *  @param runnable the `Runnable` to add to the current async batch, or to submit as a new batch if no batch is active
    */
   protected final def submitAsyncBatched(runnable: Runnable): Unit = {
     val b = _tasksLocal.get
@@ -240,6 +246,8 @@ private[concurrent] trait BatchingExecutor extends Executor {
 
   /** WARNING: Never use both `submitAsyncBatched` and `submitSyncBatched` in the same
    *  implementation of `BatchingExecutor`
+   *
+   *  @param runnable the `Runnable` to submit for synchronous execution, either directly or via a sync batch; must not be null
    */
   protected final def submitSyncBatched(runnable: Runnable): Unit = {
     Objects.requireNonNull(runnable, "runnable is null")

--- a/library/src/scala/concurrent/Future.scala
+++ b/library/src/scala/concurrent/Future.scala
@@ -103,6 +103,8 @@ import scala.concurrent.impl.Promise.DefaultPromise
  *  in a batch within a single `execute()` and it may run
  *  `execute()` either immediately or asynchronously.
  *  Completion of the `Future` must *happen-before* the invocation of the callback.
+ *
+ *  @tparam T the type of the value contained in this `Future`
  */
 trait Future[+T] extends Awaitable[T] {
 
@@ -122,6 +124,7 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  @tparam U    only used to accept any return type of the given callback function
    *  @param f     the function to be executed when this `Future` completes
+   *  @param executor the `ExecutionContext` on which the callback will be executed
    *  @group Callbacks
    */
   def onComplete[U](f: Try[T] => U)(implicit executor: ExecutionContext): Unit
@@ -179,6 +182,7 @@ trait Future[+T] extends Awaitable[T] {
    *  @tparam U     only used to accept any return type of the given callback function
    *  @param f      the function which will be executed if this `Future` completes with a result,
    *               the return value of `f` will be discarded.
+   *  @param executor the `ExecutionContext` on which the callback will be executed
    *  @group Callbacks
    */
   def foreach[U](f: T => U)(implicit executor: ExecutionContext): Unit = onComplete { _ foreach f }
@@ -191,6 +195,7 @@ trait Future[+T] extends Awaitable[T] {
    *  @tparam S  the type of the returned `Future`
    *  @param  s  function that transforms a successful result of the receiver into a successful result of the returned future
    *  @param  f  function that transforms a failure of the receiver into a failure of the returned future
+   *  @param executor the `ExecutionContext` on which the transformation will be executed
    *  @return    a `Future` that will be completed with the transformed value
    *  @group Transformations
    */
@@ -207,6 +212,7 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  @tparam S  the type of the returned `Future`
    *  @param  f  function that transforms the result of this future
+   *  @param executor the `ExecutionContext` on which the transformation will be executed
    *  @return    a `Future` that will be completed with the transformed value
    *  @group Transformations
    */
@@ -218,6 +224,7 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  @tparam S  the type of the returned `Future`
    *  @param  f  function that transforms the result of this future
+   *  @param executor the `ExecutionContext` on which the transformation will be executed
    *  @return    a `Future` that will be completed with the transformed value
    *  @group Transformations
    */
@@ -242,6 +249,7 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  @tparam S  the type of the returned `Future`
    *  @param f   the function which will be applied to the successful result of this `Future`
+   *  @param executor the `ExecutionContext` on which the callback will be executed
    *  @return    a `Future` which will be completed with the result of the application of the function
    *  @group Transformations
    */
@@ -256,6 +264,7 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  @tparam S  the type of the returned `Future`
    *  @param f   the function which will be applied to the successful result of this `Future`
+   *  @param executor the `ExecutionContext` on which the callback will be executed
    *  @return    a `Future` which will be completed with the result of the application of the function
    *  @group Transformations
    */
@@ -269,6 +278,7 @@ trait Future[+T] extends Awaitable[T] {
    *  to `flatMap(identity)`.
    *
    *  @tparam S  the type of the returned `Future`
+   *  @param ev evidence that `T` is itself a `Future[S]`
    *  @group Transformations
    */
   def flatten[S](implicit ev: T <:< Future[S]): Future[S] = flatMap(ev)(using parasitic)
@@ -290,6 +300,7 @@ trait Future[+T] extends Awaitable[T] {
    *  ```
    *
    *  @param p   the predicate to apply to the successful result of this `Future`
+   *  @param executor the `ExecutionContext` on which the callback will be executed
    *  @return    a `Future` which will hold the successful result of this `Future` if it matches the predicate or a `NoSuchElementException`
    *  @group Transformations
    */
@@ -304,6 +315,9 @@ trait Future[+T] extends Awaitable[T] {
 
   /** Used by for-comprehensions.
    *  @group Transformations
+   *
+   *  @param p the predicate to apply to the successful result of this `Future`
+   *  @param executor the `ExecutionContext` on which the callback will be executed
    */
   final def withFilter(p: T => Boolean)(implicit executor: ExecutionContext): Future[T] = filter(p)(using executor)
 
@@ -329,6 +343,7 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  @tparam S    the type of the returned `Future`
    *  @param pf    the `PartialFunction` to apply to the successful result of this `Future`
+   *  @param executor the `ExecutionContext` on which the callback will be executed
    *  @return      a `Future` holding the result of application of the `PartialFunction` or a `NoSuchElementException`
    *  @group Transformations
    */
@@ -354,6 +369,7 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  @tparam U    the type of the returned `Future`
    *  @param pf    the `PartialFunction` to apply if this `Future` fails
+   *  @param executor the `ExecutionContext` on which the callback will be executed
    *  @return      a `Future` with the successful value of this `Future` or the result of the `PartialFunction`
    *  @group Transformations
    */
@@ -375,6 +391,7 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  @tparam U    the type of the returned `Future`
    *  @param pf    the `PartialFunction` to apply if this `Future` fails
+   *  @param executor the `ExecutionContext` on which the callback will be executed
    *  @return      a `Future` with the successful value of this `Future` or the outcome of the `Future` returned by the `PartialFunction`
    *  @group Transformations
    */
@@ -505,6 +522,7 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  @tparam U     only used to accept any return type of the given `PartialFunction`
    *  @param pf     a `PartialFunction` which will be conditionally applied to the outcome of this `Future`
+   *  @param executor the `ExecutionContext` on which the callback will be executed
    *  @return       a `Future` which will be completed with the exact same outcome as this `Future` but after the `PartialFunction` has been executed.
    *  @group Callbacks
    */
@@ -726,6 +744,7 @@ object Future {
    *
    *  @tparam T        the type of the value in the future
    *  @param futures   the `IterableOnce` of Futures in which to find the first completed
+   *  @param executor the `ExecutionContext` on which the futures' completion handlers will be executed
    *  @return          the `Future` holding the result of the future that is first to be completed
    */
   final def firstCompletedOf[T](futures: IterableOnce[Future[T]])(implicit executor: ExecutionContext): Future[T] = {
@@ -765,6 +784,7 @@ object Future {
    *  @tparam T        the type of the value in the future
    *  @param futures   the `scala.collection.immutable.Iterable` of Futures to search
    *  @param p         the predicate which indicates if it's a match
+   *  @param executor the `ExecutionContext` on which the futures' completion handlers will be executed
    *  @return          the `Future` holding the optional result of the search
    */
   final def find[T](futures: scala.collection.immutable.Iterable[Future[T]])(p: T => Boolean)(implicit executor: ExecutionContext): Future[Option[T]] = {

--- a/library/src/scala/concurrent/Promise.scala
+++ b/library/src/scala/concurrent/Promise.scala
@@ -33,6 +33,8 @@ import scala.util.{ Try, Success, Failure }
  *
  *  @define nonDeterministic
  *  Note: Using this method may result in non-deterministic concurrent programs.
+ *
+ *  @tparam T the type of the value held by this promise and its associated future
  */
 trait Promise[T] {
   /** Future containing the value of this promise. */
@@ -49,7 +51,8 @@ trait Promise[T] {
 
   /** Completes the promise with either an exception or a value.
    *
-   *  @param result     Either the value or the exception to complete the promise with.
+   *  @param result     either the value or the exception to complete the promise with
+   *  @return this promise
    *
    *  $promiseCompletion
    */
@@ -60,12 +63,14 @@ trait Promise[T] {
    *
    *  $nonDeterministic
    *
+   *  @param result either the value or the exception to complete the promise with
    *  @return    If the promise has already been completed returns `false`, or `true` otherwise.
    */
   def tryComplete(result: Try[T]): Boolean
 
   /** Completes this promise with the specified future, once that future is completed.
    *
+   *  @param other the future whose result will be used to complete this promise
    *  @return   This promise
    */
    def completeWith(other: Future[T]): this.type = {
@@ -84,7 +89,8 @@ trait Promise[T] {
 
   /** Completes the promise with a value.
    *
-   *  @param value The value to complete the promise with.
+   *  @param value the value to complete the promise with
+   *  @return this promise
    *
    *  $promiseCompletion
    */
@@ -94,13 +100,15 @@ trait Promise[T] {
    *
    *  $nonDeterministic
    *
+   *  @param value the value to complete the promise with
    *  @return    If the promise has already been completed returns `false`, or `true` otherwise.
    */
   def trySuccess(value: T): Boolean = tryComplete(Success(value))
 
   /** Completes the promise with an exception.
    *
-   *  @param cause    The throwable to complete the promise with.
+   *  @param cause    the throwable to complete the promise with
+   *  @return this promise
    *
    *  $allowedThrowables
    *
@@ -112,6 +120,7 @@ trait Promise[T] {
    *
    *  $nonDeterministic
    *
+   *  @param cause the throwable to complete the promise with
    *  @return    If the promise has already been completed returns `false`, or `true` otherwise.
    */
   def tryFailure(cause: Throwable): Boolean = tryComplete(Failure(cause))
@@ -128,6 +137,7 @@ object Promise {
   /** Creates an already completed Promise with the specified exception.
    *
    *  @tparam T       the type of the value in the promise
+   *  @param exception the throwable to fail the promise with
    *  @return         the newly created `Promise` instance
    */
   final def failed[T](exception: Throwable): Promise[T] = fromTry(Failure(exception))
@@ -135,6 +145,7 @@ object Promise {
   /** Creates an already completed Promise with the specified result.
    *
    *  @tparam T       the type of the value in the promise
+   *  @param result the successful value to complete the promise with
    *  @return         the newly created `Promise` instance
    */
   final def successful[T](result: T): Promise[T] = fromTry(Success(result))
@@ -142,6 +153,7 @@ object Promise {
   /** Creates an already completed Promise with the specified result or exception.
    *
    *  @tparam T       the type of the value in the promise
+   *  @param result the `Try` value (success or failure) to complete the promise with
    *  @return         the newly created `Promise` instance
    */
   final def fromTry[T](result: Try[T]): Promise[T] = new impl.Promise.DefaultPromise[T](result)

--- a/library/src/scala/concurrent/SyncVar.scala
+++ b/library/src/scala/concurrent/SyncVar.scala
@@ -37,6 +37,8 @@ class SyncVar[A] {
 
   /** Waits `timeout` millis. If `timeout <= 0` just returns 0.
    *  It never returns negative results.
+   *
+   *  @param timeout the maximum time to wait, in milliseconds
    */
   private def waitMeasuringElapsed(timeout: Long): Long = if (timeout <= 0) 0 else {
     val start = System.nanoTime()
@@ -80,8 +82,8 @@ class SyncVar[A] {
    *  to become defined and then gets the stored value, unsetting it
    *  as a side effect.
    *
-   *  @param timeout     the amount of milliseconds to wait
-   *  @return            the value or a throws an exception if the timeout occurs
+   *  @param timeout     the maximum time to wait, in milliseconds
+   *  @return            the value held in this `SyncVar`
    *  @throws NoSuchElementException on timeout
    */
   def take(timeout: Long): A = synchronized {
@@ -91,6 +93,8 @@ class SyncVar[A] {
 
   /** Place a value in the SyncVar. If the SyncVar already has a stored value,
    *  wait until another thread takes it. 
+   *
+   *  @param x the value to store in this `SyncVar`
    */
   def put(x: A): Unit = synchronized {
     while (isDefined) wait()

--- a/library/src/scala/concurrent/duration/Deadline.scala
+++ b/library/src/scala/concurrent/duration/Deadline.scala
@@ -29,31 +29,49 @@ import scala.language.`2.13`
  *  seconds).
  */
 case class Deadline private (time: FiniteDuration) extends Ordered[Deadline] {
-  /** Returns a deadline advanced (i.e., moved into the future) by the given duration. */
+  /** Returns a deadline advanced (i.e., moved into the future) by the given duration.
+   *
+   *  @param other the duration by which to advance this deadline
+   */
   def +(other: FiniteDuration): Deadline = copy(time = time + other)
-  /** Returns a deadline moved backwards (i.e., towards the past) by the given duration. */
+  /** Returns a deadline moved backwards (i.e., towards the past) by the given duration.
+   *
+   *  @param other the duration by which to move this deadline backwards
+   */
   def -(other: FiniteDuration): Deadline = copy(time = time - other)
-  /** Calculates time difference between this and the other deadline, where the result is directed (i.e., may be negative). */
+  /** Calculates time difference between this and the other deadline, where the result is directed (i.e., may be negative).
+   *
+   *  @param other the deadline to subtract from this deadline, yielding a directed duration
+   */
   def -(other: Deadline): FiniteDuration = time - other.time
   /** Calculates time difference between this duration and now; the result is negative if the deadline has passed.
    *
    *  ***Note that on some systems this operation is costly because it entails a system call.***
    *  Checks `System.nanoTime` for your platform.
+   *
+   *  @return the duration remaining until this deadline, negative if the deadline has passed
    */
   def timeLeft: FiniteDuration = this - Deadline.now
   /** Determine whether the deadline still lies in the future at the point where this method is called.
    *
    *  ***Note that on some systems this operation is costly because it entails a system call.***
    *  Checks `System.nanoTime` for your platform.
+   *
+   *  @return `true` if the deadline has not yet passed, `false` otherwise
    */
   def hasTimeLeft(): Boolean = !isOverdue()
   /** Determine whether the deadline lies in the past at the point where this method is called.
    *
    *  ***Note that on some systems this operation is costly because it entails a system call.***
    *  Checks `System.nanoTime` for your platform.
+   *
+   *  @return `true` if the deadline has passed, `false` otherwise
    */
   def isOverdue(): Boolean = (time.toNanos - System.nanoTime()) < 0
-  /** The natural ordering for deadline is determined by the natural order of the underlying (finite) duration. */
+  /** The natural ordering for deadline is determined by the natural order of the underlying (finite) duration.
+   *
+   *  @param other the deadline to compare against
+   */
   def compare(other: Deadline): Int = time compare other.time
 }
 

--- a/library/src/scala/deriving/Mirror.scala
+++ b/library/src/scala/deriving/Mirror.scala
@@ -19,14 +19,20 @@ object Mirror {
 
   /** The `Mirror` for a sum type. */
   trait Sum extends Mirror { self =>
-    /** The ordinal number of the case class of `x`. For enums, `ordinal(x) == x.ordinal`. */
+    /** The ordinal number of the case class of `x`. For enums, `ordinal(x) == x.ordinal`.
+     *
+     *  @param x the instance of the sum type whose ordinal is returned
+     */
     def ordinal(x: MirroredMonoType): Int
   }
 
   /** The `Mirror` for a product type. */
   trait Product extends Mirror { self =>
 
-    /** Creates a new instance of type `T` with elements taken from product `p`. */
+    /** Creates a new instance of type `T` with elements taken from product `p`.
+     *
+     *  @param p the product whose elements are used to create the new instance
+     */
     def fromProduct(p: scala.Product): MirroredMonoType
   }
 
@@ -38,7 +44,10 @@ object Mirror {
     def fromProduct(p: scala.Product): MirroredMonoType = this
   }
 
-  /** A proxy for Scala 2 singletons, which do not inherit `Singleton` directly. */
+  /** A proxy for Scala 2 singletons, which do not inherit `Singleton` directly.
+   *
+   *  @param value the Scala 2 singleton instance being proxied
+   */
   class SingletonProxy(val value: AnyRef) extends Product {
     type MirroredMonoType = value.type
     type MirroredType = value.type
@@ -52,11 +61,20 @@ object Mirror {
   type SumOf[T] = Mirror.Sum { type MirroredType = T; type MirroredMonoType = T; type MirroredElemTypes <: Tuple }
 
   extension [T](p: ProductOf[T])
-    /** Creates a new instance of type `T` with elements taken from product `a`. */
+    /** Creates a new instance of type `T` with elements taken from product `a`.
+     *
+     *  @tparam A the product type whose elements are used as input
+     *  @tparam Elems the tuple type representing `A`'s elements, constrained to be a subtype of `T`'s `MirroredElemTypes`
+     *  @param a the product instance whose elements are copied into the new `T`
+
+     */
     def fromProductTyped[A <: scala.Product, Elems <: p.MirroredElemTypes](a: A)(using ProductOf[A] { type MirroredElemTypes = Elems }): T =
       p.fromProduct(a)
 
-    /** Creates a new instance of type `T` with elements taken from tuple `t`. */
+    /** Creates a new instance of type `T` with elements taken from tuple `t`.
+     *
+     *  @param t the tuple containing the elements for the new `T` instance
+     */
     def fromTuple(t: p.MirroredElemTypes): T =
       p.fromProduct(t)
 }

--- a/library/src/scala/io/BufferedSource.scala
+++ b/library/src/scala/io/BufferedSource.scala
@@ -20,6 +20,9 @@ import scala.collection.mutable.StringBuilder
 
 /** This object provides convenience methods to create an iterable
  *  representation of a source file.
+ *
+ *  @param inputStream the underlying input stream to read characters from
+ *  @param bufferSize the size of the internal buffer used for reading
  */
 class BufferedSource(inputStream: InputStream, bufferSize: Int)(implicit val codec: Codec) extends Source {
   def this(inputStream: InputStream)(implicit codec: Codec) = this(inputStream, DefaultBufSize)(using codec)
@@ -91,6 +94,12 @@ class BufferedSource(inputStream: InputStream, bufferSize: Int)(implicit val cod
    *
    *  Note: This function may temporarily load the entire buffer into
    *  memory.
+   *
+   *  @param sb the string builder to append to
+   *  @param start the string to prepend before the first character
+   *  @param sep the separator string inserted between elements
+   *  @param end the string to append after the last element
+   *  @return the string builder `sb` with all elements appended
    */
   override def addString(sb: StringBuilder, start: String, sep: String, end: String): sb.type =
     if (sep.isEmpty) {

--- a/library/src/scala/io/Codec.scala
+++ b/library/src/scala/io/Codec.scala
@@ -30,7 +30,10 @@ import scala.language.implicitConversions
 // MacRoman vs. UTF-8: see https://groups.google.com/d/msg/jruby-developers/-qtwRhoE1WM/whSPVpTNV28J
 // -Dfile.encoding: see https://bugs.java.com/view_bug.do?bug_id=4375816
 
-/** A class for character encoding/decoding preferences. */
+/** A class for character encoding/decoding preferences.
+ *
+ *  @param charSet the character set used for encoding and decoding operations
+ */
 class Codec(val charSet: Charset) {
   type Configure[T] = (T => T, Boolean)
   type Handler      = CharacterCodingException => Int

--- a/library/src/scala/io/Position.scala
+++ b/library/src/scala/io/Position.scala
@@ -41,7 +41,11 @@ import annotation.nowarn
  */
 @deprecated("this class will be removed", "2.10.0")
 private[scala] abstract class Position {
-  /** Definable behavior for overflow conditions. */
+  /** Definable behavior for overflow conditions.
+   *
+   *  @param line the 1-based line number to validate (0 for undefined, negative values throw)
+   *  @param column the 1-based column number to validate (must be 0 when `line` is 0, negative values throw)
+   */
   def checkInput(line: Int, column: Int): Unit
 
   /** Number of bits used to encode the line number. */
@@ -53,7 +57,11 @@ private[scala] abstract class Position {
   /** Mask to decode the column number. */
   final val COLUMN_MASK = (1 << COLUMN_BITS) - 1
 
-  /** Encodes a position into a single integer. */
+  /** Encodes a position into a single integer.
+   *
+   *  @param line the 1-based line number, or 0 for undefined; values at or above `LINE_MASK` are clamped and the column is set to 0
+   *  @param column the 1-based column number, or 0 for undefined; clamped to `COLUMN_MASK`, ignored when `line` >= `LINE_MASK`
+   */
   final def encode(line: Int, column: Int): Int = {
     checkInput(line, column)
 
@@ -63,13 +71,22 @@ private[scala] abstract class Position {
       (line << COLUMN_BITS) | scala.math.min(COLUMN_MASK, column)
   }
 
-  /** Returns the line number of the encoded position. */
+  /** Returns the line number of the encoded position.
+   *
+   *  @param pos the encoded position as returned by `encode`
+   */
   final def line(pos: Int): Int = (pos >> COLUMN_BITS) & LINE_MASK
 
-  /** Returns the column number of the encoded position. */
+  /** Returns the column number of the encoded position.
+   *
+   *  @param pos the encoded position as returned by `encode`
+   */
   final def column(pos: Int): Int = pos & COLUMN_MASK
 
-  /** Returns a string representation of the encoded position. */
+  /** Returns a string representation of the encoded position.
+   *
+   *  @param pos the encoded position as returned by `encode`
+   */
   def toString(pos: Int): String = line(pos) + ":" + column(pos)
 }
 

--- a/library/src/scala/io/Source.scala
+++ b/library/src/scala/io/Source.scala
@@ -38,42 +38,72 @@ object Source {
     val iter = iterable.iterator
   } withReset(() => fromIterable(iterable))
 
-  /** Creates a Source instance from a single character. */
+  /** Creates a Source instance from a single character.
+   *
+   *  @param c the character to use as the source content
+   */
   def fromChar(c: Char): Source = fromIterable(Array(c))
 
-  /** creates Source from array of characters, with empty description. */
+  /** creates Source from array of characters, with empty description.
+   *
+   *  @param chars the array of characters to use as the source content
+   */
   def fromChars(chars: Array[Char]): Source = fromIterable(chars)
 
-  /** creates Source from a String, with no description. */
+  /** creates Source from a String, with no description.
+   *
+   *  @param s the string to use as the source content
+   */
   def fromString(s: String): Source = fromIterable(s)
 
   /** creates Source from file with given name, setting its description to
    *  filename.
+   *
+   *  @param name the name of the file to read
+   *  @param codec the implicit codec used for character encoding
    */
   def fromFile(name: String)(implicit codec: Codec): BufferedSource =
     fromFile(new JFile(name))(using codec)
 
   /** creates Source from file with given name, using given encoding, setting
    *  its description to filename.
+   *
+   *  @param name the name of the file to read
+   *  @param enc the name of the character encoding to use
    */
   def fromFile(name: String, enc: String): BufferedSource =
     fromFile(name)(using Codec(enc))
 
-  /** creates `source` from file with given file `URI`. */
+  /** creates `source` from file with given file `URI`.
+   *
+   *  @param uri the file URI to read from
+   *  @param codec the implicit codec used for character encoding
+   */
   def fromFile(uri: URI)(implicit codec: Codec): BufferedSource =
     fromFile(new JFile(uri))(using codec)
 
-  /** creates Source from file with given file: URI */
+  /** creates Source from file with given file: URI
+   *
+   *  @param uri the file URI to read from
+   *  @param enc the name of the character encoding to use
+   */
   def fromFile(uri: URI, enc: String): BufferedSource =
     fromFile(uri)(using Codec(enc))
 
   /** creates Source from file, using default character encoding, setting its
    *  description to filename.
+   *
+   *  @param file the file to read from
+   *  @param codec the implicit codec used for character encoding
    */
   def fromFile(file: JFile)(implicit codec: Codec): BufferedSource =
     fromFile(file, Source.DefaultBufSize)(using codec)
 
-  /** same as fromFile(file, enc, Source.DefaultBufSize) */
+  /** same as fromFile(file, enc, Source.DefaultBufSize)
+   *
+   *  @param file the file to read from
+   *  @param enc the name of the character encoding to use
+   */
   def fromFile(file: JFile, enc: String): BufferedSource =
     fromFile(file)(using Codec(enc))
 
@@ -83,6 +113,10 @@ object Source {
   /** Creates Source from `file`, using given character encoding, setting
    *  its description to filename. Input is buffered in a buffer of size
    *  `bufferSize`.
+   *
+   *  @param file the file to read from
+   *  @param bufferSize the size of the input buffer, in characters
+   *  @param codec the implicit codec used for character encoding
    */
   def fromFile(file: JFile, bufferSize: Int)(implicit codec: Codec): BufferedSource = {
     val inputStream = new FileInputStream(file)
@@ -98,6 +132,8 @@ object Source {
   /** Creates a `Source` from array of bytes, decoding
    *  the bytes according to codec.
    *
+   *  @param bytes the array of bytes to decode into characters
+   *  @param codec the implicit codec used for character encoding
    *  @return      the created `Source` instance.
    */
   def fromBytes(bytes: Array[Byte])(implicit codec: Codec): Source =
@@ -113,23 +149,43 @@ object Source {
   def fromRawBytes(bytes: Array[Byte]): Source =
     fromString(new String(bytes, Codec.ISO8859.charSet))
 
-  /** creates `Source` from file with given file: URI */
+  /** creates `Source` from file with given file: URI
+   *
+   *  @param uri the file URI to read from
+   *  @param codec the implicit codec used for character encoding
+   */
   def fromURI(uri: URI)(implicit codec: Codec): BufferedSource =
     fromFile(new JFile(uri))(using codec)
 
-  /** same as fromURL(new URL(s))(Codec(enc)) */
+  /** same as fromURL(new URL(s))(Codec(enc))
+   *
+   *  @param s the URL string to read from
+   *  @param enc the name of the character encoding to use
+   */
   def fromURL(s: String, enc: String): BufferedSource =
     fromURL(s)(using Codec(enc))
 
-  /** same as fromURL(new URL(s)) */
+  /** same as fromURL(new URL(s))
+   *
+   *  @param s the URL string to read from
+   *  @param codec the implicit codec used for character encoding
+   */
   def fromURL(s: String)(implicit codec: Codec): BufferedSource =
     fromURL(new URI(s).toURL)(using codec)
 
-  /** same as fromInputStream(url.openStream())(Codec(enc)) */
+  /** same as fromInputStream(url.openStream())(Codec(enc))
+   *
+   *  @param url the URL to read from
+   *  @param enc the name of the character encoding to use
+   */
   def fromURL(url: URL, enc: String): BufferedSource =
     fromURL(url)(using Codec(enc))
 
-  /** same as fromInputStream(url.openStream())(codec) */
+  /** same as fromInputStream(url.openStream())(codec)
+   *
+   *  @param url the URL to read from
+   *  @param codec the implicit codec used for character encoding
+   */
   def fromURL(url: URL)(implicit codec: Codec): BufferedSource =
     fromInputStream(url.openStream())(using codec)
 
@@ -347,7 +403,10 @@ abstract class Source extends Iterator[Char] with Closeable {
     descr = text
     this
   }
-  /** Change or disable the positioner. */
+  /** Change or disable the positioner.
+   *
+   *  @param on whether to enable (`true`) or disable (`false`) position tracking
+   */
   def withPositioning(on: Boolean): this.type = {
     positioner = if (on) RelaxedPositioner else NoPositioner
     this

--- a/library/src/scala/jdk/DoubleAccumulator.scala
+++ b/library/src/scala/jdk/DoubleAccumulator.scala
@@ -62,7 +62,10 @@ final class DoubleAccumulator
     else history = java.util.Arrays.copyOf(history, history.length << 1)
   }
 
-  /** Appends an element to this `DoubleAccumulator`. */
+  /** Appends an element to this `DoubleAccumulator`.
+   *
+   *  @param a the `Double` value to append
+   */
   def addOne(a: Double): this.type = {
     totalSize += 1
     if (index+1 >= current.length) expand()
@@ -74,7 +77,10 @@ final class DoubleAccumulator
   /** Result collection consisting of all elements appended so far. */
   override def result(): DoubleAccumulator = this
 
-  /** Removes all elements from `that` and appends them to this `DoubleAccumulator`. */
+  /** Removes all elements from `that` and appends them to this `DoubleAccumulator`.
+   *
+   *  @param that the `DoubleAccumulator` to drain elements from; it will be empty after this operation
+   */
   def drain(that: DoubleAccumulator): Unit = {
     var h = 0
     var prev = 0L
@@ -137,7 +143,10 @@ final class DoubleAccumulator
     history = DoubleAccumulator.emptyDoubleArrayArray
   }
 
-  /** Retrieves the `ix`th element. */
+  /** Retrieves the `ix`th element.
+   *
+   *  @param ix the zero-based index of the element to retrieve
+   */
   def apply(ix: Long): Double = {
     if (totalSize - ix <= index || hIndex == 0) current((ix - (totalSize - index)).toInt)
     else {
@@ -146,7 +155,10 @@ final class DoubleAccumulator
     }
   }
 
-  /** Retrieves the `ix`th element, using an `Int` index. */
+  /** Retrieves the `ix`th element, using an `Int` index.
+   *
+   *  @param i the zero-based index of the element to retrieve (converted to `Long` internally)
+   */
   def apply(i: Int): Double = apply(i.toLong)
 
   def update(idx: Long, elem: Double): Unit = {
@@ -283,6 +295,9 @@ final class DoubleAccumulator
   /** Copies the elements in this `DoubleAccumulator` to a specified collection.
    *  Note that the target collection is not specialized.
    *  Usage example: `acc.to(Vector)`
+   *
+   *  @tparam C1 the result type of the target collection (e.g., `Vector[Double]`)
+   *  @param factory the factory for creating the target collection from elements
    */
   override def to[C1](factory: Factory[Double, C1]): C1 = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for a Scala collection: "+totalSize.toString)

--- a/library/src/scala/jdk/IntAccumulator.scala
+++ b/library/src/scala/jdk/IntAccumulator.scala
@@ -65,7 +65,10 @@ final class IntAccumulator
     else history = java.util.Arrays.copyOf(history, history.length << 1)
   }
 
-  /** Appends an element to this `IntAccumulator`. */
+  /** Appends an element to this `IntAccumulator`.
+   *
+   *  @param a the `Int` value to append
+   */
   def addOne(a: Int): this.type = {
     totalSize += 1
     if (index+2 >= current.length) expand()
@@ -77,7 +80,10 @@ final class IntAccumulator
   /** Result collection consisting of all elements appended so far. */
   override def result(): IntAccumulator = this
 
-  /** Removes all elements from `that` and appends them to this `IntAccumulator`. */
+  /** Removes all elements from `that` and appends them to this `IntAccumulator`.
+   *
+   *  @param that the `IntAccumulator` to drain elements from; it will be empty after this operation
+   */
   def drain(that: IntAccumulator): Unit = {
     var h = 0
     var prev = 0L
@@ -143,7 +149,10 @@ final class IntAccumulator
     history = IntAccumulator.emptyIntArrayArray
   }
 
-  /** Retrieves the `ix`th element. */
+  /** Retrieves the `ix`th element.
+   *
+   *  @param ix the zero-based index of the element to retrieve, as a `Long`
+   */
   def apply(ix: Long): Int = {
     if (totalSize - ix <= index || hIndex == 0) current((ix - (totalSize - index)).toInt)
     else {
@@ -152,7 +161,10 @@ final class IntAccumulator
     }
   }
 
-  /** Retrieves the `ix`th element, using an `Int` index. */
+  /** Retrieves the `ix`th element, using an `Int` index.
+   *
+   *  @param i the zero-based index of the element to retrieve
+   */
   def apply(i: Int): Int = apply(i.toLong)
 
   def update(idx: Long, elem: Int): Unit = {
@@ -289,6 +301,9 @@ final class IntAccumulator
   /** Copies the elements in this `IntAccumulator` to a specified collection.
    *  Note that the target collection is not specialized.
    *  Usage example: `acc.to(Vector)`
+   *
+   *  @tparam C1 the type of the target collection
+   *  @param factory the factory for building the target collection from `Int` elements
    */
   override def to[C1](factory: Factory[Int, C1]): C1 = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for a Scala collection: "+totalSize.toString)

--- a/library/src/scala/jdk/LongAccumulator.scala
+++ b/library/src/scala/jdk/LongAccumulator.scala
@@ -63,7 +63,10 @@ final class LongAccumulator
     else history = java.util.Arrays.copyOf(history, history.length << 1)
   }
 
-  /** Appends an element to this `LongAccumulator`. */
+  /** Appends an element to this `LongAccumulator`.
+   *
+   *  @param a the `Long` value to append
+   */
   def addOne(a: Long): this.type = {
     totalSize += 1
     if (index+1 >= current.length) expand()
@@ -75,7 +78,10 @@ final class LongAccumulator
   /** Result collection consisting of all elements appended so far. */
   override def result(): LongAccumulator = this
 
-  /** Removes all elements from `that` and appends them to this `LongAccumulator`. */
+  /** Removes all elements from `that` and appends them to this `LongAccumulator`.
+   *
+   *  @param that the `LongAccumulator` to drain elements from; it will be empty after this operation
+   */
   def drain(that: LongAccumulator): Unit = {
     var h = 0
     var prev = 0L
@@ -138,7 +144,10 @@ final class LongAccumulator
     history = LongAccumulator.emptyLongArrayArray
   }
 
-  /** Retrieves the `ix`th element. */
+  /** Retrieves the `ix`th element.
+   *
+   *  @param ix the zero-based index of the element to retrieve
+   */
   def apply(ix: Long): Long = {
     if (totalSize - ix <= index || hIndex == 0) current((ix - (totalSize - index)).toInt)
     else {
@@ -147,7 +156,10 @@ final class LongAccumulator
     }
   }
 
-  /** Retrieves the `ix`th element, using an `Int` index. */
+  /** Retrieves the `ix`th element, using an `Int` index.
+   *
+   *  @param i the zero-based index of the element to retrieve
+   */
   def apply(i: Int): Long = apply(i.toLong)
 
   def update(idx: Long, elem: Long): Unit = {
@@ -284,6 +296,9 @@ final class LongAccumulator
   /** Copies the elements in this `LongAccumulator` to a specified collection.
    *  Note that the target collection is not specialized.
    *  Usage example: `acc.to(Vector)`
+   *
+   *  @tparam C1 the result type of the target collection
+   *  @param factory the factory for the target collection type
    */
   override def to[C1](factory: Factory[Long, C1]): C1 = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for a Scala collection: "+totalSize.toString)

--- a/library/src/scala/jdk/OptionConverters.scala
+++ b/library/src/scala/jdk/OptionConverters.scala
@@ -45,7 +45,11 @@ import java.util.{Optional, OptionalDouble, OptionalInt, OptionalLong}
  *  ```
  */
 object OptionConverters {
-  /** Provides conversions from Java `Optional` to Scala `Option` and specialized `Optional` types. */
+  /** Provides conversions from Java `Optional` to Scala `Option` and specialized `Optional` types.
+   *
+   *  @tparam A the type of the value contained in the `Optional`
+   *  @param o the Java `Optional` to convert
+   */
   implicit class RichOptional[A](private val o: java.util.Optional[A]) extends AnyVal {
     /** Converts a Java `Optional` to a Scala `Option`. */
     def toScala: Option[A] = if (o.isPresent) Some(o.get) else None
@@ -54,11 +58,19 @@ object OptionConverters {
     @deprecated("Use `toScala` instead", "2.13.0")
     def asScala: Option[A] = if (o.isPresent) Some(o.get) else None
 
-    /** Converts a generic Java `Optional` to a specialized variant. */
+    /** Converts a generic Java `Optional` to a specialized variant.
+     *
+     *  @tparam O the target specialized Java `Optional` type, inferred from the available `OptionShape` instance (e.g., `OptionalInt`, `OptionalDouble`, `OptionalLong`)
+     *  @param shape implicit evidence that defines how to convert between `Optional[A]` and the specialized type `O`
+     */
     def toJavaPrimitive[O](implicit shape: OptionShape[A, O]): O = shape.fromJava(o)
   }
 
-  /** Provides conversions from Scala `Option` to Java `Optional` types. */
+  /** Provides conversions from Scala `Option` to Java `Optional` types.
+   *
+   *  @tparam A the type of the value contained in the `Option`
+   *  @param o the Scala `Option` to convert
+   */
   implicit class RichOption[A](private val o: Option[A]) extends AnyVal {
     /** Converts a Scala `Option` to a generic Java `Optional`. */
     def toJava: Optional[A] = o match { case Some(a) => Optional.ofNullable(a); case _ => Optional.empty[A] }
@@ -67,11 +79,18 @@ object OptionConverters {
     @deprecated("Use `toJava` instead", "2.13.0")
     def asJava: Optional[A] = o match { case Some(a) => Optional.ofNullable(a); case _ => Optional.empty[A] }
 
-    /** Converts a Scala `Option` to a specialized Java `Optional`. */
+    /** Converts a Scala `Option` to a specialized Java `Optional`.
+     *
+     *  @tparam O the specialized Java `Optional` type (e.g., `OptionalInt`, `OptionalDouble`, `OptionalLong`)
+     *  @param shape implicit evidence that defines how to convert between `Option[A]` and the specialized type `O`
+     */
     def toJavaPrimitive[O](implicit shape: OptionShape[A, O]): O = shape.fromScala(o)
   }
 
-  /** Provides conversions from `OptionalDouble` to Scala `Option` and the generic `Optional`. */
+  /** Provides conversions from `OptionalDouble` to Scala `Option` and the generic `Optional`.
+   *
+   *  @param o the Java `OptionalDouble` to convert
+   */
   implicit class RichOptionalDouble(private val o: OptionalDouble) extends AnyVal {
     /** Converts a Java `OptionalDouble` to a Scala `Option`. */
     def toScala: Option[Double] = if (o.isPresent) Some(o.getAsDouble) else None
@@ -84,7 +103,10 @@ object OptionConverters {
     def toJavaGeneric: Optional[Double] = if (o.isPresent) Optional.of(o.getAsDouble) else Optional.empty[Double]
   }
 
-  /** Provides conversions from `OptionalInt` to Scala `Option` and the generic `Optional`. */
+  /** Provides conversions from `OptionalInt` to Scala `Option` and the generic `Optional`.
+   *
+   *  @param o the Java `OptionalInt` to convert
+   */
   implicit class RichOptionalInt(private val o: OptionalInt) extends AnyVal {
     /** Converts a Java `OptionalInt` to a Scala `Option`. */
     def toScala: Option[Int] = if (o.isPresent) Some(o.getAsInt) else None
@@ -97,7 +119,10 @@ object OptionConverters {
     def toJavaGeneric: Optional[Int] = if (o.isPresent) Optional.of(o.getAsInt) else Optional.empty[Int]
   }
 
-  /** Provides conversions from `OptionalLong` to Scala `Option` and the generic `Optional`. */
+  /** Provides conversions from `OptionalLong` to Scala `Option` and the generic `Optional`.
+   *
+   *  @param o the Java `OptionalLong` to convert
+   */
   implicit class RichOptionalLong(private val o: OptionalLong) extends AnyVal {
     /** Converts a Java `OptionalLong` to a Scala `Option`. */
     def toScala: Option[Long] = if (o.isPresent) Some(o.getAsLong) else None

--- a/library/src/scala/jdk/OptionShape.scala
+++ b/library/src/scala/jdk/OptionShape.scala
@@ -26,9 +26,15 @@ import scala.annotation.implicitNotFound
  */
 @implicitNotFound("No specialized Optional type exists for elements of type ${A}")
 sealed abstract class OptionShape[A, O] {
-  /** Converts from `Optional` to the specialized variant `O`. */
+  /** Converts from `Optional` to the specialized variant `O`.
+   *
+   *  @param o the generic `Optional` to convert to the specialized variant
+   */
   def fromJava(o: Optional[A]): O
-  /** Converts from `Option` to the specialized variant `O`. */
+  /** Converts from `Option` to the specialized variant `O`.
+   *
+   *  @param o the Scala `Option` to convert to the specialized Java variant
+   */
   def fromScala(o: Option[A]): O
 }
 

--- a/library/src/scala/jdk/javaapi/DurationConverters.scala
+++ b/library/src/scala/jdk/javaapi/DurationConverters.scala
@@ -29,6 +29,8 @@ object  DurationConverters {
    *  zero, the returned duration will have a time unit of seconds. If there is a nanoseconds part,
    *  the Scala duration will have a time unit of nanoseconds.
    *
+   *  @param duration the Java `java.time.Duration` to convert
+   *  @return a Scala `FiniteDuration` with the same length, using seconds or nanoseconds as the time unit
    *  @throws IllegalArgumentException If the given Java Duration is out of bounds of what can be
    *                                  expressed by [[scala.concurrent.duration.FiniteDuration]].
    */
@@ -58,6 +60,9 @@ object  DurationConverters {
   /** Converts a Scala `FiniteDuration` to a Java duration. Note that the Scala duration keeps the
    *  time unit it was created with, while a Java duration always is a pair of seconds and nanos,
    *  so the unit it lost.
+   *
+   *  @param duration the Scala `FiniteDuration` to convert
+   *  @return a Java `java.time.Duration` representing the same length of time
    */
   def toJava(duration: FiniteDuration): JDuration = {
     if (duration.length == 0) JDuration.ZERO

--- a/library/src/scala/jdk/javaapi/FunctionConverters.scala
+++ b/library/src/scala/jdk/javaapi/FunctionConverters.scala
@@ -32,6 +32,10 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the first input type of the bi-consumer
+   *  @tparam U the second input type of the bi-consumer
+   *  @param jf the Java `BiConsumer` to convert
    */
   @inline def asScalaFromBiConsumer[T, U](jf: java.util.function.BiConsumer[T, U]): scala.Function2[T, U, scala.runtime.BoxedUnit] = jf match {
     case AsJavaBiConsumer((f @ _)) => f.asInstanceOf[scala.Function2[T, U, scala.runtime.BoxedUnit]]
@@ -43,18 +47,32 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the first input type of the bi-consumer
+   *  @tparam U the second input type of the bi-consumer
+   *  @param sf the Scala `Function2` to convert to a Java `BiConsumer`
    */
   @inline def asJavaBiConsumer[T, U](sf: scala.Function2[T, U, scala.runtime.BoxedUnit]): java.util.function.BiConsumer[T, U] = ((sf): AnyRef) match {
     case FromJavaBiConsumer((f @ _)) => f.asInstanceOf[java.util.function.BiConsumer[T, U]]
     case _ => new AsJavaBiConsumer[T, U](sf.asInstanceOf[scala.Function2[T, U, Unit]])
   }
   
-  
+
+  /** @tparam T the first input type of the bi-function
+   *  @tparam U the second input type of the bi-function
+   *  @tparam R the return type of the bi-function
+   *  @param jf the Java `BiFunction` to convert
+   */
   @inline def asScalaFromBiFunction[T, U, R](jf: java.util.function.BiFunction[T, U, R]): scala.Function2[T, U, R] = jf match {
     case AsJavaBiFunction((f @ _)) => f.asInstanceOf[scala.Function2[T, U, R]]
     case _ => new FromJavaBiFunction[T, U, R](jf).asInstanceOf[scala.Function2[T, U, R]]
   }
   
+  /** @tparam T the first input type of the bi-function
+   *  @tparam U the second input type of the bi-function
+   *  @tparam R the return type of the bi-function
+   *  @param sf the Scala `Function2` to convert to a Java `BiFunction`
+   */
   @inline def asJavaBiFunction[T, U, R](sf: scala.Function2[T, U, R]): java.util.function.BiFunction[T, U, R] = ((sf): AnyRef) match {
     case FromJavaBiFunction((f @ _)) => f.asInstanceOf[java.util.function.BiFunction[T, U, R]]
     case _ => new AsJavaBiFunction[T, U, R](sf.asInstanceOf[scala.Function2[T, U, R]])
@@ -66,6 +84,10 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the first input type of the bi-predicate
+   *  @tparam U the second input type of the bi-predicate
+   *  @param jf the Java `BiPredicate` to convert
    */
   @inline def asScalaFromBiPredicate[T, U](jf: java.util.function.BiPredicate[T, U]): scala.Function2[T, U, java.lang.Boolean] = jf match {
     case AsJavaBiPredicate((f @ _)) => f.asInstanceOf[scala.Function2[T, U, java.lang.Boolean]]
@@ -77,6 +99,10 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the first input type of the bi-predicate
+   *  @tparam U the second input type of the bi-predicate
+   *  @param sf the Scala `Function2` to convert to a Java `BiPredicate`
    */
   @inline def asJavaBiPredicate[T, U](sf: scala.Function2[T, U, java.lang.Boolean]): java.util.function.BiPredicate[T, U] = ((sf): AnyRef) match {
     case FromJavaBiPredicate((f @ _)) => f.asInstanceOf[java.util.function.BiPredicate[T, U]]
@@ -84,11 +110,17 @@ object FunctionConverters {
   }
   
   
+  /** @tparam T the input and output type of the binary operator
+   *  @param jf the Java `BinaryOperator` to convert
+   */
   @inline def asScalaFromBinaryOperator[T](jf: java.util.function.BinaryOperator[T]): scala.Function2[T, T, T] = jf match {
     case AsJavaBinaryOperator((f @ _)) => f.asInstanceOf[scala.Function2[T, T, T]]
     case _ => new FromJavaBinaryOperator[T](jf).asInstanceOf[scala.Function2[T, T, T]]
   }
   
+  /** @tparam T the input and output type of the binary operator
+   *  @param sf the Scala `Function2` to convert to a Java `BinaryOperator`
+   */
   @inline def asJavaBinaryOperator[T](sf: scala.Function2[T, T, T]): java.util.function.BinaryOperator[T] = ((sf): AnyRef) match {
     case FromJavaBinaryOperator((f @ _)) => f.asInstanceOf[java.util.function.BinaryOperator[T]]
     case _ => new AsJavaBinaryOperator[T](sf.asInstanceOf[scala.Function2[T, T, T]])
@@ -100,6 +132,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `BooleanSupplier` to convert
    */
   @inline def asScalaFromBooleanSupplier(jf: java.util.function.BooleanSupplier): scala.Function0[java.lang.Boolean] = jf match {
     case AsJavaBooleanSupplier((f @ _)) => f.asInstanceOf[scala.Function0[java.lang.Boolean]]
@@ -111,6 +145,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function0` to convert to a Java `BooleanSupplier`
    */
   @inline def asJavaBooleanSupplier(sf: scala.Function0[java.lang.Boolean]): java.util.function.BooleanSupplier = ((sf): AnyRef) match {
     case FromJavaBooleanSupplier((f @ _)) => f.asInstanceOf[java.util.function.BooleanSupplier]
@@ -123,6 +159,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the input type of the consumer
+   *  @param jf the Java `Consumer` to convert
    */
   @inline def asScalaFromConsumer[T](jf: java.util.function.Consumer[T]): scala.Function1[T, scala.runtime.BoxedUnit] = jf match {
     case AsJavaConsumer((f @ _)) => f.asInstanceOf[scala.Function1[T, scala.runtime.BoxedUnit]]
@@ -134,6 +173,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the input type of the consumer
+   *  @param sf the Scala `Function1` to convert to a Java `Consumer`
    */
   @inline def asJavaConsumer[T](sf: scala.Function1[T, scala.runtime.BoxedUnit]): java.util.function.Consumer[T] = ((sf): AnyRef) match {
     case FromJavaConsumer((f @ _)) => f.asInstanceOf[java.util.function.Consumer[T]]
@@ -146,6 +188,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `DoubleBinaryOperator` to convert
    */
   @inline def asScalaFromDoubleBinaryOperator(jf: java.util.function.DoubleBinaryOperator): scala.Function2[java.lang.Double, java.lang.Double, java.lang.Double] = jf match {
     case AsJavaDoubleBinaryOperator((f @ _)) => f.asInstanceOf[scala.Function2[java.lang.Double, java.lang.Double, java.lang.Double]]
@@ -157,6 +201,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function2` to convert to a Java `DoubleBinaryOperator`
    */
   @inline def asJavaDoubleBinaryOperator(sf: scala.Function2[java.lang.Double, java.lang.Double, java.lang.Double]): java.util.function.DoubleBinaryOperator = ((sf): AnyRef) match {
     case FromJavaDoubleBinaryOperator((f @ _)) => f.asInstanceOf[java.util.function.DoubleBinaryOperator]
@@ -169,6 +215,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `DoubleConsumer` to convert
    */
   @inline def asScalaFromDoubleConsumer(jf: java.util.function.DoubleConsumer): scala.Function1[java.lang.Double, scala.runtime.BoxedUnit] = jf match {
     case AsJavaDoubleConsumer((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Double, scala.runtime.BoxedUnit]]
@@ -180,6 +228,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `DoubleConsumer`
    */
   @inline def asJavaDoubleConsumer(sf: scala.Function1[java.lang.Double, scala.runtime.BoxedUnit]): java.util.function.DoubleConsumer = ((sf): AnyRef) match {
     case FromJavaDoubleConsumer((f @ _)) => f.asInstanceOf[java.util.function.DoubleConsumer]
@@ -192,6 +242,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam R the return type of the function
+   *  @param jf the Java `DoubleFunction` to convert
    */
   @inline def asScalaFromDoubleFunction[R](jf: java.util.function.DoubleFunction[R]): scala.Function1[java.lang.Double, R] = jf match {
     case AsJavaDoubleFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Double, R]]
@@ -203,6 +256,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam R the return type of the function
+   *  @param sf the Scala `Function1` to convert to a Java `DoubleFunction`
    */
   @inline def asJavaDoubleFunction[R](sf: scala.Function1[java.lang.Double, R]): java.util.function.DoubleFunction[R] = ((sf): AnyRef) match {
     case FromJavaDoubleFunction((f @ _)) => f.asInstanceOf[java.util.function.DoubleFunction[R]]
@@ -215,6 +271,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `DoublePredicate` to convert
    */
   @inline def asScalaFromDoublePredicate(jf: java.util.function.DoublePredicate): scala.Function1[java.lang.Double, java.lang.Boolean] = jf match {
     case AsJavaDoublePredicate((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Double, java.lang.Boolean]]
@@ -226,6 +284,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `DoublePredicate`
    */
   @inline def asJavaDoublePredicate(sf: scala.Function1[java.lang.Double, java.lang.Boolean]): java.util.function.DoublePredicate = ((sf): AnyRef) match {
     case FromJavaDoublePredicate((f @ _)) => f.asInstanceOf[java.util.function.DoublePredicate]
@@ -238,6 +298,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `DoubleSupplier` to convert
    */
   @inline def asScalaFromDoubleSupplier(jf: java.util.function.DoubleSupplier): scala.Function0[java.lang.Double] = jf match {
     case AsJavaDoubleSupplier((f @ _)) => f.asInstanceOf[scala.Function0[java.lang.Double]]
@@ -249,6 +311,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function0` to convert to a Java `DoubleSupplier`
    */
   @inline def asJavaDoubleSupplier(sf: scala.Function0[java.lang.Double]): java.util.function.DoubleSupplier = ((sf): AnyRef) match {
     case FromJavaDoubleSupplier((f @ _)) => f.asInstanceOf[java.util.function.DoubleSupplier]
@@ -261,6 +325,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `DoubleToIntFunction` to convert
    */
   @inline def asScalaFromDoubleToIntFunction(jf: java.util.function.DoubleToIntFunction): scala.Function1[java.lang.Double, java.lang.Integer] = jf match {
     case AsJavaDoubleToIntFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Double, java.lang.Integer]]
@@ -272,6 +338,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `DoubleToIntFunction`
    */
   @inline def asJavaDoubleToIntFunction(sf: scala.Function1[java.lang.Double, java.lang.Integer]): java.util.function.DoubleToIntFunction = ((sf): AnyRef) match {
     case FromJavaDoubleToIntFunction((f @ _)) => f.asInstanceOf[java.util.function.DoubleToIntFunction]
@@ -284,6 +352,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `DoubleToLongFunction` to convert
    */
   @inline def asScalaFromDoubleToLongFunction(jf: java.util.function.DoubleToLongFunction): scala.Function1[java.lang.Double, java.lang.Long] = jf match {
     case AsJavaDoubleToLongFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Double, java.lang.Long]]
@@ -295,6 +365,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `DoubleToLongFunction`
    */
   @inline def asJavaDoubleToLongFunction(sf: scala.Function1[java.lang.Double, java.lang.Long]): java.util.function.DoubleToLongFunction = ((sf): AnyRef) match {
     case FromJavaDoubleToLongFunction((f @ _)) => f.asInstanceOf[java.util.function.DoubleToLongFunction]
@@ -307,6 +379,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `DoubleUnaryOperator` to convert
    */
   @inline def asScalaFromDoubleUnaryOperator(jf: java.util.function.DoubleUnaryOperator): scala.Function1[java.lang.Double, java.lang.Double] = jf match {
     case AsJavaDoubleUnaryOperator((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Double, java.lang.Double]]
@@ -318,6 +392,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `DoubleUnaryOperator`
    */
   @inline def asJavaDoubleUnaryOperator(sf: scala.Function1[java.lang.Double, java.lang.Double]): java.util.function.DoubleUnaryOperator = ((sf): AnyRef) match {
     case FromJavaDoubleUnaryOperator((f @ _)) => f.asInstanceOf[java.util.function.DoubleUnaryOperator]
@@ -325,11 +401,19 @@ object FunctionConverters {
   }
   
   
+  /** @tparam T the input type of the function
+   *  @tparam R the return type of the function
+   *  @param jf the Java `Function` to convert
+   */
   @inline def asScalaFromFunction[T, R](jf: java.util.function.Function[T, R]): scala.Function1[T, R] = jf match {
     case AsJavaFunction((f @ _)) => f.asInstanceOf[scala.Function1[T, R]]
     case _ => new FromJavaFunction[T, R](jf).asInstanceOf[scala.Function1[T, R]]
   }
   
+  /** @tparam T the input type of the function
+   *  @tparam R the return type of the function
+   *  @param sf the Scala `Function1` to convert to a Java `Function`
+   */
   @inline def asJavaFunction[T, R](sf: scala.Function1[T, R]): java.util.function.Function[T, R] = ((sf): AnyRef) match {
     case FromJavaFunction((f @ _)) => f.asInstanceOf[java.util.function.Function[T, R]]
     case _ => new AsJavaFunction[T, R](sf.asInstanceOf[scala.Function1[T, R]])
@@ -341,6 +425,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `IntBinaryOperator` to convert
    */
   @inline def asScalaFromIntBinaryOperator(jf: java.util.function.IntBinaryOperator): scala.Function2[java.lang.Integer, java.lang.Integer, java.lang.Integer] = jf match {
     case AsJavaIntBinaryOperator((f @ _)) => f.asInstanceOf[scala.Function2[java.lang.Integer, java.lang.Integer, java.lang.Integer]]
@@ -352,6 +438,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function2` to convert to a Java `IntBinaryOperator`
    */
   @inline def asJavaIntBinaryOperator(sf: scala.Function2[java.lang.Integer, java.lang.Integer, java.lang.Integer]): java.util.function.IntBinaryOperator = ((sf): AnyRef) match {
     case FromJavaIntBinaryOperator((f @ _)) => f.asInstanceOf[java.util.function.IntBinaryOperator]
@@ -364,6 +452,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `IntConsumer` to convert
    */
   @inline def asScalaFromIntConsumer(jf: java.util.function.IntConsumer): scala.Function1[java.lang.Integer, scala.runtime.BoxedUnit] = jf match {
     case AsJavaIntConsumer((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Integer, scala.runtime.BoxedUnit]]
@@ -375,6 +465,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `IntConsumer`
    */
   @inline def asJavaIntConsumer(sf: scala.Function1[java.lang.Integer, scala.runtime.BoxedUnit]): java.util.function.IntConsumer = ((sf): AnyRef) match {
     case FromJavaIntConsumer((f @ _)) => f.asInstanceOf[java.util.function.IntConsumer]
@@ -387,6 +479,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam R the return type of the function
+   *  @param jf the Java `IntFunction` to convert
    */
   @inline def asScalaFromIntFunction[R](jf: java.util.function.IntFunction[R]): scala.Function1[java.lang.Integer, R] = jf match {
     case AsJavaIntFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Integer, R]]
@@ -398,6 +493,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam R the return type of the function
+   *  @param sf the Scala `Function1` to convert to a Java `IntFunction`
    */
   @inline def asJavaIntFunction[R](sf: scala.Function1[java.lang.Integer, R]): java.util.function.IntFunction[R] = ((sf): AnyRef) match {
     case FromJavaIntFunction((f @ _)) => f.asInstanceOf[java.util.function.IntFunction[R]]
@@ -410,6 +508,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `IntPredicate` to convert
    */
   @inline def asScalaFromIntPredicate(jf: java.util.function.IntPredicate): scala.Function1[java.lang.Integer, java.lang.Boolean] = jf match {
     case AsJavaIntPredicate((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Integer, java.lang.Boolean]]
@@ -421,6 +521,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `IntPredicate`
    */
   @inline def asJavaIntPredicate(sf: scala.Function1[java.lang.Integer, java.lang.Boolean]): java.util.function.IntPredicate = ((sf): AnyRef) match {
     case FromJavaIntPredicate((f @ _)) => f.asInstanceOf[java.util.function.IntPredicate]
@@ -433,6 +535,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `IntSupplier` to convert
    */
   @inline def asScalaFromIntSupplier(jf: java.util.function.IntSupplier): scala.Function0[java.lang.Integer] = jf match {
     case AsJavaIntSupplier((f @ _)) => f.asInstanceOf[scala.Function0[java.lang.Integer]]
@@ -444,6 +548,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function0` to convert to a Java `IntSupplier`
    */
   @inline def asJavaIntSupplier(sf: scala.Function0[java.lang.Integer]): java.util.function.IntSupplier = ((sf): AnyRef) match {
     case FromJavaIntSupplier((f @ _)) => f.asInstanceOf[java.util.function.IntSupplier]
@@ -456,6 +562,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `IntToDoubleFunction` to convert
    */
   @inline def asScalaFromIntToDoubleFunction(jf: java.util.function.IntToDoubleFunction): scala.Function1[java.lang.Integer, java.lang.Double] = jf match {
     case AsJavaIntToDoubleFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Integer, java.lang.Double]]
@@ -467,6 +575,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `IntToDoubleFunction`
    */
   @inline def asJavaIntToDoubleFunction(sf: scala.Function1[java.lang.Integer, java.lang.Double]): java.util.function.IntToDoubleFunction = ((sf): AnyRef) match {
     case FromJavaIntToDoubleFunction((f @ _)) => f.asInstanceOf[java.util.function.IntToDoubleFunction]
@@ -479,6 +589,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `IntToLongFunction` to convert
    */
   @inline def asScalaFromIntToLongFunction(jf: java.util.function.IntToLongFunction): scala.Function1[java.lang.Integer, java.lang.Long] = jf match {
     case AsJavaIntToLongFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Integer, java.lang.Long]]
@@ -490,6 +602,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `IntToLongFunction`
    */
   @inline def asJavaIntToLongFunction(sf: scala.Function1[java.lang.Integer, java.lang.Long]): java.util.function.IntToLongFunction = ((sf): AnyRef) match {
     case FromJavaIntToLongFunction((f @ _)) => f.asInstanceOf[java.util.function.IntToLongFunction]
@@ -502,6 +616,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `IntUnaryOperator` to convert
    */
   @inline def asScalaFromIntUnaryOperator(jf: java.util.function.IntUnaryOperator): scala.Function1[java.lang.Integer, java.lang.Integer] = jf match {
     case AsJavaIntUnaryOperator((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Integer, java.lang.Integer]]
@@ -513,6 +629,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `IntUnaryOperator`
    */
   @inline def asJavaIntUnaryOperator(sf: scala.Function1[java.lang.Integer, java.lang.Integer]): java.util.function.IntUnaryOperator = ((sf): AnyRef) match {
     case FromJavaIntUnaryOperator((f @ _)) => f.asInstanceOf[java.util.function.IntUnaryOperator]
@@ -525,6 +643,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `LongBinaryOperator` to convert
    */
   @inline def asScalaFromLongBinaryOperator(jf: java.util.function.LongBinaryOperator): scala.Function2[java.lang.Long, java.lang.Long, java.lang.Long] = jf match {
     case AsJavaLongBinaryOperator((f @ _)) => f.asInstanceOf[scala.Function2[java.lang.Long, java.lang.Long, java.lang.Long]]
@@ -536,6 +656,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function2` to convert to a Java `LongBinaryOperator`
    */
   @inline def asJavaLongBinaryOperator(sf: scala.Function2[java.lang.Long, java.lang.Long, java.lang.Long]): java.util.function.LongBinaryOperator = ((sf): AnyRef) match {
     case FromJavaLongBinaryOperator((f @ _)) => f.asInstanceOf[java.util.function.LongBinaryOperator]
@@ -548,6 +670,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `LongConsumer` to convert
    */
   @inline def asScalaFromLongConsumer(jf: java.util.function.LongConsumer): scala.Function1[java.lang.Long, scala.runtime.BoxedUnit] = jf match {
     case AsJavaLongConsumer((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Long, scala.runtime.BoxedUnit]]
@@ -559,6 +683,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `LongConsumer`
    */
   @inline def asJavaLongConsumer(sf: scala.Function1[java.lang.Long, scala.runtime.BoxedUnit]): java.util.function.LongConsumer = ((sf): AnyRef) match {
     case FromJavaLongConsumer((f @ _)) => f.asInstanceOf[java.util.function.LongConsumer]
@@ -571,6 +697,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam R the return type of the function
+   *  @param jf the Java `LongFunction` to convert
    */
   @inline def asScalaFromLongFunction[R](jf: java.util.function.LongFunction[R]): scala.Function1[java.lang.Long, R] = jf match {
     case AsJavaLongFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Long, R]]
@@ -582,6 +711,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam R the return type of the function
+   *  @param sf the Scala `Function1` to convert to a Java `LongFunction`
    */
   @inline def asJavaLongFunction[R](sf: scala.Function1[java.lang.Long, R]): java.util.function.LongFunction[R] = ((sf): AnyRef) match {
     case FromJavaLongFunction((f @ _)) => f.asInstanceOf[java.util.function.LongFunction[R]]
@@ -594,6 +726,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `LongPredicate` to convert
    */
   @inline def asScalaFromLongPredicate(jf: java.util.function.LongPredicate): scala.Function1[java.lang.Long, java.lang.Boolean] = jf match {
     case AsJavaLongPredicate((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Long, java.lang.Boolean]]
@@ -605,6 +739,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `LongPredicate`
    */
   @inline def asJavaLongPredicate(sf: scala.Function1[java.lang.Long, java.lang.Boolean]): java.util.function.LongPredicate = ((sf): AnyRef) match {
     case FromJavaLongPredicate((f @ _)) => f.asInstanceOf[java.util.function.LongPredicate]
@@ -617,6 +753,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `LongSupplier` to convert
    */
   @inline def asScalaFromLongSupplier(jf: java.util.function.LongSupplier): scala.Function0[java.lang.Long] = jf match {
     case AsJavaLongSupplier((f @ _)) => f.asInstanceOf[scala.Function0[java.lang.Long]]
@@ -628,6 +766,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function0` to convert to a Java `LongSupplier`
    */
   @inline def asJavaLongSupplier(sf: scala.Function0[java.lang.Long]): java.util.function.LongSupplier = ((sf): AnyRef) match {
     case FromJavaLongSupplier((f @ _)) => f.asInstanceOf[java.util.function.LongSupplier]
@@ -640,6 +780,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `LongToDoubleFunction` to convert
    */
   @inline def asScalaFromLongToDoubleFunction(jf: java.util.function.LongToDoubleFunction): scala.Function1[java.lang.Long, java.lang.Double] = jf match {
     case AsJavaLongToDoubleFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Long, java.lang.Double]]
@@ -651,6 +793,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `LongToDoubleFunction`
    */
   @inline def asJavaLongToDoubleFunction(sf: scala.Function1[java.lang.Long, java.lang.Double]): java.util.function.LongToDoubleFunction = ((sf): AnyRef) match {
     case FromJavaLongToDoubleFunction((f @ _)) => f.asInstanceOf[java.util.function.LongToDoubleFunction]
@@ -663,6 +807,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `LongToIntFunction` to convert
    */
   @inline def asScalaFromLongToIntFunction(jf: java.util.function.LongToIntFunction): scala.Function1[java.lang.Long, java.lang.Integer] = jf match {
     case AsJavaLongToIntFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Long, java.lang.Integer]]
@@ -674,6 +820,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `LongToIntFunction`
    */
   @inline def asJavaLongToIntFunction(sf: scala.Function1[java.lang.Long, java.lang.Integer]): java.util.function.LongToIntFunction = ((sf): AnyRef) match {
     case FromJavaLongToIntFunction((f @ _)) => f.asInstanceOf[java.util.function.LongToIntFunction]
@@ -686,6 +834,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `LongUnaryOperator` to convert
    */
   @inline def asScalaFromLongUnaryOperator(jf: java.util.function.LongUnaryOperator): scala.Function1[java.lang.Long, java.lang.Long] = jf match {
     case AsJavaLongUnaryOperator((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Long, java.lang.Long]]
@@ -697,6 +847,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `LongUnaryOperator`
    */
   @inline def asJavaLongUnaryOperator(sf: scala.Function1[java.lang.Long, java.lang.Long]): java.util.function.LongUnaryOperator = ((sf): AnyRef) match {
     case FromJavaLongUnaryOperator((f @ _)) => f.asInstanceOf[java.util.function.LongUnaryOperator]
@@ -709,6 +861,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the type of the first (object) argument to the consumer
+   *  @param jf the Java `ObjDoubleConsumer` to convert
    */
   @inline def asScalaFromObjDoubleConsumer[T](jf: java.util.function.ObjDoubleConsumer[T]): scala.Function2[T, java.lang.Double, scala.runtime.BoxedUnit] = jf match {
     case AsJavaObjDoubleConsumer((f @ _)) => f.asInstanceOf[scala.Function2[T, java.lang.Double, scala.runtime.BoxedUnit]]
@@ -720,6 +875,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the type of the first (object) argument to the consumer
+   *  @param sf the Scala `Function2` to convert to a Java `ObjDoubleConsumer`
    */
   @inline def asJavaObjDoubleConsumer[T](sf: scala.Function2[T, java.lang.Double, scala.runtime.BoxedUnit]): java.util.function.ObjDoubleConsumer[T] = ((sf): AnyRef) match {
     case FromJavaObjDoubleConsumer((f @ _)) => f.asInstanceOf[java.util.function.ObjDoubleConsumer[T]]
@@ -732,6 +890,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the type of the first (object) argument to the consumer
+   *  @param jf the Java `ObjIntConsumer` to convert
    */
   @inline def asScalaFromObjIntConsumer[T](jf: java.util.function.ObjIntConsumer[T]): scala.Function2[T, java.lang.Integer, scala.runtime.BoxedUnit] = jf match {
     case AsJavaObjIntConsumer((f @ _)) => f.asInstanceOf[scala.Function2[T, java.lang.Integer, scala.runtime.BoxedUnit]]
@@ -743,6 +904,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the type of the first (object) argument to the consumer
+   *  @param sf the Scala `Function2` to convert to a Java `ObjIntConsumer`
    */
   @inline def asJavaObjIntConsumer[T](sf: scala.Function2[T, java.lang.Integer, scala.runtime.BoxedUnit]): java.util.function.ObjIntConsumer[T] = ((sf): AnyRef) match {
     case FromJavaObjIntConsumer((f @ _)) => f.asInstanceOf[java.util.function.ObjIntConsumer[T]]
@@ -755,6 +919,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the type of the first (object) argument to the consumer
+   *  @param jf the Java `ObjLongConsumer` to convert
    */
   @inline def asScalaFromObjLongConsumer[T](jf: java.util.function.ObjLongConsumer[T]): scala.Function2[T, java.lang.Long, scala.runtime.BoxedUnit] = jf match {
     case AsJavaObjLongConsumer((f @ _)) => f.asInstanceOf[scala.Function2[T, java.lang.Long, scala.runtime.BoxedUnit]]
@@ -766,6 +933,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the type of the first (object) argument to the consumer
+   *  @param sf the Scala `Function2` to convert to a Java `ObjLongConsumer`
    */
   @inline def asJavaObjLongConsumer[T](sf: scala.Function2[T, java.lang.Long, scala.runtime.BoxedUnit]): java.util.function.ObjLongConsumer[T] = ((sf): AnyRef) match {
     case FromJavaObjLongConsumer((f @ _)) => f.asInstanceOf[java.util.function.ObjLongConsumer[T]]
@@ -778,6 +948,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the input type of the predicate
+   *  @param jf the Java `Predicate` to convert
    */
   @inline def asScalaFromPredicate[T](jf: java.util.function.Predicate[T]): scala.Function1[T, java.lang.Boolean] = jf match {
     case AsJavaPredicate((f @ _)) => f.asInstanceOf[scala.Function1[T, java.lang.Boolean]]
@@ -789,6 +962,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the input type of the predicate
+   *  @param sf the Scala `Function1` to convert to a Java `Predicate`
    */
   @inline def asJavaPredicate[T](sf: scala.Function1[T, java.lang.Boolean]): java.util.function.Predicate[T] = ((sf): AnyRef) match {
     case FromJavaPredicate((f @ _)) => f.asInstanceOf[java.util.function.Predicate[T]]
@@ -796,11 +972,17 @@ object FunctionConverters {
   }
   
   
+  /** @tparam T the return type of the supplier
+   *  @param jf the Java `Supplier` to convert
+   */
   @inline def asScalaFromSupplier[T](jf: java.util.function.Supplier[T]): scala.Function0[T] = jf match {
     case AsJavaSupplier((f @ _)) => f.asInstanceOf[scala.Function0[T]]
     case _ => new FromJavaSupplier[T](jf).asInstanceOf[scala.Function0[T]]
   }
   
+  /** @tparam T the return type of the supplier
+   *  @param sf the Scala `Function0` to convert to a Java `Supplier`
+   */
   @inline def asJavaSupplier[T](sf: scala.Function0[T]): java.util.function.Supplier[T] = ((sf): AnyRef) match {
     case FromJavaSupplier((f @ _)) => f.asInstanceOf[java.util.function.Supplier[T]]
     case _ => new AsJavaSupplier[T](sf.asInstanceOf[scala.Function0[T]])
@@ -812,6 +994,10 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the first input type of the function
+   *  @tparam U the second input type of the function
+   *  @param jf the Java `ToDoubleBiFunction` to convert
    */
   @inline def asScalaFromToDoubleBiFunction[T, U](jf: java.util.function.ToDoubleBiFunction[T, U]): scala.Function2[T, U, java.lang.Double] = jf match {
     case AsJavaToDoubleBiFunction((f @ _)) => f.asInstanceOf[scala.Function2[T, U, java.lang.Double]]
@@ -823,6 +1009,10 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the first input type of the function
+   *  @tparam U the second input type of the function
+   *  @param sf the Scala `Function2` to convert to a Java `ToDoubleBiFunction`
    */
   @inline def asJavaToDoubleBiFunction[T, U](sf: scala.Function2[T, U, java.lang.Double]): java.util.function.ToDoubleBiFunction[T, U] = ((sf): AnyRef) match {
     case FromJavaToDoubleBiFunction((f @ _)) => f.asInstanceOf[java.util.function.ToDoubleBiFunction[T, U]]
@@ -835,6 +1025,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the input type of the function
+   *  @param jf the Java `ToDoubleFunction` to convert
    */
   @inline def asScalaFromToDoubleFunction[T](jf: java.util.function.ToDoubleFunction[T]): scala.Function1[T, java.lang.Double] = jf match {
     case AsJavaToDoubleFunction((f @ _)) => f.asInstanceOf[scala.Function1[T, java.lang.Double]]
@@ -846,6 +1039,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the input type of the function
+   *  @param sf the Scala `Function1` to convert to a Java `ToDoubleFunction`
    */
   @inline def asJavaToDoubleFunction[T](sf: scala.Function1[T, java.lang.Double]): java.util.function.ToDoubleFunction[T] = ((sf): AnyRef) match {
     case FromJavaToDoubleFunction((f @ _)) => f.asInstanceOf[java.util.function.ToDoubleFunction[T]]
@@ -858,6 +1054,10 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the first input type of the function
+   *  @tparam U the second input type of the function
+   *  @param jf the Java `ToIntBiFunction` to convert
    */
   @inline def asScalaFromToIntBiFunction[T, U](jf: java.util.function.ToIntBiFunction[T, U]): scala.Function2[T, U, java.lang.Integer] = jf match {
     case AsJavaToIntBiFunction((f @ _)) => f.asInstanceOf[scala.Function2[T, U, java.lang.Integer]]
@@ -869,6 +1069,10 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the first input type of the function
+   *  @tparam U the second input type of the function
+   *  @param sf the Scala `Function2` to convert to a Java `ToIntBiFunction`
    */
   @inline def asJavaToIntBiFunction[T, U](sf: scala.Function2[T, U, java.lang.Integer]): java.util.function.ToIntBiFunction[T, U] = ((sf): AnyRef) match {
     case FromJavaToIntBiFunction((f @ _)) => f.asInstanceOf[java.util.function.ToIntBiFunction[T, U]]
@@ -881,6 +1085,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the input type of the function
+   *  @param jf the Java `ToIntFunction` to convert
    */
   @inline def asScalaFromToIntFunction[T](jf: java.util.function.ToIntFunction[T]): scala.Function1[T, java.lang.Integer] = jf match {
     case AsJavaToIntFunction((f @ _)) => f.asInstanceOf[scala.Function1[T, java.lang.Integer]]
@@ -892,6 +1099,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the input type of the function
+   *  @param sf the Scala `Function1` to convert to a Java `ToIntFunction`
    */
   @inline def asJavaToIntFunction[T](sf: scala.Function1[T, java.lang.Integer]): java.util.function.ToIntFunction[T] = ((sf): AnyRef) match {
     case FromJavaToIntFunction((f @ _)) => f.asInstanceOf[java.util.function.ToIntFunction[T]]
@@ -904,6 +1114,10 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the first input type of the function
+   *  @tparam U the second input type of the function
+   *  @param jf the Java `ToLongBiFunction` to convert
    */
   @inline def asScalaFromToLongBiFunction[T, U](jf: java.util.function.ToLongBiFunction[T, U]): scala.Function2[T, U, java.lang.Long] = jf match {
     case AsJavaToLongBiFunction((f @ _)) => f.asInstanceOf[scala.Function2[T, U, java.lang.Long]]
@@ -915,6 +1129,10 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the first input type of the function
+   *  @tparam U the second input type of the function
+   *  @param sf the Scala `Function2` to convert to a Java `ToLongBiFunction`
    */
   @inline def asJavaToLongBiFunction[T, U](sf: scala.Function2[T, U, java.lang.Long]): java.util.function.ToLongBiFunction[T, U] = ((sf): AnyRef) match {
     case FromJavaToLongBiFunction((f @ _)) => f.asInstanceOf[java.util.function.ToLongBiFunction[T, U]]
@@ -927,6 +1145,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the input type of the function
+   *  @param jf the Java `ToLongFunction` to convert
    */
   @inline def asScalaFromToLongFunction[T](jf: java.util.function.ToLongFunction[T]): scala.Function1[T, java.lang.Long] = jf match {
     case AsJavaToLongFunction((f @ _)) => f.asInstanceOf[scala.Function1[T, java.lang.Long]]
@@ -938,6 +1159,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the input type of the function
+   *  @param sf the Scala `Function1` to convert to a Java `ToLongFunction`
    */
   @inline def asJavaToLongFunction[T](sf: scala.Function1[T, java.lang.Long]): java.util.function.ToLongFunction[T] = ((sf): AnyRef) match {
     case FromJavaToLongFunction((f @ _)) => f.asInstanceOf[java.util.function.ToLongFunction[T]]
@@ -945,11 +1169,17 @@ object FunctionConverters {
   }
   
   
+  /** @tparam T the input and output type of the unary operator
+   *  @param jf the Java `UnaryOperator` to convert
+   */
   @inline def asScalaFromUnaryOperator[T](jf: java.util.function.UnaryOperator[T]): scala.Function1[T, T] = jf match {
     case AsJavaUnaryOperator((f @ _)) => f.asInstanceOf[scala.Function1[T, T]]
     case _ => new FromJavaUnaryOperator[T](jf).asInstanceOf[scala.Function1[T, T]]
   }
   
+  /** @tparam T the input and output type of the unary operator
+   *  @param sf the Scala `Function1` to convert to a Java `UnaryOperator`
+   */
   @inline def asJavaUnaryOperator[T](sf: scala.Function1[T, T]): java.util.function.UnaryOperator[T] = ((sf): AnyRef) match {
     case FromJavaUnaryOperator((f @ _)) => f.asInstanceOf[java.util.function.UnaryOperator[T]]
     case _ => new AsJavaUnaryOperator[T](sf.asInstanceOf[scala.Function1[T, T]])

--- a/library/src/scala/jdk/javaapi/FutureConverters.scala
+++ b/library/src/scala/jdk/javaapi/FutureConverters.scala
@@ -40,6 +40,7 @@ object FutureConverters {
    *  therefore the returned CompletionStage routes all calls to synchronous transformations to
    *  their asynchronous counterparts, i.e., `thenRun` will internally call `thenRunAsync`.
    *
+   *  @tparam T the result type of the Future and CompletionStage
    *  @param f The Scala Future which may eventually supply the completion for the returned
    *          CompletionStage
    *  @return a CompletionStage that runs all callbacks asynchronously and does not support the
@@ -62,6 +63,7 @@ object FutureConverters {
    *  executed asynchronously as specified by the ExecutionContext that is given to the combinator
    *  methods.
    *
+   *  @tparam T the result type of the CompletionStage and Future
    *  @param cs The CompletionStage which may eventually supply the completion for the returned
    *           Scala Future
    *  @return a Scala Future that represents the CompletionStage's completion

--- a/library/src/scala/jdk/javaapi/OptionConverters.scala
+++ b/library/src/scala/jdk/javaapi/OptionConverters.scala
@@ -29,7 +29,12 @@ import java.{lang => jl}
  *                       extension methods instead.
  */
 object OptionConverters {
-  /** Converts a Scala `Option` to a Java `Optional`. */
+  /** Converts a Scala `Option` to a Java `Optional`.
+   *
+   *  @tparam A the element type of the `Option` and the resulting `Optional`
+   *  @param o the Scala `Option` to convert
+   *  @return a Java `Optional` containing the value, or empty if `o` is `None`
+   */
   def toJava[A](o: Option[A]): Optional[A] = o match {
     case Some(a) => Optional.ofNullable(a)
     case _ => Optional.empty[A]
@@ -38,6 +43,9 @@ object OptionConverters {
   /** Converts a Scala `Option[java.lang.Double]` to a Java `OptionalDouble`.
    *
    *  $primitiveNote
+   *
+   *  @param o the Scala `Option` to convert
+   *  @return a Java `OptionalDouble` containing the value, or empty if `o` is `None`
    */
   def toJavaOptionalDouble(o: Option[jl.Double]): OptionalDouble = o match {
     case Some(a) => OptionalDouble.of(a)
@@ -47,6 +55,9 @@ object OptionConverters {
   /** Converts a Scala `Option[java.lang.Integer]` to a Java `OptionalInt`.
    *
    *  $primitiveNote
+   *
+   *  @param o the Scala `Option` to convert
+   *  @return a Java `OptionalInt` containing the value, or empty if `o` is `None`
    */
   def toJavaOptionalInt(o: Option[jl.Integer]): OptionalInt = o match {
     case Some(a) => OptionalInt.of(a)
@@ -56,30 +67,47 @@ object OptionConverters {
   /** Converts a Scala `Option[java.lang.Long]` to a Java `OptionalLong`.
    *
    *  $primitiveNote
+   *
+   *  @param o the Scala `Option` to convert
+   *  @return a Java `OptionalLong` containing the value, or empty if `o` is `None`
    */
   def toJavaOptionalLong(o: Option[jl.Long]): OptionalLong = o match {
     case Some(a) => OptionalLong.of(a)
     case _ => OptionalLong.empty
   }
 
-  /** Converts a Java `Optional` to a Scala `Option`. */
+  /** Converts a Java `Optional` to a Scala `Option`.
+   *
+   *  @tparam A the element type of the `Optional`
+   *  @param o the Java `Optional` to convert
+   *  @return a Scala `Option` containing the value, or `None` if the `Optional` is empty
+   */
   def toScala[A](o: Optional[A]): Option[A] = if (o.isPresent) Some(o.get) else None
 
   /** Converts a Java `OptionalDouble` to a Scala `Option[java.lang.Double]`.
    *
    *  $primitiveNote
+   *
+   *  @param o the Java `OptionalDouble` to convert
+   *  @return a Scala `Option` containing the value as a boxed `java.lang.Double`, or `None` if empty
    */
   def toScala(o: OptionalDouble): Option[jl.Double] = if (o.isPresent) Some(o.getAsDouble) else None
 
   /** Converts a Java `OptionalInt` to a Scala `Option[java.lang.Integer]`.
    *
    *  $primitiveNote
+   *
+   *  @param o the Java `OptionalInt` to convert
+   *  @return a Scala `Option` containing the value as a boxed `java.lang.Integer`, or `None` if empty
    */
   def toScala(o: OptionalInt): Option[jl.Integer] = if (o.isPresent) Some(o.getAsInt) else None
 
   /** Converts a Java `OptionalLong` to a Scala `Option[java.lang.Long]`.
    *
    *  $primitiveNote
+   *
+   *  @param o the Java `OptionalLong` to convert
+   *  @return a Scala `Option` containing the value as a boxed `java.lang.Long`, or `None` if empty
    */
   def toScala(o: OptionalLong): Option[jl.Long] = if (o.isPresent) Some(o.getAsLong) else None
 }

--- a/library/src/scala/jdk/javaapi/StreamConverters.scala
+++ b/library/src/scala/jdk/javaapi/StreamConverters.scala
@@ -45,130 +45,224 @@ object StreamConverters {
   // sequential streams for collections
   /////////////////////////////////////
 
-  /** Creates a sequential [[java.util.stream.Stream Java Stream]] for a Scala collection. */
+  /** Creates a sequential [[java.util.stream.Stream Java Stream]] for a Scala collection.
+   *
+   *  @tparam A the element type of the collection
+   *  @param cc the Scala collection to convert to a Java Stream
+   *  @return a sequential `Stream` for the collection
+   */
   def asJavaSeqStream[A](cc: IterableOnce[A]): Stream[A] = StreamSupport.stream(cc.stepper.spliterator, false)
 
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of integers to convert
+   *  @return a sequential `IntStream` for the collection
    */
   def asJavaSeqIntStream         (cc: IterableOnce[jl.Integer]):   IntStream = StreamSupport.intStream(cc.stepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of bytes to convert
+   *  @return a sequential `IntStream` for the collection
    */
   def asJavaSeqIntStreamFromByte (cc: IterableOnce[jl.Byte]):      IntStream = StreamSupport.intStream(cc.stepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of shorts to convert
+   *  @return a sequential `IntStream` for the collection
    */
   def asJavaSeqIntStreamFromShort(cc: IterableOnce[jl.Short]):     IntStream = StreamSupport.intStream(cc.stepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of characters to convert
+   *  @return a sequential `IntStream` for the collection
    */
   def asJavaSeqIntStreamFromChar (cc: IterableOnce[jl.Character]): IntStream = StreamSupport.intStream(cc.stepper.spliterator, false)
 
   /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for a Scala collection.
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of doubles to convert
+   *  @return a sequential `DoubleStream` for the collection
    */
   def asJavaSeqDoubleStream         (cc: IterableOnce[jl.Double]): DoubleStream = StreamSupport.doubleStream(cc.stepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for a Scala collection.
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of floats to convert
+   *  @return a sequential `DoubleStream` for the collection
    */
   def asJavaSeqDoubleStreamFromFloat(cc: IterableOnce[jl.Float]):  DoubleStream = StreamSupport.doubleStream(cc.stepper.spliterator, false)
 
   /** Creates a sequential [[java.util.stream.LongStream Java LongStream]] for a Scala collection.
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of longs to convert
+   *  @return a sequential `LongStream` for the collection
    */
   def asJavaSeqLongStream(cc: IterableOnce[jl.Long]): LongStream = StreamSupport.longStream(cc.stepper.spliterator, false)
 
   // Map Key Streams
 
-  /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the keys of a Scala Map. */
+  /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the keys of a Scala Map.
+   *
+   *  @tparam K the key type of the map
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a sequential `Stream` for the map's keys
+   */
   def asJavaSeqKeyStream[K, V](m: collection.Map[K, V]): Stream[K] = StreamSupport.stream(m.keyStepper.spliterator, false)
 
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a sequential `IntStream` for the map's keys
    */
   def asJavaSeqKeyIntStream         [V](m: collection.Map[jl.Integer, V]):   IntStream = StreamSupport.intStream(m.keyStepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a sequential `IntStream` for the map's keys
    */
   def asJavaSeqKeyIntStreamFromByte [V](m: collection.Map[jl.Byte, V]):      IntStream = StreamSupport.intStream(m.keyStepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a sequential `IntStream` for the map's keys
    */
   def asJavaSeqKeyIntStreamFromShort[V](m: collection.Map[jl.Short, V]):     IntStream = StreamSupport.intStream(m.keyStepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a sequential `IntStream` for the map's keys
    */
   def asJavaSeqKeyIntStreamFromChar [V](m: collection.Map[jl.Character, V]): IntStream = StreamSupport.intStream(m.keyStepper.spliterator, false)
 
   /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for the keys of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a sequential `DoubleStream` for the map's keys
    */
   def asJavaSeqKeyDoubleStream         [V](m: collection.Map[jl.Double, V]): DoubleStream = StreamSupport.doubleStream(m.keyStepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for the keys of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a sequential `DoubleStream` for the map's keys
    */
   def asJavaSeqKeyDoubleStreamFromFloat[V](m: collection.Map[jl.Float, V]):  DoubleStream = StreamSupport.doubleStream(m.keyStepper.spliterator, false)
 
   /** Creates a sequential [[java.util.stream.LongStream Java LongStream]] for the keys of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a sequential `LongStream` for the map's keys
    */
   def asJavaSeqKeyLongStream[V](m: collection.Map[jl.Long, V]): LongStream = StreamSupport.longStream(m.keyStepper.spliterator, false)
 
   // Map Value Streams
 
-  /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the values of a Scala Map. */
+  /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the values of a Scala Map.
+   *
+   *  @tparam K the key type of the map
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a sequential `Stream` for the map's values
+   */
   def asJavaSeqValueStream[K, V](m: collection.Map[K, V]): Stream[V] = StreamSupport.stream(m.valueStepper.spliterator, false)
 
-  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a
+  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a sequential `IntStream` for the map's values
    */
   def asJavaSeqValueIntStream         [K](m: collection.Map[K, jl.Integer]):   IntStream = StreamSupport.intStream(m.valueStepper.spliterator, false)
-  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a
+  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a sequential `IntStream` for the map's values
    */
   def asJavaSeqValueIntStreamFromByte [K](m: collection.Map[K, jl.Byte]):      IntStream = StreamSupport.intStream(m.valueStepper.spliterator, false)
-  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a
+  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a sequential `IntStream` for the map's values
    */
   def asJavaSeqValueIntStreamFromShort[K](m: collection.Map[K, jl.Short]):     IntStream = StreamSupport.intStream(m.valueStepper.spliterator, false)
-  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a
+  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a sequential `IntStream` for the map's values
    */
   def asJavaSeqValueIntStreamFromChar [K](m: collection.Map[K, jl.Character]): IntStream = StreamSupport.intStream(m.valueStepper.spliterator, false)
 
-  /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for the values of a
+  /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for the values of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a sequential `DoubleStream` for the map's values
    */
   def asJavaSeqValueDoubleStream         [K](m: collection.Map[K, jl.Double]): DoubleStream = StreamSupport.doubleStream(m.valueStepper.spliterator, false)
-  /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for the values of a
+  /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for the values of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a sequential `DoubleStream` for the map's values
    */
   def asJavaSeqValueDoubleStreamFromFloat[K](m: collection.Map[K, jl.Float]):  DoubleStream = StreamSupport.doubleStream(m.valueStepper.spliterator, false)
 
-  /** Creates a sequential [[java.util.stream.LongStream Java LongStream]] for the values of a
+  /** Creates a sequential [[java.util.stream.LongStream Java LongStream]] for the values of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a sequential `LongStream` for the map's values
    */
   def asJavaSeqValueLongStream[K](m: collection.Map[K, jl.Long]): LongStream = StreamSupport.longStream(m.valueStepper.spliterator, false)
 
@@ -179,6 +273,10 @@ object StreamConverters {
   /** Creates a parallel [[java.util.stream.Stream Java Stream]] for a Scala collection.
    *
    *  $parNote
+   *
+   *  @tparam A the element type of the collection
+   *  @param cc the Scala collection to convert to a parallel Java Stream
+   *  @return a parallel `Stream` for the collection
    */
   def asJavaParStream[A](cc: IterableOnce[A]): Stream[A] = StreamSupport.stream(cc.stepper.spliterator, true)
 
@@ -187,6 +285,9 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of integers to convert
+   *  @return a parallel `IntStream` for the collection
    */
   def asJavaParIntStream         (cc: IterableOnce[jl.Integer]):   IntStream = StreamSupport.intStream(cc.stepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
@@ -194,6 +295,9 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of bytes to convert
+   *  @return a parallel `IntStream` for the collection
    */
   def asJavaParIntStreamFromByte (cc: IterableOnce[jl.Byte]):      IntStream = StreamSupport.intStream(cc.stepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
@@ -201,6 +305,9 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of shorts to convert
+   *  @return a parallel `IntStream` for the collection
    */
   def asJavaParIntStreamFromShort(cc: IterableOnce[jl.Short]):     IntStream = StreamSupport.intStream(cc.stepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
@@ -208,6 +315,9 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of characters to convert
+   *  @return a parallel `IntStream` for the collection
    */
   def asJavaParIntStreamFromChar (cc: IterableOnce[jl.Character]): IntStream = StreamSupport.intStream(cc.stepper.spliterator, true)
 
@@ -216,6 +326,9 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of doubles to convert
+   *  @return a parallel `DoubleStream` for the collection
    */
   def asJavaParDoubleStream         (cc: IterableOnce[jl.Double]): DoubleStream = StreamSupport.doubleStream(cc.stepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for a Scala collection.
@@ -223,6 +336,9 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of floats to convert
+   *  @return a parallel `DoubleStream` for the collection
    */
   def asJavaParDoubleStreamFromFloat(cc: IterableOnce[jl.Float]):  DoubleStream = StreamSupport.doubleStream(cc.stepper.spliterator, true)
 
@@ -231,6 +347,9 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of longs to convert
+   *  @return a parallel `LongStream` for the collection
    */
   def asJavaParLongStream(cc: IterableOnce[jl.Long]): LongStream = StreamSupport.longStream(cc.stepper.spliterator, true)
 
@@ -240,6 +359,11 @@ object StreamConverters {
   /** Creates a parallel [[java.util.stream.Stream Java Stream]] for the keys of a Scala Map.
    *
    *  $parNote
+   *
+   *  @tparam K the key type of the map
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a parallel `Stream` for the map's keys
    */
   def asJavaParKeyStream[K, V](m: collection.Map[K, V]): Stream[K] = StreamSupport.stream(m.keyStepper.spliterator, true)
 
@@ -248,6 +372,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a parallel `IntStream` for the map's keys
    */
   def asJavaParKeyIntStream         [V](m: collection.Map[jl.Integer, V]):   IntStream = StreamSupport.intStream(m.keyStepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
@@ -255,6 +383,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a parallel `IntStream` for the map's keys
    */
   def asJavaParKeyIntStreamFromByte [V](m: collection.Map[jl.Byte, V]):      IntStream = StreamSupport.intStream(m.keyStepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
@@ -262,6 +394,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a parallel `IntStream` for the map's keys
    */
   def asJavaParKeyIntStreamFromShort[V](m: collection.Map[jl.Short, V]):     IntStream = StreamSupport.intStream(m.keyStepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
@@ -269,6 +405,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a parallel `IntStream` for the map's keys
    */
   def asJavaParKeyIntStreamFromChar [V](m: collection.Map[jl.Character, V]): IntStream = StreamSupport.intStream(m.keyStepper.spliterator, true)
 
@@ -277,6 +417,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a parallel `DoubleStream` for the map's keys
    */
   def asJavaParKeyDoubleStream         [V](m: collection.Map[jl.Double, V]): DoubleStream = StreamSupport.doubleStream(m.keyStepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for the keys of a Scala Map.
@@ -284,6 +428,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a parallel `DoubleStream` for the map's keys
    */
   def asJavaParKeyDoubleStreamFromFloat[V](m: collection.Map[jl.Float, V]):  DoubleStream = StreamSupport.doubleStream(m.keyStepper.spliterator, true)
 
@@ -292,6 +440,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a parallel `LongStream` for the map's keys
    */
   def asJavaParKeyLongStream[V](m: collection.Map[jl.Long, V]): LongStream = StreamSupport.longStream(m.keyStepper.spliterator, true)
 
@@ -300,6 +452,11 @@ object StreamConverters {
   /** Creates a parallel [[java.util.stream.Stream Java Stream]] for the values of a Scala Map.
    *
    *  $parNote
+   *
+   *  @tparam K the key type of the map
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a parallel `Stream` for the map's values
    */
   def asJavaParValueStream[K, V](m: collection.Map[K, V]): Stream[V] = StreamSupport.stream(m.valueStepper.spliterator, true)
 
@@ -308,6 +465,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a parallel `IntStream` for the map's values
    */
   def asJavaParValueIntStream         [K](m: collection.Map[K, jl.Integer]):   IntStream = StreamSupport.intStream(m.valueStepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
@@ -315,6 +476,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a parallel `IntStream` for the map's values
    */
   def asJavaParValueIntStreamFromByte [K](m: collection.Map[K, jl.Byte]):      IntStream = StreamSupport.intStream(m.valueStepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
@@ -322,6 +487,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a parallel `IntStream` for the map's values
    */
   def asJavaParValueIntStreamFromShort[K](m: collection.Map[K, jl.Short]):     IntStream = StreamSupport.intStream(m.valueStepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
@@ -329,6 +498,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a parallel `IntStream` for the map's values
    */
   def asJavaParValueIntStreamFromChar [K](m: collection.Map[K, jl.Character]): IntStream = StreamSupport.intStream(m.valueStepper.spliterator, true)
 
@@ -337,6 +510,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a parallel `DoubleStream` for the map's values
    */
   def asJavaParValueDoubleStream         [K](m: collection.Map[K, jl.Double]): DoubleStream = StreamSupport.doubleStream(m.valueStepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for the values of a Scala Map.
@@ -344,6 +521,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a parallel `DoubleStream` for the map's values
    */
   def asJavaParValueDoubleStreamFromFloat[K](m: collection.Map[K, jl.Float]):  DoubleStream = StreamSupport.doubleStream(m.valueStepper.spliterator, true)
 
@@ -352,6 +533,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a parallel `LongStream` for the map's values
    */
   def asJavaParValueLongStream[K](m: collection.Map[K, jl.Long]): LongStream = StreamSupport.longStream(m.valueStepper.spliterator, true)
 }

--- a/library/src/scala/math/BigDecimal.scala
+++ b/library/src/scala/math/BigDecimal.scala
@@ -48,16 +48,26 @@ object BigDecimal {
     val UNNECESSARY = Value(JRM.UNNECESSARY.ordinal)
   }
 
-  /** Constructs a `BigDecimal` using the decimal text representation of `Double` value `d`, rounding if necessary. */
+  /** Constructs a `BigDecimal` using the decimal text representation of `Double` value `d`, rounding if necessary.
+   *
+   *  @param d the `Double` value to convert to a `BigDecimal`
+   *  @param mc the precision and rounding mode for the conversion
+   */
   def decimal(d: Double, mc: MathContext): BigDecimal =
     new BigDecimal(new BigDec(java.lang.Double.toString(d), mc), mc)
 
-  /** Constructs a `BigDecimal` using the decimal text representation of `Double` value `d`. */
+  /** Constructs a `BigDecimal` using the decimal text representation of `Double` value `d`.
+   *
+   *  @param d the `Double` value to convert to a `BigDecimal`
+   */
   def decimal(d: Double): BigDecimal = decimal(d, defaultMathContext)
 
   /** Constructs a `BigDecimal` using the decimal text representation of `Float` value `f`, rounding if necessary.
    *  Note that `BigDecimal.decimal(0.1f) != 0.1f` since equality agrees with the `Double` representation, and
    *  `0.1 != 0.1f`.
+   *
+   *  @param f the `Float` value to convert to a `BigDecimal`
+   *  @param mc the precision and rounding mode for the conversion
    */
   def decimal(f: Float, mc: MathContext): BigDecimal =
     new BigDecimal(new BigDec(java.lang.Float.toString(f), mc), mc)
@@ -65,18 +75,31 @@ object BigDecimal {
   /** Constructs a `BigDecimal` using the decimal text representation of `Float` value `f`.
    *  Note that `BigDecimal.decimal(0.1f) != 0.1f` since equality agrees with the `Double` representation, and
    *  `0.1 != 0.1f`.
+   *
+   *  @param f the `Float` value to convert to a `BigDecimal`
    */
   def decimal(f: Float): BigDecimal = decimal(f, defaultMathContext)
 
   // This exists solely to avoid conversion from Int/Long to Float, screwing everything up.
-  /** Constructs a `BigDecimal` from a `Long`, rounding if necessary.  This is identical to `BigDecimal(l, mc)`. */
+  /** Constructs a `BigDecimal` from a `Long`, rounding if necessary.  This is identical to `BigDecimal(l, mc)`.
+   *
+   *  @param l the `Long` value to convert to a `BigDecimal`
+   *  @param mc the precision and rounding mode for the conversion
+   */
   def decimal(l: Long, mc: MathContext): BigDecimal = apply(l, mc)
 
   // This exists solely to avoid conversion from Int/Long to Float, screwing everything up.
-  /** Constructs a `BigDecimal` from a `Long`.  This is identical to `BigDecimal(l)`. */
+  /** Constructs a `BigDecimal` from a `Long`.  This is identical to `BigDecimal(l)`.
+   *
+   *  @param l the `Long` value to convert to a `BigDecimal`
+   */
   def decimal(l: Long): BigDecimal = apply(l)
 
-  /** Constructs a `BigDecimal` using a `java.math.BigDecimal`, rounding if necessary. */
+  /** Constructs a `BigDecimal` using a `java.math.BigDecimal`, rounding if necessary.
+   *
+   *  @param bd the `java.math.BigDecimal` to convert
+   *  @param mc the precision and rounding mode for the conversion
+   */
   def decimal(bd: BigDec, mc: MathContext): BigDecimal = new BigDecimal(bd.round(mc), mc)
 
   /** Constructs a `BigDecimal` by expanding the binary fraction
@@ -84,18 +107,25 @@ object BigDecimal {
    *  rounding if necessary.  When a `Float` is converted to a
    *  `Double`, the binary fraction is preserved, so this method
    *  also works for converted `Float`s.
+   *
+   *  @param d the `Double` value whose binary fraction is expanded
+   *  @param mc the precision and rounding mode for the conversion
    */
   def binary(d: Double, mc: MathContext): BigDecimal = new BigDecimal(new BigDec(d, mc), mc)
 
   /** Constructs a `BigDecimal` by expanding the binary fraction
    *  contained by `Double` value `d` into a decimal representation.
    *  Note: this also works correctly on converted `Float`s.
+   *
+   *  @param d the `Double` value whose binary fraction is expanded
    */
   def binary(d: Double): BigDecimal = binary(d, defaultMathContext)
 
   /** Constructs a `BigDecimal` from a `java.math.BigDecimal`.  The
    *  precision is the default for `BigDecimal` or enough to represent
    *  the `java.math.BigDecimal` exactly, whichever is greater.
+   *
+   *  @param repr the `java.math.BigDecimal` to represent exactly
    */
   def exact(repr: BigDec): BigDecimal = {
     val mc =
@@ -107,25 +137,36 @@ object BigDecimal {
   /** Constructs a `BigDecimal` by fully expanding the binary fraction
    *  contained by `Double` value `d`, adjusting the precision as
    *  necessary.  Note: this works correctly on converted `Float`s also.
+   *
+   *  @param d the `Double` value whose binary fraction is fully expanded
    */
   def exact(d: Double): BigDecimal = exact(new BigDec(d))
 
-  /** Constructs a `BigDecimal` that exactly represents a `BigInt`. */
+  /** Constructs a `BigDecimal` that exactly represents a `BigInt`.
+   *
+   *  @param bi the `BigInt` value to represent exactly
+   */
   def exact(bi: BigInt): BigDecimal = exact(new BigDec(bi.bigInteger))
 
   /** Constructs a `BigDecimal` that exactly represents a `Long`.  Note that
    *  all creation methods for `BigDecimal` that do not take a `MathContext`
    *  represent a `Long`; this is equivalent to `apply`, `valueOf`, etc..
+   *
+   *  @param l the `Long` value to represent exactly
    */
   def exact(l: Long): BigDecimal = apply(l)
 
   /** Constructs a `BigDecimal` that exactly represents the number
    *  specified in a `String`.
+   *
+   *  @param s the string representation of the number
    */
   def exact(s: String): BigDecimal = exact(new BigDec(s))
 
   /** Constructs a `BigDecimal` that exactly represents the number
    *  specified in base 10 in a character array.
+   *
+   *  @param cs the character array containing the decimal representation
    */
   def exact(cs: Array[Char]): BigDecimal = exact(new BigDec(cs))
 
@@ -233,22 +274,32 @@ object BigDecimal {
 
   /** Translates a character array representation of a `BigDecimal`
    *  into a `BigDecimal`.
+   *
+   *  @param x the character array containing the decimal representation
    */
   def apply(x: Array[Char]): BigDecimal = exact(x)
 
   /** Translates a character array representation of a `BigDecimal`
    *  into a `BigDecimal`, rounding if necessary.
+   *
+   *  @param x the character array containing the decimal representation
+   *  @param mc the precision and rounding mode for creation of this value and future operations on it
    */
   def apply(x: Array[Char], mc: MathContext): BigDecimal =
     new BigDecimal(new BigDec(x, mc), mc)
 
   /** Translates the decimal String representation of a `BigDecimal`
    *  into a `BigDecimal`.
+   *
+   *  @param x the string representation of the decimal value
    */
   def apply(x: String): BigDecimal = exact(x)
 
   /** Translates the decimal String representation of a `BigDecimal`
    *  into a `BigDecimal`, rounding if necessary.
+   *
+   *  @param x the string representation of the decimal value
+   *  @param mc the precision and rounding mode for creation of this value and future operations on it
    */
   def apply(x: String, mc: MathContext): BigDecimal =
     new BigDecimal(new BigDec(x, mc), mc)
@@ -292,16 +343,28 @@ object BigDecimal {
   def apply(unscaledVal: BigInt, scale: Int, mc: MathContext): BigDecimal =
     new BigDecimal(new BigDec(unscaledVal.bigInteger, scale, mc), mc)
 
-  /** Constructs a `BigDecimal` from a `java.math.BigDecimal`. */
+  /** Constructs a `BigDecimal` from a `java.math.BigDecimal`.
+   *
+   *  @param bd the `java.math.BigDecimal` to convert
+   */
   def apply(bd: BigDec): BigDecimal = new BigDecimal(bd, defaultMathContext)
 
-  /** Implicit conversion from `Int` to `BigDecimal`. */
+  /** Implicit conversion from `Int` to `BigDecimal`.
+   *
+   *  @param i the `Int` value to convert
+   */
   implicit def int2bigDecimal(i: Int): BigDecimal = apply(i)
 
-  /** Implicit conversion from `Long` to `BigDecimal`. */
+  /** Implicit conversion from `Long` to `BigDecimal`.
+   *
+   *  @param l the `Long` value to convert
+   */
   implicit def long2bigDecimal(l: Long): BigDecimal = apply(l)
 
-  /** Implicit conversion from `Double` to `BigDecimal`. */
+  /** Implicit conversion from `Double` to `BigDecimal`.
+   *
+   *  @param d the `Double` value to convert
+   */
   implicit def double2bigDecimal(d: Double): BigDecimal = decimal(d)
 
   // For the following function, both the parameter and the return type are non-nullable.
@@ -309,7 +372,10 @@ object BigDecimal {
   // We intentionally keep this signature to discourage passing nulls implicitly while
   // preserving the previous behavior for backward compatibility.
 
-  /** Implicit conversion from `java.math.BigDecimal` to `scala.BigDecimal`. */
+  /** Implicit conversion from `java.math.BigDecimal` to `scala.BigDecimal`.
+   *
+   *  @param x the `java.math.BigDecimal` to convert
+   */
   implicit def javaBigDecimal2bigDecimal(x: BigDec): BigDecimal = mapNull(x, apply(x))
 }
 
@@ -358,6 +424,9 @@ object BigDecimal {
  *  and powers.  The left-hand argument's `MathContext` always determines the
  *  degree of rounding, if any, and is the one propagated through arithmetic
  *  operations that do not apply rounding themselves.
+ *
+ *  @param bigDecimal the underlying `java.math.BigDecimal`
+ *  @param mc the `MathContext` specifying the precision and rounding mode for operations
  */
 final class BigDecimal(val bigDecimal: BigDec, val mc: MathContext)
 extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[BigDecimal] {
@@ -403,6 +472,8 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
 
   /** Compares this BigDecimal with the specified value for equality.  Where `Float` and `Double`
    *  disagree, `BigDecimal` will agree with the `Double` value
+   *
+   *  @param that the value to compare with this `BigDecimal`
    */
   override def equals (that: Any): Boolean = that match {
     case that: BigDecimal     => this equals that
@@ -474,55 +545,93 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
   def underlying: java.math.BigDecimal = bigDecimal
 
 
-  /** Compares this BigDecimal with the specified BigDecimal for equality. */
+  /** Compares this BigDecimal with the specified BigDecimal for equality.
+   *
+   *  @param that the `BigDecimal` to compare with
+   */
   def equals (that: BigDecimal): Boolean = compare(that) == 0
 
-  /** Compares this BigDecimal with the specified BigDecimal */
+  /** Compares this BigDecimal with the specified BigDecimal
+   *
+   *  @param that the `BigDecimal` to compare with
+   */
   def compare (that: BigDecimal): Int = this.bigDecimal.compareTo(that.bigDecimal)
 
-  /** Addition of BigDecimals */
+  /** Addition of BigDecimals
+   *
+   *  @param that the `BigDecimal` to add to this value
+   */
   def +  (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.add(that.bigDecimal, mc), mc)
 
-  /** Subtraction of BigDecimals */
+  /** Subtraction of BigDecimals
+   *
+   *  @param that the `BigDecimal` to subtract from this value
+   */
   def -  (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.subtract(that.bigDecimal, mc), mc)
 
-  /** Multiplication of BigDecimals */
+  /** Multiplication of BigDecimals
+   *
+   *  @param that the `BigDecimal` to multiply with this value
+   */
   def *  (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.multiply(that.bigDecimal, mc), mc)
 
-  /** Division of BigDecimals */
+  /** Division of BigDecimals
+   *
+   *  @param that the `BigDecimal` to divide this value by
+   */
   def /  (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.divide(that.bigDecimal, mc), mc)
 
   /** Division and Remainder - returns tuple containing the result of
    *  divideToIntegralValue and the remainder.  The computation is exact: no rounding is applied.
+   *
+   *  @param that the `BigDecimal` divisor
    */
   def /% (that: BigDecimal): (BigDecimal, BigDecimal) = {
     val qr = this.bigDecimal.divideAndRemainder(that.bigDecimal, mc)
     (new BigDecimal(qr(0), mc), new BigDecimal(qr(1), mc))
   }
 
-  /** Divide to Integral value. */
+  /** Divide to Integral value.
+   *
+   *  @param that the `BigDecimal` divisor
+   */
   def quot (that: BigDecimal): BigDecimal =
     new BigDecimal(this.bigDecimal.divideToIntegralValue(that.bigDecimal, mc), mc)
 
-  /** Returns the minimum of this and that, or this if the two are equal */
+  /** Returns the minimum of this and that, or this if the two are equal
+   *
+   *  @param that the `BigDecimal` to compare with
+   */
   def min (that: BigDecimal): BigDecimal = (this compare that) match {
     case x if x <= 0 => this
     case _           => that
   }
 
-  /** Returns the maximum of this and that, or this if the two are equal */
+  /** Returns the maximum of this and that, or this if the two are equal
+   *
+   *  @param that the `BigDecimal` to compare with
+   */
   def max (that: BigDecimal): BigDecimal = (this compare that) match {
     case x if x >= 0 => this
     case _           => that
   }
 
-  /** Remainder after dividing this by that. */
+  /** Remainder after dividing this by that.
+   *
+   *  @param that the `BigDecimal` divisor
+   */
   def remainder (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.remainder(that.bigDecimal, mc), mc)
 
-  /** Remainder after dividing this by that. */
+  /** Remainder after dividing this by that.
+   *
+   *  @param that the `BigDecimal` divisor
+   */
   def % (that: BigDecimal): BigDecimal = this.remainder(that)
 
-  /** Returns a BigDecimal whose value is this ** n. */
+  /** Returns a BigDecimal whose value is this ** n.
+   *
+   *  @param n the exponent to raise this `BigDecimal` to
+   */
   def pow (n: Int): BigDecimal = new BigDecimal(this.bigDecimal.pow(n, mc), mc)
 
   /** Returns a BigDecimal whose value is the negation of this BigDecimal */
@@ -550,6 +659,8 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
 
   /** Returns a BigDecimal rounded according to the supplied MathContext settings, but
    *  preserving its own MathContext for future operations.
+   *
+   *  @param mc the `MathContext` specifying the precision and rounding mode
    */
   def round(mc: MathContext): BigDecimal = {
     val r = this.bigDecimal.round(mc)
@@ -568,11 +679,16 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
   /** Returns the size of an ulp, a unit in the last place, of this BigDecimal. */
   def ulp: BigDecimal = new BigDecimal(this.bigDecimal.ulp, mc)
 
-  /** Returns a new BigDecimal based on the supplied MathContext, rounded as needed. */
+  /** Returns a new BigDecimal based on the supplied MathContext, rounded as needed.
+   *
+   *  @param mc the new `MathContext` for precision and rounding
+   */
   def apply(mc: MathContext): BigDecimal = new BigDecimal(this.bigDecimal.round(mc), mc)
 
   /** Returns a `BigDecimal` whose scale is the specified value, and whose value is
    *  numerically equal to this BigDecimal's.
+   *
+   *  @param scale the scale to set for this `BigDecimal`
    */
   def setScale(scale: Int): BigDecimal =
     if (this.scale == scale) this
@@ -677,14 +793,25 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
   def until(end: BigDecimal): Range.Partial[BigDecimal, NumericRange.Exclusive[BigDecimal]] =
     new Range.Partial(until(end, _))
 
-  /** Same as the one-argument `until`, but creates the range immediately. */
+  /** Same as the one-argument `until`, but creates the range immediately.
+   *
+   *  @param end the end value of the range (exclusive)
+   *  @param step the increment between successive values in the range
+   */
   def until(end: BigDecimal, step: BigDecimal): NumericRange.Exclusive[BigDecimal] = Range.BigDecimal(this, end, step)
 
-  /** Like `until`, but inclusive of the end value. */
+  /** Like `until`, but inclusive of the end value.
+   *
+   *  @param end the end value of the range (inclusive)
+   */
   def to(end: BigDecimal): Range.Partial[BigDecimal, NumericRange.Inclusive[BigDecimal]] =
     new Range.Partial(to(end, _))
 
-  /** Like `until`, but inclusive of the end value. */
+  /** Like `until`, but inclusive of the end value.
+   *
+   *  @param end the end value of the range (inclusive)
+   *  @param step the increment between successive values in the range
+   */
   def to(end: BigDecimal, step: BigDecimal) = Range.BigDecimal.inclusive(this, end, step)
 
   /** Converts this `BigDecimal` to a scala.BigInt. */

--- a/library/src/scala/math/BigInt.scala
+++ b/library/src/scala/math/BigInt.scala
@@ -64,6 +64,8 @@ object BigInt {
 
   /** Translates a byte array containing the two's-complement binary
    *  representation of a BigInt into a BigInt.
+   *
+   *  @param x the two's-complement big-endian binary representation of a `BigInt`
    */
   def apply(x: Array[Byte]): BigInt =
     apply(new BigInteger(x))
@@ -74,33 +76,50 @@ object BigInt {
    *                   for positive).
    *  @param  magnitude big-endian binary representation of the magnitude of
    *                   the number.
+   *  @return the `BigInt` with the specified sign and magnitude
    */
   def apply(signum: Int, magnitude: Array[Byte]): BigInt =
     apply(new BigInteger(signum, magnitude))
 
   /** Constructs a randomly generated positive BigInt that is probably prime,
    *  with the specified bitLength.
+   *
+   *  @param bitlength the bit length of the generated probable prime `BigInt`
+   *  @param certainty a measure of the uncertainty that the caller is willing to tolerate: the probability of primality exceeds `(1 - 1/2 ^ certainty)`
+   *  @param rnd the source of randomness used to generate the candidate
    */
   def apply(bitlength: Int, certainty: Int, rnd: scala.util.Random): BigInt =
     apply(new BigInteger(bitlength, certainty, rnd.self))
 
   /** Constructs a randomly generated BigInt, uniformly distributed over the
    *  range `0` to `(2 ^ numBits - 1)`, inclusive.
+   *
+   *  @param numbits the number of random bits used to generate the `BigInt`
+   *  @param rnd the source of randomness used for the generation
    */
   def apply(numbits: Int, rnd: scala.util.Random): BigInt =
     apply(new BigInteger(numbits, rnd.self))
 
-  /** Translates the decimal String representation of a BigInt into a BigInt. */
+  /** Translates the decimal String representation of a BigInt into a BigInt.
+   *
+   *  @param x the decimal string representation of the `BigInt`
+   */
   def apply(x: String): BigInt =
     apply(new BigInteger(x))
 
   /** Translates the string representation of a `BigInt` in the
    *  specified `radix` into a BigInt.
+   *
+   *  @param x the string representation of the `BigInt` in the specified radix
+   *  @param radix the radix to use when parsing `x`
    */
   def apply(x: String, radix: Int): BigInt =
     apply(new BigInteger(x, radix))
 
-  /** Translates a `java.math.BigInteger` into a BigInt. */
+  /** Translates a `java.math.BigInteger` into a BigInt.
+   *
+   *  @param x the `java.math.BigInteger` value to convert
+   */
   def apply(x: BigInteger): BigInt = {
     if (x.bitLength <= 63) {
       val l = x.longValue
@@ -108,14 +127,24 @@ object BigInt {
     } else new BigInt(x, Long.MinValue)
   }
 
-  /** Returns a positive BigInt that is probably prime, with the specified bitLength. */
+  /** Returns a positive BigInt that is probably prime, with the specified bitLength.
+   *
+   *  @param bitLength the bit length of the returned probable prime `BigInt`
+   *  @param rnd the source of randomness used to generate the candidate
+   */
   def probablePrime(bitLength: Int, rnd: scala.util.Random): BigInt =
     apply(BigInteger.probablePrime(bitLength, rnd.self))
 
-  /** Implicit conversion from `Int` to `BigInt`. */
+  /** Implicit conversion from `Int` to `BigInt`.
+   *
+   *  @param i the `Int` value to convert
+   */
   implicit def int2bigInt(i: Int): BigInt = apply(i)
 
-  /** Implicit conversion from `Long` to `BigInt`. */
+  /** Implicit conversion from `Long` to `BigInt`.
+   *
+   *  @param l the `Long` value to convert
+   */
   implicit def long2bigInt(l: Long): BigInt = apply(l)
 
   // For the following function, both the parameter and the return type are non-nullable.
@@ -123,7 +152,10 @@ object BigInt {
   // We intentionally keep this signature to discourage passing nulls implicitly while
   // preserving the previous behavior for backward compatibility.
 
-  /** Implicit conversion from `java.math.BigInteger` to `scala.BigInt`. */
+  /** Implicit conversion from `java.math.BigInteger` to `scala.BigInt`.
+   *
+   *  @param x the `java.math.BigInteger` value to convert
+   */
   implicit def javaBigInteger2bigInt(x: BigInteger): BigInt = mapNull(x, apply(x))
 
   // this method is adapted from Google Guava's version at
@@ -132,7 +164,11 @@ object BigInt {
   //   * Copyright (C) 2011 The Guava Authors
   //   *
   //   * Licensed under the Apache License, Version 2.0 (the "License")
-  /** Returns the greatest common divisor of a and b. Returns 0 if a == 0 && b == 0. */
+  /** Returns the greatest common divisor of a and b. Returns 0 if a == 0 && b == 0.
+   *
+   *  @param a the first non-negative operand
+   *  @param b the second non-negative operand
+   */
   private def longGcd(a: Long, b: Long): Long = {
     // both a and b must be >= 0
     if (a == 0) { // 0 % b == 0, so b divides a, but the converse doesn't hold.
@@ -201,7 +237,10 @@ final class BigInt private (
   //
   // Additionally, we know that if this.isValidLong is true, then _long is the encoded value.
 
-  /** Public constructor present for compatibility. Use the BigInt.apply companion object method instead. */
+  /** Public constructor present for compatibility. Use the BigInt.apply companion object method instead.
+   *
+   *  @param bigInteger the `java.math.BigInteger` value to wrap
+   */
   def this(bigInteger: BigInteger) = this(
     bigInteger, // even if it is a short BigInteger, we cache the instance
     if (bigInteger.bitLength <= 63)
@@ -282,14 +321,20 @@ final class BigInt private (
   def isWhole: Boolean = true
   def underlying: BigInteger = bigInteger
 
-  /** Compares this BigInt with the specified BigInt for equality. */
+  /** Compares this BigInt with the specified BigInt for equality.
+   *
+   *  @param that the `BigInt` to compare against
+   */
   def equals(that: BigInt): Boolean =
     if (this.longEncoding)
       that.longEncoding && (this._long == that._long)
     else
       !that.longEncoding && (this._bigInteger == that._bigInteger)
 
-  /** Compares this BigInt with the specified BigInt */
+  /** Compares this BigInt with the specified BigInt
+   *
+   *  @param that the `BigInt` to compare against
+   */
   def compare(that: BigInt): Int =
     if (this.longEncoding) {
       if (that.longEncoding) java.lang.Long.compare(this._long, that._long) else -that._bigInteger.nn.signum()
@@ -297,7 +342,10 @@ final class BigInt private (
       if (that.longEncoding) _bigInteger.nn.signum() else this._bigInteger.nn.compareTo(that._bigInteger)
     }
 
-  /** Addition of BigInts */
+  /** Addition of BigInts
+   *
+   *  @param that the value to add to this `BigInt`
+   */
   def +(that: BigInt): BigInt = {
     if (this.longEncoding && that.longEncoding) { // fast path
       val x = this._long
@@ -308,7 +356,10 @@ final class BigInt private (
     BigInt(this.bigInteger.add(that.bigInteger))
   }
 
-  /** Subtraction of BigInts */
+  /** Subtraction of BigInts
+   *
+   *  @param that the value to subtract from this `BigInt`
+   */
   def -(that: BigInt): BigInt = {
     if (this.longEncoding && that.longEncoding) { // fast path
       val x = this._long
@@ -319,7 +370,10 @@ final class BigInt private (
     BigInt(this.bigInteger.subtract(that.bigInteger))
   }
 
-  /** Multiplication of BigInts */
+  /** Multiplication of BigInts
+   *
+   *  @param that the value to multiply with this `BigInt`
+   */
   def *(that: BigInt): BigInt = {
     if (this.longEncoding && that.longEncoding) { // fast path
       val x = this._long
@@ -332,7 +386,10 @@ final class BigInt private (
     BigInt(this.bigInteger.multiply(that.bigInteger))
   }
 
-  /** Division of BigInts */
+  /** Division of BigInts
+   *
+   *  @param that the divisor
+   */
   def /(that: BigInt): BigInt =
   // in the fast path, note that the original code avoided storing -Long.MinValue in a long:
   //    if (this._long != Long.MinValue || that._long != -1) return BigInt(this._long / that._long)
@@ -340,13 +397,19 @@ final class BigInt private (
     if (this.longEncoding && that.longEncoding) BigInt(this._long / that._long)
     else BigInt(this.bigInteger.divide(that.bigInteger))
 
-  /** Remainder of BigInts */
+  /** Remainder of BigInts
+   *
+   *  @param that the divisor
+   */
   def %(that: BigInt): BigInt =
   // see / for the original logic regarding Long.MinValue
     if (this.longEncoding && that.longEncoding) BigInt(this._long % that._long)
     else BigInt(this.bigInteger.remainder(that.bigInteger))
 
-  /** Returns a pair of two BigInts containing (this / that) and (this % that). */
+  /** Returns a pair of two BigInts containing (this / that) and (this % that).
+   *
+   *  @param that the divisor
+   */
   def /%(that: BigInt): (BigInt, BigInt) =
     if (this.longEncoding && that.longEncoding) {
       val x = this._long
@@ -358,11 +421,17 @@ final class BigInt private (
       (BigInt(dr(0)), BigInt(dr(1)))
     }
 
-  /** Leftshift of BigInt */
+  /** Leftshift of BigInt
+   *
+   *  @param n the number of bits to shift left
+   */
   def <<(n: Int): BigInt =
     if (longEncoding && n <= 0) (this >> (-n)) else BigInt(this.bigInteger.shiftLeft(n))
 
-  /** (Signed) rightshift of BigInt */
+  /** (Signed) rightshift of BigInt
+   *
+   *  @param n the number of bits to shift right
+   */
   def >>(n: Int): BigInt =
     if (longEncoding && n >= 0) {
       if (n < 64) BigInt(_long >> n)
@@ -370,31 +439,46 @@ final class BigInt private (
       else BigInt(0) // for _long >= 0
     } else BigInt(this.bigInteger.shiftRight(n))
 
-  /** Bitwise and of BigInts */
+  /** Bitwise and of BigInts
+   *
+   *  @param that the value to AND with this `BigInt`
+   */
   def &(that: BigInt): BigInt =
     if (this.longEncoding && that.longEncoding)
       BigInt(this._long & that._long)
     else BigInt(this.bigInteger.and(that.bigInteger))
 
-  /** Bitwise or of BigInts */
+  /** Bitwise or of BigInts
+   *
+   *  @param that the value to OR with this `BigInt`
+   */
   def |(that: BigInt): BigInt =
     if (this.longEncoding && that.longEncoding)
       BigInt(this._long | that._long)
     else BigInt(this.bigInteger.or(that.bigInteger))
 
-  /** Bitwise exclusive-or of BigInts */
+  /** Bitwise exclusive-or of BigInts
+   *
+   *  @param that the value to XOR with this `BigInt`
+   */
   def ^(that: BigInt): BigInt =
     if (this.longEncoding && that.longEncoding)
       BigInt(this._long ^ that._long)
     else BigInt(this.bigInteger.xor(that.bigInteger))
 
-  /** Bitwise and-not of BigInts. Returns a BigInt whose value is (this & ~that). */
+  /** Bitwise and-not of BigInts. Returns a BigInt whose value is (this & ~that).
+   *
+   *  @param that the value whose complement is ANDed with this `BigInt`
+   */
   def &~(that: BigInt): BigInt =
     if (this.longEncoding && that.longEncoding)
       BigInt(this._long & ~that._long)
     else BigInt(this.bigInteger.andNot(that.bigInteger))
 
-  /** Returns the greatest common divisor of abs(this) and abs(that) */
+  /** Returns the greatest common divisor of abs(this) and abs(that)
+   *
+   *  @param that the other value for computing the greatest common divisor
+   */
   def gcd(that: BigInt): BigInt =
     if (this.longEncoding) {
       if (this._long == 0) return that.abs
@@ -427,23 +511,38 @@ final class BigInt private (
       if (res >= 0) BigInt(res) else BigInt(res + that._long)
     } else BigInt(this.bigInteger.mod(that.bigInteger))
 
-  /** Returns the minimum of this and that */
+  /** Returns the minimum of this and that
+   *
+   *  @param that the value to compare with this `BigInt`
+   */
   def min(that: BigInt): BigInt =
     if (this <= that) this else that
 
-  /** Returns the maximum of this and that */
+  /** Returns the maximum of this and that
+   *
+   *  @param that the value to compare with this `BigInt`
+   */
   def max(that: BigInt): BigInt =
     if (this >= that) this else that
 
-  /** Returns a BigInt whose value is (<tt>this</tt> raised to the power of <tt>exp</tt>). */
+  /** Returns a BigInt whose value is (<tt>this</tt> raised to the power of <tt>exp</tt>).
+   *
+   *  @param exp the exponent, must be non-negative
+   */
   def pow(exp: Int): BigInt = BigInt(this.bigInteger.pow(exp))
 
   /** Returns a BigInt whose value is
    *  (<tt>this</tt> raised to the power of <tt>exp</tt> modulo <tt>m</tt>).
+   *
+   *  @param exp the exponent
+   *  @param m the modulus, must be positive
    */
   def modPow(exp: BigInt, m: BigInt): BigInt = BigInt(this.bigInteger.modPow(exp.bigInteger, m.bigInteger))
 
-  /** Returns a BigInt whose value is (the inverse of <tt>this</tt> modulo <tt>m</tt>). */
+  /** Returns a BigInt whose value is (the inverse of <tt>this</tt> modulo <tt>m</tt>).
+   *
+   *  @param m the modulus, must be positive
+   */
   def modInverse(m: BigInt): BigInt = BigInt(this.bigInteger.modInverse(m.bigInteger))
 
   /** Returns a BigInt whose value is the negation of this BigInt */
@@ -471,7 +570,10 @@ final class BigInt private (
     // it is equal to -(this + 1)
     if (longEncoding && _long != Long.MaxValue) BigInt(-(_long + 1)) else BigInt(this.bigInteger.not())
 
-  /** Returns true if and only if the designated bit is set. */
+  /** Returns true if and only if the designated bit is set.
+   *
+   *  @param n the zero-based index of the bit to test
+   */
   def testBit(n: Int): Boolean =
     if (longEncoding && n >= 0) {
       if (n <= 63)
@@ -480,15 +582,24 @@ final class BigInt private (
         _long < 0 // give the sign bit
     } else this.bigInteger.testBit(n)
 
-  /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit set. */
+  /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit set.
+   *
+   *  @param n the zero-based index of the bit to set
+   */
   def setBit(n: Int): BigInt  = // note that we do not operate on the Long sign bit #63
     if (longEncoding && n <= 62 && n >= 0) BigInt(_long | (1L << n)) else BigInt(this.bigInteger.setBit(n))
 
-  /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit cleared. */
+  /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit cleared.
+   *
+   *  @param n the zero-based index of the bit to clear
+   */
   def clearBit(n: Int): BigInt  = // note that we do not operate on the Long sign bit #63
     if (longEncoding && n <= 62 && n >= 0) BigInt(_long & ~(1L << n)) else BigInt(this.bigInteger.clearBit(n))
 
-  /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit flipped. */
+  /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit flipped.
+   *
+   *  @param n the zero-based index of the bit to flip
+   */
   def flipBit(n: Int): BigInt  = // note that we do not operate on the Long sign bit #63
     if (longEncoding && n <= 62 && n >= 0) BigInt(_long ^ (1L << n)) else BigInt(this.bigInteger.flipBit(n))
 
@@ -586,17 +697,24 @@ final class BigInt private (
    *
    *  @param end    the end value of the range (exclusive)
    *  @param step   the distance between elements (defaults to 1)
-   *  @return       the range
+   *  @return       the exclusive `NumericRange` from this to `end`
    */
   def until(end: BigInt, step: BigInt = BigInt(1)): NumericRange.Exclusive[BigInt] = Range.BigInt(this, end, step)
 
-  /** Like until, but inclusive of the end value. */
+  /** Like until, but inclusive of the end value.
+   *
+   *  @param end the end value of the range (inclusive)
+   *  @param step the distance between elements (defaults to 1)
+   */
   def to(end: BigInt, step: BigInt = BigInt(1)): NumericRange.Inclusive[BigInt] = Range.BigInt.inclusive(this, end, step)
 
   /** Returns the decimal String representation of this BigInt. */
   override def toString(): String = if (longEncoding) _long.toString() else _bigInteger.toString()
 
-  /** Returns the String representation in the specified radix of this BigInt. */
+  /** Returns the String representation in the specified radix of this BigInt.
+   *
+   *  @param radix the radix to use in the string representation
+   */
   def toString(radix: Int): String = this.bigInteger.toString(radix)
 
   /** Returns a byte array containing the two's-complement representation of

--- a/library/src/scala/math/Equiv.scala
+++ b/library/src/scala/math/Equiv.scala
@@ -30,10 +30,16 @@ import scala.annotation.migration
  *    1. symmetric: `equiv(x, y) == equiv(y, x)` for any `x` and `y` of type `T`.
  *    1. transitive: if `equiv(x, y) == true` and `equiv(y, z) == true`, then
  *       `equiv(x, z) == true` for any `x`, `y`, and `z` of type `T`.
+ *
+ *  @tparam T the type of values being compared for equivalence
  */
 
 trait Equiv[T] extends Any with Serializable {
-  /** Returns `true` iff `x` is equivalent to `y`. */
+  /** Returns `true` iff `x` is equivalent to `y`.
+   *
+   *  @param x the first value to compare
+   *  @param y the second value to compare
+   */
   def equiv(x: T, y: T): Boolean
 }
 
@@ -95,10 +101,16 @@ object Equiv extends LowPriorityEquiv {
   trait ExtraImplicits {
     /** Not in the standard scope due to the potential for divergence:
      *  For instance `implicitly[Equiv[Any]]` diverges in its presence.
+     *
+     *  @tparam CC the collection type constructor, a subtype of `Seq` (e.g., `List`, `Vector`)
+     *  @tparam T the element type of the collection
      */
     implicit def seqEquiv[CC[X] <: scala.collection.Seq[X], T](implicit eqv: Equiv[T]): Equiv[CC[T]] =
       new IterableEquiv[CC, T](eqv)
 
+    /** @tparam CC the collection type constructor, a subtype of `SortedSet`
+     *  @tparam T the element type of the collection
+     */
     implicit def sortedSetEquiv[CC[X] <: scala.collection.SortedSet[X], T](implicit eqv: Equiv[T]): Equiv[CC[T]] =
       new IterableEquiv[CC, T](eqv)
   }

--- a/library/src/scala/math/Integral.scala
+++ b/library/src/scala/math/Integral.scala
@@ -35,6 +35,10 @@ object Integral {
     /** The regrettable design of Numeric/Integral/Fractional has them all
      *  bumping into one another when searching for this implicit, so they
      *  are exiled into their own companions.
+     *
+     *  @tparam T the numeric type for which an `Integral` instance exists
+     *  @param x the value to wrap with integral operator syntax (`/`, `%`, `/%`)
+     *  @param num the implicit `Integral` instance for type `T`
      */
     implicit def infixIntegralOps[T](x: T)(implicit num: Integral[T]): Integral[T]#IntegralOps = new num.IntegralOps(x)
   }

--- a/library/src/scala/math/Numeric.scala
+++ b/library/src/scala/math/Numeric.scala
@@ -28,6 +28,10 @@ object Numeric {
      *  ```
      *  def plus[T: Numeric](x: T, y: T) = x + y
      *  ```
+     *
+     *  @tparam T the numeric type for which a `Numeric` instance exists
+     *  @param x the value to wrap with numeric infix operations
+     *  @param num the implicit `Numeric` instance that provides the arithmetic operations
      */
     implicit def infixNumericOps[T](x: T)(implicit num: Numeric[T]): Numeric[T]#NumericOps = new num.NumericOps(x)
   }

--- a/library/src/scala/math/Ordered.scala
+++ b/library/src/scala/math/Ordered.scala
@@ -56,6 +56,8 @@ import scala.language.implicitConversions
  *  provide it yourself either when inheriting or instantiating.
  *
  *  @see [[scala.math.Ordering]], [[scala.math.PartiallyOrdered]]
+ *
+ *  @tparam A the type of the objects that this object can be compared to
  */
 trait Ordered[A] extends Any with java.lang.Comparable[A] {
 
@@ -70,13 +72,22 @@ trait Ordered[A] extends Any with java.lang.Comparable[A] {
    *   - `x == 0` when `this == that`
    *
    *   - `x > 0` when  `this > that`
+   *
+   *  @param that the instance to compare against
+   *  @return an integer whose sign indicates the ordering relation between `this` and `that`
    */
   def compare(that: A): Int
 
-  /** Returns true if `this` is less than `that` */
+  /** Returns true if `this` is less than `that`
+   *
+   *  @param that the instance to compare against
+   */
   def <  (that: A): Boolean = (this compare that) <  0
 
-  /** Returns true if `this` is greater than `that`. */
+  /** Returns true if `this` is greater than `that`.
+   *
+   *  @param that the instance to compare against
+   */
   def >  (that: A): Boolean = (this compare that) >  0
 
   /** Returns true if `this` is less than or equal to `that`. */
@@ -85,12 +96,20 @@ trait Ordered[A] extends Any with java.lang.Comparable[A] {
   /** Returns true if `this` is greater than or equal to `that`. */
   def >= (that: A): Boolean = (this compare that) >= 0
 
-  /** Result of comparing `this` with operand `that`. */
+  /** Result of comparing `this` with operand `that`.
+   *
+   *  @param that the instance to compare against
+   */
   def compareTo(that: A): Int = compare(that)
 }
 
 object Ordered {
-  /** Lens from `Ordering[T]` to `Ordered[T]`. */
+  /** Lens from `Ordering[T]` to `Ordered[T]`.
+   *
+   *  @tparam T the type of the value to be wrapped as `Ordered`
+   *  @param x the value to be converted to an `Ordered` instance
+   *  @param ord the implicit `Ordering` instance used to perform comparisons
+   */
   implicit def orderingToOrdered[T](x: T)(implicit ord: Ordering[T]): Ordered[T] =
     new Ordered[T] { def compare(that: T): Int = ord.compare(x, that) }
 }

--- a/library/src/scala/math/PartialOrdering.scala
+++ b/library/src/scala/math/PartialOrdering.scala
@@ -38,6 +38,8 @@ import scala.language.`2.13`
  *  `lteq(x, y) && lteq(y, x) == **true**`. This equivalence relation is
  *  exposed as the `equiv` method, inherited from the
  *  [[scala.math.Equiv Equiv]] trait.
+ *
+ *  @tparam T the type of elements being ordered
  */
 
 trait PartialOrdering[T] extends Equiv[T] {
@@ -49,26 +51,47 @@ trait PartialOrdering[T] extends Equiv[T] {
    *  - `r < 0`    iff    `x < y`
    *  - `r == 0`   iff    `x == y`
    *  - `r > 0`    iff    `x > y`
+   *
+   *  @param x the first element to compare
+   *  @param y the second element to compare
    */
   def tryCompare(x: T, y: T): Option[Int]
 
-  /** Returns `**true**` iff `x` comes before `y` in the ordering. */
+  /** Returns `**true**` iff `x` comes before `y` in the ordering.
+   *
+   *  @param x the first element to compare
+   *  @param y the second element to compare
+   */
   def lteq(x: T, y: T): Boolean
 
-  /** Returns `**true**` iff `y` comes before `x` in the ordering. */
+  /** Returns `**true**` iff `y` comes before `x` in the ordering.
+   *
+   *  @param x the first element to compare
+   *  @param y the second element to compare
+   */
   def gteq(x: T, y: T): Boolean = lteq(y, x)
 
   /** Returns `**true**` iff `x` comes before `y` in the ordering
    *  and is not the same as `y`.
+   *
+   *  @param x the first element to compare
+   *  @param y the second element to compare
    */
   def lt(x: T, y: T): Boolean = lteq(x, y) && !equiv(x, y)
 
   /** Returns `**true**` iff `y` comes before `x` in the ordering
    *  and is not the same as `x`.
+   *
+   *  @param x the first element to compare
+   *  @param y the second element to compare
    */
   def gt(x: T, y: T): Boolean = gteq(x, y) && !equiv(x, y)
 
-  /** Returns `**true**` iff `x` is equivalent to `y` in the ordering. */
+  /** Returns `**true**` iff `x` is equivalent to `y` in the ordering.
+   *
+   *  @param x the first element to compare
+   *  @param y the second element to compare
+   */
   def equiv(x: T, y: T): Boolean = lteq(x,y) && lteq(y,x)
 
   def reverse : PartialOrdering[T] = new PartialOrdering[T] {

--- a/library/src/scala/math/PartiallyOrdered.scala
+++ b/library/src/scala/math/PartiallyOrdered.scala
@@ -15,7 +15,10 @@ package math
 
 import scala.language.`2.13`
 
-/** A class for partially ordered data. */
+/** A class for partially ordered data.
+ *
+ *  @tparam A the type of the elements being ordered
+ */
 trait PartiallyOrdered[+A] extends Any {
 
   type AsPartiallyOrdered[B] = B => PartiallyOrdered[B]
@@ -26,6 +29,9 @@ trait PartiallyOrdered[+A] extends Any {
    *  - `x < 0`    iff   `**this** &lt; that`
    *  - `x == 0`   iff   `**this** == that`
    *  - `x > 0`    iff   `**this** &gt; that`
+   *
+   *  @tparam B a supertype of `A` for which an implicit conversion to `PartiallyOrdered[B]` exists
+   *  @param that the value to compare against
    */
   def tryCompareTo [B >: A: AsPartiallyOrdered](that: B): Option[Int]
 

--- a/library/src/scala/math/ScalaNumericConversions.scala
+++ b/library/src/scala/math/ScalaNumericConversions.scala
@@ -27,7 +27,7 @@ trait ScalaNumericConversions extends ScalaNumber with ScalaNumericAnyConversion
  */
 trait ScalaNumericAnyConversions extends Any {
   /**
-   *  @return `**true**` if this number has no decimal component, `**false**` otherwise.
+   *  @return `true` if this number has no decimal component, `false` otherwise.
    */
   def isWhole: Boolean
 
@@ -112,6 +112,8 @@ trait ScalaNumericAnyConversions extends Any {
    *  in its lower 64 bits.  Or a BigDecimal with more precision
    *  than Double can hold: same thing.  There's no way given the
    *  interface available here to prevent this error.
+   *
+   *  @param x the value to compare against this numeric value for primitive equality
    */
   protected def unifiedPrimitiveEquals(x: Any) = x match {
     case x: Char    => isValidChar && (toInt == x.toInt)

--- a/library/src/scala/math/package.scala
+++ b/library/src/scala/math/package.scala
@@ -105,17 +105,41 @@ package object math {
    */
   def random(): Double = java.lang.Math.random()
 
-  /**  @group trig */
+  /**
+   *  @group trig
+   *
+   *  @param x the angle, in radians
+   */
   def sin(x: Double): Double = java.lang.Math.sin(x)
-  /**  @group trig */
+  /**
+   *  @group trig
+   *
+   *  @param x the angle, in radians
+   */
   def cos(x: Double): Double = java.lang.Math.cos(x)
-  /**  @group trig */
+  /**
+   *  @group trig
+   *
+   *  @param x the angle, in radians
+   */
   def tan(x: Double): Double = java.lang.Math.tan(x)
-  /**  @group trig */
+  /**
+   *  @group trig
+   *
+   *  @param x the value whose arc sine is to be returned
+   */
   def asin(x: Double): Double = java.lang.Math.asin(x)
-  /**  @group trig */
+  /**
+   *  @group trig
+   *
+   *  @param x the value whose arc cosine is to be returned
+   */
   def acos(x: Double): Double = java.lang.Math.acos(x)
-  /**  @group trig */
+  /**
+   *  @group trig
+   *
+   *  @param x the value whose arc tangent is to be returned
+   */
   def atan(x: Double): Double = java.lang.Math.atan(x)
 
   /** Converts an angle measured in degrees to an approximately equivalent
@@ -138,8 +162,8 @@ package object math {
 
   /** Converts rectangular coordinates `(x, y)` to polar `(r, theta)`.
    *
-   *  @param  x the ordinate coordinate
-   *  @param  y the abscissa coordinate
+   *  @param  y the ordinate coordinate
+   *  @param  x the abscissa coordinate
    *  @return the *theta* component of the point `(r, theta)` in polar
    *          coordinates that corresponds to the point `(x, y)` in
    *          Cartesian coordinates.
@@ -154,6 +178,10 @@ package object math {
    *  coordinates that corresponds to the point `(x, y)` in
    *  Cartesian coordinates.
    *  @group polar-coords
+   *
+   *  @param x the x coordinate value
+   *  @param y the y coordinate value
+   *  @return sqrt(`x`² + `y`²) without intermediate overflow or underflow
    */
   def hypot(x: Double, y: Double): Double = java.lang.Math.hypot(x, y)
 
@@ -161,9 +189,17 @@ package object math {
   // rounding functions
   // -----------------------------------------------------------------------
 
-  /** @group rounding */
+  /**
+   *  @group rounding
+   *
+   *  @param x the value to be rounded up
+   */
   def ceil(x: Double): Double  = java.lang.Math.ceil(x)
-  /** @group rounding */
+  /**
+   *  @group rounding
+   *
+   *  @param x the value to be rounded down
+   */
   def floor(x: Double): Double = java.lang.Math.floor(x)
 
   /** Returns the `Double` value that is closest in value to the
@@ -195,93 +231,227 @@ package object math {
   /** Returns the closest `Long` to the argument.
    *
    *  @param  x a floating-point value to be rounded to a `Long`.
-   *  @return the value of the argument rounded to the nearest`long` value.
+   *  @return the value of the argument rounded to the nearest `Long` value.
    *  @group rounding
    */
   def round(x: Double): Long = java.lang.Math.round(x)
 
-  /** @group abs */
+  /**
+   *  @group abs
+   *
+   *  @param x the value whose absolute value is to be determined
+   */
   def abs(x: Int): Int       = java.lang.Math.abs(x)
-  /** @group abs */
+  /**
+   *  @group abs
+   *
+   *  @param x the value whose absolute value is to be determined
+   */
   def abs(x: Long): Long     = java.lang.Math.abs(x)
-  /** @group abs */
+  /**
+   *  @group abs
+   *
+   *  @param x the value whose absolute value is to be determined
+   */
   def abs(x: Float): Float   = java.lang.Math.abs(x)
-  /** @group abs */
+  /**
+   *  @group abs
+   *
+   *  @param x the value whose absolute value is to be determined
+   */
   def abs(x: Double): Double = java.lang.Math.abs(x)
 
-  /** @group minmax */
+  /**
+   *  @group minmax
+   *
+   *  @param x the first value to compare
+   *  @param y the second value to compare
+   */
   def max(x: Int, y: Int): Int          = java.lang.Math.max(x, y)
-  /** @group minmax */
+  /**
+   *  @group minmax
+   *
+   *  @param x the first value to compare
+   *  @param y the second value to compare
+   */
   def max(x: Long, y: Long): Long       = java.lang.Math.max(x, y)
-  /** @group minmax */
+  /**
+   *  @group minmax
+   *
+   *  @param x the first value to compare
+   *  @param y the second value to compare
+   */
   def max(x: Float, y: Float): Float    = java.lang.Math.max(x, y)
-  /** @group minmax */
+  /**
+   *  @group minmax
+   *
+   *  @param x the first value to compare
+   *  @param y the second value to compare
+   */
   def max(x: Double, y: Double): Double = java.lang.Math.max(x, y)
 
-  /** @group minmax */
+  /**
+   *  @group minmax
+   *
+   *  @param x the first value to compare
+   *  @param y the second value to compare
+   */
   def min(x: Int, y: Int): Int          = java.lang.Math.min(x, y)
-  /** @group minmax */
+  /**
+   *  @group minmax
+   *
+   *  @param x the first value to compare
+   *  @param y the second value to compare
+   */
   def min(x: Long, y: Long): Long       = java.lang.Math.min(x, y)
-  /** @group minmax */
+  /**
+   *  @group minmax
+   *
+   *  @param x the first value to compare
+   *  @param y the second value to compare
+   */
   def min(x: Float, y: Float): Float    = java.lang.Math.min(x, y)
-  /** @group minmax */
+  /**
+   *  @group minmax
+   *
+   *  @param x the first value to compare
+   *  @param y the second value to compare
+   */
   def min(x: Double, y: Double): Double = java.lang.Math.min(x, y)
 
   /**
    *  @group signs
    *  @note Forwards to [[java.lang.Integer]]
+   *
+   *  @param x the value whose signum is to be computed
    */
   def signum(x: Int): Int       = java.lang.Integer.signum(x)
   /**
    *  @group signs
    *  @note Forwards to [[java.lang.Long]]
+   *
+   *  @param x the value whose signum is to be computed
    */
   def signum(x: Long): Long     = java.lang.Long.signum(x)
-  /** @group signs */
+  /**
+   *  @group signs
+   *
+   *  @param x the value whose signum is to be computed
+   */
   def signum(x: Float): Float   = java.lang.Math.signum(x)
-  /** @group signs */
+  /**
+   *  @group signs
+   *
+   *  @param x the value whose signum is to be computed
+   */
   def signum(x: Double): Double = java.lang.Math.signum(x)
 
-  /** @group modquo */
+  /**
+   *  @group modquo
+   *
+   *  @param x the dividend
+   *  @param y the divisor
+   */
   def floorDiv(x: Int, y: Int): Int = java.lang.Math.floorDiv(x, y)
 
-  /** @group modquo */
+  /**
+   *  @group modquo
+   *
+   *  @param x the dividend
+   *  @param y the divisor
+   */
   def floorDiv(x: Long, y: Long): Long = java.lang.Math.floorDiv(x, y)
 
-  /** @group modquo */
+  /**
+   *  @group modquo
+   *
+   *  @param x the dividend
+   *  @param y the divisor
+   */
   def floorMod(x: Int, y: Int): Int = java.lang.Math.floorMod(x, y)
 
-  /** @group modquo */
+  /**
+   *  @group modquo
+   *
+   *  @param x the dividend
+   *  @param y the divisor
+   */
   def floorMod(x: Long, y: Long): Long = java.lang.Math.floorMod(x, y)
 
-  /** @group signs */
+  /**
+   *  @group signs
+   *
+   *  @param magnitude the value providing the magnitude of the result
+   *  @param sign the value providing the sign of the result
+   */
   def copySign(magnitude: Double, sign: Double): Double = java.lang.Math.copySign(magnitude, sign)
 
-  /** @group signs */
+  /**
+   *  @group signs
+   *
+   *  @param magnitude the value providing the magnitude of the result
+   *  @param sign the value providing the sign of the result
+   */
   def copySign(magnitude: Float, sign: Float): Float = java.lang.Math.copySign(magnitude, sign)
 
-  /** @group adjacent-float */
+  /**
+   *  @group adjacent-float
+   *
+   *  @param start the starting floating-point value
+   *  @param direction the value indicating which of `start`'s neighbors should be returned
+   */
   def nextAfter(start: Double, direction: Double): Double = java.lang.Math.nextAfter(start, direction)
 
-  /** @group adjacent-float */
+  /**
+   *  @group adjacent-float
+   *
+   *  @param start the starting floating-point value
+   *  @param direction the value indicating which of `start`'s neighbors should be returned
+   */
   def nextAfter(start: Float, direction: Double): Float = java.lang.Math.nextAfter(start, direction)
 
-  /** @group adjacent-float */
+  /**
+   *  @group adjacent-float
+   *
+   *  @param d the starting floating-point value
+   */
   def nextUp(d: Double): Double = java.lang.Math.nextUp(d)
 
-  /** @group adjacent-float */
+  /**
+   *  @group adjacent-float
+   *
+   *  @param f the starting floating-point value
+   */
   def nextUp(f: Float): Float = java.lang.Math.nextUp(f)
 
-  /** @group adjacent-float */
+  /**
+   *  @group adjacent-float
+   *
+   *  @param d the starting floating-point value
+   */
   def nextDown(d: Double): Double = java.lang.Math.nextDown(d)
 
-  /** @group adjacent-float */
+  /**
+   *  @group adjacent-float
+   *
+   *  @param f the starting floating-point value
+   */
   def nextDown(f: Float): Float = java.lang.Math.nextDown(f)
 
-  /** @group scaling */
+  /**
+   *  @group scaling
+   *
+   *  @param d the value to be scaled by a power of two
+   *  @param scaleFactor the power of 2 used to scale `d`
+   */
   def scalb(d: Double, scaleFactor: Int): Double = java.lang.Math.scalb(d, scaleFactor)
 
-  /** @group scaling */
+  /**
+   *  @group scaling
+   *
+   *  @param f the value to be scaled by a power of two
+   *  @param scaleFactor the power of 2 used to scale `f`
+   */
   def scalb(f: Float, scaleFactor: Int): Float = java.lang.Math.scalb(f, scaleFactor)
 
   // -----------------------------------------------------------------------
@@ -321,7 +491,7 @@ package object math {
   /** Returns Euler's number `e` raised to the power of a `Double` value.
    *
    *  @param  x the exponent to raise `e` to.
-   *  @return the value `e^a^`, where `e` is the base of the natural
+   *  @return the value `e^x^`, where `e` is the base of the natural
    *          logarithms.
    *  @group explog
    */
@@ -329,13 +499,23 @@ package object math {
 
   /** Returns `exp(x) - 1`.
    *  @group explog
+   *
+   *  @param x the exponent to raise `e` to in the computation of `e`^`x`^ - 1
    */
   def expm1(x: Double): Double = java.lang.Math.expm1(x)
 
-  /** @group explog */
+  /**
+   *  @group explog
+   *
+   *  @param f the `Float` value whose unbiased exponent is to be extracted
+   */
   def getExponent(f: Float): Int = java.lang.Math.getExponent(f)
 
-  /** @group explog */
+  /**
+   *  @group explog
+   *
+   *  @param d the `Double` value whose unbiased exponent is to be extracted
+   */
   def getExponent(d: Double): Int = java.lang.Math.getExponent(d)
 
   // -----------------------------------------------------------------------
@@ -345,18 +525,22 @@ package object math {
   /** Returns the natural logarithm of a `Double` value.
    *
    *  @param  x the number to take the natural logarithm of
-   *  @return the value `logₑ(x)` where `e` is Eulers number
+   *  @return the value `logₑ(x)` where `e` is Euler's number
    *  @group explog
    */
   def log(x: Double): Double = java.lang.Math.log(x)
 
   /** Returns the natural logarithm of the sum of the given `Double` value and 1.
    *  @group explog
+   *
+   *  @param x the value for which to compute `ln(1 + x)`
    */
   def log1p(x: Double): Double = java.lang.Math.log1p(x)
 
   /** Returns the base 10 logarithm of the given `Double` value.
    *  @group explog
+   *
+   *  @param x the value whose base 10 logarithm is to be computed
    */
   def log10(x: Double): Double = java.lang.Math.log10(x)
 
@@ -366,16 +550,22 @@ package object math {
 
   /** Returns the hyperbolic sine of the given `Double` value.
    *  @group hyperbolic
+   *
+   *  @param x the value whose hyperbolic sine is to be returned
    */
   def sinh(x: Double): Double = java.lang.Math.sinh(x)
 
   /** Returns the hyperbolic cosine of the given `Double` value.
    *  @group hyperbolic
+   *
+   *  @param x the value whose hyperbolic cosine is to be returned
    */
   def cosh(x: Double): Double = java.lang.Math.cosh(x)
 
   /** Returns the hyperbolic tangent of the given `Double` value.
    *  @group hyperbolic
+   *
+   *  @param x the value whose hyperbolic tangent is to be returned
    */
   def tanh(x: Double):Double = java.lang.Math.tanh(x)
 
@@ -385,58 +575,125 @@ package object math {
 
   /** Returns the size of an ulp of the given `Double` value.
    *  @group ulp
+   *
+   *  @param x the `Double` value whose ulp is to be returned
    */
   def ulp(x: Double): Double = java.lang.Math.ulp(x)
 
   /** Returns the size of an ulp of the given `Float` value.
    *  @group ulp
+   *
+   *  @param x the `Float` value whose ulp is to be returned
    */
   def ulp(x: Float): Float = java.lang.Math.ulp(x)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the dividend value
+   *  @param y the divisor value
+   */
   def IEEEremainder(x: Double, y: Double): Double = java.lang.Math.IEEEremainder(x, y)
 
   // -----------------------------------------------------------------------
   // exact functions
   // -----------------------------------------------------------------------
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the first addend
+   *  @param y the second addend
+   */
   def addExact(x: Int, y: Int): Int = java.lang.Math.addExact(x, y)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the first addend
+   *  @param y the second addend
+   */
   def addExact(x: Long, y: Long): Long = java.lang.Math.addExact(x, y)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the minuend
+   *  @param y the subtrahend
+   */
   def subtractExact(x: Int, y: Int): Int = java.lang.Math.subtractExact(x, y)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the minuend
+   *  @param y the subtrahend
+   */
   def subtractExact(x: Long, y: Long): Long = java.lang.Math.subtractExact(x, y)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the first factor
+   *  @param y the second factor
+   */
   def multiplyExact(x: Int, y: Int): Int = java.lang.Math.multiplyExact(x, y)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the first factor
+   *  @param y the second factor
+   */
   def multiplyExact(x: Long, y: Long): Long = java.lang.Math.multiplyExact(x, y)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the value to be incremented
+   */
   def incrementExact(x: Int): Int = java.lang.Math.incrementExact(x)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the value to be incremented
+   */
   def incrementExact(x: Long) =  java.lang.Math.incrementExact(x)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the value to be decremented
+   */
   def decrementExact(x: Int) =  java.lang.Math.decrementExact(x)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the value to be decremented
+   */
   def decrementExact(x: Long) =  java.lang.Math.decrementExact(x)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the value to be negated
+   */
   def negateExact(x: Int) =  java.lang.Math.negateExact(x)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the value to be negated
+   */
   def negateExact(x: Long) =  java.lang.Math.negateExact(x)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the `Long` value to convert to an `Int`
+   */
   def toIntExact(x: Long): Int = java.lang.Math.toIntExact(x)
 
 }

--- a/library/src/scala/quoted/ExprMap.scala
+++ b/library/src/scala/quoted/ExprMap.scala
@@ -4,10 +4,22 @@ import language.experimental.captureChecking
 
 trait ExprMap:
 
-  /** Maps an expression `e` with a type `T`. */
+  /** Maps an expression `e` with a type `T`.
+   *  Requires a given `Type[T]` instance for staging and a `Quotes` instance
+   *  for access to the reflection API.
+   *
+   *  @tparam T the type of the expression being transformed
+   *  @param e the expression to transform
+   */
   def transform[T](e: Expr[T])(using Type[T])(using Quotes): Expr[T]
 
-  /** Maps sub-expressions an expression `e` with a type `T`. */
+  /** Maps the sub-expressions of an expression `e` with type `T`.
+   *  Requires a given `Type[T]` instance for staging and a `Quotes` instance
+   *  for access to the reflection API.
+   *
+   *  @tparam T the type of the expression whose children are transformed
+   *  @param e the expression whose direct sub-expressions will be transformed via `transform`
+   */
   def transformChildren[T](e: Expr[T])(using Type[T])(using Quotes): Expr[T] = {
     import quotes.reflect.*
     final class MapChildren() {

--- a/library/src/scala/quoted/Exprs.scala
+++ b/library/src/scala/quoted/Exprs.scala
@@ -14,6 +14,12 @@ object Exprs:
    *      // args: Seq[Int]
    *  ```
    *  To directly get the value of all expressions in a sequence `exprs: Seq[Expr[T]]` consider using `exprs.map(_.value)`/`exprs.map(_.valueOrError)` instead.
+   *
+   *  @tparam T the type of values being extracted from the expressions
+   *  @param exprs the sequence of expressions to extract values from
+   *  @param FromExpr the typeclass instance used to extract a value of type `T` from each `Expr[T]`
+   *  @param Quotes the quotation context
+   *  @return `Some` containing the sequence of extracted values if all expressions yield a value, or `None` if any expression cannot be converted
    */
   def unapply[T](exprs: Seq[Expr[T]])(using FromExpr[T])(using Quotes): Option[Seq[T]] =
     val builder = Seq.newBuilder[T]

--- a/library/src/scala/quoted/FromExpr.scala
+++ b/library/src/scala/quoted/FromExpr.scala
@@ -11,6 +11,8 @@ import language.experimental.captureChecking
  *    - This expression must be some kind of data structure (`Some`, `List`, `Either`, ...)
  *    - Calls to `new X` or `X.apply` can be lifted into its value
  *    - Arguments of constructors can be recursively unlifted
+ *
+ *  @tparam T the type of the value that can be extracted from the quoted expression
  */
 trait FromExpr[T] {
 
@@ -18,6 +20,9 @@ trait FromExpr[T] {
    *
    *  Returns `None` if the expression does not represent a value or possibly contains side effects.
    *  Otherwise returns the `Some` of the value.
+   *
+   *  @param x the quoted expression to extract a value from
+   *  @return `Some(value)` if the expression contains an extractable value, `None` otherwise
    */
   def unapply(x: Expr[T])(using Quotes): Option[T]
 
@@ -81,7 +86,10 @@ object FromExpr {
    */
   given StringFromExpr[T <: String]: FromExpr[T] = new PrimitiveFromExpr
 
-  /** Lift a quoted primitive value `'{ x }` into `x`. */
+  /** Lift a quoted primitive value `'{ x }` into `x`.
+   *
+   *  @tparam T the primitive or `String` type to extract from the quoted literal
+   */
   private class PrimitiveFromExpr[T <: Boolean | Byte | Short | Int | Long | Float | Double | Char | String] extends FromExpr[T] {
     def unapply(expr: Expr[T])(using Quotes) =
       import quotes.reflect.*

--- a/library/src/scala/quoted/ToExpr.scala
+++ b/library/src/scala/quoted/ToExpr.scala
@@ -6,10 +6,15 @@ import scala.reflect.ClassTag
 
 /** A type class for types that can convert a value of `T` into `quoted.Expr[T]`
  *  an expression that will create a copy of the value.
+ *
+ *  @tparam T the type of the value to be lifted into an `Expr[T]`
  */
 trait ToExpr[T] {
 
-  /** Lift a value into an expression containing the construction of that value. */
+  /** Lift a value into an expression containing the construction of that value.
+   *
+   *  @param x the value to lift into a quoted expression
+   */
   def apply(x: T)(using Quotes): Expr[T]
 
 }

--- a/library/src/scala/quoted/Type.scala
+++ b/library/src/scala/quoted/Type.scala
@@ -4,7 +4,10 @@ import language.experimental.captureChecking
 
 import scala.annotation.{compileTimeOnly, experimental}
 
-/** Type (or type constructor) `T` needed contextually when using `T` in a quoted expression `'{... T ...}`. */
+/** Type (or type constructor) `T` needed contextually when using `T` in a quoted expression `'{... T ...}`.
+ *
+ *  @tparam T the type or type constructor being represented
+ */
 abstract class Type[T <: AnyKind] private[scala]:
   /** The type represented by `Type`. */
   type Underlying = T
@@ -13,7 +16,12 @@ end Type
 /** Methods to interact with the current `Type[T]` in scope. */
 object Type:
 
-  /** Shows a source code like representation of this type without syntax highlight. */
+  /** Shows a source code like representation of this type without syntax highlight.
+   *
+   *  @tparam T the type or type constructor to show
+   *  @param Type the implicit type representation of `T`
+   *  @param Quotes the implicit quotation context
+   */
   def show[T <: AnyKind](using Type[T])(using Quotes): String =
     import quotes.reflect.*
     TypeTree.of[T].show
@@ -43,6 +51,11 @@ object Type:
    *  }
    *  //}
    *  ```
+   *
+   *  @tparam T the singleton constant type to extract the value from
+   *  @param Type the implicit type representation of `T`
+   *  @param Quotes the implicit quotation context
+   *  @return `Some` with the constant value if `T` is a singleton constant type, `None` otherwise
    */
   def valueOfConstant[T](using Type[T])(using Quotes): Option[T] =
     ValueOf.unapply(quotes.reflect.TypeRepr.of[T]).asInstanceOf[Option[T]]
@@ -67,6 +80,11 @@ object Type:
    *  }
    *  //}
    *  ```
+   *
+   *  @tparam T the tuple type of singleton constant types to extract values from
+   *  @param Type the implicit type representation of `T`
+   *  @param Quotes the implicit quotation context
+   *  @return `Some` with the tuple of constant values if all elements are singleton constant types, `None` otherwise
    */
   def valueOfTuple[T <: Tuple](using Type[T])(using Quotes): Option[T] =
     valueOfTuple(quotes.reflect.TypeRepr.of[T]).asInstanceOf[Option[T]]

--- a/library/src/scala/quoted/Varargs.scala
+++ b/library/src/scala/quoted/Varargs.scala
@@ -27,6 +27,10 @@ object Varargs {
    *  }
    *  //}
    *  ```
+   *
+   *  @tparam T the element type of the expressions in the sequence
+   *  @param xs the sequence of individual expressions to lift into a single expression
+   *  @return an expression representing the sequence `Seq(xs(0), xs(1), ...)` as an `Expr[Seq[T]]`
    */
   def apply[T](xs: Seq[Expr[T]])(using Type[T])(using Quotes): Expr[Seq[T]] = {
     import quotes.reflect.*
@@ -41,7 +45,11 @@ object Varargs {
    *  def sumExpr(argsExpr: Expr[Seq[Int]])(using Quotes): Expr[Int] = argsExpr match
    *    case Varargs(argVarargs) => ???
    *      // argVarargs: Seq[Expr[Int]]
+   *  ```
    *
+   *  @tparam T the element type of the varargs sequence
+   *  @param expr the expression of a sequence to destructure into individual expressions
+   *  @return `Some` containing the individual element expressions, or `None` if the expression is not a literal sequence
    */
   def unapply[T](expr: Expr[Seq[T]])(using Quotes): Option[Seq[Expr[T]]] = {
     import quotes.reflect.*

--- a/library/src/scala/quoted/runtime/QuoteMatching.scala
+++ b/library/src/scala/quoted/runtime/QuoteMatching.scala
@@ -25,6 +25,8 @@ trait QuoteMatching:
      *    - scala.quoted.runtime.Patterns.patternHole[T]: hole that matches an expression `x` of type `Expr[U]`
      *                                            if `U <:< T` and returns `x` as part of the match.
      *
+     *  @tparam TypeBindings a kind-level list (`KList`) encoding the type variables bound in the pattern during matching
+     *  @tparam Tup the tuple type containing the types of the matched expression holes, where each element is an `Expr[Ti]`
      *  @param scrutinee `Expr[Any]` on which we are pattern matching
      *  @param pattern `Expr[Any]` containing the pattern tree
      *  @return None if it did not match, `Some(tup)` if it matched where `tup` contains `Expr[Ti]``
@@ -38,6 +40,8 @@ trait QuoteMatching:
     /** Pattern matches an the scrutineeType against the patternType and returns a tuple
      *  with the matched holes if successful.
      *
+     *  @tparam TypeBindings a kind-level list (`KList`) encoding the type variables bound in the pattern during matching
+     *  @tparam Tup the tuple type containing the types of the matched type holes, where each element is a `Type[Ti]`
      *  @param scrutinee `Type[?]` on which we are pattern matching
      *  @param pattern `Type[?]` containing the pattern tree
      *  @return None if it did not match, `Some(tup)` if it matched where `tup` contains `Type[Ti]``

--- a/library/src/scala/quoted/runtime/QuoteUnpickler.scala
+++ b/library/src/scala/quoted/runtime/QuoteUnpickler.scala
@@ -11,6 +11,11 @@ trait QuoteUnpickler:
    *  replacing splice nodes with `holes`
    *
    *  Generated for code compiled with Scala 3.0.x and 3.1.x
+   *
+   *  @tparam T the type of the expression being unpickled
+   *  @param pickled the pickled representation of the expression tree, as a single string or a list of strings
+   *  @param typeHole a function that resolves type splice nodes by index and captured arguments
+   *  @param termHole a function that resolves term splice nodes by index, with captured arguments and a `Quotes` context
    */
   def unpickleExpr[T](pickled: String | List[String], typeHole: (Int, Seq[Any]) => Type[?], termHole: (Int, Seq[Any], Quotes) => Expr[?]): scala.quoted.Expr[T]
 
@@ -18,6 +23,11 @@ trait QuoteUnpickler:
    *  replacing splice nodes with `holes`.
    *
    *  Generated for code compiled with Scala 3.2.0+
+   *
+   *  @tparam T the type of the expression being unpickled
+   *  @param pickled the pickled representation of the expression tree, as a single string or a list of strings
+   *  @param types the types used in splice nodes, or `null` if there are none
+   *  @param termHole a function that resolves term splice nodes by index, with spliced types/expressions and a `Quotes` context, or `null` if there are none
    */
   def unpickleExprV2[T](pickled: String | List[String], types: Null | Seq[Type[?]], termHole: Null | ((Int, Seq[Type[?] | Expr[Any]], Quotes) => Expr[?])): scala.quoted.Expr[T]
 
@@ -25,6 +35,11 @@ trait QuoteUnpickler:
    *  replacing splice nodes with `holes`
    *
    *  Generated for code compiled with Scala 3.0.x and 3.1.x
+   *
+   *  @tparam T the type being unpickled, which may be of any kind (e.g., `*`, `* => *`)
+   *  @param pickled the pickled representation of the type tree, as a single string or a list of strings
+   *  @param typeHole a function that resolves type splice nodes by index and captured arguments
+   *  @param termHole a function that resolves term splice nodes by index, with captured arguments and a `Quotes` context
    */
   def unpickleType[T <: AnyKind](pickled: String | List[String], typeHole: (Int, Seq[Any]) => Type[?], termHole: (Int, Seq[Any], Quotes) => Expr[?]): scala.quoted.Type[T]
 
@@ -32,5 +47,9 @@ trait QuoteUnpickler:
    *  replacing splice nodes with `holes`
    *
    *  Generated for code compiled with Scala 3.2.0+
+   *
+   *  @tparam T the type being unpickled, which may be of any kind (e.g., `*`, `* => *`)
+   *  @param pickled the pickled representation of the type tree, as a single string or a list of strings
+   *  @param types the types used in splice nodes, or `null` if there are none
    */
   def unpickleTypeV2[T <: AnyKind](pickled: String | List[String], types: Null | Seq[Type[?]]): scala.quoted.Type[T]

--- a/library/src/scala/ref/Reference.scala
+++ b/library/src/scala/ref/Reference.scala
@@ -16,6 +16,8 @@ import scala.language.`2.13`
 
 /**
  *  @see `java.lang.ref.Reference`
+ *
+ *  @tparam T the type of the referenced object, constrained to `AnyRef` (i.e., non-primitive types)
  */
 trait Reference[+T <: AnyRef] extends Function0[T] {
   /** Returns the underlying value. */

--- a/library/src/scala/ref/SoftReference.scala
+++ b/library/src/scala/ref/SoftReference.scala
@@ -24,10 +24,18 @@ class SoftReference[+T <: AnyRef](value : T, queue : ReferenceQueue[T] | Null) e
 /** A companion object that implements an extractor for `SoftReference` values */
 object SoftReference {
 
-  /** Creates a `SoftReference` pointing to `value`. */
+  /** Creates a `SoftReference` pointing to `value`.
+   *
+   *  @tparam T the type of the referenced object, must be a reference type
+   *  @param value the object to be softly referenced; may be reclaimed by the garbage collector when memory is low
+   */
   def apply[T <: AnyRef](value: T): SoftReference[T] = new SoftReference(value)
 
-  /** Optionally returns the referenced value, or `None` if that value no longer exists. */
+  /** Optionally returns the referenced value, or `None` if that value no longer exists.
+   *
+   *  @tparam T the type of the referenced object, must be a reference type
+   *  @param sr the `SoftReference` to extract the value from
+   */
   def unapply[T <: AnyRef](sr: SoftReference[T]): Option[T] = Option(sr.underlying.get)
 }
 

--- a/library/src/scala/ref/WeakReference.scala
+++ b/library/src/scala/ref/WeakReference.scala
@@ -17,6 +17,10 @@ import scala.language.`2.13`
 /** A wrapper class for java.lang.ref.WeakReference
  *  The new functionality is (1) results are Option values, instead of using null.
  *  (2) There is an extractor that maps the weak reference itself into an option.
+ *
+ *  @tparam T the covariant type of the weakly referenced object, must be a subtype of `AnyRef`
+ *  @param value the object to be weakly referenced
+ *  @param queue an optional reference queue to which the reference will be enqueued when the referent becomes weakly reachable, or `null` for no queue
  */
 class WeakReference[+T <: AnyRef](value: T, queue: ReferenceQueue[T] | Null) extends ReferenceWrapper[T] {
   def this(value: T) = this(value, null)
@@ -27,10 +31,18 @@ class WeakReference[+T <: AnyRef](value: T, queue: ReferenceQueue[T] | Null) ext
 /** An extractor for weak reference values. */
 object WeakReference {
 
-  /** Creates a weak reference pointing to `value`. */
+  /** Creates a weak reference pointing to `value`.
+   *
+   *  @tparam T the type of the value to wrap in a weak reference
+   *  @param value the object to be weakly referenced
+   */
   def apply[T <: AnyRef](value: T): WeakReference[T] = new WeakReference(value)
 
-  /** Optionally returns the referenced value, or `None` if that value no longer exists. */
+  /** Optionally returns the referenced value, or `None` if that value no longer exists.
+   *
+   *  @tparam T the type of the value to extract from the weak reference
+   *  @param wr the weak reference to extract a value from
+   */
   def unapply[T <: AnyRef](wr: WeakReference[T]): Option[T] = Option(wr.underlying.get)
 }
 

--- a/library/src/scala/reflect/ClassManifestDeprecatedApis.scala
+++ b/library/src/scala/reflect/ClassManifestDeprecatedApis.scala
@@ -191,18 +191,31 @@ object ClassManifestFactory {
    *       it's called from ScalaRunTime.boxArray itself. If we
    *       pass varargs as arrays into this, we get an infinitely recursive call
    *       to boxArray. (Besides, having a separate case is more efficient)
+   *
+   *  @tparam T the type represented by the manifest
+   *  @param clazz the runtime `Class` object for the type `T`
    */
   def classType[T](clazz: jClass[?]): ClassManifest[T] =
     new ClassTypeManifest[T](None, clazz, Nil)
 
   /** ClassManifest for the class type `clazz[args]`, where `clazz` is
    *  a top-level or static class and `args` are its type arguments 
+   *
+   *  @tparam T the type represented by the manifest
+   *  @param clazz the runtime `Class` object for the type `T`
+   *  @param arg1 the manifest for the first type argument of `clazz`, ensuring at least one type argument is provided
+   *  @param args the manifests for the remaining type arguments of `clazz`
    */
   def classType[T](clazz: jClass[?], arg1: OptManifest[?], args: OptManifest[?]*): ClassManifest[T] =
     new ClassTypeManifest[T](None, clazz, arg1 :: args.toList)
 
   /** ClassManifest for the class type `clazz[args]`, where `clazz` is
    *  a class with non-package prefix type `prefix` and type arguments `args`.
+   *
+   *  @tparam T the type represented by the manifest
+   *  @param prefix the manifest for the non-package prefix type of `clazz`
+   *  @param clazz the runtime `Class` object for the type `T`
+   *  @param args the manifests for the type arguments of `clazz`
    */
   def classType[T](prefix: OptManifest[?], clazz: jClass[?], args: OptManifest[?]*): ClassManifest[T] =
     new ClassTypeManifest[T](Some(prefix), clazz, args.toList)
@@ -222,6 +235,12 @@ object ClassManifestFactory {
   /** ClassManifest for the abstract type `prefix # name`. `upperBound` is not
    *  strictly necessary as it could be obtained by reflection. It was
    *  added so that erasure can be calculated without reflection. 
+   *
+   *  @tparam T the type represented by the manifest
+   *  @param prefix the manifest for the prefix type of the abstract type
+   *  @param name the name of the abstract type
+   *  @param clazz the runtime `Class` for the upper bound of the abstract type, used for erasure
+   *  @param args the manifests for the type arguments of the abstract type (note: currently unused in the implementation)
    */
   def abstractType[T](prefix: OptManifest[?], name: String, clazz: jClass[?], args: OptManifest[?]*): ClassManifest[T] =
     new AbstractTypeClassManifest(prefix, name, clazz)
@@ -230,6 +249,12 @@ object ClassManifestFactory {
    *  strictly necessary as it could be obtained by reflection. It was
    *  added so that erasure can be calculated without reflection.
    *  todo: remove after next bootstrap
+   *
+   *  @tparam T the type represented by the manifest
+   *  @param prefix the manifest for the prefix type of the abstract type
+   *  @param name the name of the abstract type
+   *  @param upperbound the `ClassManifest` for the upper bound, whose `runtimeClass` is used for erasure
+   *  @param args the manifests for the type arguments of the abstract type (note: currently unused in the implementation)
    */
   def abstractType[T](prefix: OptManifest[?], name: String, upperbound: ClassManifest[?], args: OptManifest[?]*): ClassManifest[T] =
     new AbstractTypeClassManifest(prefix, name, upperbound.runtimeClass)

--- a/library/src/scala/reflect/ClassTag.scala
+++ b/library/src/scala/reflect/ClassTag.scala
@@ -57,7 +57,10 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
   /** Produces a `ClassTag` that knows how to instantiate an `Array[Array[T]]`. */
   def wrap: ClassTag[Array[T]] = ClassTag[Array[T]](arrayClass(runtimeClass))
 
-  /** Produces a new array with element type `T` and length `len`. */
+  /** Produces a new array with element type `T` and length `len`.
+   *
+   *  @param len the length of the new array
+   */
   def newArray(len: Int): Array[T] =
     java.lang.reflect.Array.newInstance(runtimeClass, len).asInstanceOf[Array[T]]
 
@@ -68,6 +71,9 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
    *  Type tests necessary before calling other extractors are treated similarly.
    *  `SomeExtractor(...)` is turned into `ct(SomeExtractor(...))` if `T` in `SomeExtractor.unapply(x: T)`
    *  is uncheckable, but we have an instance of `ClassTag[T]`.
+   *
+   *  @param x the value to match against the runtime class of `T`
+   *  @return `Some(x)` if `x` is an instance of `T`, `None` otherwise
    */
   def unapply(x: Any): Option[T] =
     if (runtimeClass.isInstance(x)) Some(x.asInstanceOf[T])

--- a/library/src/scala/reflect/Selectable.scala
+++ b/library/src/scala/reflect/Selectable.scala
@@ -19,7 +19,10 @@ trait Selectable extends scala.Selectable:
   protected def selectedValue: Any = this
 
   // The Scala.js codegen relies on this method being final for correctness
-  /** Selects member with given name. */
+  /** Selects member with given name.
+   *
+   *  @param name the name of the structural member (field or no-arg method) to select
+   */
   final def selectDynamic(name: String): Any =
     val rcls = selectedValue.getClass
     try
@@ -31,9 +34,9 @@ trait Selectable extends scala.Selectable:
 
   // The Scala.js codegen relies on this method being final for correctness
   /** Selects method and applies to arguments.
-   *  @param name       The name of the selected method
-   *  @param paramTypes The class tags of the selected method's formal parameter types
-   *  @param args       The arguments to pass to the selected method
+   *  @param name       the name of the selected method
+   *  @param paramTypes the `Class` instances representing the selected method's formal parameter types
+   *  @param args       the arguments to pass to the selected method
    */
   final def applyDynamic(name: String, paramTypes: Class[?]*)(args: Any*): Any =
     val rcls = selectedValue.getClass
@@ -45,6 +48,8 @@ object Selectable:
 
   /** An implicit conversion that turns a value into a Selectable
    *  such that structural selections are performed on that value.
+   *
+   *  @param x the value to wrap in a `Selectable` for reflection-based structural member access
    */
   implicit def reflectiveSelectable(x: Any): Selectable =
     new DefaultSelectable(x)

--- a/library/src/scala/reflect/TypeTest.scala
+++ b/library/src/scala/reflect/TypeTest.scala
@@ -22,10 +22,16 @@ trait TypeTest[-S, T] extends Serializable:
    *  Type tests necessary before calling other extractors are treated similarly.
    *  `SomeExtractor(...)` is turned into `tt(SomeExtractor(...))` if `T` in `SomeExtractor.unapply(x: T)`
    *  is uncheckable, but we have an instance of `TypeTest[S, T]`.
+   *
+   *  @param x the value of type `S` to test for being an instance of `T`
+   *  @return an `Option` containing `x` refined to type `x.type & T` if `x` is an instance of `T`, or `None` otherwise
    */
   def unapply(x: S): Option[x.type & T]
 
 object TypeTest:
 
-  /** Trivial type test that always succeeds. */
+  /** Trivial type test that always succeeds.
+   *
+   *  @tparam T the type for both the input and output of the type test, ensuring the test always succeeds
+   */
   def identity[T]: TypeTest[T, T] = Some(_)

--- a/library/src/scala/reflect/macros/internal/macroImpl.scala
+++ b/library/src/scala/reflect/macros/internal/macroImpl.scala
@@ -28,5 +28,7 @@ import scala.language.`2.13`
  *
  *  To lessen the weirdness we define this annotation as `private[scala]`.
  *  It will not prevent pickling, but it will prevent application developers (and scaladocs) from seeing the annotation.
+ *
+ *  @param referenceToMacroImpl the typechecked reference to the macro implementation method, as produced by `typedMacroBody`. Typed as `Any` because the concrete tree type is not available in scala-library.
  */
 private[scala] final class macroImpl(val referenceToMacroImpl: Any) extends scala.annotation.StaticAnnotation

--- a/library/src/scala/reflect/package.scala
+++ b/library/src/scala/reflect/package.scala
@@ -55,6 +55,9 @@ package object reflect {
   /** Makes a java reflection object accessible, if it is not already
    *  and it is possible to do so. If a SecurityException is thrown in the
    *  attempt, it is caught and discarded.
+   *
+   *  @tparam T the concrete subtype of `java.lang.reflect.AccessibleObject` to make accessible
+   *  @param m the reflection object to make accessible
    */
   def ensureAccessible[T <: jAccessibleObject](m: T): T = {
     // This calls `setAccessible` unnecessarily, because `isAccessible` is only `true` if `setAccessible(true)`

--- a/library/src/scala/runtime/Arrays.scala
+++ b/library/src/scala/runtime/Arrays.scala
@@ -16,18 +16,33 @@ object Arrays {
 
   /** Creates an array of some element type determined by the given `ClassTag`
    *  argument. The erased type of applications of this method is `Object`.
+   *
+   *  @tparam T the element type of the array to create
+   *  @param length the number of elements in the new array
+   *  @param tag the `ClassTag` providing the runtime class information for `T`
    */
   def newGenericArray[T](length: Int)(implicit tag: ClassTag[T]): Array[T] =
     tag.newArray(length)
 
-  /** Converts a sequence to a Java array with element type given by `clazz`. */
+  /** Converts a sequence to a Java array with element type given by `clazz`.
+   *
+   *  @tparam T the element type of the sequence and resulting array
+   *  @param xs the sequence to convert to an array
+   *  @param clazz the runtime `Class` of the element type `T`
+   */
   def seqToArray[T](xs: Seq[T], clazz: Class[?]): Array[T] = {
     val arr = java.lang.reflect.Array.newInstance(clazz, xs.length).asInstanceOf[Array[T]]
     xs.copyToArray(arr)
     arr
   }
 
-  /** Creates an array of a reference type T. */
+  /** Creates an array of a reference type T.
+   *
+   *  @tparam Arr the type of the resulting array, which may be multi-dimensional (e.g., `Array[Array[Int]]`)
+   *  @param componentType the runtime `Class` of the array's component type
+   *  @param returnType the `Class` representing the return type `Arr` (unused at runtime, provides type information for the compiler)
+   *  @param dimensions the sizes for each dimension of the new array
+   */
   def newArray[Arr](componentType: Class[?], @unused returnType: Class[Arr], dimensions: Array[Int]): Arr =
     jlr.Array.newInstance(componentType, dimensions*).asInstanceOf[Arr]
 }

--- a/library/src/scala/runtime/FunctionXXL.scala
+++ b/library/src/scala/runtime/FunctionXXL.scala
@@ -5,7 +5,10 @@ import language.experimental.captureChecking
 /** A function with all parameters grouped in an array. */
 trait FunctionXXL {
 
-  /** Applies all parameters grouped in xs to this function. */
+  /** Applies all parameters grouped in xs to this function.
+   *
+   *  @param xs the function arguments, packed into an immutable array of `Object`
+   */
   def apply(xs: IArray[Object]): Object
 
   override def toString() = "<functionXXL>"

--- a/library/src/scala/runtime/LambdaDeserializer.scala
+++ b/library/src/scala/runtime/LambdaDeserializer.scala
@@ -39,7 +39,10 @@ object LambdaDeserializer {
    *  @param cache       A cache used to avoid spinning up a class for each deserialization of a given lambda. May be `null`
    *  @param serialized  The lambda to deserialize. Note that this is typically created by the `readResolve`
    *                    member of the anonymous class created by `LambdaMetaFactory`.
-   *  @return            An instance of the functional interface
+   *  @param targetMethodMap a mapping from lambda implementation method name and signature keys (as produced by
+   *                    `LambdaDeserialize.nameAndDescriptorKey`) to their `MethodHandle`s, used to look up the
+   *                    implementation method during deserialization. Must not be `null`
+   *  @return            an instance of the functional interface
    */
   def deserializeLambda(lookup: MethodHandles.Lookup, cache: java.util.Map[String, MethodHandle],
                         targetMethodMap: java.util.Map[String, MethodHandle], serialized: SerializedLambda): AnyRef = {

--- a/library/src/scala/runtime/MatchCase.scala
+++ b/library/src/scala/runtime/MatchCase.scala
@@ -2,5 +2,9 @@ package scala.runtime
 
 import language.experimental.captureChecking
 
-/** A type constructor for a case in a match type. */
+/** A type constructor for a case in a match type.
+ *
+ *  @tparam Pat the pattern type to match against the scrutinee of the match type
+ *  @tparam Body the result type produced when the scrutinee matches `Pat`
+ */
 final abstract class MatchCase[Pat, +Body]

--- a/library/src/scala/runtime/MethodCache.scala
+++ b/library/src/scala/runtime/MethodCache.scala
@@ -33,6 +33,8 @@ private[scala] sealed abstract class MethodCache {
    *  `null` is returned. If `null` is returned, find's caller should look-
    *  up the right method using whichever means it prefers, and add it to
    *  the cache for later use. 
+   *
+   *  @param forReceiver the runtime `Class` of the receiver object to look up in the cache
    */
   def find(forReceiver: JClass[?]): JMethod | Null
   def add(forReceiver: JClass[?], forMethod: JMethod): MethodCache
@@ -68,6 +70,8 @@ private[scala] final class PolyMethodCache(
 
   /** To achieve tail recursion this must be a separate method
    *  from `find`, because the type of next is not `PolyMethodCache`.
+   *
+   *  @param forReceiver the runtime `Class` of the receiver object to look up in the cache chain via tail recursion
    */
   @tailrec private def findInternal(forReceiver: JClass[?]): JMethod | Null =
     if (forReceiver eq receiver) method

--- a/library/src/scala/runtime/RichInt.scala
+++ b/library/src/scala/runtime/RichInt.scala
@@ -56,33 +56,33 @@ final class RichInt(val self: Int) extends AnyVal with ScalaNumberProxy[Int] wit
   type ResultWithoutStep = Range
 
   /**
-   *  @param end The final bound of the range to make.
-   *  @return A [[scala.collection.immutable.Range]] from `this` up to but
-   *         not including `end`.
+   *  @param end the final bound of the range to make (exclusive)
+   *  @return a [[scala.collection.immutable.Range]] from `this` up to but
+   *         not including `end`
    */
   def until(end: Int): Range = Range(self, end)
 
   /**
-   *  @param end The final bound of the range to make.
-   *  @param step The number to increase by for each step of the range.
-   *  @return A [[scala.collection.immutable.Range]] from `this` up to but
-   *         not including `end`.
+   *  @param end the final bound of the range to make (exclusive)
+   *  @param step the increment value of the range
+   *  @return a [[scala.collection.immutable.Range]] from `this` up to but
+   *         not including `end`
    */
   def until(end: Int, step: Int): Range = Range(self, end, step)
 
-  /** Like `until`, but includes the last index. */
-  /**
-   *  @param end The final bound of the range to make.
-   *  @return A [[scala.collection.immutable.Range]] from `**this**` up to
-   *         and including `end`.
+  /** Like `until`, but includes the last index.
+   *
+   *  @param end the final bound of the range to make (inclusive)
+   *  @return a [[scala.collection.immutable.Range.Inclusive]] from `this` up to
+   *         and including `end`
    */
   def to(end: Int): Range.Inclusive = Range.inclusive(self, end)
 
   /**
-   *  @param end The final bound of the range to make.
-   *  @param step The number to increase by for each step of the range.
-   *  @return A [[scala.collection.immutable.Range]] from `**this**` up to
-   *         and including `end`.
+   *  @param end the final bound of the range to make (inclusive)
+   *  @param step the increment value of the range
+   *  @return a [[scala.collection.immutable.Range.Inclusive]] from `this` up to
+   *         and including `end`
    */
   def to(end: Int, step: Int): Range.Inclusive = Range.inclusive(self, end, step)
 }

--- a/library/src/scala/runtime/Scala3RunTime.scala
+++ b/library/src/scala/runtime/Scala3RunTime.scala
@@ -25,6 +25,8 @@ object Scala3RunTime:
   /** Called by the inline extension def `nn`.
    *
    *  Extracted to minimize the bytecode size at call site.
+   *
+   *  @throws NullPointerException always, indicating that a null value was encountered where non-null was expected
    */
   def nnFail(): Nothing =
     throw new NullPointerException("tried to cast away nullability, but value is null")

--- a/library/src/scala/runtime/ScalaNumberProxy.scala
+++ b/library/src/scala/runtime/ScalaNumberProxy.scala
@@ -33,9 +33,17 @@ trait ScalaNumberProxy[T] extends Any with ScalaNumericAnyConversions with Proxy
   def byteValue   = intValue.toByte
   def shortValue  = intValue.toShort
 
-  /** Returns `**this**` if `**this** < that` or `that` otherwise. */
+  /** Returns `**this**` if `**this** < that` or `that` otherwise.
+   *
+   *  @param that the value to compare against for finding the minimum
+   *  @return the smaller of `this` and `that`
+   */
   def min(that: T): T = num.min(self, that)
-  /** Returns `**this**` if `**this** > that` or `that` otherwise. */
+  /** Returns `**this**` if `**this** > that` or `that` otherwise.
+   *
+   *  @param that the value to compare against for finding the maximum
+   *  @return the larger of `this` and `that`
+   */
   def max(that: T): T = num.max(self, that)
   /** Returns the absolute value of `**this**`. */
   def abs             = num.abs(self)

--- a/library/src/scala/runtime/ScalaRunTime.scala
+++ b/library/src/scala/runtime/ScalaRunTime.scala
@@ -38,7 +38,10 @@ object ScalaRunTime {
   def drop[Repr](coll: Repr, num: Int)(implicit iterable: IsIterable[Repr] { type C <: Repr }): Repr =
     iterable(coll) drop num
 
-  /** Returns the class object representing an array with element class `clazz`. */
+  /** Returns the class object representing an array with element class `clazz`.
+   *
+   *  @param clazz the element class of the desired array type
+   */
   def arrayClass(clazz: jClass[?]): jClass[?] = {
     // newInstance throws an exception if the erasure is Void.TYPE. see scala/bug#5680
     if (clazz == java.lang.Void.TYPE) classOf[Array[Unit]]
@@ -48,11 +51,18 @@ object ScalaRunTime {
   /** Returns the class object representing an unboxed value type,
    *  e.g., classOf[int], not classOf[java.lang.Integer].  The compiler
    *  rewrites expressions like 5.getClass to come here.
+   *
+   *  @tparam T the value type whose runtime class is retrieved
+   *  @param value the boxed value whose unboxed class is returned
    */
   def anyValClass[T <: AnyVal : ClassTag](value: T): jClass[T] =
     classTag[T].runtimeClass.asInstanceOf[jClass[T]]
 
-  /** Retrieves generic array element. */
+  /** Retrieves generic array element.
+   *
+   *  @param xs the array to read from (typed as `AnyRef` to support both reference and primitive arrays)
+   *  @param idx the index of the element to retrieve
+   */
   def array_apply(xs: AnyRef, idx: Int): Any = {
     (xs: @unchecked) match {
       case x: Array[AnyRef]  => x(idx).asInstanceOf[Any]
@@ -68,7 +78,12 @@ object ScalaRunTime {
     }
   }
 
-  /** Updates generic array element. */
+  /** Updates generic array element.
+   *
+   *  @param xs the array to update (typed as `AnyRef` to support both reference and primitive arrays)
+   *  @param idx the index of the element to set
+   *  @param value the value to store at the given index
+   */
   def array_update(xs: AnyRef, idx: Int, value: Any): Unit = {
     (xs: @unchecked) match {
       case x: Array[AnyRef]  => x(idx) = value.asInstanceOf[AnyRef]
@@ -84,7 +99,10 @@ object ScalaRunTime {
     }
   }
 
-  /** Gets generic array length. */
+  /** Gets generic array length.
+   *
+   *  @param xs the array to measure, as an `AnyRef`
+   */
   @inline def array_length(xs: AnyRef): Int = java.lang.reflect.Array.getLength(xs)
 
   // TODO: bytecode Object.clone() will in fact work here and avoids
@@ -105,6 +123,8 @@ object ScalaRunTime {
   /** Converts an array to an object array.
    *  Needed to deal with vararg arguments of primitive types that are passed
    *  to a generic Java vararg parameter T ...
+   *
+   *  @param src the source array to convert, which may be a primitive array
    */
   def toObjectArray(src: AnyRef): Array[Object] = {
     def copy[@specialized T <: AnyVal](src: Array[T]): Array[Object] = {
@@ -163,7 +183,11 @@ object ScalaRunTime {
   // There used to be an `_equals` method as well which was removed in 5e7e81ab2a.
   def _hashCode(x: Product): Int = scala.util.hashing.MurmurHash3.caseClassHash(x)
 
-  /** A helper for case classes. */
+  /** A helper for case classes.
+   *
+   *  @tparam T the expected element type; elements are cast to this type without checking
+   *  @param x the product whose elements are iterated over
+   */
   def typedProductIterator[T](x: Product): Iterator[T] = {
     new AbstractIterator[T] {
       private var c: Int = 0
@@ -272,7 +296,11 @@ object ScalaRunTime {
     }
   }
 
-  /** stringOf formatted for use in a repl result. */
+  /** stringOf formatted for use in a repl result.
+   *
+   *  @param arg the value to convert to its string representation
+   *  @param maxElements the maximum number of collection elements to include
+   */
   def replStringOf(arg: Any, maxElements: Int): String =
     stringOf(arg, maxElements) match {
       case null => "null toString"

--- a/library/src/scala/runtime/TupleMirror.scala
+++ b/library/src/scala/runtime/TupleMirror.scala
@@ -4,6 +4,8 @@ import language.experimental.captureChecking
 
 /** A concrete subclass of `scala.deriving.Mirror.Product`, enabling reduction of bytecode size.
  *  as we do not need to synthesize an anonymous Mirror class at every callsite.
+ *
+ *  @param arity the number of elements in the mirrored tuple type, must be non-negative
  */
 final class TupleMirror(arity: Int) extends scala.deriving.Mirror.Product with Serializable:
   assert(arity >= 0) // technically could be used for EmptyTuple also, but it has its own singleton mirror.

--- a/library/src/scala/runtime/TypeBox.scala
+++ b/library/src/scala/runtime/TypeBox.scala
@@ -7,6 +7,9 @@ import language.experimental.captureChecking
  *  is a tree `t` of type `C[_ >: L <: U]` and an expected type `C[X]` where `X` is an
  *  instantiatable type variable. To be able to instantiate `X`, we cast the tree to type
  *  `X[$n.CAP]` where `$n` is a fresh skolem type with underlying type `TypeBox[L, U]`.
+ *
+ *  @tparam L the lower bound of the wildcard type being captured
+ *  @tparam U the upper bound of the wildcard type being captured
  */
 final abstract class TypeBox[-L <: U, +U] {
   type CAP >: L <: U

--- a/library/src/scala/runtime/stdLibPatches/Predef.scala
+++ b/library/src/scala/runtime/stdLibPatches/Predef.scala
@@ -28,6 +28,9 @@ private[scala] object Predef:
    *  // bar is 23.type = 23
    *  ```
    *  @group utilities
+   *
+   *  @tparam T the singleton type whose unique value is to be retrieved
+   *  @return the unique inhabitant of type `T`
    */
   inline def valueOf[T]: T = summonFrom {
     case ev: ValueOf[T] => ev.value
@@ -36,7 +39,8 @@ private[scala] object Predef:
   /** Summon a given value of type `T`. Usually, the argument is not passed explicitly.
    *
    *  @tparam T the type of the value to be summoned
-   *  @return the given value typed: the provided type parameter
+   *  @param x the given instance of `T` to return
+   *  @return the summoned given instance of type `T`
    */
   transparent inline def summon[T](using x: T): x.type = x
 
@@ -51,6 +55,8 @@ private[scala] object Predef:
    *  val s3: String | Null = null
    *  val s4: String = s3.nn // throw NullPointerException
    *  ```
+   *
+   *  @return the value cast to its non-nullable type
    */
   extension [T](x: T | Null) inline def nn: x.type & T =
     if x.asInstanceOf[Any] == null then scala.runtime.Scala3RunTime.nnFail()
@@ -60,12 +66,16 @@ private[scala] object Predef:
     /** Enables an expression of type `T|Null`, where `T` is a subtype of `AnyRef`, to be checked for `null`
      *  using `eq` rather than only `==`. This is needed because `Null` no longer has
      *  `eq` or `ne` methods, only `==` and `!=` inherited from `Any`. 
+     *
+     *  @param inline y the reference to compare against for referential equality
      */
     inline infix def eq(inline y: AnyRef | Null): Boolean =
       x.asInstanceOf[AnyRef] eq y.asInstanceOf[AnyRef]
     /** Enables an expression of type `T|Null`, where `T` is a subtype of `AnyRef`, to be checked for `null`
      *  using `ne` rather than only `!=`. This is needed because `Null` no longer has
      *  `eq` or `ne` methods, only `==` and `!=` inherited from `Any`. 
+     *
+     *  @param inline y the reference to compare against for referential inequality
      */
     inline infix def ne(inline y: AnyRef | Null): Boolean =
       !(x eq y)

--- a/library/src/scala/specialized.scala
+++ b/library/src/scala/specialized.scala
@@ -27,6 +27,8 @@ import Specializable._
  *  ```
  *    class MyList[@specialized(Int, Double, Boolean) T] ..
  *  ```
+ *
+ *  @param group the group of primitive types for which specialization should be performed (typically constructed implicitly via the varargs constructor)
  */
 // class tspecialized[T](group: Group[T]) extends scala.annotation.StaticAnnotation {
 

--- a/library/src/scala/sys/BooleanProp.scala
+++ b/library/src/scala/sys/BooleanProp.scala
@@ -67,6 +67,8 @@ object BooleanProp {
    *  the value be equal to the String "true", case insensitively.  This method
    *  creates a BooleanProp instance which adheres to that definition.
    *
+   *  @tparam T unused type parameter, retained for API compatibility
+   *  @param key the name of the system property to look up
    *  @return   A BooleanProp which acts like java's Boolean.getBoolean
    */
   def valueIsTrue[T](key: String): BooleanProp = new BooleanPropImpl(key, _.toLowerCase == "true")
@@ -76,11 +78,17 @@ object BooleanProp {
    *  compared case-insensitively, or the empty string.  This way -Dmy.property
    *  results in a true-valued property, but -Dmy.property=false does not.
    *
+   *  @tparam T unused type parameter, retained for API compatibility
+   *  @param key the name of the system property to look up
    *  @return   A BooleanProp with a liberal truth policy
    */
   def keyExists[T](key: String): BooleanProp = new BooleanPropImpl(key, s => s == "" || s.equalsIgnoreCase("true"))
 
-  /** A constant true or false property which ignores all method calls. */
+  /** A constant true or false property which ignores all method calls.
+   *
+   *  @param key the name of the system property
+   *  @param isOn whether the constant property is true or false
+   */
   def constant(key: String, isOn: Boolean): BooleanProp = new ConstantImpl(key, isOn)
 
   implicit def booleanPropAsBoolean(b: BooleanProp): Boolean = b.value

--- a/library/src/scala/sys/Prop.scala
+++ b/library/src/scala/sys/Prop.scala
@@ -20,6 +20,8 @@ import scala.language.`2.13`
  *  is not a requirement.
  *
  *  See `scala.sys.SystemProperties` for an example usage.
+ *
+ *  @tparam T the type of the property value after conversion from string
  */
 trait Prop[+T] {
   /** The full name of the property, e.g., "java.awt.headless". */
@@ -45,7 +47,12 @@ trait Prop[+T] {
    */
   def set(newValue: String): String | Null
 
-  /** Sets the property with a value of the represented type. */
+  /** Sets the property with a value of the represented type.
+   *
+   *  @tparam T1 a supertype of `T`, used as the input type since `Prop` is covariant in `T`
+   *  @param value the value to set for this property
+   *  @return the previous value of this property
+   */
   def setValue[T1 >: T](value: T1): T
 
   /** Gets the current string value if any.  Will not return null: use
@@ -58,7 +65,11 @@ trait Prop[+T] {
   def option: Option[T]
 
   // Do not open until 2.12.
-  //** This value if the property is set, an alternative value otherwise. */
+  /** This value if the property is set, an alternative value otherwise.
+   *
+   *  @tparam T1 a supertype of `T`, the result type
+   *  @param alt the alternative value to use if the property is not set
+   */
   //def or[T1 >: T](alt: => T1): T1
 
   /** Removes the property from the underlying map. */
@@ -78,7 +89,10 @@ object Prop {
    */
   @annotation.implicitNotFound("No implicit property creator available for type ${T}.")
   trait Creator[+T] {
-    /** Creates a Prop[T] of this type based on the given key. */
+    /** Creates a Prop[T] of this type based on the given key.
+     *
+     *  @param key the property name used for lookup
+     */
     def apply(key: String): Prop[T]
   }
 

--- a/library/src/scala/sys/PropImpl.scala
+++ b/library/src/scala/sys/PropImpl.scala
@@ -16,7 +16,12 @@ package sys
 import scala.language.`2.13`
 import scala.collection.mutable
 
-/** The internal implementation of scala.sys.Prop. */
+/** The internal implementation of scala.sys.Prop.
+ *
+ *  @tparam T the type of the property value after conversion from `String`
+ *  @param key the system property key used to look up the value
+ *  @param valueFn the function that converts the raw `String` property value to type `T`
+ */
 private[sys] class PropImpl[+T](val key: String, valueFn: String => T) extends Prop[T] {
   def value: T = if (isSet) valueFn(get) else zero
   def isSet    = underlying contains key

--- a/library/src/scala/sys/ShutdownHookThread.scala
+++ b/library/src/scala/sys/ShutdownHookThread.scala
@@ -30,6 +30,8 @@ object ShutdownHookThread {
   }
   /** Creates, names, and registers a shutdown hook to run the
    *  given code.
+   *
+   *  @param body the code to execute when the JVM shuts down
    */
   def apply(body: => Unit): ShutdownHookThread = {
     val t = new ShutdownHookThread(() => body, hookName())

--- a/library/src/scala/sys/SystemProperties.scala
+++ b/library/src/scala/sys/SystemProperties.scala
@@ -67,6 +67,9 @@ extends mutable.AbstractMap[String, String | Null] {
 object SystemProperties {
   /** An unenforceable, advisory only place to do some synchronization when
    *  mutating system properties.
+   *
+   *  @tparam T the return type of the body expression
+   *  @param body the code to execute while holding the lock
    */
   def exclusively[T](body: => T): T = this.synchronized:
     body

--- a/library/src/scala/sys/package.scala
+++ b/library/src/scala/sys/package.scala
@@ -23,19 +23,21 @@ import scala.jdk.CollectionConverters._
 package object sys {
   /** Throws a new RuntimeException with the supplied message.
    *
-   *  @return   Nothing.
+   *  @param message the detail message for the `RuntimeException`
+   *  @return   this method never returns normally (return type is `Nothing`)
    */
   def error(message: String): Nothing = throw new RuntimeException(message)
 
   /** Exits the JVM with the default status code.
    *
-   *  @return   Nothing.
+   *  @return   this method never returns normally (return type is `Nothing`)
    */
   def exit(): Nothing = exit(0)
 
   /** Exits the JVM with the given status code.
    *
-   *  @return   Nothing.
+   *  @param status the exit status code passed to `System.exit` (0 for success, non-zero for failure)
+   *  @return   this method never returns normally (return type is `Nothing`)
    */
   def exit(status: Int): Nothing = {
     java.lang.System.exit(status)
@@ -50,7 +52,7 @@ package object sys {
 
   /** A bidirectional, mutable Map representing the current system Properties.
    *
-   *  @return   a SystemProperties.
+   *  @return   a `SystemProperties` instance wrapping the current system properties
    *  @see      [[scala.sys.SystemProperties]]
    */
   def props: SystemProperties = new SystemProperties
@@ -79,7 +81,7 @@ package object sys {
    *  Note that shutdown hooks are NOT guaranteed to be run.
    *
    *  @param    body  the body of code to run at shutdown
-   *  @return   the   Thread which will run the shutdown hook.
+   *  @return   the `ShutdownHookThread` which will run the shutdown hook
    *  @see      [[scala.sys.ShutdownHookThread]]
    */
   def addShutdownHook(body: => Unit): ShutdownHookThread = ShutdownHookThread(body)

--- a/library/src/scala/sys/process/Parser.scala
+++ b/library/src/scala/sys/process/Parser.scala
@@ -23,7 +23,9 @@ private[scala] object Parser {
 
   /** Splits the line into tokens separated by whitespace or quotes.
    *
-   *  @return either an error message or reverse list of tokens
+   *  @param line the command line string to parse
+   *  @param errorFn the error handler invoked with a message when parsing fails (e.g., unmatched quote)
+   *  @return a list of parsed tokens in order of appearance, or `Nil` after invoking `errorFn` on failure
    */
   def tokenize(line: String, errorFn: String => Unit): List[String] = {
     import Character.isWhitespace

--- a/library/src/scala/sys/process/Process.scala
+++ b/library/src/scala/sys/process/Process.scala
@@ -57,6 +57,9 @@ trait ProcessCreation {
    *  ```
    *  apply("cat file.txt")
    *  ```
+   *
+   *  @param command the command string, including parameters separated by spaces
+   *  @return a new `ProcessBuilder` for the given command
    */
   def apply(command: String): ProcessBuilder                         = apply(command, None)
 
@@ -67,6 +70,9 @@ trait ProcessCreation {
    *  ```
    *  apply("cat" :: files)
    *  ```
+   *
+   *  @param command a sequence where the first element is the executable and the rest are arguments
+   *  @return a new `ProcessBuilder` for the given command
    */
   def apply(command: scala.collection.Seq[String]): ProcessBuilder   = apply(command, None)
 
@@ -77,6 +83,10 @@ trait ProcessCreation {
    *  ```
    *  apply("cat", files)
    *  ```
+   *
+   *  @param command the executable to run
+   *  @param arguments the arguments to pass to the command
+   *  @return a new `ProcessBuilder` for the given command and arguments
    */
   def apply(command: String, arguments: scala.collection.Seq[String]): ProcessBuilder = apply(command +: arguments, None)
 
@@ -87,6 +97,10 @@ trait ProcessCreation {
    *  ```
    *  apply("java", new java.io.File("/opt/app"), "CLASSPATH" -> "library.jar")
    *  ```
+   *
+   *  @param command the command string, including parameters separated by spaces
+   *  @param cwd the working directory for the process
+   *  @param extraEnv environment variable name-value pairs to add to the process environment
    */
   def apply(command: String, cwd: File, extraEnv: (String, String)*): ProcessBuilder =
     apply(command, Some(cwd), extraEnv*)
@@ -98,6 +112,10 @@ trait ProcessCreation {
    *  ```
    *  apply("java" :: javaArgs, new java.io.File("/opt/app"), "CLASSPATH" -> "library.jar")
    *  ```
+   *
+   *  @param command a sequence where the first element is the executable and the rest are arguments
+   *  @param cwd the working directory for the process
+   *  @param extraEnv environment variable name-value pairs to add to the process environment
    */
   def apply(command: scala.collection.Seq[String], cwd: File, extraEnv: (String, String)*): ProcessBuilder =
     apply(command, Some(cwd), extraEnv*)
@@ -109,6 +127,10 @@ trait ProcessCreation {
    *  ```
    *  apply("java", params.get("cwd"), "CLASSPATH" -> "library.jar")
    *  ```
+   *
+   *  @param command the command string, including parameters separated by spaces
+   *  @param cwd an optional working directory for the process
+   *  @param extraEnv environment variable name-value pairs to add to the process environment
    */
   def apply(command: String, cwd: Option[File], extraEnv: (String, String)*): ProcessBuilder =
     apply(Parser.tokenize(command), cwd, extraEnv*)
@@ -120,6 +142,10 @@ trait ProcessCreation {
    *  ```
    *  apply("java" :: javaArgs, params.get("cwd"), "CLASSPATH" -> "library.jar")
    *  ```
+   *
+   *  @param command a sequence where the first element is the executable and the rest are arguments
+   *  @param cwd an optional working directory for the process
+   *  @param extraEnv environment variable name-value pairs to add to the process environment
    */
   def apply(command: scala.collection.Seq[String], cwd: Option[File], extraEnv: (String, String)*): ProcessBuilder = {
     val jpb = new JProcessBuilder(command.toArray*)
@@ -133,34 +159,50 @@ trait ProcessCreation {
    *  @example ```
    *  apply((new java.lang.ProcessBuilder("ls", "-l")) directory new java.io.File(System.getProperty("user.home")))
    *  ```
+   *
+   *  @param builder the `java.lang.ProcessBuilder` to wrap
+   *  @return a new `ProcessBuilder` wrapping the given Java process builder
    */
   def apply(builder: JProcessBuilder): ProcessBuilder = new Simple(builder)
 
   /** Creates a [[scala.sys.process.ProcessBuilder]] from a `java.io.File`. This
    *  `ProcessBuilder` can then be used as a `Source` or a `Sink`, so one can
    *  pipe things from and to it.
+   *
+   *  @param file the file to use as a source or sink for the process
    */
   def apply(file: File): FileBuilder                  = new FileImpl(file)
 
   /** Creates a [[scala.sys.process.ProcessBuilder]] from a `java.net.URL`. This
    *  `ProcessBuilder` can then be used as a `Source`, so that one can pipe things
    *  from it.
+   *
+   *  @param url the URL to use as a source for the process
    */
   def apply(url: URL): URLBuilder                     = new URLImpl(url)
 
   /** Creates a [[scala.sys.process.ProcessBuilder]] from a `Boolean`. This can be
    *  to force an exit value.
+   *
+   *  @param value if `true`, the process exits with code 0; if `false`, with code 1
    */
   def apply(value: Boolean): ProcessBuilder           = apply(value.toString, if (value) 0 else 1)
 
   /** Creates a [[scala.sys.process.ProcessBuilder]] from a `String` name and a
    *  `Boolean`. This can be used to force an exit value, with the name being
    *  used for `toString`.
+   *
+   *  @param name the name used for the `toString` representation of this process
+   *  @param exitValue the exit code that this process will return (by-name, evaluated on each access)
    */
   def apply(name: String, exitValue: => Int): ProcessBuilder = new Dummy(name, exitValue)
 
   /** Creates a sequence of [[scala.sys.process.ProcessBuilder.Source]] from a sequence of
    *  something else for which there's an implicit conversion to `Source`.
+   *
+   *  @tparam T the type of the elements to be converted to `Source`
+   *  @param builders the sequence of elements to convert
+   *  @param convert the implicit conversion from `T` to `Source`
    */
   def applySeq[T](builders: scala.collection.Seq[T])(implicit convert: T => Source): scala.collection.Seq[Source] = builders.map(convert)
 
@@ -181,6 +223,10 @@ trait ProcessCreation {
    *  val build = new File("project/build.properties")
    *  cat(spde, dispatch, build) #| "grep -i scala" !
    *  ```
+   *
+   *  @param file the first `Source` to concatenate
+   *  @param files additional `Source` values to concatenate after the first
+   *  @return a `ProcessBuilder` whose output is the concatenation of all sources
    */
   def cat(file: Source, files: Source*): ProcessBuilder = cat(file +: files)
 
@@ -189,6 +235,9 @@ trait ProcessCreation {
    *  piped to something else.
    *
    *  This will concatenate the output of all sources.
+   *
+   *  @param files the non-empty sequence of sources to concatenate; throws `IllegalArgumentException` if empty
+   *  @return a `ProcessBuilder` whose output is the concatenation of all sources
    */
   def cat(files: scala.collection.Seq[Source]): ProcessBuilder = {
     require(files.nonEmpty)
@@ -206,10 +255,17 @@ trait ProcessImplicits {
 
   /** Returns a sequence of [[scala.sys.process.ProcessBuilder.Source]] from a sequence
    *  of values for which an implicit conversion to `Source` is available.
+   *
+   *  @tparam T the type of the elements to be converted to `Source`
+   *  @param builders the sequence of elements to convert
+   *  @param convert the implicit conversion from `T` to `Source`
    */
   implicit def buildersToProcess[T](builders: scala.collection.Seq[T])(implicit convert: T => Source): scala.collection.Seq[Source] = applySeq(builders)
 
-  /** Implicitly convert a `java.lang.ProcessBuilder` into a Scala one. */
+  /** Implicitly convert a `java.lang.ProcessBuilder` into a Scala one.
+   *
+   *  @param builder the `java.lang.ProcessBuilder` to convert
+   */
   implicit def builderToProcess(builder: JProcessBuilder): ProcessBuilder = apply(builder)
 
   /** Implicitly convert a `java.io.File` into a
@@ -219,6 +275,8 @@ trait ProcessImplicits {
    *  import scala.sys.process._
    *  "ls" #> new java.io.File("dirContents.txt") !
    *  ```
+   *
+   *  @param file the file to convert into a `FileBuilder`
    */
   implicit def fileToProcess(file: File): FileBuilder                     = apply(file)
 
@@ -229,16 +287,23 @@ trait ProcessImplicits {
    *  import scala.sys.process._
    *  Seq("xmllint", "--html", "-") #< new java.net.URL("https://www.scala-lang.org") #> new java.io.File("fixed.html") !
    *  ```
+   *
+   *  @param url the URL to convert into a `URLBuilder`
    */
   implicit def urlToProcess(url: URL): URLBuilder                         = apply(url)
 
-  /** Implicitly convert a `String` into a [[scala.sys.process.ProcessBuilder]]. */
+  /** Implicitly convert a `String` into a [[scala.sys.process.ProcessBuilder]].
+   *
+   *  @param command the command string to convert into a `ProcessBuilder`
+   */
   implicit def stringToProcess(command: String): ProcessBuilder           = apply(command)
 
   /** Implicitly convert a sequence of `String` into a
    *  [[scala.sys.process.ProcessBuilder]]. The first argument will be taken to
    *  be the command to be executed, and the remaining will be its arguments.
    *  When using this, arguments may contain spaces.
+   *
+   *  @param command a sequence where the first element is the executable and the rest are arguments
    */
   implicit def stringSeqToProcess(command: scala.collection.Seq[String]): ProcessBuilder = apply(command)
 }

--- a/library/src/scala/sys/process/ProcessBuilder.scala
+++ b/library/src/scala/sys/process/ProcessBuilder.scala
@@ -145,6 +145,8 @@ trait ProcessBuilder extends Source with Sink {
   /** Starts the process represented by this builder, blocks until it exits, and
    *  returns the output as a String.  Standard error is sent to the provided
    *  ProcessLogger.  If the exit code is non-zero, an exception is thrown.
+   *
+   *  @param log the `ProcessLogger` to receive standard error output
    */
   def !!(log: ProcessLogger): String
 
@@ -159,6 +161,8 @@ trait ProcessBuilder extends Source with Sink {
    *  returns the output as a String.  Standard error is sent to the provided
    *  ProcessLogger.  If the exit code is non-zero, an exception is thrown.  The
    *  newly started process reads from standard input of the current process.
+   *
+   *  @param log the `ProcessLogger` to receive standard error output
    */
   def !!<(log: ProcessLogger): String
 
@@ -178,6 +182,8 @@ trait ProcessBuilder extends Source with Sink {
    *  Standard error is sent to the console.  If the process exits
    *  with a non-zero value, the `LazyList` will provide all lines up to termination
    *  and then throw an exception.
+   *
+   *  @param capacity the maximum number of lines to buffer before blocking the producer
    */
   def lazyLines(capacity: Integer): LazyList[String]
 
@@ -186,6 +192,8 @@ trait ProcessBuilder extends Source with Sink {
    *  completed.  Standard error is sent to the provided `ProcessLogger`.  If the
    *  process exits with a non-zero value, the `LazyList` will provide all lines up
    *  to termination and then throw an exception.
+   *
+   *  @param log the `ProcessLogger` to receive standard error output
    */
   def lazyLines(log: ProcessLogger): LazyList[String]
 
@@ -197,6 +205,9 @@ trait ProcessBuilder extends Source with Sink {
    *  Standard error is sent to the provided `ProcessLogger`.  If the
    *  process exits with a non-zero value, the `LazyList` will provide all lines up
    *  to termination and then throw an exception.
+   *
+   *  @param log the `ProcessLogger` to receive standard error output
+   *  @param capacity the maximum number of lines to buffer before blocking the producer
    */
   def lazyLines(log: ProcessLogger, capacity: Integer): LazyList[String]
 
@@ -216,6 +227,8 @@ trait ProcessBuilder extends Source with Sink {
    *  Standard error is sent to the console. If the process exits
    *  with a non-zero value, the `LazyList` will provide all lines up to termination
    *  but will not throw an exception.
+   *
+   *  @param capacity the maximum number of lines to buffer before blocking the producer
    */
   def lazyLines_!(capacity: Integer): LazyList[String]
 
@@ -224,6 +237,8 @@ trait ProcessBuilder extends Source with Sink {
    *  completed.  Standard error is sent to the provided `ProcessLogger`. If the
    *  process exits with a non-zero value, the `LazyList` will provide all lines up
    *  to termination but will not throw an exception.
+   *
+   *  @param log the `ProcessLogger` to receive standard error output
    */
   def lazyLines_!(log: ProcessLogger): LazyList[String]
 
@@ -235,6 +250,9 @@ trait ProcessBuilder extends Source with Sink {
    *  Standard error is sent to the provided `ProcessLogger`. If the
    *  process exits with a non-zero value, the `LazyList` will provide all lines up
    *  to termination but will not throw an exception.
+   *
+   *  @param log the `ProcessLogger` to receive standard error output
+   *  @param capacity the maximum number of lines to buffer before blocking the producer
    */
   def lazyLines_!(log: ProcessLogger, capacity: Integer): LazyList[String]
 
@@ -330,6 +348,8 @@ trait ProcessBuilder extends Source with Sink {
   /** Starts the process represented by this builder, blocks until it exits, and
    *  returns the exit code.  Standard output and error are sent to the given
    *  ProcessLogger.
+   *
+   *  @param log the `ProcessLogger` to receive standard output and error
    */
   def !(log: ProcessLogger): Int
 
@@ -343,6 +363,8 @@ trait ProcessBuilder extends Source with Sink {
    *  returns the exit code.  Standard output and error are sent to the given
    *  ProcessLogger.  The newly started process reads from standard input of the
    *  current process.
+   *
+   *  @param log the `ProcessLogger` to receive standard output and error
    */
   def !<(log: ProcessLogger): Int
 
@@ -353,43 +375,60 @@ trait ProcessBuilder extends Source with Sink {
 
   /** Starts the process represented by this builder.  Standard output and error
    *  are sent to the given ProcessLogger.
+   *
+   *  @param log the `ProcessLogger` to receive standard output and error
    */
   def run(log: ProcessLogger): Process
 
   /** Starts the process represented by this builder.  I/O is handled by the
    *  given ProcessIO instance.
+   *
+   *  @param io the `ProcessIO` that handles the process's standard input, output, and error streams
    */
   def run(io: ProcessIO): Process
 
   /** Starts the process represented by this builder.  Standard output and error
    *  are sent to the console.  The newly started process reads from standard
    *  input of the current process if `connectInput` is true.
+   *
+   *  @param connectInput whether to connect the process's standard input to the current process's stdin
    */
   def run(connectInput: Boolean): Process
 
   /** Starts the process represented by this builder.  Standard output and error
    *  are sent to the given ProcessLogger.  The newly started process reads from
    *  standard input of the current process if `connectInput` is true.
+   *
+   *  @param log the `ProcessLogger` to receive standard output and error
+   *  @param connectInput whether to connect the process's standard input to the current process's stdin
    */
   def run(log: ProcessLogger, connectInput: Boolean): Process
 
   /** Constructs a command that runs this command first and then `other` if this
    *  command succeeds.
+   *
+   *  @param other the command to run if this one returns an exit code of zero
    */
   def #&& (other: ProcessBuilder): ProcessBuilder
 
   /** Constructs a command that runs this command first and then `other` if this
    *  command does not succeed.
+   *
+   *  @param other the command to run if this one returns a non-zero exit code
    */
   def #|| (other: ProcessBuilder): ProcessBuilder
 
   /** Constructs a command that will run this command and pipes the output to
    *  `other`.  `other` must be a simple command.
+   *
+   *  @param other the command to receive the output of this process as its input
    */
   def #| (other: ProcessBuilder): ProcessBuilder
 
   /** Constructs a command that will run this command and then `other`.  The
    *  exit code will be the exit code of `other`.
+   *
+   *  @param other the command to run after this one, regardless of exit code
    */
   def ### (other: ProcessBuilder): ProcessBuilder
 
@@ -417,16 +456,28 @@ object ProcessBuilder extends ProcessBuilderImpl {
    *  [[scala.sys.process.ProcessBuilder.Sink]] from a file.
    */
   trait FileBuilder extends Sink with Source {
-    /** Appends the contents of a `java.io.File` to this file. */
+    /** Appends the contents of a `java.io.File` to this file.
+     *
+     *  @param f the file whose contents will be appended
+     */
     def #<<(f: File): ProcessBuilder
 
-    /** Appends the contents from a `java.net.URL` to this file. */
+    /** Appends the contents from a `java.net.URL` to this file.
+     *
+     *  @param u the URL whose contents will be appended
+     */
     def #<<(u: URL): ProcessBuilder
 
-    /** Appends the contents of a `java.io.InputStream` to this file. */
+    /** Appends the contents of a `java.io.InputStream` to this file.
+     *
+     *  @param i the input stream whose contents will be appended
+     */
     def #<<(i: => InputStream): ProcessBuilder
 
-    /** Appends the contents of a [[scala.sys.process.ProcessBuilder]] to this file. */
+    /** Appends the contents of a [[scala.sys.process.ProcessBuilder]] to this file.
+     *
+     *  @param p the process builder whose output will be appended
+     */
     def #<<(p: ProcessBuilder): ProcessBuilder
   }
 
@@ -436,19 +487,30 @@ object ProcessBuilder extends ProcessBuilderImpl {
   trait Source {
     protected def toSource: ProcessBuilder
 
-    /** Writes the output stream of this process to the given file. */
+    /** Writes the output stream of this process to the given file.
+     *
+     *  @param f the file to write the output to
+     */
     def #> (f: File): ProcessBuilder = toFile(f, append = false)
 
-    /** Appends the output stream of this process to the given file. */
+    /** Appends the output stream of this process to the given file.
+     *
+     *  @param f the file to append the output to
+     */
     def #>> (f: File): ProcessBuilder = toFile(f, append = true)
 
     /** Writes the output stream of this process to the given OutputStream. The
      *  argument is call-by-name, so the stream is recreated, written, and closed each
      *  time this process is executed.
+     *
+     *  @param out the output stream to write to, created anew for each execution
      */
     def #>(out: => OutputStream): ProcessBuilder = #> (new OStreamBuilder(out, "<output stream>"))
 
-    /** Writes the output stream of this process to a [[scala.sys.process.ProcessBuilder]]. */
+    /** Writes the output stream of this process to a [[scala.sys.process.ProcessBuilder]].
+     *
+     *  @param b the process builder to receive this process's output as input
+     */
     def #>(b: ProcessBuilder): ProcessBuilder = new PipedBuilder(toSource, b, toError = false)
 
     /** Returns a [[scala.sys.process.ProcessBuilder]] representing this `Source`. */
@@ -462,19 +524,30 @@ object ProcessBuilder extends ProcessBuilderImpl {
   trait Sink {
     protected def toSink: ProcessBuilder
 
-    /** Reads the given file into the input stream of this process. */
+    /** Reads the given file into the input stream of this process.
+     *
+     *  @param f the file to read from as input
+     */
     def #< (f: File): ProcessBuilder = #< (new FileInput(f))
 
-    /** Reads the given URL into the input stream of this process. */
+    /** Reads the given URL into the input stream of this process.
+     *
+     *  @param f the `URL` to read from as input
+     */
     def #< (f: URL): ProcessBuilder = #< (new URLInput(f))
 
     /** Reads the given InputStream into the input stream of this process. The
      *  argument is call-by-name, so the stream is recreated, read, and closed each
      *  time this process is executed.
+     *
+     *  @param in the input stream to read from, created anew for each execution
      */
     def #<(in: => InputStream): ProcessBuilder = #< (new IStreamBuilder(in, "<input stream>"))
 
-    /** Reads the output of a [[scala.sys.process.ProcessBuilder]] into the input stream of this process. */
+    /** Reads the output of a [[scala.sys.process.ProcessBuilder]] into the input stream of this process.
+     *
+     *  @param b the process builder whose output will be used as input to this process
+     */
     def #<(b: ProcessBuilder): ProcessBuilder = new PipedBuilder(b, toSink, toError = false)
   }
 }

--- a/library/src/scala/sys/process/ProcessBuilderImpl.scala
+++ b/library/src/scala/sys/process/ProcessBuilderImpl.scala
@@ -74,7 +74,10 @@ private[process] trait ProcessBuilderImpl {
     }
   }
 
-  /** Represents a simple command without any redirection or combination. */
+  /** Represents a simple command without any redirection or combination.
+   *
+   *  @param p the underlying `java.lang.ProcessBuilder` used to start the external process
+   */
   private[process] class Simple(p: JProcessBuilder) extends AbstractBuilder {
     override def run(io: ProcessIO): Process = {
       import java.lang.ProcessBuilder.Redirect.{INHERIT => Inherit}
@@ -154,6 +157,8 @@ private[process] trait ProcessBuilderImpl {
      *
      *  Note: not in the public API because it's not fully baked, but I need the capability
      *  for fsc.
+     *
+     *  @return a new `ProcessBuilder` that runs this command with all I/O threads daemonized
      */
     def daemonized(): ProcessBuilder = new DaemonBuilder(this)
 

--- a/library/src/scala/sys/process/ProcessIO.scala
+++ b/library/src/scala/sys/process/ProcessIO.scala
@@ -59,13 +59,22 @@ final class ProcessIO(
 ) {
   def this(in: OutputStream => Unit, out: InputStream => Unit, err: InputStream => Unit) = this(in, out, err, daemonizeThreads = false)
 
-  /** Creates a new `ProcessIO` with a different handler for the process input. */
+  /** Creates a new `ProcessIO` with a different handler for the process input.
+   *
+   *  @param write the new function to handle the process input `OutputStream`
+   */
   def withInput(write: OutputStream => Unit): ProcessIO   = new ProcessIO(write, processOutput, processError, daemonizeThreads)
 
-  /** Creates a new `ProcessIO` with a different handler for the normal output. */
+  /** Creates a new `ProcessIO` with a different handler for the normal output.
+   *
+   *  @param process the new function to handle the process standard output `InputStream`
+   */
   def withOutput(process: InputStream => Unit): ProcessIO = new ProcessIO(writeInput, process, processError, daemonizeThreads)
 
-  /** Creates a new `ProcessIO` with a different handler for the error output. */
+  /** Creates a new `ProcessIO` with a different handler for the error output.
+   *
+   *  @param process the new function to handle the process error output `InputStream`
+   */
   def withError(process: InputStream => Unit): ProcessIO  = new ProcessIO(writeInput, processOutput, process, daemonizeThreads)
 
   /** Creates a new `ProcessIO`, with `daemonizeThreads` true. */

--- a/library/src/scala/sys/process/ProcessImpl.scala
+++ b/library/src/scala/sys/process/ProcessImpl.scala
@@ -242,6 +242,8 @@ private[process] trait ProcessImpl {
 
   /** A thin wrapper around a java.lang.Process.  `ioThreads` are the Threads created to do I/O.
    *  The implementation of `exitValue` waits until these threads die before returning.
+   *
+   *  @param action the by-name computation whose result will be used as the exit value
    */
   private[process] class DummyProcess(action: => Int) extends Process {
     private val (thread, value) = Future(action)
@@ -260,6 +262,10 @@ private[process] trait ProcessImpl {
    *
    *  The implementation of `exitValue` interrupts `inputThread`
    *  and then waits until all I/O threads die before returning.
+   *
+   *  @param p the underlying `java.lang.Process` being wrapped
+   *  @param inputThread the thread writing to the process's stdin, or null if stdin was inherited
+   *  @param outputThreads the threads reading from the process's stdout and stderr streams
    */
   private[process] class SimpleProcess(p: JProcess, inputThread: Thread | Null, outputThreads: List[Thread]) extends Process {
     override def isAlive() = p.isAlive()

--- a/library/src/scala/sys/process/ProcessLogger.scala
+++ b/library/src/scala/sys/process/ProcessLogger.scala
@@ -38,10 +38,16 @@ import java.io._
  *  @see [[scala.sys.process.ProcessBuilder]]
  */
 trait ProcessLogger {
-  /** Will be called with each line read from the process output stream. */
+  /** Will be called with each line read from the process output stream.
+   *
+   *  @param s a lazily-evaluated line from the process standard output
+   */
   def out(s: => String): Unit
 
-  /** Will be called with each line read from the process error stream. */
+  /** Will be called with each line read from the process error stream.
+   *
+   *  @param s a lazily-evaluated line from the process standard error
+   */
   def err(s: => String): Unit
 
   /** If a process is begun with one of these `ProcessBuilder` methods:
@@ -53,11 +59,17 @@ trait ProcessLogger {
    *  an opportunity to set up and tear down buffering.  At present the
    *  library implementations of `ProcessLogger` simply execute the body
    *  unbuffered.
+   *
+   *  @tparam T the return type of the buffered operation
+   *  @param f the code to execute with buffering, evaluated by name
    */
   def buffer[T](f: => T): T
 }
 
-/** A [[scala.sys.process.ProcessLogger]] that writes output to a file. */
+/** A [[scala.sys.process.ProcessLogger]] that writes output to a file.
+ *
+ *  @param file the file to which both standard and error output will be appended
+ */
 class FileProcessLogger(file: File) extends ProcessLogger with Closeable with Flushable {
   private val writer = (
     new PrintWriter(
@@ -80,20 +92,25 @@ class FileProcessLogger(file: File) extends ProcessLogger with Closeable with Fl
  *  when run.
  */
 object ProcessLogger {
-  /** Creates a [[scala.sys.process.ProcessLogger]] that redirects output to a `java.io.File`. */
+  /** Creates a [[scala.sys.process.ProcessLogger]] that redirects output to a `java.io.File`.
+   *
+   *  @param file the `java.io.File` to which output will be appended
+   */
   def apply(file: File): FileProcessLogger = new FileProcessLogger(file)
 
   /** Creates a [[scala.sys.process.ProcessLogger]] that sends all output, standard and error,
    *  to the passed function.
+   *
+   *  @param fn the function to apply to each line of standard and error output
    */
   def apply(fn: String => Unit): ProcessLogger = apply(fn, fn)
 
   /** Creates a [[scala.sys.process.ProcessLogger]] that sends all output to the corresponding
    *  function.
    *
-   *  @param fout  This function will receive standard output.
+   *  @param fout the function that will receive each line of standard output
    *
-   *  @param ferr  This function will receive standard error.
+   *  @param ferr the function that will receive each line of standard error
    */
   def apply(fout: String => Unit, ferr: String => Unit): ProcessLogger =
     new ProcessLogger {

--- a/library/src/scala/throws.scala
+++ b/library/src/scala/throws.scala
@@ -23,6 +23,9 @@ import scala.language.`2.13`
  *   def read() = in.read()
  *  }
  *  ```
+ *
+ *  @tparam T the type of exception that the annotated method may throw
+ *  @param cause a description of the condition under which the exception is thrown
  */
 final class throws[T <: Throwable](cause: String = "") extends scala.annotation.StaticAnnotation {
   def this(clazz: Class[T]) = this("")

--- a/library/src/scala/util/ChainingOps.scala
+++ b/library/src/scala/util/ChainingOps.scala
@@ -20,7 +20,11 @@ trait ChainingSyntax {
   @inline implicit final def scalaUtilChainingOps[A](a: A): ChainingOps[A] = new ChainingOps(a)
 }
 
-/** Adds chaining methods `tap` and `pipe` to every type. */
+/** Adds chaining methods `tap` and `pipe` to every type.
+ *
+ *  @tparam A the type of the wrapped value
+ *  @param self the value to enrich with chaining operations
+ */
 final class ChainingOps[A](private val self: A) extends AnyVal {
   /** Applies `f` to the value for its side effects, and returns the original value.
    *

--- a/library/src/scala/util/CommandLineParser.scala
+++ b/library/src/scala/util/CommandLineParser.scala
@@ -12,6 +12,11 @@ object CommandLineParser {
   class ParseError(val idx: Int, val msg: String) extends Exception
 
   /** Parses command line argument `s`, which has index `n`, as a value of type `T`.
+   *
+   *  @tparam T the target type to parse the string into
+   *  @param str the command line argument string to parse
+   *  @param n the zero-based index of the argument, used for error reporting
+   *  @param fs the type class instance (usually provided implicitly) that converts a string to type `T`
    *  @throws ParseError if argument cannot be converted to type `T`.
    */
   def parseString[T](str: String, n: Int)(using fs: FromString[T]^): T = {
@@ -22,6 +27,11 @@ object CommandLineParser {
   }
 
   /** Parses `n`'th argument in `args` (counting from 0) as a value of type `T`.
+   *
+   *  @tparam T the target type to parse the argument into
+   *  @param args the command line arguments array
+   *  @param n the zero-based index of the argument to parse
+   *  @param fs the type class instance that converts a string to type `T`
    *  @throws ParseError if argument does not exist or cannot be converted to type `T`.
    */
   def parseArgument[T](args: Array[String], n: Int)(using fs: FromString[T]^): T =
@@ -29,13 +39,21 @@ object CommandLineParser {
     else throw ParseError(n, "more arguments expected")
 
   /** Parses all arguments from `n`'th one (counting from 0) as a list of values of type `T`.
+   *
+   *  @tparam T the target type to parse each argument into
+   *  @param args the command line arguments array
+   *  @param n the zero-based index of the first remaining argument to parse
+   *  @param fs the type class instance that converts a string to type `T`
    *  @throws ParseError if some of the arguments cannot be converted to type `T`.
    */
   def parseRemainingArguments[T](args: Array[String], n: Int)(using fs: FromString[T]^): List[T] =
     if n < args.length then parseString(args(n), n) :: parseRemainingArguments(args, n + 1)
     else Nil
 
-  /** Prints error message explaining given ParserError. */
+  /** Prints error message explaining given ParserError.
+   *
+   *  @param err the parse error to display
+   */
   def showError(err: ParseError): Unit = {
     val where =
       if err.idx == 0 then ""
@@ -45,7 +63,10 @@ object CommandLineParser {
   }
 
   trait FromString[T] {
-    /** Can throw java.lang.IllegalArgumentException. */
+    /** Can throw java.lang.IllegalArgumentException.
+     *
+     *  @param s the string to convert to type `T`
+     */
     def fromString(s: String): T
 
     def fromStringOption(s: String): Option[T] =

--- a/library/src/scala/util/DynamicVariable.scala
+++ b/library/src/scala/util/DynamicVariable.scala
@@ -38,6 +38,9 @@ import java.lang.InheritableThreadLocal
  *  of the stack of bindings from the parent thread, and
  *  from then on the bindings for the new thread
  *  are independent of those for the original thread.
+ *
+ *  @tparam T the type of the dynamic variable's value
+ *  @param init the initial value of the variable, inherited by new threads
  */
 class DynamicVariable[T](init: T) {
   private val tl = new InheritableThreadLocal[T] {
@@ -50,8 +53,9 @@ class DynamicVariable[T](init: T) {
   /** Sets the value of the variable while executing the specified
    *  thunk.
    *
-   *  @param newval The value to which to set the variable
-   *  @param thunk The code to evaluate under the new setting
+   *  @tparam S the result type of the thunk
+   *  @param newval the value to which to set the variable
+   *  @param thunk the code to evaluate under the new setting
    */
   def withValue[S](newval: T)(thunk: => S): S = {
     val oldval = value

--- a/library/src/scala/util/NotGiven.scala
+++ b/library/src/scala/util/NotGiven.scala
@@ -23,6 +23,8 @@ import language.experimental.captureChecking
  *
  *  In Dotty, ambiguity is a global error, and therefore cannot be used to implement negation.
  *  Instead, `NotGiven` is treated natively in implicit search.
+ *
+ *  @tparam T the type for which no implicit instance should be available
  */
 final class NotGiven[+T] private ()
 

--- a/library/src/scala/util/Random.scala
+++ b/library/src/scala/util/Random.scala
@@ -21,10 +21,16 @@ import scala.collection.immutable.LazyList
 import scala.language.implicitConversions
 
 class Random(val self: java.util.Random) extends AnyRef with Serializable {
-  /** Creates a new random number generator using a single long seed. */
+  /** Creates a new random number generator using a single long seed.
+   *
+   *  @param seed the initial seed for the random number generator
+   */
   def this(seed: Long) = this(new java.util.Random(seed))
 
-  /** Creates a new random number generator using a single integer seed. */
+  /** Creates a new random number generator using a single integer seed.
+   *
+   *  @param seed the initial seed for the random number generator
+   */
   def this(seed: Int) = this(seed.toLong)
 
   /** Creates a new random number generator. */
@@ -37,10 +43,15 @@ class Random(val self: java.util.Random) extends AnyRef with Serializable {
 
   /** Generates random bytes and places them into a user-supplied byte
    *  array.
+   *
+   *  @param bytes the byte array to fill with random bytes
    */
   def nextBytes(bytes: Array[Byte]): Unit = { self.nextBytes(bytes) }
   
-  /** Generates `n` random bytes and returns them in a new array. */
+  /** Generates `n` random bytes and returns them in a new array.
+   *
+   *  @param n the number of random bytes to generate
+   */
   def nextBytes(n: Int): Array[Byte] = {
     val bytes = new Array[Byte](0 max n)
     self.nextBytes(bytes)
@@ -54,6 +65,9 @@ class Random(val self: java.util.Random) extends AnyRef with Serializable {
 
   /** Returns the next pseudorandom, uniformly distributed double value
    *  between min (inclusive) and max (exclusive) from this random number generator's sequence.
+   *
+   *  @param minInclusive the lower bound (inclusive) of the range
+   *  @param maxExclusive the upper bound (exclusive) of the range, must be greater than `minInclusive`
    */
   def between(minInclusive: Double, maxExclusive: Double): Double = {
     require(minInclusive < maxExclusive, "Invalid bounds")
@@ -70,6 +84,9 @@ class Random(val self: java.util.Random) extends AnyRef with Serializable {
 
   /** Returns the next pseudorandom, uniformly distributed float value
    *  between min (inclusive) and max (exclusive) from this random number generator's sequence.
+   *
+   *  @param minInclusive the lower bound (inclusive) of the range
+   *  @param maxExclusive the upper bound (exclusive) of the range, must be greater than `minInclusive`
    */
   def between(minInclusive: Float, maxExclusive: Float): Float = {
     require(minInclusive < maxExclusive, "Invalid bounds")
@@ -93,12 +110,17 @@ class Random(val self: java.util.Random) extends AnyRef with Serializable {
   /** Returns a pseudorandom, uniformly distributed int value between 0
    *  (inclusive) and the specified value (exclusive), drawn from this
    *  random number generator's sequence.
+   *
+   *  @param n the exclusive upper bound for the returned value (0 is the inclusive lower bound), must be positive
    */
   def nextInt(n: Int): Int = self.nextInt(n)
 
   /** Returns a pseudorandom, uniformly distributed int value between min
    *  (inclusive) and the specified value max (exclusive), drawn from this
    *  random number generator's sequence.
+   *
+   *  @param minInclusive the lower bound (inclusive) of the range
+   *  @param maxExclusive the upper bound (exclusive) of the range, must be greater than `minInclusive`
    */
   def between(minInclusive: Int, maxExclusive: Int): Int = {
     require(minInclusive < maxExclusive, "Invalid bounds")
@@ -128,6 +150,8 @@ class Random(val self: java.util.Random) extends AnyRef with Serializable {
   /** Returns a pseudorandom, uniformly distributed long value between 0
    *  (inclusive) and the specified value (exclusive), drawn from this
    *  random number generator's sequence.
+   *
+   *  @param n the exclusive upper bound for the returned value (0 is the inclusive lower bound), must be positive
    */
   def nextLong(n: Long): Long = {
     require(n > 0, "n must be positive")
@@ -159,6 +183,9 @@ class Random(val self: java.util.Random) extends AnyRef with Serializable {
   /** Returns a pseudorandom, uniformly distributed long value between min
    *  (inclusive) and the specified value max (exclusive), drawn from this
    *  random number generator's sequence.
+   *
+   *  @param minInclusive the lower bound (inclusive) of the range
+   *  @param maxExclusive the upper bound (exclusive) of the range, must be greater than `minInclusive`
    */
   def between(minInclusive: Long, maxExclusive: Long): Long = {
     require(minInclusive < maxExclusive, "Invalid bounds")
@@ -187,7 +214,7 @@ class Random(val self: java.util.Random) extends AnyRef with Serializable {
    *  intended for generating test data.
    *
    *  @param  length    the desired length of the String
-   *  @return           the String
+   *  @return           a randomly generated String of the specified length
    */
   def nextString(length: Int): String = {
     def safeChar(): Char = {
@@ -221,6 +248,10 @@ class Random(val self: java.util.Random) extends AnyRef with Serializable {
 
   /** Returns a new collection of the same type in a randomly chosen order.
    *
+   *  @tparam T the element type of the collection
+   *  @tparam C the type of the collection returned, determined by the implicit `BuildFrom`
+   *  @param xs the collection to shuffle
+   *  @param bf the implicit `BuildFrom` instance used to build the result collection
    *  @return         the shuffled collection
    */
   def shuffle[T, C](xs: IterableOnce[T])(implicit bf: BuildFrom[xs.type, T, C]): C = {

--- a/library/src/scala/util/Sorting.scala
+++ b/library/src/scala/util/Sorting.scala
@@ -37,13 +37,22 @@ import scala.math.Ordering
  *  other libraries that cover this use case.
  */
 object Sorting {
-  /** Sorts an array of Doubles using `java.util.Arrays.sort`. */
+  /** Sorts an array of Doubles using `java.util.Arrays.sort`.
+   *
+   *  @param a the array of `Double`s to sort in place
+   */
   def quickSort(a: Array[Double]): Unit = java.util.Arrays.sort(a)
 
-  /** Sorts an array of Ints using `java.util.Arrays.sort`. */
+  /** Sorts an array of Ints using `java.util.Arrays.sort`.
+   *
+   *  @param a the array of `Int`s to sort in place
+   */
   def quickSort(a: Array[Int]): Unit    = java.util.Arrays.sort(a)
 
-  /** Sorts an array of Floats using `java.util.Arrays.sort`. */
+  /** Sorts an array of Floats using `java.util.Arrays.sort`.
+   *
+   *  @param a the array of `Float`s to sort in place
+   */
   def quickSort(a: Array[Float]): Unit  = java.util.Arrays.sort(a)
 
   private final val qsortThreshold = 16
@@ -51,6 +60,9 @@ object Sorting {
   /** Sorts array `a` with quicksort, using the Ordering on its elements.
    *  This algorithm sorts in place, so no additional memory is used aside from
    *  what might be required to box individual elements during comparison.
+   *
+   *  @tparam K the element type of the array, which must have an `Ordering`
+   *  @param a the array to sort in place
    */
   def quickSort[K: Ordering](a: Array[K]): Unit = {
     // Must have iN >= i0 or math will fail.  Also, i0 >= 0.
@@ -253,20 +265,28 @@ object Sorting {
 
   /** Sorts array `a` using the Ordering on its elements, preserving the original ordering where possible.
    *  Uses `java.util.Arrays.sort` unless `K` is a primitive type. This is the same as `stableSort(a, 0, a.length)`. 
+   *
+   *  @tparam K the element type of the array, which must have an `Ordering`
+   *  @param a the array to sort in place
    */
   @`inline` def stableSort[K: Ordering](a: Array[K]): Unit = stableSort(a, 0, a.length)
 
   /** Sorts array `a` or a part of it using the Ordering on its elements, preserving the original ordering where possible.
    *  Uses `java.util.Arrays.sort` unless `K` is a primitive type.
    *
-   *  @param a The array to sort
-   *  @param from The first index in the array to sort
-   *  @param until The last index (exclusive) in the array to sort
+   *  @tparam K the element type of the array, which must have an `Ordering`
+   *  @param a the array to sort in place
+   *  @param from the first index in the array to sort
+   *  @param until the last index (exclusive) in the array to sort
    */
   def stableSort[K: Ordering](a: Array[K], from: Int, until: Int): Unit = sort(a, from, until, Ordering[K])
 
   /** Sorts array `a` using function `f` that computes the less-than relation for each element.
    *  Uses `java.util.Arrays.sort` unless `K` is a primitive type. This is the same as `stableSort(a, f, 0, a.length)`. 
+   *
+   *  @tparam K the element type of the array
+   *  @param a the array to sort in place
+   *  @param f a function that returns `true` if its first argument is less than its second
    */
   @`inline` def stableSort[K](a: Array[K], f: (K, K) => Boolean): Unit = stableSort(a, f, 0, a.length)
 
@@ -274,14 +294,19 @@ object Sorting {
   /** Sorts array `a` or a part of it using function `f` that computes the less-than relation for each element.
    *  Uses `java.util.Arrays.sort` unless `K` is a primitive type.
    *
-   *  @param a The array to sort
-   *  @param f A function that computes the less-than relation for each element
-   *  @param from The first index in the array to sort
-   *  @param until The last index (exclusive) in the array to sort
+   *  @tparam K the element type of the array
+   *  @param a the array to sort in place
+   *  @param f a function that returns `true` if its first argument is less than its second
+   *  @param from the first index in the array to sort
+   *  @param until the last index (exclusive) in the array to sort
    */
   def stableSort[K](a: Array[K], f: (K, K) => Boolean, from: Int, until: Int): Unit = sort(a, from, until, Ordering fromLessThan f)
 
-  /** A sorted Array, using the Ordering for the elements in the sequence `a`.  Uses `java.util.Arrays.sort` unless `K` is a primitive type. */
+  /** A sorted Array, using the Ordering for the elements in the sequence `a`.  Uses `java.util.Arrays.sort` unless `K` is a primitive type.
+   *
+   *  @tparam K the element type, which must have a `ClassTag` and an `Ordering`
+   *  @param a the sequence of elements to sort
+   */
   def stableSort[K: ClassTag: Ordering](a: scala.collection.Seq[K]): Array[K] = {
     val ret = a.toArray
     sort(ret, 0, ret.length, Ordering[K])
@@ -289,14 +314,25 @@ object Sorting {
   }
 
   // TODO: make this fast for primitive K (could be specialized if it didn't go through Ordering)
-  /** A sorted Array, given a function `f` that computes the less-than relation for each item in the sequence `a`.  Uses `java.util.Arrays.sort` unless `K` is a primitive type. */
+  /** A sorted Array, given a function `f` that computes the less-than relation for each item in the sequence `a`.  Uses `java.util.Arrays.sort` unless `K` is a primitive type.
+   *
+   *  @tparam K the element type, which must have a `ClassTag`
+   *  @param a the sequence of elements to sort
+   *  @param f a function that returns `true` if its first argument is less than its second
+   */
   def stableSort[K: ClassTag](a: scala.collection.Seq[K], f: (K, K) => Boolean): Array[K] = {
     val ret = a.toArray
     sort(ret, 0, ret.length, Ordering fromLessThan f)
     ret
   }
 
-  /** A sorted Array, given an extraction function `f` that returns an ordered key for each item in the sequence `a`.  Uses `java.util.Arrays.sort` unless `K` is a primitive type. */
+  /** A sorted Array, given an extraction function `f` that returns an ordered key for each item in the sequence `a`.  Uses `java.util.Arrays.sort` unless `K` is a primitive type.
+   *
+   *  @tparam K the element type, which must have a `ClassTag`
+   *  @tparam M the key type returned by the extraction function, which must have an `Ordering`
+   *  @param a the sequence of elements to sort
+   *  @param f a function that extracts a comparable key from each element
+   */
   def stableSort[K: ClassTag, M: Ordering](a: scala.collection.Seq[K], f: K => M): Array[K] = {
     val ret = a.toArray
     sort(ret, 0, ret.length, Ordering[M] on f)

--- a/library/src/scala/util/Using.scala
+++ b/library/src/scala/util/Using.scala
@@ -143,6 +143,10 @@ object Using {
    *
    *  $suppressionBehavior
    *
+   *  @tparam R the type of the resource
+   *  @tparam A the return type of the operation
+   *  @param resource the resource to be used and then released
+   *  @param f the operation to perform using the resource
    *  @return a [[Try]] containing an exception if one or more were thrown,
    *         or the result of the operation if no exceptions were thrown
    */
@@ -183,6 +187,9 @@ object Using {
     /** Registers the specified resource with this manager, so that
      *  the resource is released when the manager is closed, and then
      *  returns the (unmodified) resource.
+     *
+     *  @tparam R the type of the resource, which must have a `Releasable` instance
+     *  @param resource the resource to register with this manager
      */
     def apply[R: Releasable](resource: R): resource.type = {
       acquire(resource)
@@ -191,6 +198,9 @@ object Using {
 
     /** Registers the specified resource with this manager, so that
      *  the resource is released when the manager is closed.
+     *
+     *  @tparam R the type of the resource, which must have a `Releasable` instance
+     *  @param resource the resource to register, must be non-null
      */
     def acquire[R: Releasable](resource: R): Unit = {
       if (resource == null) throw new NullPointerException("null resource")
@@ -285,8 +295,9 @@ object Using {
    *
    *  @tparam R the type of the resource
    *  @tparam A the return type of the operation
-   *  @param resource the resource
+   *  @param resource the resource to be used and then released
    *  @param body     the operation to perform with the resource
+   *  @param releasable the implicit `Releasable` instance used to release the resource
    *  @return the result of the operation, if neither the operation nor
    *         releasing the resource throws
    */
@@ -319,8 +330,8 @@ object Using {
    *  @tparam R1 the type of the first resource
    *  @tparam R2 the type of the second resource
    *  @tparam A  the return type of the operation
-   *  @param resource1 the first resource
-   *  @param resource2 the second resource
+   *  @param resource1 the first resource (eagerly evaluated)
+   *  @param resource2 the second resource (by-name, evaluated after the first is acquired)
    *  @param body      the operation to perform using the resources
    *  @return the result of the operation, if neither the operation nor
    *         releasing the resources throws
@@ -418,7 +429,10 @@ object Using {
    *  @tparam R the type of the resource
    */
   trait Releasable[-R] {
-    /** Releases the specified resource. */
+    /** Releases the specified resource.
+     *
+     *  @param resource the resource to release
+     */
     def release(resource: R): Unit
   }
 

--- a/library/src/scala/util/boundary.scala
+++ b/library/src/scala/util/boundary.scala
@@ -35,11 +35,16 @@ object boundary:
    *
    *  Note that it is **capability unsafe** to access `label` from a `Break`.
    *  This field will be marked private in a future release.
+   *
+   *  @tparam T the type of the value carried by this `Break` exception
    */
   final class Break[T] private[boundary](val label: Label[T]^{}, val value: T)
   extends RuntimeException(
     /*message*/ null, /*cause*/ null, /*enableSuppression=*/ false, /*writableStackTrace*/ false):
-    /** Compares the given [[Label]] to the one this [[Break]] was constructed with. */
+    /** Compares the given [[Label]] to the one this [[Break]] was constructed with.
+     *
+     *  @param other the `Label` to compare against this `Break`'s label
+     */
     def isSameLabelAs(other: Label[T]) = label eq other
 
   object Break:
@@ -54,12 +59,18 @@ object boundary:
 
   /** Abort current computation and instead return `value` as the value of
    *  the enclosing `boundary` call that created `label`.
+   *
+   *  @tparam T the type of the value to return from the enclosing `boundary`
+   *  @param value the value to return from the enclosing `boundary` call
+   *  @param label the label identifying the target `boundary` to exit
    */
   def break[T](value: T)(using label: Label[T]): Nothing =
     throw Break(label, value)
 
   /** Abort current computation and instead continue after the `boundary` call that
    *  created `label`.
+   *
+   *  @param label the label identifying the target `boundary` to exit
    */
   def break()(using label: Label[Unit]): Nothing =
     throw Break(label, ())
@@ -67,6 +78,9 @@ object boundary:
   /** Run `body` with freshly generated label as implicit argument. Catch any
    *  breaks associated with that label and return their results instead of
    *  `body`'s result.
+   *
+   *  @tparam T the result type of the boundary block
+   *  @param body the computation to execute, which receives a fresh `Label[T]` as a context parameter
    */
   inline def apply[T](inline body: Label[T] ?=> T): T =
     val local = Label[T]()

--- a/library/src/scala/util/control/Breaks.scala
+++ b/library/src/scala/util/control/Breaks.scala
@@ -74,6 +74,8 @@ class Breaks {
   /** A block from which one can exit with a `break`. The `break` may be
    *  executed further down in the call stack provided that it is called on the
    *  exact same instance of `Breaks`.
+   *
+   *  @param op the computation to execute, which may call `break` to exit early
    */
   def breakable(op: => Unit): Unit =
     try op catch { case ex: BreakControl if ex eq breakException => }
@@ -92,6 +94,10 @@ class Breaks {
    *   Vector.empty
    *  }
    *  ```
+   *
+   *  @tparam T the result type of the computation
+   *  @param op the computation to evaluate, which may call `break` to abort
+   *  @return a `TryBlock` whose `catchBreak` method provides the fallback value if `break` is invoked
    */
   def tryBreakable[T](op: => T): TryBlock[T] =
     new TryBlock[T] {

--- a/library/src/scala/util/control/ControlThrowable.scala
+++ b/library/src/scala/util/control/ControlThrowable.scala
@@ -41,6 +41,8 @@ import scala.language.`2.13`
  *
  *  Instances of `ControlThrowable` should not normally have a cause.
  *  Legacy subclasses may set a cause using `initCause`.
+ *
+ *  @param message the detail message for this control throwable, or `null` if none
  */
 abstract class ControlThrowable(message: String | Null) extends Throwable(
   message, /*cause*/ null, /*enableSuppression=*/ false, /*writableStackTrace*/ false) {

--- a/library/src/scala/util/control/NonFatal.scala
+++ b/library/src/scala/util/control/NonFatal.scala
@@ -41,6 +41,9 @@ object NonFatal {
     case _: VirtualMachineError | _: ThreadDeath | _: InterruptedException | _: LinkageError | _: ControlThrowable => false
     case _ => true
   }
-  /** Returns `Some`(t) if `NonFatal`(t) == true, otherwise `None` */
+  /** Returns `Some`(t) if `NonFatal`(t) == true, otherwise `None`
+   *
+   *  @param t the `Throwable` to test for being non-fatal
+   */
   def unapply(t: Throwable): Option[Throwable] = if (apply(t)) Some(t) else None
 }

--- a/library/src/scala/util/control/TailCalls.scala
+++ b/library/src/scala/util/control/TailCalls.scala
@@ -48,14 +48,24 @@ import annotation.tailrec
  */
 object TailCalls {
 
-  /** This class represents a tailcalling computation. */
+  /** This class represents a tailcalling computation.
+   *
+   *  @tparam A the result type of the computation
+   */
   sealed abstract class TailRec[+A] {
 
-    /** Continue the computation with `f`. */
+    /** Continue the computation with `f`.
+     *
+     *  @tparam B the result type of the mapped computation
+     *  @param f the function to apply to the result, transforming `A` to `B`
+     */
     final def map[B](f: A => B): TailRec[B] = flatMap(a => Call(() => Done(f(a))))
 
     /** Continue the computation with `f` and merge the trampolining
      *  of this computation with that of `f`. 
+     *
+     *  @tparam B the result type of the continuation
+     *  @param f the function to apply to the result, returning a new tailcalling computation
      */
     final def flatMap[B](f: A => TailRec[B]): TailRec[B] = this match {
       case Done(a)         => Call(() => f(a))
@@ -89,27 +99,43 @@ object TailCalls {
     }
   }
 
-  /** Internal class representing a tailcall. */
+  /** Internal class representing a tailcall.
+   *
+   *  @tparam A the result type of the computation
+   *  @param rest a thunk that computes the next step of the tailcalling computation
+   */
   protected case class Call[A](rest: () => TailRec[A]) extends TailRec[A]
 
   /** Internal class representing the final result returned from a tailcalling
    *  computation. 
+   *
+   *  @tparam A the result type of the computation
+   *  @param value the final result of the tailcalling computation
    */
   protected case class Done[A](value: A) extends TailRec[A]
 
   /** Internal class representing a continuation with function A => TailRec[B].
    *  It is needed for the flatMap to be implemented. 
+   *
+   *  @tparam A the intermediate result type
+   *  @tparam B the final result type of the continuation
+   *  @param a the first computation to evaluate
+   *  @param f the continuation function to apply to the result of `a`
    */
   protected case class Cont[A, B](a: TailRec[A], f: A => TailRec[B]) extends TailRec[B]
 
   /** Perform a tailcall.
+   *
+   *  @tparam A the result type of the tailcalling computation
    *  @param rest  the expression to be evaluated in the tailcall
    *  @return a `TailRec` object representing the expression `rest`
    */
   def tailcall[A](rest: => TailRec[A]): TailRec[A] = Call(() => rest)
 
   /** Returns the final result from a tailcalling computation.
-   *  @param  `result` the result value
+   *
+   *  @tparam A the result type of the computation
+   *  @param result the value to wrap as a completed computation
    *  @return a `TailRec` object representing a computation which immediately
    *          returns `result`
    */

--- a/library/src/scala/util/hashing/ByteswapHashing.scala
+++ b/library/src/scala/util/hashing/ByteswapHashing.scala
@@ -15,7 +15,10 @@ package util.hashing
 
 import scala.language.`2.13`
 
-/** A fast multiplicative hash by Phil Bagwell. */
+/** A fast multiplicative hash by Phil Bagwell.
+ *
+ *  @tparam T the type of values to be hashed
+ */
 final class ByteswapHashing[T] extends Hashing[T] {
 
   def hash(v: T) = byteswap32(v.##)
@@ -29,7 +32,11 @@ object ByteswapHashing {
     def hash(v: T) = byteswap32(h.hash(v))
   }
 
-  /** Composes another `Hashing` with the Byteswap hash. */
+  /** Composes another `Hashing` with the Byteswap hash.
+   *
+   *  @tparam T the type of values to be hashed
+   *  @param h the hashing instance whose result is passed through byteswap hashing
+   */
   def chain[T](h: Hashing[T]): Hashing[T] = new Chained(h)
 
 }

--- a/library/src/scala/util/hashing/package.scala
+++ b/library/src/scala/util/hashing/package.scala
@@ -17,7 +17,10 @@ import scala.language.`2.13`
 
 package object hashing {
 
-  /** Fast multiplicative hash with a nice distribution. */
+  /** Fast multiplicative hash with a nice distribution.
+   *
+   *  @param v the 32-bit `Int` value to hash
+   */
   def byteswap32(v: Int): Int = {
     var hc = v * 0x9e3775cd
     hc = java.lang.Integer.reverseBytes(hc)
@@ -26,6 +29,8 @@ package object hashing {
 
   /** Fast multiplicative hash with a nice distribution
    *  for 64-bit values.
+   *
+   *  @param v the 64-bit `Long` value to hash
    */
   def byteswap64(v: Long): Long = {
     var hc = v * 0x9e3775cd9e3775cdL

--- a/library/src/scala/util/matching/Regex.scala
+++ b/library/src/scala/util/matching/Regex.scala
@@ -335,6 +335,9 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *
    *  Otherwise, this Regex is applied to the previously matched input,
    *  and the result of that match is used.
+   *
+   *  @param m the `Match` to extract groups from
+   *  @return the matched groups, or `None` if the match was unsuccessful
    */
   def unapplySeq(m: Match): Option[List[String | Null]] =
     if (m.matched == null) None
@@ -655,6 +658,8 @@ object Regex {
 
     /** The index of the first matched character in group `i`,
      *  or -1 if nothing was matched for that group.
+     *
+     *  @param i the index of the capturing group
      */
     def start(i: Int): Int
 
@@ -663,6 +668,8 @@ object Regex {
 
     /** The index following the last matched character in group `i`,
      *  or -1 if nothing was matched for that group.
+     *
+     *  @param i the index of the capturing group
      */
     def end(i: Int): Int
 
@@ -673,6 +680,8 @@ object Regex {
 
     /** The matched string in group `i`,
      *  or `null` if nothing was matched.
+     *
+     *  @param i the index of the capturing group
      */
     def group(i: Int): String | Null =
       if (start(i) >= 0) source.subSequence(start(i), end(i)).toString
@@ -690,6 +699,8 @@ object Regex {
 
     /** The char sequence before first character of match in group `i`,
      *  or `null` if nothing was matched for that group.
+     *
+     *  @param i the index of the capturing group
      */
     def before(i: Int): CharSequence | Null =
       if (start(i) >= 0) source.subSequence(0, start(i))
@@ -704,6 +715,8 @@ object Regex {
 
     /** The char sequence after last character of match in group `i`,
      *  or `null` if nothing was matched for that group.
+     *
+     *  @param i the index of the capturing group
      */
     def after(i: Int): CharSequence | Null =
       if (end(i) >= 0) source.subSequence(end(i), source.length)
@@ -739,7 +752,11 @@ object Regex {
     override def toString(): String = matched.nn
   }
 
-  /** Provides information about a successful match. */
+  /** Provides information about a successful match.
+   *
+   *  @param source the source character sequence that was matched against
+   *  @param matcher the underlying `Matcher` that performed the match
+   */
   class Match(val source: CharSequence,
               protected[matching] val matcher: Matcher,
               _groupNames: Seq[String]) extends MatchData {
@@ -761,10 +778,16 @@ object Regex {
     private lazy val ends: Array[Int] =
       Array.tabulate(groupCount + 1) { matcher.end }
 
-    /** The index of the first matched character in group `i`. */
+    /** The index of the first matched character in group `i`.
+     *
+     *  @param i the index of the capturing group
+     */
     def start(i: Int): Int = starts(i)
 
-    /** The index following the last matched character in group `i`. */
+    /** The index following the last matched character in group `i`.
+     *
+     *  @param i the index of the capturing group
+     */
     def end(i: Int): Int = ends(i)
 
     /** The match itself with matcher-dependent lazy vals forced,
@@ -818,6 +841,10 @@ object Regex {
    *  [[java.lang.IllegalStateException]].
    *
    *  @see [[java.util.regex.Matcher]]
+   *
+   *  @param source the character sequence being matched against
+   *  @param regex the `Regex` whose pattern is used for matching
+   *  @param _groupNames the names of the capturing groups, if any
    */
   class MatchIterator(val source: CharSequence, val regex: Regex, private[Regex] val _groupNames: Seq[String])
   extends AbstractIterator[String] with MatchData { self =>
@@ -871,13 +898,19 @@ object Regex {
     /** The index of the first matched character. */
     def start: Int = { ensure() ; matcher.start }
 
-    /** The index of the first matched character in group `i`. */
+    /** The index of the first matched character in group `i`.
+     *
+     *  @param i the index of the capturing group
+     */
     def start(i: Int): Int = { ensure() ; matcher.start(i) }
 
     /** The index of the last matched character. */
     def end: Int = { ensure() ; matcher.end }
 
-    /** The index following the last matched character in group `i`. */
+    /** The index following the last matched character in group `i`.
+     *
+     *  @param i the index of the capturing group
+     */
     def end(i: Int): Int = { ensure() ; matcher.end(i) }
 
     /** The number of subgroups. */
@@ -921,6 +954,9 @@ object Regex {
    *  ```
    *  List("US\$", "CAN\$").map(Regex.quote).mkString("|").r
    *  ```
+   *
+   *  @param text the string to quote as a literal pattern
+   *  @return a regex pattern string that matches `text` literally
    */
   def quote(text: String): String = Pattern.quote(text)
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/signaturehelp/SignatureHelpDocSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/signaturehelp/SignatureHelpDocSuite.scala
@@ -262,5 +262,6 @@ class SignatureHelpDocSuite extends BaseSignatureHelpSuite:
       """|Found documentation for scala/Some#
          |Some[A](value: A)
          |        ^^^^^^^^
+         |  @param value the contained value
          |""".stripMargin
     )

--- a/tests/neg-custom-args/captures/boundary.check
+++ b/tests/neg-custom-args/captures/boundary.check
@@ -17,8 +17,8 @@
    |--------------------------------------------------------------------------------------------------------------------
    |Inline stack trace
    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from boundary.scala:72
-72 |    val local = Label[T]()
+   |This location contains code that was inlined from boundary.scala:86
+86 |    val local = Label[T]()
    |                ^^^^^^^^^^
     --------------------------------------------------------------------------------------------------------------------
    |
@@ -57,8 +57,8 @@
    |--------------------------------------------------------------------------------------------------------------------
    |Inline stack trace
    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from boundary.scala:74
-74 |    catch case ex: Break[T] @unchecked =>
+   |This location contains code that was inlined from boundary.scala:88
+88 |    catch case ex: Break[T] @unchecked =>
    |                   ^
     --------------------------------------------------------------------------------------------------------------------
    |

--- a/tests/neg-macros/annot-crash.check
+++ b/tests/neg-macros/annot-crash.check
@@ -3,5 +3,5 @@
   |^^^^^^
   |Failed to evaluate macro annotation '@crash'.
   |  Caused by class scala.NotImplementedError: an implementation is missing
-  |    scala.Predef$.$qmark$qmark$qmark(Predef.scala:383)
+  |    scala.Predef$.$qmark$qmark$qmark(Predef.scala:396)
   |    crash.transform(Macro_1.scala:7)

--- a/tests/neg/i24460.check
+++ b/tests/neg/i24460.check
@@ -6,13 +6,13 @@
     |-------------------------------------------------------------------------------------------------------------------
     |Inline stack trace
     |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    |This location contains code that was inlined from Predef.scala:151
-151 |  inline def valueOf[T]: T = summonFrom {
+    |This location contains code that was inlined from Predef.scala:160
+160 |  inline def valueOf[T]: T = summonFrom {
     |                             ^
-152 |    case ev: ValueOf[T] => ev.value
-153 |  }
+161 |    case ev: ValueOf[T] => ev.value
+162 |  }
     |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    |This location contains code that was inlined from Predef.scala:151
+    |This location contains code that was inlined from Predef.scala:160
   7 |      case _: (h *: t) => valueOf[`h` & T] +: singletons[T, t]
     |                          ^^^^^^^^^^^^^^^^
      -------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
As a next step in improving the Scaladoc documentation for the Scala 3 standard library, this PR fills in missing @param, @tparam, and @return tags. I'm submitting it as a draft PR so that I can get the CI to run on it, to see if it breaks anything, and to start getting feedback. I automated the generation of these changes and have not reviewed all of them yet. I will review them all before making the PR non-draft. Please let me know whether you think this is going in the right direction in general, and anything specific that you notice that could be improved.