### PR TITLE
[CI] Disable upickle in community_build due to unrelated errors

### DIFF
--- a/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
+++ b/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
@@ -98,7 +98,8 @@ class CommunityBuildTestC:
   @Test def specs2 = projects.specs2.run()
 
   @Test def ujson = projects.ujson.run()
-  @Test def upickle = projects.upickle.run()
+  // StackOverflowError in the mill build, temporarily disabled until the problem is investigated
+  // @Test def upickle = projects.upickle.run()
   @Test def utest = projects.utest.run()
   @Test def verify = projects.verify.run()
   @Test def xmlInterpolator = projects.xmlInterpolator.run()


### PR DESCRIPTION
Upickle builds started to fail with StackOverflowError, most likely during project compilation. It does not seem to be realted to any recent changes and impacts both main and 3.3-LTS 

