### PR TITLE
Normalize tuple types when typing patterns

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -294,7 +294,7 @@ object Applications {
         case argType :: Nil
         if args.lengthCompare(1) > 0
             && Feature.autoTuplingEnabled
-            && defn.isTupleNType(argType) =>
+            && defn.isTupleNType(argType.normalizedTupleType) =>
           untpd.Tuple(args) :: Nil
         case _ =>
           args

--- a/tests/pos/i22923.scala
+++ b/tests/pos/i22923.scala
@@ -1,0 +1,10 @@
+object Test {
+  object E1 {
+    def unapply(x: Int): Some[Tuple.Map[(Int, Int), Option]] = ???
+  }
+
+  val s: Int = ???
+  s match {
+    case E1(x, y) => x
+  }
+}

--- a/tests/pos/i23155b.scala
+++ b/tests/pos/i23155b.scala
@@ -1,6 +1,6 @@
 object Unpack_T {
   (1, 2) match {
-    case Unpack_T(first, _) => first // error
+    case Unpack_T(first, _) => first
   }
   def unapply(e: (Int, Int)): Some[Int *: Int *: EmptyTuple] = ???
 }


### PR DESCRIPTION
Generic Tuples and TupleN for N < 23 are technically equivalent (from a spec point of view).
As such, we add support to auto untupling in patterns to conform to [the following part of the specification](https://scala-lang.org/files/archive/spec/3.4/08-pattern-matching.html#extractor-patterns) by normalizing the tuple types before checking the number of arguments.
 
Closes #22923