### PR TITLE
InCase has indent width of case

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2478,8 +2478,12 @@ object Parsers {
 
           val t = expr1(location)
           if in.isArrow then
-            placeholderParams = Nil // don't interpret `_' to the left of `=>` as placeholder
-            wrapPlaceholders(closureRest(start, location, convertToParams(t)))
+            if in.currentRegion.isInstanceOf[Scanners.InCase] && location == Location.InBlock then
+              checkNonParamTuple(t)
+              wrapPlaceholders(t)
+            else
+              placeholderParams = Nil // don't interpret `_' to the left of `=>` as placeholder
+              wrapPlaceholders(closureRest(start, location, convertToParams(t)))
           else if isWildcard(t) then
             placeholderParams = placeholderParams ::: saved
             t

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -782,6 +782,11 @@ object Scanners {
                 lastOffset = prev.lastOffset
               else
                 reset()
+        case ARROW =>
+          currentRegion match
+          case r: Indented if r.outer.isInstanceOf[InCase] =>
+            insert(OUTDENT, offset)
+          case _ =>
         case END =>
           if !isEndMarker then token = IDENTIFIER
         case COLONop =>

--- a/tests/pos/i25002.scala
+++ b/tests/pos/i25002.scala
@@ -19,3 +19,36 @@ def fNormalized(x: Any) =
 @main def main =
   println:
     f("hello, world")
+
+def failure =
+  List(42)
+    .collect {
+      case i if
+        (i > 27) =>
+          -1
+      }
+
+def good =
+  List(42)
+    .collect {
+      case i
+      if (i > 27) =>
+          -1
+      }
+
+class C:
+
+  def list = List[Int | Double](42, 3.14)
+  val n = 27
+
+  def test = //2
+    list.map: //4
+      case i: Int => //6 //6 indent then case
+        n match //8
+        case j: Int //8
+        if list.exists: k =>
+          list.exists(_ == j && j == k) //10
+        =>
+          1
+        case _ => 2
+      case _ => 3


### PR DESCRIPTION
Fixes #25002 

Set the indent width of `InCase` using the offset of `case` instead of in `handleNewLine`.