### PR TITLE
Fix #25342: Transfer `methodsAllowingJSAwait` to forcefully inlined methods.

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -3170,6 +3170,10 @@ class JSCodeGen()(using genCtx: Context) {
     val target = targetDefDef.symbol
     val isTargetStatic = isMethodStaticInIR(target)
 
+    // #25342 If we can use js.await, then so can the forcefully inlined target
+    if (methodsAllowingJSAwait.contains(currentMethodSym))
+      methodsAllowingJSAwait += target
+
     // Gen the receiver and arguments
     val genReceiver =
       if isTargetStatic then None

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2340,10 +2340,15 @@ object Build {
 
         val isWebAssembly = linkerConfig.experimentalUseWebAssembly
 
+        val b = List.newBuilder[File]
+
         if (linkerConfig.moduleKind != ModuleKind.NoModule && !linkerConfig.closureCompiler && !isWebAssembly)
-          Seq(baseDirectory.value / "test-require-multi-modules")
-        else
-          Nil
+          b += baseDirectory.value / "test-require-multi-modules"
+
+        if (linkerConfig.esFeatures.esVersion >= ESVersion.ES2017)
+          b += baseDirectory.value / "test-require-async-await"
+
+        b.result()
       },
 
       (Compile / managedSources) ++= {

--- a/tests/sjs-junit/test-require-async-await/org/scalajs/testsuite/jsinterop/JSAsyncAwaitTestScala3.scala
+++ b/tests/sjs-junit/test-require-async-await/org/scalajs/testsuite/jsinterop/JSAsyncAwaitTestScala3.scala
@@ -1,0 +1,44 @@
+package org.scalajs.testsuite.jsinterop
+
+import scala.scalajs.js
+import scala.scalajs.js.JSConverters._
+import scala.scalajs.js.|
+
+import scala.concurrent.{Future, ExecutionContext}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.Test
+
+import org.scalajs.junit.async._
+
+class JSAsyncAwaitTestScala3 {
+  @Test
+  def unitAsyncBlock_Issue25342(): AsyncResult = await {
+    val buf = new ArrayBuffer[String]()
+
+    val px = js.Promise.resolve[Int](5)
+
+    buf += "before"
+    val p = js.async {
+      buf += "start async"
+      val x = js.await(px)
+      buf += s"got x: $x"
+      ()
+    }
+    buf += "after"
+
+    assertArrayEquals(
+        Array[AnyRef]("before", "start async", "after"),
+        buf.toArray[AnyRef])
+
+    p.toFuture.map { _ =>
+      assertArrayEquals(
+          Array[AnyRef]("before", "start async", "after", "got x: 5"),
+          buf.toArray[AnyRef])
+    }
+  }
+}


### PR DESCRIPTION
This PR was done entirely by a human (obviously).