### PR TITLE
Fix crashing for context bound type variables in quoted patterns

### DIFF
--- a/tests/neg/i25260.check
+++ b/tests/neg/i25260.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg/i25260.scala:3:28 ----------------------------------------------------------------------------------
+3 |  expr match { case '{ type t : List; $x: t } => ??? } // error
+  |                       ^^^^^^^^^^^^^
+  |                       Quote type variable definition cannot have context bounds

--- a/tests/neg/i25260.scala
+++ b/tests/neg/i25260.scala
@@ -1,0 +1,3 @@
+import scala.quoted._
+def expr(expr: Expr[Any])(using Quotes) =
+  expr match { case '{ type t : List; $x: t } => ??? } // error


### PR DESCRIPTION
Instead, we get a nicer error.
Fixes #25260