### PR TITLE
Drop SafeMode attribute in Tasty

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/Attributes.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/Attributes.scala
@@ -15,7 +15,6 @@ class Attributes private[tasty](
   def withPureFuns: Boolean = booleanTags(WITHPUREFUNSattr)
   def isJava: Boolean = booleanTags(JAVAattr)
   def isOutline: Boolean = booleanTags(OUTLINEattr)
-  def isSafeMode: Boolean = booleanTags(SAFEMODEattr)
   def sourceFile: Option[String] = stringTagValues.find(_._1 == SOURCEFILEattr).map(_._2)
 }
 
@@ -27,8 +26,7 @@ object Attributes:
     captureChecked: Boolean,
     withPureFuns: Boolean,
     isJava: Boolean,
-    isOutline: Boolean,
-    isSafeMode: Boolean
+    isOutline: Boolean
   ): Attributes =
     val booleanTags = BitSet.newBuilder
     if scala2StandardLibrary then booleanTags += SCALA2STANDARDLIBRARYattr
@@ -37,7 +35,6 @@ object Attributes:
     if withPureFuns then booleanTags += WITHPUREFUNSattr
     if isJava then booleanTags += JAVAattr
     if isOutline then booleanTags += OUTLINEattr
-    if isSafeMode then booleanTags += SAFEMODEattr
 
     val stringTagValues = List.newBuilder[(Int, String)]
     stringTagValues += SOURCEFILEattr -> sourceFile

--- a/compiler/src/dotty/tools/dotc/transform/Pickler.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Pickler.scala
@@ -297,7 +297,6 @@ class Pickler extends Phase {
         withPureFuns = Feature.pureFunsEnabled,
         isJava = isJavaAttr,
         isOutline = isOutline,
-        isSafeMode = unit.safeMode
       )
 
       val pickler = new TastyPickler(cls, isBestEffortTasty = isBestEffort)

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -75,7 +75,6 @@ object MiMaFilters {
     val ForwardsBreakingChanges: Map[String, Seq[ProblemFilter]] = Map(
       // Additions that require a new minor version of tasty core
       Build.mimaPreviousDottyVersion -> Seq(
-         ProblemFilters.exclude[DirectMissingMethodProblem]("dotty.tools.tasty.TastyFormat.SAFEMODEattr"),
       )
     )
 

--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -287,7 +287,6 @@ Standard Section: "Attributes" Attribute*
                   WITHPUREFUNSattr
                   JAVAattr
                   OUTLINEattr
-                  SAFEMODEattr
                   SOURCEFILEattr Utf8Ref
 ```
 Attribute tags cannot be repeated in an attribute section. Attributes are ordered by the tag ordinal.
@@ -643,7 +642,6 @@ object TastyFormat {
   final val WITHPUREFUNSattr = 4
   final val JAVAattr = 5
   final val OUTLINEattr = 6
-  final val SAFEMODEattr = 7
 
   // Attribute Category 2 (tags 33-128): unassigned
 
@@ -886,7 +884,6 @@ object TastyFormat {
     case WITHPUREFUNSattr => "WITHPUREFUNSattr"
     case JAVAattr => "JAVAattr"
     case OUTLINEattr => "OUTLINEattr"
-    case SAFEMODEattr => "SAFEMODEattr"
     case SOURCEFILEattr => "SOURCEFILEattr"
   }
 


### PR DESCRIPTION
We don't actually need it, except for compilation from Tasty. But then we could also use the language import directly.
