### PR TITLE
Don't enable compact annotations under 2.13.

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
+++ b/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
@@ -47,7 +47,7 @@ enum SourceVersion:
   def enablesBetterFors(using Context) = isAtLeast(`3.8`) || (isAtLeast(`3.7`) && isPreviewEnabled)
   /** See PR #23441 and tests/neg/i23435-min */
   def enablesDistributeAnd = !isAtLeast(`future`)
-  def enablesCompactAnnotation = isAtLeast(`3.9`)
+  def enablesCompactAnnotation = isAtLeast(`3.9`) && this != `2.13`
 
   def requiresNewSyntax = isAtLeast(future)
 


### PR DESCRIPTION
The previous definition was

```scala
def enablesCompactAnnotation = isAtLeast(`3.9`)
```
I mistakenly assumed this would exclude 2.13, but it does not. 2.13 is *higher* than all versions except future. This is dangerous since we might accidentally enable in 2.13 all new features that we add. There's a discussioin to be had here, but for now I am simply refining the `enablesCompactAnnotation` test to explicitly exclude 2.13.

Fixes #25406 for 3.8.1 -> main. We have to think about what we can do with backport mitigations.
