### PR TITLE
Fix class super-call invokespecial owner

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -778,7 +778,7 @@ trait BCodeBodyBuilder(val primitives: DottyPrimitives)(using ctx: Context) exte
             if (t.symbol ne defn.Object_synchronized) genTypeApply(t)
             else genSynchronized(app, expectedType)
 
-        case Apply(fun @ DesugaredSelect(Super(superQual, _), _), args) =>
+        case Apply(fun @ DesugaredSelect(superRef @ Super(superQual, _), _), args) =>
           // 'super' call: Note: since constructors are supposed to
           // return an instance of what they construct, we have to take
           // special care. On JVM they are 'void', and Scala forbids (syntactically)
@@ -791,7 +791,20 @@ trait BCodeBodyBuilder(val primitives: DottyPrimitives)(using ctx: Context) exte
           stack.push(superQualTK)
           genLoadArguments(args, paramTKs(app))
           stack.pop()
-          generatedType = genCallMethod(fun.symbol, InvokeStyle.Super, app.span)
+          // The receiver in bytecode should be based on the call site qualifier type,
+          // instead of method declaration owner class
+          // (`fun.symbol.owner`, which is default receiver type in `genCallMethod`).
+          // This avoids IllegalAccessError when the declaration owner is less accessible than the
+          // direct superclass (see https://github.com/scala/scala3/issues/22628).
+          val specificReceiver = superRef.tpe.dealias match {
+            case superType: SuperType =>
+              val sym = superType.supertpe.typeSymbol
+              if (sym.isClass && !isEmittedInterface(sym)) sym
+              else null
+            case _ =>
+              null
+          }
+          generatedType = genCallMethod(fun.symbol, InvokeStyle.Super, app.span, specificReceiver)
 
         // 'new' constructor call: Note: since constructors are
         // thought to return an instance of what they construct,
@@ -1395,7 +1408,7 @@ trait BCodeBodyBuilder(val primitives: DottyPrimitives)(using ctx: Context) exte
     /**
      * Generate a method invocation. If `specificReceiver != null`, it is used as receiver in the
      * invocation instruction, otherwise `method.owner`. A specific receiver class is needed to
-     * prevent an IllegalAccessError, (aladdin bug 455).
+     * prevent IllegalAccessError in some virtual and super calls (aladdin bug 455, i22628).
      */
     def genCallMethod(method: Symbol, style: InvokeStyle, pos: Span = NoSpan, specificReceiver: Symbol = null): BType = {
       val methodOwner = method.owner
@@ -1403,7 +1416,7 @@ trait BCodeBodyBuilder(val primitives: DottyPrimitives)(using ctx: Context) exte
       // the class used in the invocation's method descriptor in the classfile
       val receiverClass = {
         if (specificReceiver != null)
-          assert(style.isVirtual || specificReceiver == methodOwner, s"specificReceiver can only be specified for virtual calls. $method - $specificReceiver")
+          assert(style.isVirtual || style.isSuper || specificReceiver == methodOwner, s"specificReceiver can only be specified for virtual and super calls. $method - $specificReceiver")
 
         val useSpecificReceiver = specificReceiver != null && !defn.isBottomClass(specificReceiver) && !method.isScalaStatic
         val receiver = if (useSpecificReceiver) specificReceiver else methodOwner

--- a/tests/run/i22628.check
+++ b/tests/run/i22628.check
@@ -1,0 +1,2 @@
+MyServerCall.close
+InnerServerCallBase.close

--- a/tests/run/i22628/InnerServerCallBase.java
+++ b/tests/run/i22628/InnerServerCallBase.java
@@ -1,0 +1,8 @@
+package mylib;
+
+abstract class InnerServerCallBase implements ServerCall {
+  @Override
+  public void close() {
+    System.out.println("InnerServerCallBase.close");
+  }
+}

--- a/tests/run/i22628/MyServerCall.scala
+++ b/tests/run/i22628/MyServerCall.scala
@@ -1,0 +1,8 @@
+package mycode
+
+class MyServerCall extends mylib.PublicServerCallBase {
+  override def close(): Unit = {
+    println("MyServerCall.close")
+    super.close()
+  }
+}

--- a/tests/run/i22628/PublicServerCallBase.java
+++ b/tests/run/i22628/PublicServerCallBase.java
@@ -1,0 +1,4 @@
+package mylib;
+
+public abstract class PublicServerCallBase extends InnerServerCallBase {
+}

--- a/tests/run/i22628/ServerCall.java
+++ b/tests/run/i22628/ServerCall.java
@@ -1,0 +1,5 @@
+package mylib;
+
+public interface ServerCall {
+  void close();
+}

--- a/tests/run/i22628/Test.scala
+++ b/tests/run/i22628/Test.scala
@@ -1,0 +1,5 @@
+// scalajs: --skip
+
+object Test extends App {
+  new mycode.MyServerCall().close()
+}


### PR DESCRIPTION
Fix #22628 
https://github.com/scala/scala3/issues/24084 as well ?

Super call like `super.m()` were emitted with `invokespecial` where owner = `fun.symbol.owner` (the method declaration owner).

However, that is wrong for some inherited Java members: the declaration owner can be less accessible than the direct superclass at the Scala call site. In that case it causes `IllegalAccessError` at runtime.

This aligns with the normal call behavior, see: https://github.com/scala/scala3/commit/fa42b81039f6d9daaf26f4bd552470c85b89aa8f

**example**

In the example below, `fun.symbol.owner` for `super.close()` is `InnerServerCallBase` (where `close` is declared) that is not accessible from `mycode` package.

```scala
// mylib/InnerServerCallBase.java (package-private)
package mylib;
abstract class InnerServerCallBase implements ServerCall {
  @Override public void close() {
    System.out.println("InnerServerCallBase.close");
  }
}

// mylib/PublicServerCallBase.java
package mylib;
public abstract class PublicServerCallBase extends InnerServerCallBase {}

// mycode/MyServerCall.scala
package mycode
class MyServerCall extends mylib.PublicServerCallBase:
  override def close(): Unit =
    println("MyServerCall.close")
    super.close()
```

As a result, Scala3 emits the following Java bytecode where `invokespecial` on non-accessible class method. And it causes `IllegalAccessError` at runtime.

Scala 3 (before):
```java
  0: getstatic     #18  // Field scala/Predef$.MODULE$:Lscala/Predef$;
  3: ldc           #20  // String MyServerCall.close
  5: invokevirtual #24  // Method scala/Predef$.println:(Ljava/lang/Object;)V
  8: aload_0
  9: invokespecial #28  // Method mylib/InnerServerCallBase.close:()V
 12: return
```

We should generate `invokespecial` on the call-site qualifier type instead, like Scala 2.13 emits.

Scala 2.13
```
  0: getstatic     #16  // Field scala/Predef$.MODULE$:Lscala/Predef$;
  3: ldc           #18  // String MyServerCall.close
  5: invokevirtual #22  // Method scala/Predef$.println:(Ljava/lang/Object;)V
  8: aload_0
  9: invokespecial #24  // Method mylib/PublicServerCallBase.close:()V
 12: return
```

This commit fixes the issue by using call-site qualifier type for invokespecial on super call.

---

Huge thanks to @migesok for creating a reproducible example 🙌  https://github.com/migesok/scala3-bug-super-IllegalAccessError