### PR TITLE
[chore] Set developedVersion to 3.8.4

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -71,7 +71,7 @@ object Build {
    *
    *  Warning: Change of this variable might require updating `expectedTastyVersion`
    */
-  val developedVersion = "3.8.3"
+  val developedVersion = "3.8.4"
 
   /** The version of the compiler including the RC prefix.
    *  Defined as common base before calculating environment specific suffixes in `dottyVersion`


### PR DESCRIPTION
We're now in the Scala 3.8.4 development cycle, Scala 3.8.3 has been cut of in `release-3.8.3` branch