### PR TITLE
Backport "Fix REPL usage of macros loaded via `:dep` and `:jar`" to 3.8.3

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/MacroClassLoader.scala
+++ b/compiler/src/dotty/tools/dotc/core/MacroClassLoader.scala
@@ -1,6 +1,7 @@
 package dotty.tools.dotc.core
 
 import dotty.tools.dotc.core.Contexts.*
+import dotty.tools.dotc.core.Mode
 import dotty.tools.dotc.util.Property
 import dotty.tools.dotc.reporting.trace
 import dotty.tools.io.ClassPath
@@ -12,16 +13,32 @@ object MacroClassLoader {
 
   /** Get the macro class loader */
   def fromContext(using Context): ClassLoader =
-    ctx.property(MacroClassLoaderKey).getOrElse(makeMacroClassLoader)
+    if ctx.mode.is(Mode.Interactive) then
+      // In interactive mode (:dep/:jar), classpath can change during the session.
+      // Recompute on demand from the current platform classpath.
+      makeMacroClassLoader
+    else
+      ctx.property(MacroClassLoaderKey).getOrElse(makeMacroClassLoader)
 
   /** Context with a cached macro class loader that can be accessed with `macroClassLoader` */
   def init(ctx: FreshContext): ctx.type =
     ctx.setProperty(MacroClassLoaderKey, makeMacroClassLoader(using ctx))
 
   private def makeMacroClassLoader(using Context): ClassLoader = trace("new macro class loader") {
-    val entries = ClassPath.expandPath(ctx.settings.classpath.value, expandStar=true)
-    val urls = entries.map(cp => java.nio.file.Paths.get(cp).toUri.toURL).toArray
+    val urls: List[java.net.URL] =
+      def settingsUrls: List[java.net.URL] =
+        val entries = ClassPath.expandPath(ctx.settings.classpath.value, expandStar=true)
+        entries.map(cp => java.nio.file.Paths.get(cp).toUri.toURL).toList
+
+      if ctx.mode.is(Mode.Interactive) then
+        try
+          ctx.platform.classPath.asURLs.toList
+        catch
+          case _: IllegalStateException =>
+            settingsUrls
+      else
+        settingsUrls
     val out = Option(ctx.settings.outputDir.value.toURL) // to find classes in case of suspended compilation
-    new java.net.URLClassLoader(urls ++ out.toList, getClass.getClassLoader)
+    new java.net.URLClassLoader((urls ++ out.toList).toArray, getClass.getClassLoader)
   }
 }

--- a/repl/test/dotty/tools/repl/ReplDependencyMacroTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDependencyMacroTests.scala
@@ -1,0 +1,81 @@
+package dotty.tools
+package repl
+
+import org.junit.Assert.{assertFalse, assertTrue}
+import org.junit.Test
+
+class ReplDependencyMacroTests extends ReplTest:
+
+  private def assertNoMacroFailure(output: String): Unit =
+    assertFalse(output, output.contains("Failed to evaluate macro"))
+    assertFalse(output, output.contains("ClassNotFoundException"))
+    assertFalse(output, output.contains("Cannot reduce `inline if`"))
+    assertFalse(output, output.contains("-- Error:"))
+
+  private def resolveUpickle()(using State): Unit =
+    run(":dep com.lihaoyi::upickle:4.4.3")
+    val output = storedOutput()
+    println(s"[debug][i25291] :dep output:\n$output")
+    assertTrue(output, output.contains("Resolved 1 dependencies"))
+    assertNoMacroFailure(output)
+
+  private def addUpickleViaJar()(using State): Unit =
+    val deps = List(("com.lihaoyi", "upickle_3", "4.4.3"))
+    val files = DependencyResolver.resolveDependencies(deps) match
+      case Right(value) => value
+      case Left(error) =>
+        assertTrue(s"Failed to resolve dependency for :jar test: $error", false)
+        Nil
+
+    val filesToAdd =
+      files.filterNot: file =>
+        val name = file.getName
+        name.startsWith("scala3-library_3-")
+          || name.startsWith("scala-library-")
+          || name.startsWith("scala3-interfaces-")
+          || name.startsWith("tasty-core_3-")
+
+    assertTrue("No JAR files available to add via :jar", filesToAdd.nonEmpty)
+
+    filesToAdd.foreach: file =>
+      run(s":jar ${file.getAbsolutePath}")
+      val output = storedOutput()
+      println(s"[debug][i25291] :jar output (${file.getName}):\n$output")
+      assertTrue(output, output.contains("Added"))
+      assertNoMacroFailure(output)
+
+  @Test def `i25291 derives ReadWriter after :dep`: Unit =
+    initially:
+      resolveUpickle()
+      run("case class FooDerives(x: Int) derives upickle.default.ReadWriter")
+      val output = storedOutput()
+      println(s"[debug][i25291] derives output:\n$output")
+      assertNoMacroFailure(output)
+      assertTrue(output, output.contains("// defined case class FooDerives"))
+
+  @Test def `i25291 macroRW after :dep`: Unit =
+    initially:
+      resolveUpickle()
+      run("case class FooMacroRw(x: Int); object FooMacroRw { given upickle.default.ReadWriter[FooMacroRw] = upickle.default.macroRW }")
+      val second = storedOutput()
+      println(s"[debug][i25291] macroRW output:\n$second")
+      assertNoMacroFailure(second)
+      assertTrue(second, second.contains("// defined case class FooMacroRw"))
+
+  @Test def `i25291 derives ReadWriter after :jar`: Unit =
+    initially:
+      addUpickleViaJar()
+      run("case class FooJar(x: Int) derives upickle.default.ReadWriter")
+      val output = storedOutput()
+      println(s"[debug][i25291] :jar derives output:\n$output")
+      assertNoMacroFailure(output)
+      assertTrue(output, output.contains("// defined case class FooJar"))
+
+  @Test def `i25291 readwriter summon after :dep`: Unit =
+    initially:
+      resolveUpickle()
+      run("case class FooSummon(x: Int) derives upickle.default.ReadWriter; summon[upickle.default.ReadWriter[FooSummon]]")
+      val second = storedOutput()
+      println(s"[debug][i25291] summon output:\n$second")
+      assertNoMacroFailure(second)
+      assertTrue(second, second.contains("// defined case class FooSummon"))


### PR DESCRIPTION
Backports #25312 to the 3.8.3-RC1.

PR submitted by the release tooling.