### PR TITLE
fetch the right kind for synthesised definitions

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
@@ -127,7 +127,7 @@ trait ClassLikeSupport:
       getSupertypesGraph(LinkToType(selfSignature, classDef.symbol.dri, bareClasslikeKind(classDef.symbol)), unpackTreeToClassDef(classDef).parents)
     )
 
-    val kind = if intrinsicClassDefs.contains(classDef.symbol) then Kind.Class(Nil, Nil) else kindForClasslike(classDef)
+    val kind = if intrinsicClassDefs.contains(classDef.symbol) then bareClasslikeKind(classDef.symbol) else kindForClasslike(classDef)
 
     val baseMember = mkMember(classDef.symbol, kind, selfSignature)(
       modifiers = modifiers,


### PR DESCRIPTION
Instead of assuming all synthetic definitions to be a class, fetch their scaladoc kind.
It also fixes the rendering of `scala.Singleton` (it is a `trait` too, not a `class`).

## How much have you relied on LLM-based tools in this contribution?

None.

## How was the solution tested?

visually by rendering the scaladoc (which is not enough for a long term testing).
Maybe our student in the summer can write better unit tests too.

Closes #25396
