### PR TITLE
Don't absolutize sources outside of the sourceroot in TASTy

### DIFF
--- a/compiler/src/dotty/tools/dotc/util/SourceFile.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourceFile.scala
@@ -264,7 +264,7 @@ object SourceFile {
 
   /** Returns the relative path of `source` within the `reference` path
    *
-   *  It returns the absolute path of `source` if it is not contained in `reference`.
+   *  It returns the current path under `source.file.jpath` if it is not contained in `reference`.
    */
   def relativePath(source: SourceFile, reference: String): String = {
     val file = source.file


### PR DESCRIPTION
With inlining and standard library patching, it's inevitable that, when
writing TASTy files, we'll encounter sources outside the sourceroot.
However, we shouldn't write those sources as absolute paths because
that's non-reproducible and can cause determinism issues. Instead, we
should write the paths as-is.
    
While these sorts of paths aren't correct when written relatively, they
weren't correct to begin with because they don't actually exist on the
filesystem.

## How much have your relied on LLM-based tools in this contribution?

None

## How was the solution tested?

Manual

## Additional notes

Based on https://github.com/scala/scala3/pull/24491 since we can't edit the PR