### PR TITLE
do not hide when a `class` or a `trait` extends `Any`

### DIFF
--- a/scaladoc-testcases/src/tests/traitSignatures.scala
+++ b/scaladoc-testcases/src/tests/traitSignatures.scala
@@ -8,3 +8,5 @@ trait B extends A
 trait C(a: Int)
 
 trait D(b: Double) extends C, A
+
+trait E extends Any

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
@@ -297,7 +297,7 @@ trait ClassLikeSupport:
           case t: TypeTree => t.tpe.typeSymbol
           case tree if tree.symbol.isClassConstructor => tree.symbol.owner
           case tree => tree.symbol
-        if parentSymbol != defn.ObjectClass && parentSymbol != defn.AnyClass && !parentSymbol.isHiddenByVisibility
+        if parentSymbol != defn.ObjectClass && !parentSymbol.isHiddenByVisibility
       yield (parentTree, parentSymbol)
 
     def getConstructors: List[Symbol] = c.membersToDocument.collect {


### PR DESCRIPTION
Scaladoc hides the parents if they have a weak visibility, or if it's `Object` or `Any`. In this PR, we don't hide `Any` as extending it directly is not the default mode (while extending `Object` is). For that reason, we keep hiding `Object` but not `Any`.

## How much have you relied on LLM-based tools in this contribution?

None.

Closes #25402
