### PR TITLE
Update README: This is Scala 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-Dotty
+Scala 3
 =====
-[![Dotty CI](https://github.com/scala/scala3/workflows/Dotty/badge.svg?branch=main)](https://github.com/scala/scala3/actions?query=branch%3Amain)
+[![Scala 3 CI](https://github.com/scala/scala3/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/scala/scala3/actions/workflows/ci.yaml?query=branch%3Amain)
 [![Join the chat at https://discord.com/invite/scala](https://img.shields.io/discord/632150470000902164)](https://discord.com/invite/scala)
+
+This is the home of the [Scala 3](https://www.scala-lang.org) standard library, compiler, and language spec.
 
 * [Documentation](https://docs.scala-lang.org/scala3/)
 
@@ -28,4 +30,4 @@ How to Contribute
 
 License
 =======
-Dotty is licensed under the [Apache License Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+Scala 3 is licensed under the [Apache License Version 2.0](https://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
<insert obligatory 300 movie reference>

The CI badge was using the legacy name-based workflow URL which renders as greyed out on GitHub. Switch to the modern file-path-based URL. Also update remaining "Dotty" references to "Scala 3".

## How much have your relied on LLM-based tools in this contribution?

I let Claude figure out why the CI badge is not properly working. 

## How was the solution tested?

By reading it :)