### PR TITLE
Remove preamble snippets in CC docs

### DIFF
--- a/docs/_docs/reference/experimental/capture-checking/advanced.md
+++ b/docs/_docs/reference/experimental/capture-checking/advanced.md
@@ -4,14 +4,11 @@ title: "Capability Polymorphism"
 nightlyOf: https://docs.scala-lang.org/scala3/reference/experimental/capture-checking/advanced.html
 ---
 
-```scala sc:nocompile sc-name:preamble
-```
-
 Advanced use cases.
 
 ## Access Control
 Analogously to type parameters, we can lower- and upper-bound capability parameters where the bounds consist of concrete capture sets:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def main() =
   // We can close over anything branded by the 'trusted' capability, but nothing else
   def runSecure[C^ >: {trusted} <: {trusted}](block: () ->{C} Unit): Unit = ...
@@ -43,7 +40,7 @@ The idea is that every capability derived from the marker capability `trusted` (
 passed to `runSecure`. We can enforce this by an explicit capability parameter `C` constraining the possible captures of `block` to the interval `>: {trusted} <: {trusted}`.
 
 Note that since capabilities of function types are covariant, we could have equivalently specified `runSecure`'s signature using implicit capture polymorphism to achieve the same behavior:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def runSecure(block: () ->{trusted} Unit): Unit
 ```
 
@@ -51,7 +48,7 @@ def runSecure(block: () ->{trusted} Unit): Unit
 
 Capability members and paths to these members can prevent leakage
 of labels for lexically-delimited control operators:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 trait Label extends Capability:
   type Fv^ // the capability set occurring freely in the `block` passed to `boundary` below.
 

--- a/docs/_docs/reference/experimental/capture-checking/basics.md
+++ b/docs/_docs/reference/experimental/capture-checking/basics.md
@@ -4,13 +4,10 @@ title: "Capture Checking Basics"
 nightlyOf: https://docs.scala-lang.org/scala3/reference/experimental/capture-checking/basics.html
 ---
 
-```scala sc:nocompile sc-name:preamble
-```
-
 ## Introduction
 
 Capture checking can be enabled by the language import
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 import language.experimental.captureChecking
 ```
 At present, capture checking is still highly experimental and unstable, and it evolves quickly.
@@ -33,7 +30,7 @@ operation's result is returned. This is a typical _try-with-resources_ pattern, 
 The problem is that `usingLogFile`'s implementation is not entirely safe. One can
 undermine it by passing an operation that performs the logging at some later point
 after it has terminated. For instance:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 val later = usingLogFile { file => () => file.write(0) }
 later() // crash
 ```
@@ -42,7 +39,7 @@ results in an uncaught `IOException`.
 
 Capture checking gives us the mechanism to prevent such errors _statically_. To
 prevent unsafe usages of `usingLogFile`, we can declare it like this:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def usingLogFile[T](op: FileOutputStream^ => T): T =
   // same body as before
 ```
@@ -60,13 +57,13 @@ If we now try to define the problematic value `later`, we get a static error:
 ```
 In this case, it was easy to see that the `logFile` capability escapes in the closure passed to `usingLogFile`. But capture checking also works for more complex cases.
 For instance, capture checking is able to distinguish between the following safe code:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 val xs = usingLogFile { f =>
   List(1, 2, 3).map { x => f.write(x); x * x }
 }
 ```
 and the following unsafe one:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 val xs = usingLogFile { f =>
   LzyList(1, 2, 3).map { x => f.write(x); x * x }
 }
@@ -106,7 +103,7 @@ capability gets its authority from some other, more sweeping capability which it
 If `T` is a type, then `T^` is a shorthand for `T^{any}`, meaning `T` can capture arbitrary capabilities.
 
 Here is an example:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 class FileSystem
 
 class Logger(fs: FileSystem^):
@@ -161,20 +158,20 @@ capabilities in a method are instead counted in the capture set of the enclosing
 ## By-Name Parameter Types
 
 A convention analogous to function types also extends to by-name parameters. In
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def f(x: => Int): Int
 ```
 the actual argument can refer to arbitrary capabilities. So the following would be OK:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 f(if p(y) then throw Ex() else 1)
 ```
 On the other hand, if `f` was defined like this
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def f(x: -> Int): Int
 ```
 the actual argument to `f` could not refer to any capabilities, so the call above would be rejected.
 One can also allow specific capabilities like this:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def f(x: ->{c} Int): Int
 ```
 Here, the actual argument to `f` is allowed to use the `c` capability but no others.
@@ -190,7 +187,7 @@ Lazy vals receive special treatment under capture checking, similar to parameter
 
 When a lazy val is declared, its initializer is checked in its own environment (like a method body). The initializer can capture capabilities, and these are tracked separately:
 
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def example(console: Console^) =
   lazy val x: () -> String =
     console.println("Computing x")  // console captured by initializer
@@ -208,7 +205,7 @@ The type system tracks that accessing `x` requires the `console` capability, eve
 
 When accessing a lazy val member through a qualifier, the qualifier is charged to the current capture set, just like calling a parameterless method:
 
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 trait Container:
   lazy val lazyMember: String
 
@@ -223,7 +220,7 @@ Accessing `c.lazyMember` can trigger initialization, which may use capabilities 
 
 For capture checking purposes, lazy vals behave identically to parameterless methods:
 
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 trait T:
   def methodMember: String
   lazy val lazyMember: String
@@ -256,7 +253,7 @@ A subcapturing relation `C₁ <: C₂` holds if `C₂` _accounts for_ every elem
 
 
 **Example 1.** Given
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 fs: FileSystem^
 ct: CanThrow[Exception]^
 l : Logger^{fs}
@@ -289,7 +286,7 @@ A type extending `SharedCapability` always comes with a capture set. If no captu
 
 This means we could equivalently express the `FileSystem` and `Logger` classes as follows:
 
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 import caps.SharedCapability
 
 class FileSystem extends SharedCapability
@@ -313,7 +310,7 @@ can contain only capabilities that are visible at the point where the set is def
 
 We now reconstruct how this principle produced the error in the introductory example, where
 `usingLogFile` was declared like this:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def usingLogFile[T](op: FileOutputStream^ => T): T = ...
 ```
 The error message was:
@@ -343,7 +340,7 @@ An analogous restriction applies to the type of a mutable variable.
 Another way one could try to undermine capture checking would be to
 assign a closure with a local capability to a global variable. Maybe
 like this:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 var loophole: () => Unit = () => ()
 usingLogFile { f =>
   loophole = () => f.write(0)

--- a/docs/_docs/reference/experimental/capture-checking/checked-exceptions.md
+++ b/docs/_docs/reference/experimental/capture-checking/checked-exceptions.md
@@ -4,16 +4,13 @@ title: "Checked Exceptions"
 nightlyOf: https://docs.scala-lang.org/scala3/reference/experimental/capture-checking/checked-exceptions.html
 ---
 
-```scala sc:nocompile sc-name:preamble
-```
-
 ## Introduction
 
 Scala enables checked exceptions through a language import. Here is an example,
 taken from the [safer exceptions page](../canthrow.md), and also described in a
 [paper](https://infoscience.epfl.ch/record/290885) presented at the
  2021 Scala Symposium.
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 import language.experimental.saferExceptions
 
 class LimitExceeded extends Exception
@@ -25,11 +22,11 @@ def f(x: Double): Double throws LimitExceeded =
 The new `throws` clause expands into an implicit parameter that provides
 a `CanThrow` capability. Hence, function `f` could equivalently be written
 like this:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def f(x: Double)(using CanThrow[LimitExceeded]): Double = ...
 ```
 If the implicit parameter is missing, an error is reported. For instance, the  function definition
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def g(x: Double): Double =
   if x < limit then x * x else throw LimitExceeded()
 ```
@@ -45,12 +42,12 @@ is rejected with this error message:
 ```
 `CanThrow` capabilities are required by `throw` expressions and are created
 by `try` expressions. For instance, the expression
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 try xs.map(f).sum
 catch case ex: LimitExceeded => -1
 ```
 would be expanded by the compiler to something like the following:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 try
   erased given ctl: CanThrow[LimitExceeded] = compiletime.erasedValue
   xs.map(f).sum
@@ -61,7 +58,7 @@ erased.)
 
 As with other capability based schemes, one needs to guard against capabilities
 that are captured in results. For instance, here is a problematic use case:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def escaped(xs: Double*): (() => Double) throws LimitExceeded =
   try () => xs.map(f).sum
   catch case ex: LimitExceeded => () => -1

--- a/docs/_docs/reference/experimental/capture-checking/classes.md
+++ b/docs/_docs/reference/experimental/capture-checking/classes.md
@@ -4,13 +4,10 @@ title: "Capture Checking of Classes"
 nightlyOf: https://docs.scala-lang.org/scala3/reference/experimental/capture-checking/classes.html
 ---
 
-```scala sc:nocompile sc-name:preamble
-```
-
 ## Introduction
 
 The principles for capture checking closures also apply to classes. For instance, consider:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 class Logger(using fs: FileSystem):
   def log(s: String): Unit = ... summon[FileSystem] ...
 
@@ -23,7 +20,7 @@ of `test` is of type `Logger^{xfs}`
 Sometimes, a tracked capability is meant to be used only in the constructor of a class, but
 is not intended to be retained as a field. This fact can be communicated to the capture
 checker by declaring the parameter as `@constructorOnly`. Example:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 import annotation.constructorOnly
 
 class NullLogger(using @constructorOnly fs: FileSystem):
@@ -34,7 +31,7 @@ def test2(using fs: FileSystem): NullLogger = NullLogger() // OK
 The captured references of a class include _local capabilities_ and _argument capabilities_. Local capabilities are capabilities defined outside the class and referenced from its body. Argument capabilities are passed as parameters to the primary constructor of the class. Local capabilities are inherited:
 the local capabilities of a superclass are also local capabilities of its subclasses. Example:
 
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 class Cap extends caps.SharedCapability
 
 def test(a: Cap, b: Cap, c: Cap) =
@@ -51,7 +48,7 @@ the capture set of that call is `{a, b, c}`.
 ## Capture Set of This
 
 The capture set of the type of `this` of a class is inferred by the capture checker, unless the type is explicitly declared with a self-type annotation like this one:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 class C:
   self: D^{a, b} => ...
 ```
@@ -63,7 +60,7 @@ The inference observes the following constraints:
  - The type of `this` must observe all constraints where `this` is used.
 
 For instance, in
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 class Cap extends caps.SharedCapability
 def test(c: Cap) =
   class A:
@@ -86,7 +83,7 @@ The self-type inference behaves differently depending on whether all subclasses 
 ¹We ignore here the possibility that non-open classes have subclasses in other compilation units (e.g. for testing) and assume that these subclasses do not change the inferred self type.
 
 For example (assuming all definitions are in the same file):
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 class A:
   def fn: A = this   // ok
 
@@ -112,7 +109,7 @@ open class E:
 
 The capture set of `this` of a class or trait also serves as an upper bound of the possible capture
 sets of extending classes
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 abstract class Root:
   this: Root^ => // the default, can capture anything
 
@@ -133,7 +130,7 @@ Generally, the further up a class hierarchy we go, the more permissive/impure th
 of a class will be (and the more restrictive/pure it will be if we traverse the hierarchy downwards).
 For example, Scala 3's top reference type `AnyRef`/`Object` conceptually has the universal
 capability
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 class AnyRef:
   this: AnyRef^ =>
   // ...
@@ -143,19 +140,19 @@ Similarly, pure `Iterator`s are subtypes of impure ones.
 ## Capture Tunneling
 
 Consider the following simple definition of a `Pair` class:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 class Pair[+A, +B](x: A, y: B):
   def fst: A = x
   def snd: B = y
 ```
 What happens if `Pair` is instantiated like this (assuming `ct` and `fs` are two capabilities in scope)?
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def x: Int ->{ct} String
 def y: Logger^{fs}
 def p = Pair(x, y)
 ```
 The last line will be typed as follows:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def p: Pair[Int ->{ct} String, Logger^{fs}] = Pair(x, y)
 ```
 This might seem surprising. The `Pair(x, y)` value does capture capabilities `ct` and `fs`. Why don't they show up in its type at the outside?
@@ -163,7 +160,7 @@ This might seem surprising. The `Pair(x, y)` value does capture capabilities `ct
 The answer is capture tunneling. Once a type variable is instantiated to a capturing type, the
 capture is not propagated beyond this point. On the other hand, if the type variable is instantiated
 again on access, the capture information "pops out" again. For instance, even though `p` is technically pure because its capture set is empty, writing `p.fst` would record a reference to the captured capability `ct`. So if this access was put in a closure, the capability would again form part of the outer capture set. E.g.
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 () => p.fst : () -> Int ->{ct} String
 ```
 In other words, references to capabilities "tunnel through" in generic instantiations from creation to access; they do not affect the capture set of the enclosing generic data constructor applications.
@@ -172,7 +169,7 @@ This principle plays an important part in making capture checking concise and pr
 ## Captures of New
 
 Consider the following class, assuming we have capabilities `io`, `async`, and `out` in our environment:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 class C(x: () => Unit):
   val f: File^{io} = File()
   def g() =
@@ -191,7 +188,7 @@ field `f`.
 
 The external elements of the capture set of a class can be declared explicitly with a `uses` clause:
 
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 class C(x: () => Unit) uses out, io:
   val f: File^{io} = File()
   def g() =
@@ -207,7 +204,7 @@ A `uses` clause must be given if a class that is visible in other compilation un
 The previous section described what capabilities get captured by the value of a class instance creation expression. But this is not the only relevant capture set linked with `new`. It's also important to know which capabilities are accessed when a class is initialized.
 
 For example, consider:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 class D():
   val str: String =
     out.println("str was initialized")
@@ -217,7 +214,7 @@ Here, the initialization of `D` accesses the capability `out`. Therefore, the fu
 
 The capabilities accessed during initialization of a class can be declared in the class with a `uses_init` clause, like this:
 
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 class D() uses_init out:
   val str: String =
     out.println("str was initialized")
@@ -243,7 +240,7 @@ As a larger example, we present an implementation of lazy lists and some use cas
 our lists are lazy only in their tail part. This corresponds to what the Scala-2 type `Stream` did, whereas Scala 3's `LazyList` type computes strictly less since it is also lazy in the first argument.
 
 Here is the base trait `LzyList` for our version of lazy lists:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 trait LzyList[+A]:
   def isEmpty: Boolean
   def head: A
@@ -253,14 +250,14 @@ Note that `tail` carries a capture annotation. It says that the tail of a lazy l
 potentially capture the same references as the lazy list as a whole.
 
 The empty case of a `LzyList` is written as usual:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 object LzyNil extends LzyList[Nothing]:
   def isEmpty = true
   def head = ???
   def tail = ???
 ```
 Here is a formulation of the class for lazy cons nodes:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 import scala.compiletime.uninitialized
 
 final class LzyCons[+A](hd: A, tl: () => LzyList[A]^) extends LzyList[A]:
@@ -282,7 +279,7 @@ the private mutable field `cache`. Note that the typing of the assignment `cache
 
 Here is an extension method to define an infix cons operator `#:` for lazy lists. It is analogous
 to `::` but instead of a strict list it produces a lazy list without evaluating its right operand.
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 extension [A](x: A)
   def #:(xs1: => LzyList[A]^): LzyList[A]^{xs1} =
     LzyCons(x, () => xs1)
@@ -293,7 +290,7 @@ of `#:` is a lazy list that captures that argument.
 As an example usage of `#:`, here is a method `tabulate` that creates a lazy list
 of given length with a generator function `gen`. The generator function is allowed
 to have side effects.
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def tabulate[A](n: Int)(gen: Int => A): LzyList[A]^{gen} =
   def recur(i: Int): LzyList[A]^{gen} =
     if i == n then LzyNil
@@ -301,7 +298,7 @@ def tabulate[A](n: Int)(gen: Int => A): LzyList[A]^{gen} =
   recur(0)
 ```
 Here is a use of `tabulate`:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 class LimitExceeded extends Exception
 def squares(n: Int)(using ct: CanThrow[LimitExceeded]) =
   tabulate(10): i =>
@@ -313,7 +310,7 @@ The inferred result type of `squares` is `LzyList[Int]^{ct}`, i.e it is a lazy l
 one or more times.
 
 Here are some further extension methods for mapping, filtering, and concatenating lazy lists:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 extension [A](xs: LzyList[A]^)
   def map[B](f: A => B): LzyList[B]^{xs, f} =
     if xs.isEmpty then LzyNil
@@ -342,7 +339,7 @@ Their capture annotations are all as one would expect:
 
 Of course the function passed to `map` or `filter` could also be pure. After all, `A -> B` is a subtype of `(A -> B)^{any}` which is the same as `A => B`. In that case, the pure function
 argument will _not_ show up in the result type of `map` or `filter`. For instance:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 val xs = squares(10)
 val ys: LzyList[Int]^{xs} = xs.map(_ + 1)
 ```
@@ -356,7 +353,7 @@ This concludes our example. It's worth mentioning that an equivalent program def
 these elements are represented by a type variable. This means we don't need to annotate anything there either.
 
 Another possibility would be a variant of lazy lists that requires all functions passed to `map`, `filter` and other operations like it to be pure. E.g. `map` on such a list would be defined like this:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 extension [A](xs: LzyList[A])
   def map[B](f: A -> B): LzyList[B] = ...
 ```

--- a/docs/_docs/reference/experimental/capture-checking/classifiers.md
+++ b/docs/_docs/reference/experimental/capture-checking/classifiers.md
@@ -4,9 +4,6 @@ title: "Capability Classifiers"
 nightlyOf: https://docs.scala-lang.org/scala3/reference/experimental/capture-checking/classifiers.html
 ---
 
-```scala sc:nocompile sc-name:preamble
-```
-
 ## Introduction
 
 Capabilities are extremely versatile. They can express concepts from many different domains. Exceptions, continuations, I/O, mutation, information flow, security permissions, are just some examples, the list goes on.
@@ -16,16 +13,16 @@ other capabilities. Or might want to allow mutation, but no other side effects. 
 
 For instance, the `scala.caps` package defines a classifier trait called `Control`,
 like this:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
   trait Control extends SharedCapability, Classifier
 ```
 The [Gears library](https://lampepfl.github.io/gears/) then defines a capability class `Async` which extends `Control`.
 
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
   trait Async extends Control
 ```
 Unlike normal inheritance, classifiers also restrict the capture set of a capability. For instance, say we have a function
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
   def f(using async: Async^) = body
 ```
 (the `^` is as usual redundant here since `Async` is a capability trait).
@@ -40,7 +37,7 @@ Classifiers are unique: a class cannot extend directly or transitively at the sa
 ### Predefined Classifiers
 
 The `caps` object defines the `Classifier` trait itself and some traits that extend it:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 trait Classifier
 
 sealed trait Capability
@@ -88,7 +85,7 @@ Consider the following problem: The `Try.apply` method takes in its `body` param
 the `get` method of a `Try` object. What should a capability-aware signature of `Try` be?
 
 The body passed to `Try.apply` can have arbitrary effects, so it can retain arbitrary capabilities. Yet the resulting `Try` object will retain only those capabilities of `body` which are classified as `Control`. So the signature of `Try.apply` should look like this:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 object Try:
   def apply[T](body: => T): Try[T]^{body.only[Control]}
 ```
@@ -107,7 +104,7 @@ Then the result of `Try { expr }` would have type `Try^{async}`. We drop `io` si
 `io`'s type is a `Capability` class that does not extend `Control`.
 
 If `expr` would use an additional capability `proc: () => Unit`, then `proc` would also show up in the result capture set. Since `proc` is fully effect-polymorphic, we can't exclude that it retains `Control` capabilities, so we have to keep it in the restricted capture set. These elements are shown together in the following example:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 class IO extends caps.SharedCapability
 class Async extends caps.Control
 

--- a/docs/_docs/reference/experimental/capture-checking/how-to-use.md
+++ b/docs/_docs/reference/experimental/capture-checking/how-to-use.md
@@ -4,22 +4,19 @@ title: "How to Use the Capture Checker"
 nightlyOf: https://docs.scala-lang.org/scala3/reference/experimental/capture-checking/how-to-use.html
 ---
 
-```scala sc:nocompile sc-name:preamble
-```
-
 ## Enabling Capture Checking
 
 Use Scala 3 nightly for the latest features and fixes.
 
 Add this import in any file that uses capture checking:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 import language.experimental.captureChecking
 ```
 
 ### Separation Checking
 
 Requires the import above:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 import language.experimental.captureChecking
 import language.experimental.separationChecking
 ```
@@ -36,7 +33,7 @@ Using the command line through explicit parameters:
 scala -S 3.nightly -language:experimental.captureChecking
 ```
 or when reading from a file:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 // foo.scala:
 //> using scala 3.nightly
 import language.experimental.captureChecking

--- a/docs/_docs/reference/experimental/capture-checking/polymorphism.md
+++ b/docs/_docs/reference/experimental/capture-checking/polymorphism.md
@@ -4,9 +4,6 @@ title: "Capability Polymorphism"
 nightlyOf: https://docs.scala-lang.org/scala3/reference/experimental/capture-checking/polymorphism.html
 ---
 
-```scala sc:nocompile sc-name:preamble
-```
-
 ## Introduction
 
 Capture checking supports capture-polymorphic programming in two complementary styles:
@@ -21,7 +18,7 @@ between polymorphism through subtyping versus parametric polymorphism through ty
 
 In many cases, such a higher-order functions, we do not need new syntax to be polymorphic over
 capturing types. The classic example is `map` over lists:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 trait List[+A]:
   // Works for pure functions AND capturing functions!
   def map[B](f: A => B): List[B]
@@ -36,7 +33,7 @@ such as `List`.
 
 Contrasting this against lazy collections such as `LzyList` from the [previous section](classes.md),
 the implicit capability polymorphism induces an additional capture set on the result of `map`:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 extension [A](xs: LzyList[A]^)
   def map[B](f: A => B): LzyList[B]^{xs, f}
 ```
@@ -51,7 +48,7 @@ with explicit generic effect parameters.
 In some situations, it is convenient or necessary to parameterize definitions by a capture set.
 This allows an API to state precisely which capabilities its clients may use. Consider a `Source`
 that stores `Listeners`:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 class Source[X^]:
   private var listeners: Set[Listener^{X}] = Set.empty
   def register(x: Listener^{X}): Unit =
@@ -70,7 +67,7 @@ Capture-set variables without user-provided bounds range over the interval
  whose domain is "all capture sets", not all types.
 
 Under the hood, a capture-set variable is implemented as a normal type parameter with special bounds:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 class Source[X >: CapSet <: CapSet^]:
   ...
 ```
@@ -84,7 +81,7 @@ be erased entirely by the compiler in the future.
 Capture-set variables are inferred in the same way as ordinary type variables.
 They can also be instantiated explicitly with capture-set literals or other
 capture-set variables:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 class Async extends caps.SharedCapability
 
 def listener(a: Async): Listener^{a} = ???
@@ -107,7 +104,7 @@ The following example takes an unordered `Set` of futures and produces a `Stream
 results in the order in which the futures complete. Using an explicit capture variable `C^`, the
 signature expresses that the cumulative capture set of the input futures is preserved in the
 resulting stream:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def collect[T, C^](fs: Set[Future[T]^{C}])(using Async^): Stream[Future[T]^{C}] =
   val channel = Channel()
   fs.forEach.(_.onComplete(v => channel.send(v)))
@@ -117,7 +114,7 @@ def collect[T, C^](fs: Set[Future[T]^{C}])(using Async^): Stream[Future[T]^{C}] 
 #### Tracking the evolution of mutable objects
 A common use case for explicit capture parameters is when a mutable object’s reachable capabilities
 _grow_ due to mutation. For example, concatenating effectful iterators:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 class ConcatIterator[A, C^](var iterators: mutable.List[IterableOnce[A]^{C}]):
   def concat(it: IterableOnce[A]^): ConcatIterator[A, {C, it}]^{this, it} =
     iterators ++= it                             //            ^
@@ -148,12 +145,12 @@ implicitly or would otherwise be unclear.
 
 Capture parameters can also be introduced as *capability members*, in the same way that type
 parameters can be replaced with type members. The earlier example
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 class Source[X^]:
   private var listeners: Set[Listener^{X}] = Set.empty
 ```
 can be written instead as:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 class Source:
   type X^
   private var listeners: Set[Listener^{this.X}] = Set.empty
@@ -167,13 +164,13 @@ A capability member behaves like a path-dependent capture-set variable. It may a
 annotations using paths such as `{this.X}`.
 
 Capability members can also have capture-set bounds, restricting which capabilities they may contain:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 trait Reactor:
   type Cap^ <: {caps.any}
   def onEvent(h: Event ->{this.Cap} Unit): Unit
 ```
 Each implementation of Reactor may refine `Cap^` to a more specific capture set:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 trait GUIReactor extends Reactor:
   type Cap^ <: {ui, log}
 ```

--- a/docs/_docs/reference/experimental/capture-checking/separation-checking.md
+++ b/docs/_docs/reference/experimental/capture-checking/separation-checking.md
@@ -4,13 +4,10 @@ title: "Separation Checking"
 nightlyOf: https://docs.scala-lang.org/scala3/reference/experimental/capture-checking/separation-checking.html
 ---
 
-```scala sc:nocompile sc-name:preamble
-```
-
 ## Introduction
 
 Separation checking is an extension of capture checking that enforces unique, un-aliased access to capabilities. It is enabled by a language import
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 import language.experimental.separationChecking
 ```
 (or the corresponding setting `-language:experimental.separationChecking`).
@@ -19,13 +16,13 @@ The reason for the second language import is that separation checking is less ma
 we got the balance of safety and expressivity right for it at the present time.
 
 The purpose of separation checking is to ensure that certain accesses to capabilities are not aliased. As an example, consider matrix multiplication. A method that multiplies matrices `a`, and `b` into `c`,  could be declared like this:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def multiply(a: Matrix, b: Matrix, c: Matrix): Unit
 ```
 But that signature alone does not tell us which matrices are supposed to be inputs and which one is the output. Nor does it guarantee that an input matrix is not re-used as the output, which would lead to wrong results.
 
 With separation checking, we can declare `Matrix` as a `Mutable` type, like this:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 class Matrix(nrows: Int, ncols: Int) extends Mutable:
   update def setElem(i: Int, j: Int, x: Double): Unit = ...
   def getElem(i: Int, j: Int): Double = ...
@@ -33,7 +30,7 @@ class Matrix(nrows: Int, ncols: Int) extends Mutable:
 We further declare that the `setElem` method in a `Matrix` is an `update` method, which means it has a side effect.
 
 Separation checking gives a special interpretation to the following modified signature of `multiply`:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def multiply(a: Matrix, b: Matrix, c: Matrix^): Unit
 ```
 In fact, only a single character was added: `c`'s type now carries a universal capability. This signature enforces at the same time two desirable properties:
@@ -48,7 +45,7 @@ So, effectively, anything that can be updated must be unaliased.
 The idea behind separation checking is simple: We now interpret each occurrence of `any` as a separate top capability. This includes derived syntaxes like `A^` and `B => C`. We further keep track during capture checking which capabilities are subsumed by each `any`. If capture checking widens a capability `x` to a top capability `anyᵢ`, we say `x` is _hidden_ by `anyᵢ`. The rule then is that any capability hidden by a top capability `anyᵢ` cannot be referenced independently or hidden in another `anyⱼ` in code that can see `anyᵢ`.
 
 Here's an example:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 val x: C^ = y
   ... x ...  // ok
   ... y ...  // error
@@ -72,19 +69,19 @@ Separation checks are applied in the following scenarios:
 
 When checking a function application `f(e_1, ..., e_n)`, we instantiate each `any` in a formal parameter of `f` to a fresh top capability and compare the argument types with these instantiated parameter types. We then check that the hidden set of each instantiated top capability for an argument `eᵢ` is separated from the capture sets of all the other arguments as well as from the capture sets of the function prefix and the function result. For instance a
 call to
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 multiply(a, b, a)
 ```
 would be rejected since `a` appears in the hidden set of the last parameter of multiply, which has type `Matrix^` and also appears in the capture set of the
 first parameter.
 
 We do not report a separation error between two sets if a formal parameter's capture set explicitly names a conflicting parameter. For instance, consider a method `seq` to apply two effectful function arguments in sequence. It can be declared as follows:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def seq(f: () => Unit; g: () ->{any, f} Unit): Unit =
   f(); g()
 ```
 Here, the `g` parameter explicitly mentions `f` in its potential capture set. This means that the `any` in the same capture set would not need to hide the  first argument, since it already appears explicitly in the same set. Consequently, we can pass the same function twice to `compose` without violating the separation criteria:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 val r = Ref(1)
 val plusOne = r.set(r.get + 1)
 seq(plusOne, plusOne)
@@ -96,21 +93,21 @@ Without the explicit mention of parameter `f` in the capture set of parameter `g
 When a capability `x` is used at some point in a statement sequence, we check that `{x}` is separated from the hidden sets of all previous definitions.
 
 Example:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 val a: Ref^ = Ref(1)
 val b: Ref^ = a
 val x = a.get // error
 ```
 Here, the last line violates the separation criterion since it uses in `a.get` the capability `a`, which is hidden by the definition of `b`.
 Note that this check only applies when there are explicit top capabilities in play. One could very well write
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 val a: Ref^ = Ref(1)
 val b: Ref^{a} = a
 val x = a.get // ok
 ```
 One can also drop the explicit type of `b` and leave it to be inferred. That would
 not cause a separation error either.
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 val a: Ref^ = Ref(0)
 val b = a
 val x = a.get // ok
@@ -121,7 +118,7 @@ val x = a.get // ok
 When a type contains top capabilities we check that their hidden sets don't interfere with other parts of the same type.
 
 Example:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 val b: (Ref^, Ref^) = (a, a)       // error
 val c: (Ref^, Ref^{a}) = (a, a)    // error
 val d: (Ref^{a}, Ref^{a}) = (a, a) // ok
@@ -131,28 +128,28 @@ Here, the definition of `b` is in error since the hidden sets of the two `^`s in
 ### Checking Return Types
 
 When an `any` appears in the return type of a method it means a top capability that is different from what is known at the call site. Separation checking makes sure this is the case. For instance, the following is OK:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def newRef(): Ref^ = Ref(1)
 ```
 And so is this:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def newRef(): Ref^ =
   val a = Ref(1)
   a
 ```
 But the next definitions would cause a separation error:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 val a = Ref(1)
 def newRef(): Ref^ = a // error
 ```
 The rule is that the hidden set of an `any` in a return type cannot reference exclusive or read-only capabilities defined outside of the function. What about parameters? Here's another illegal version:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def incr(a: Ref^): Ref^ =
   a.set(a.get + 1)
   a
 ```
 These needs to be rejected because otherwise we could have set up the following bad example:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 val a = Ref(1)
 val b: Ref^ = incr(a)
 ```
@@ -164,7 +161,7 @@ Therefore, parameters cannot appear in the hidden sets of result `any`s either, 
 While method return types use `any`, function types use `fresh` in their result positions to express that each call yields a result with a distinct capability. As explained in [scoped capabilities](scoped-capabilities.md#expansion-rules-for-function-types), `fresh` in a function result is existentially bound: `() -> Ref^{fresh}` means `() -> ∃fresh. Ref^{fresh}`.
 
 From a separation-checking perspective, `fresh` results are important because they let the checker prove non-aliasing across calls:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 val mkRef: () -> Ref^{fresh} = () => Ref(1)
 val a = mkRef()  // Ref^{fresh₁}
 val b = mkRef()  // Ref^{fresh₂}
@@ -172,7 +169,7 @@ val b = mkRef()  // Ref^{fresh₂}
 Since `fresh₁` and `fresh₂` are distinct existentials, the capture sets of `a` and `b` don't interfere — they are separated. This would not hold if the function type used `any` in its result instead, since both results would share the same capture-set bound and could therefore alias.
 
 The same hidden-set discipline applies: the hidden set of a result `fresh` cannot contain capabilities from outside the function. For instance:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 val a = Ref(1)
 val bad: () => Ref^{fresh} = () => a  // error
 ```
@@ -181,20 +178,20 @@ Here, `a` is captured by the closure and would need to flow into the result `fre
 ### Consume Parameters
 
 Returning parameters in result `any`'s is safe if the actual argument to the parameter is not used afterwards. We can signal and enforce this pattern by adding a `consume` modifier to a parameter. With that new soft modifier, the following variant of `incr` is legal:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def incr(consume a: Ref^): Ref^ =
   a.set(a.get + 1)
   a
 ```
 Here, we increment the value of a reference and then return the same reference while enforcing the condition that the original reference cannot be used afterwards. Then the following is legal:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 val a1 = Ref(1)
 val a2 = incr(a1)
 val a3 = incr(a2)
 println(a3)
 ```
 Each reference `aᵢ` is unused after it is passed to `incr`. But the following continuation of that sequence would be in error:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 val a4 = println(a2) // error
 val a5 = incr(a1)    // error
 ```
@@ -204,7 +201,7 @@ of a previous application.
 Consume parameters enforce linear access to resources. This can be very useful. As an example, consider Scala's  buffers such as `ListBuffer` or `ArrayBuffer`. We can treat these buffers as if they were purely functional, if we can enforce linear access.
 
 For instance, we can define a function `linearAdd` that adds elements to buffers in-place without violating referential transparency:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def linearAdd[T](consume buf: Buffer[T]^, elem: T): Buffer[T]^ =
   buf += elem
 ```
@@ -213,7 +210,7 @@ def linearAdd[T](consume buf: Buffer[T]^, elem: T): Buffer[T]^ =
 ### Consume Parameters and Read Accesses
 
 A good way to conceptualize consume is to that it reserves the passed capability beyond the call with the consume parameter. In the previous `Buffer` example, if we do
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
   val buf1 = linearAdd(buf, elem)
 ```
 then the exclusive `buf` capability is reserved and therefore no further accesses to `buf` are possible. This means that `linearAdd` can safely overwrite `buf` by appending `elem` to it.
@@ -221,7 +218,7 @@ then the exclusive `buf` capability is reserved and therefore no further accesse
 By the same token, when we pass a read-only capability to a consume parameter, it is
 only this capability that is reserved beyond the call. For instance, here is a
 method that consumes a read-only buffer:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def contents[T](consume buf: Buffer[T]): Int ->{buf.rd} T =
   i => buf(i)
 ```
@@ -231,7 +228,7 @@ buffer to `contents` effectively freezes it: Since `buf.rd` is reserved, we cann
 use the exclusive `buf` capability beyond the point of call, so no further appends
 are possible. On the other hand, it is possible to read the buffer, and it is also possible
 to consume that read capability again in further calls:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 val buf = Buffer[String]()
 val buf1 = linearAdd(buf, "hi") // buf unavailable from here
 val c1 = contents(buf1)         // only buf.rd is consumed
@@ -245,12 +242,12 @@ to `Buffer[T]^{any}` whereas the second expands to `Buffer[T]^{any.rd}`.
 ### Consume Methods
 
 Buffers in Scala's standard library use a single-argument method `+=` instead of a two argument global function like `linearAdd`. We can enforce linearity in this case by adding the `consume` modifier to the method itself.
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 class Buffer[T] extends Mutable:
   consume def +=(x: T): Buffer[T]^ = this // ok
 ```
 `consume` on a method in a `Mutable` class implies `update`, so there's no need to label `+=` separately as an update method. Then we can write
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 val b = Buffer[Int]() += 1 += 2
 val c = b += 3
 // b cannot be used from here
@@ -264,7 +261,7 @@ capture any capabilities. This can be achieved using the `freeze` wrapper.
 
 As an example, consider a class `Arr` which is modelled after `Array` and its immutable counterpart `IArr`:
 
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 class Arr[T: reflect.ClassTag](len: Int) extends Mutable:
   private val arr: Array[T] = new Array[T](len)
   def get(i: Int): T = arr(i)
@@ -273,7 +270,7 @@ type IArr[T] = Arr[T]^{}
 ```
 
 The `freeze` wrapper allows us to go from an `Arr` to an `IArr`, safely:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 import caps.freeze
 
 val f: IArr[String] =
@@ -283,7 +280,7 @@ val f: IArr[String] =
   freeze(a)
 ```
 The `freeze` method is defined in `caps` like this:
-```scala sc:nocompile sc-compile-with:preamble
+```scala sc:nocompile
 def freeze(consume x: Mutable): x.type = x
 ```
 It consumes a value of `Mutable` type with arbitrary capture set (since any capture set conforms to the implied `{any.rd}`). The actual signature of


### PR DESCRIPTION
I would have liked preamble code that is invisible, but this is not supported yet.