### PR TITLE
Fix REPL usage of macros loaded via `:dep` and `:jar`

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/MacroClassLoader.scala
+++ b/compiler/src/dotty/tools/dotc/core/MacroClassLoader.scala
@@ -1,6 +1,7 @@
 package dotty.tools.dotc.core
 
 import dotty.tools.dotc.core.Contexts.*
+import dotty.tools.dotc.core.Mode
 import dotty.tools.dotc.util.Property
 import dotty.tools.dotc.reporting.trace
 import dotty.tools.io.ClassPath
@@ -12,16 +13,32 @@ object MacroClassLoader {
 
   /** Get the macro class loader */
   def fromContext(using Context): ClassLoader =
-    ctx.property(MacroClassLoaderKey).getOrElse(makeMacroClassLoader)
+    if ctx.mode.is(Mode.Interactive) then
+      // In interactive mode (:dep/:jar), classpath can change during the session.
+      // Recompute on demand from the current platform classpath.
+      makeMacroClassLoader
+    else
+      ctx.property(MacroClassLoaderKey).getOrElse(makeMacroClassLoader)
 
   /** Context with a cached macro class loader that can be accessed with `macroClassLoader` */
   def init(ctx: FreshContext): ctx.type =
     ctx.setProperty(MacroClassLoaderKey, makeMacroClassLoader(using ctx))
 
   private def makeMacroClassLoader(using Context): ClassLoader = trace("new macro class loader") {
-    val entries = ClassPath.expandPath(ctx.settings.classpath.value, expandStar=true)
-    val urls = entries.map(cp => java.nio.file.Paths.get(cp).toUri.toURL).toArray
+    val urls: List[java.net.URL] =
+      def settingsUrls: List[java.net.URL] =
+        val entries = ClassPath.expandPath(ctx.settings.classpath.value, expandStar=true)
+        entries.map(cp => java.nio.file.Paths.get(cp).toUri.toURL).toList
+
+      if ctx.mode.is(Mode.Interactive) then
+        try
+          ctx.platform.classPath.asURLs.toList
+        catch
+          case _: IllegalStateException =>
+            settingsUrls
+      else
+        settingsUrls
     val out = Option(ctx.settings.outputDir.value.toURL) // to find classes in case of suspended compilation
-    new java.net.URLClassLoader(urls ++ out.toList, getClass.getClassLoader)
+    new java.net.URLClassLoader((urls ++ out.toList).toArray, getClass.getClassLoader)
   }
 }

