### PR TITLE
Improve diagnostic message for unnecessary trailing underscore in eta-expansion

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Migrations.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Migrations.scala
@@ -89,8 +89,8 @@ trait Migrations:
       else s"use `$prefix<function>$suffix` instead"
     def rewrite = Message.rewriteNotice("This construct", mversion.patchFrom)
     report.errorOrMigrationWarning(
-      em"""The syntax `<function> _` is no longer supported;
-          |you can $remedy$rewrite""",
+      em"""The trailing ` _` for eta-expansion is unnecessary;
+        |the compiler performs eta-expansion automatically, so you can write the function value directly instead.$rewrite""",
       tree.srcPos, mversion)
     if mversion.needsPatch then
       patch(Span(tree.span.start), prefix)

--- a/tests/warn/i18867.check
+++ b/tests/warn/i18867.check
@@ -1,6 +1,6 @@
 -- Warning: tests/warn/i18867.scala:3:15 -------------------------------------------------------------------------------
 3 |def test = foo _ // warn
   |           ^^^^^
-  |           The syntax `<function> _` is no longer supported;
-  |           you can simply leave out the trailing ` _`
-  |           This construct can be rewritten automatically under -rewrite -source 3.4-migration.
+  |          The trailing ` _` for eta-expansion is unnecessary;
+  |          the compiler performs eta-expansion automatically, so you can write the function value directly instead.
+  |          This construct can be rewritten automatically under -rewrite -source 3.4-migration.


### PR DESCRIPTION
Fixes #25281

Improves the warning message for unnecessary trailing `_` used for eta-expansion.

The new message clarifies that the compiler performs eta-expansion automatically and suggests writing the function value directly. The warning also supports automatic rewrite under `-rewrite -source 3.4-migration`.

Updated the corresponding warning test to match the new output.