### PR TITLE
Prevent from getting children in case of non-sealed private

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -684,7 +684,7 @@ object SpaceEngine {
             if child eq sym then List(sym) // i3145: sealed trait Baz, val x = new Baz {}, Baz.children returns Baz...
             else if tp.classSymbol == defn.TupleClass || tp.classSymbol == defn.NonEmptyTupleClass then
               List(child) // TupleN and TupleXXL classes are used for Tuple, but they aren't Tuple's children
-            else if (child.is(Private) || child.is(Sealed)) && child.isOneOf(AbstractOrTrait) then getChildren(child)
+            else if child.is(Sealed) && child.isOneOf(AbstractOrTrait) then getChildren(child)
             else List(child)
           }
         val children = trace(i"getChildren($tp)")(getChildren(tp.classSymbol))

--- a/tests/pos/i23113.scala
+++ b/tests/pos/i23113.scala
@@ -1,0 +1,10 @@
+//> using options -Werror
+sealed trait P
+object P {
+  private abstract class B extends P
+}
+
+def foo(opt: Option[P]): Unit = opt match {
+  case Some(_) => ???
+  case None    => ???
+}

--- a/tests/warn/i14579.scala
+++ b/tests/warn/i14579.scala
@@ -4,7 +4,7 @@ trait A {
   private trait X2 extends X
   sealed trait X3 extends X
 
-  def f(x: X) = x match {
+  def f(x: X) = x match { // warn
     case _: X1 => 0
   }
 }


### PR DESCRIPTION
closes https://github.com/scala/scala3/issues/23113

## How much have your relied on LLM-based tools in this contribution?

I asked if my understanding is correct.
I asked it to minimize the reproducer.

## How was the solution tested?
First I checked if the reproducer produces warning without any fixes
<img width="693" height="76" alt="image" src="https://github.com/user-attachments/assets/70c7ba15-4b53-4345-8771-8bdd0b56b257" />

After that I compiled the reproducer to see it compiles without warning, and then I added it as a test case and ran `testCompilation`

## Additional notes

https://github.com/scala/scala3/pull/14599
The PR make decompose logic recursive even if it's just private and not sealed.
Since the compiler only register children to parent when it's sealed, getting children of non-sealed private class always return empty list. This logic makes the code below compiles without warning but it's not because compiler knows `X1` is a subtype of `X2`. It just decompose `X2`, get empty list, so `X2` is disappeared from space.
 
And it triggers the issue 23113 since it assumes PromiseBase[A] has no children which is not true.

 I guess producing a warning when compile the code below is expected (https://github.com/scala/scala3/pull/23292#issuecomment-2922568982), so I move the test(i14579) below `warn/`.

```scala
trait A {
  sealed abstract class X
  private class X1 extends X with X2 { }
  private trait X2 extends X
  sealed trait X3 extends X

  def f(x: X) = x match {
    case _: X1 => 0
  }
}
```
from https://github.com/scala/scala3/issues/14579