--- a/repl/test/dotty/tools/repl/ReplDependencyMacroTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDependencyMacroTests.scala
@@ -1,0 +1,81 @@
+package dotty.tools
+package repl
+
+import org.junit.Assert.{assertFalse, assertTrue}
+import org.junit.Test
+
+class ReplDependencyMacroTests extends ReplTest:
+
+  private def assertNoMacroFailure(output: String): Unit =
+    assertFalse(output, output.contains("Failed to evaluate macro"))
+    assertFalse(output, output.contains("ClassNotFoundException"))
+    assertFalse(output, output.contains("Cannot reduce `inline if`"))
+    assertFalse(output, output.contains("-- Error:"))
+
+  private def resolveUpickle()(using State): Unit =
+    run(":dep com.lihaoyi::upickle:4.4.3")
+    val output = storedOutput()
+    println(s"[debug][i25291] :dep output:\n$output")
+    assertTrue(output, output.contains("Resolved 1 dependencies"))
+    assertNoMacroFailure(output)
+
+  private def addUpickleViaJar()(using State): Unit =
+    val deps = List(("com.lihaoyi", "upickle_3", "4.4.3"))
+    val files = DependencyResolver.resolveDependencies(deps) match
+      case Right(value) => value
+      case Left(error) =>
+        assertTrue(s"Failed to resolve dependency for :jar test: $error", false)
+        Nil
+
+    val filesToAdd =
+      files.filterNot: file =>
+        val name = file.getName
+        name.startsWith("scala3-library_3-")
+          || name.startsWith("scala-library-")
+          || name.startsWith("scala3-interfaces-")
+          || name.startsWith("tasty-core_3-")
+
+    assertTrue("No JAR files available to add via :jar", filesToAdd.nonEmpty)
+
+    filesToAdd.foreach: file =>
+      run(s":jar ${file.getAbsolutePath}")
+      val output = storedOutput()
+      println(s"[debug][i25291] :jar output (${file.getName}):\n$output")
+      assertTrue(output, output.contains("Added"))
+      assertNoMacroFailure(output)
+
+  @Test def `i25291 derives ReadWriter after :dep`: Unit =
+    initially:
+      resolveUpickle()
+      run("case class FooDerives(x: Int) derives upickle.default.ReadWriter")
+      val output = storedOutput()
+      println(s"[debug][i25291] derives output:\n$output")
+      assertNoMacroFailure(output)
+      assertTrue(output, output.contains("// defined case class FooDerives"))
+
+  @Test def `i25291 macroRW after :dep`: Unit =
+    initially:
+      resolveUpickle()
+      run("case class FooMacroRw(x: Int); object FooMacroRw { given upickle.default.ReadWriter[FooMacroRw] = upickle.default.macroRW }")
+      val second = storedOutput()
+      println(s"[debug][i25291] macroRW output:\n$second")
+      assertNoMacroFailure(second)
+      assertTrue(second, second.contains("// defined case class FooMacroRw"))
+
+  @Test def `i25291 derives ReadWriter after :jar`: Unit =
+    initially:
+      addUpickleViaJar()
+      run("case class FooJar(x: Int) derives upickle.default.ReadWriter")
+      val output = storedOutput()
+      println(s"[debug][i25291] :jar derives output:\n$output")
+      assertNoMacroFailure(output)
+      assertTrue(output, output.contains("// defined case class FooJar"))
+
+  @Test def `i25291 readwriter summon after :dep`: Unit =
+    initially:
+      resolveUpickle()
+      run("case class FooSummon(x: Int) derives upickle.default.ReadWriter; summon[upickle.default.ReadWriter[FooSummon]]")
+      val second = storedOutput()
+      println(s"[debug][i25291] summon output:\n$second")
+      assertNoMacroFailure(second)
+      assertTrue(second, second.contains("// defined case class FooSummon"))


### PR DESCRIPTION
Fixed https://github.com/scala/scala3/issues/25291, vibe coded. Seems to pass manual testing and regression tests that fail without this fix. This is an existing bug with `:jar` that was only noticed in `:dep` because people actually want to use it (whereas nobody uses `:jar`)

```scala
lihaoyi scala3$ sbt "scala3-repl/run"
Welcome to Scala 3.8.4-RC1-bin-SNAPSHOT-git-e48a0d9 (25.0.1, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.

scala> :dep com.lihaoyi::upickle:4.4.3
Resolved 1 dependencies (8 JARs)

scala> case class Foo(x: Int) derives upickle.ReadWriter
// defined case class Foo

scala> upickle.write(Foo(123))
val res0: String = "{\"x\":123}"
```

> Root cause: REPL commands `:dep` and `:jar` update the *runtime/compiler* classpath dynamically, but macro expansion was using a macro classloader derived from the static settings classpath (and cached), so newly added macro implementation classes were invisible.
> 
> Why this fix works:
> - In interactive mode, `MacroClassLoader.fromContext` now rebuilds from the live `ctx.platform.classPath` instead of reusing the cached/static loader.
> - `:dep` and `:jar` both call `ctx.platform.addToClassPath(...)`, so their additions are now visible to macro expansion immediately.
> - Fallback to settings classpath is kept only for early initialization when platform is not ready yet.
> 
> Why this is the correct fix:
> - It fixes the mismatch at the actual abstraction boundary: macro loading should follow the compiler’s effective classpath in REPL sessions, not startup CLI settings.
> - It is scoped: non-interactive compiler behavior remains unchanged (still uses cached loader).
> - It unifies behavior for both dynamic classpath mechanisms (`:dep` and `:jar`) with one coherent change.
> - It is validated by regression tests showing:
>   - failures without patch (macro CNF on both `:dep` and `:jar`)
>   - passes with patch for all reproduced scenarios.