### PR TITLE
accept `primitive.class` in annotations

### DIFF
--- a/compiler/test/dotty/tools/dotc/printing/PrintingTest.scala
+++ b/compiler/test/dotty/tools/dotc/printing/PrintingTest.scala
@@ -31,7 +31,7 @@ class PrintingTest {
     List(s"-Vprint:$phase", "-color:never", "-nowarn", "-d", outDir, "-classpath", TestConfiguration.basicClasspath) ::: flags
 
   private def compileFile(path: JPath, phase: String): Boolean = {
-    val baseFilePath  = path.toString.stripSuffix(".scala")
+    val baseFilePath  = path.toString.stripSuffix(".scala").stripSuffix(".java")
     val checkFilePath = baseFilePath + ".check"
     val flagsFilePath = baseFilePath + ".flags"
     val byteStream    = new ByteArrayOutputStream()
@@ -54,8 +54,8 @@ class PrintingTest {
 
   def testIn(testsDir: String, phase: String) =
     val res = Directory(testsDir).list.toList
-      .filter(f => f.ext.isScala)
-      .map { f => compileFile(f.jpath, phase) }
+      .filter(_.ext.isScalaOrJava)
+      .map(f => compileFile(f.jpath, phase))
 
     val failed = res.filter(!_)
 

--- a/tests/printing/untyped/i19643.check
+++ b/tests/printing/untyped/i19643.check
@@ -1,0 +1,31 @@
+[[syntax trees at end of                    parser]] // tests/printing/untyped/i19643.java
+package i19643 {
+  object MyAnnot() {}
+  trait MyAnnot private[this](x$1: scala.Unit) extends Object, _root_.java.lang.
+    annotation.Annotation {
+    def <init>(reify: Class[? <: Object],
+      args: _root_.scala.Array[Class[? <: Object]])
+    @_root_.scala.annotation.internal.AnnotationDefault def reify():
+      Class[? <: Object] = _root_.scala.Predef.???
+    @_root_.scala.annotation.internal.AnnotationDefault def args():
+      _root_.scala.Array[Class[? <: Object]] = _root_.scala.Predef.???
+  }
+  object MyAnnotated() {
+    @MyAnnot(reify = _root_.scala.Predef.classOf[String]) <static> def method1()
+      : scala.Int = _root_.scala.Predef.???
+    @MyAnnot(reify = _root_.scala.Predef.classOf[scala.Int]) <static> def
+      method2(): scala.Int = _root_.scala.Predef.???
+    @MyAnnot(reify = _root_.scala.Predef.classOf[scala.Long]) <static> def
+      method3(): scala.Int = _root_.scala.Predef.???
+    @MyAnnot(args = _root_.scala.Array(_root_.scala.Predef.classOf[String]))
+      <static> def method4(): scala.Int = _root_.scala.Predef.???
+    @MyAnnot(args = _root_.scala.Array(_root_.scala.Predef.classOf[scala.Int]))
+      <static> def method5(): scala.Int = _root_.scala.Predef.???
+    @MyAnnot(args = _root_.scala.Array(_root_.scala.Predef.classOf[scala.Long]))
+       <static> def method6(): scala.Int = _root_.scala.Predef.???
+  }
+  class MyAnnotated private[this](x$1: scala.Unit) extends Object {
+    def <init>() = _root_.scala.Predef.???
+  }
+}
+

--- a/tests/printing/untyped/i19643.java
+++ b/tests/printing/untyped/i19643.java
@@ -1,0 +1,28 @@
+package i19643;
+
+@interface MyAnnot {
+  Class<?> reify() default Object.class;
+  Class<?>[] args() default {};
+}
+
+class MyAnnotated {
+
+  @MyAnnot(reify = String.class)
+  public static int method1() { return 23; }
+
+  @MyAnnot(reify = int.class)
+  public static int method2() { return 23; }
+
+  @MyAnnot(reify = long.class)
+  public static int method3() { return 23; }
+
+  @MyAnnot(args = {String.class})
+  public static int method4() { return 23; }
+
+  @MyAnnot(args = {int.class})
+  public static int method5() { return 23; }
+
+  @MyAnnot(args = {long.class})
+  public static int method6() { return 23; }
+
+}


### PR DESCRIPTION
When we parse java code, we should also handle when `int.class`, `byte.class`,... (all primitives) are present in annotations. We used to discard them before.

## How much have you relied on LLM-based tools in this contribution?

None.

## Additional notes

Closes #19643
