### PR TITLE
do not generate documentation for `AnyVal`, it exists now

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/tasty/TastyParser.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/TastyParser.scala
@@ -194,7 +194,6 @@ case class TastyParser(
     defn.AnyClass,
     defn.MatchableClass,
     defn.ScalaPackage.typeMember("AnyKind"),
-    defn.AnyValClass,
     defn.NullClass,
     defn.NothingClass,
     defn.ScalaPackage.typeMember("Singleton"),


### PR DESCRIPTION
Since #24406, `AnyVal` is not a synthetic class anymore and has TASTy. No need for scaladoc to generate a fake member  anymore.

Closes #25398
