### PR TITLE
Remove redundant mapOver in fixThisTypeModuleClassReferences

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -607,12 +607,11 @@ object Inlines:
         TreeTypeMap(
           typeMap = new TypeMap:
             override def stopAt = StopAt.Package
-            def apply(t: Type) = mapOver {
+            def apply(t: Type) =
               t match
                 case ThisType(tref @ TypeRef(prefix, _)) if tref.symbol.flags.is(Module) && !owners.contains(tref.symbol) =>
                   TermRef(apply(prefix), tref.symbol.companionModule)
                 case _ => mapOver(t)
-            }
         ).typeMap(tpe)
 
       if !hasOpaqueProxies && !hasOpaquesInResultFromCallWithTransparentContext then inlined

--- a/tests/pos/i25362/Macro_1.scala
+++ b/tests/pos/i25362/Macro_1.scala
@@ -1,0 +1,15 @@
+package example
+import scala.deriving.Mirror
+import scala.quoted.*
+
+class TC[A] {
+  type Out
+}
+
+object TC {
+  transparent inline def derived[Left: Mirror.ProductOf as m]: TC[Left] =
+    ${ derivedImpl[Left, m.MirroredElemTypes] }
+
+  private def derivedImpl[Left: Type, LeftTypes: Type](using Quotes): Expr[TC[Left]] =
+    '{ new TC[Left] { type Out = LeftTypes } }
+}

--- a/tests/pos/i25362/Test_2.scala
+++ b/tests/pos/i25362/Test_2.scala
@@ -1,0 +1,14 @@
+package example
+
+opaque type BigTuple <: Repr = Repr
+final case class Repr(
+  f1: Int, f2: Int, f3: Int, f4: Int, f5: Int,
+  f6: Int, f7: Int, f8: Int, f9: Int, f10: Int,
+  f11: Int, f12: Int, f13: Int, f14: Int, f15: Int,
+  f16: Int, f17: Int, f18: Int, f19: Int, f20: Int,
+  f21: Int, f22: Int, f23: Int, f24: Int, f25: Int,
+)
+
+class test {
+  val merger = TC.derived[BigTuple]
+}


### PR DESCRIPTION
We should only have mapOver in the default branch or on the returned
type not both as that redundant and causes exponential growth in
compilation time.

fixes: #25362

<!-- Fixes #XYZ (where XYZ is the issue number from the issue tracker) -->

<!-- TODO description of the change -->
<!-- Ideally should have a title like "Fix #XYZ: Short fix description" -->

<!--
  TODO first sign the CLA
  https://contribute.akka.io/cla/scala
-->

<!-- if the PR is still a WIP, create it as a draft PR (or convert it into one) -->

## How much have your relied on LLM-based tools in this contribution?
An LLM did point out the extra mapOver something that was missed when I skimmed the code. And also obviously by the reviewers of https://github.com/scala/scala3/pull/23792. Not sure which place for the mapOver is preferred but having both patterns in the code base probably increases the risk of this pattern landing in the codebase. 

<!-- 
  State clearly in the pull request description, 
  whether LLM-based tools were used and to what extent 

  (extensively/moderately/minimally/not at all)
-->

<!--
  Refer to our [LLM usage policy](https://github.com/scala/scala3/blob/main/LLM_POLICY.md) for rules and guidelines
  regarding usage of LLM-based tools in contributions.
-->

## How was the solution tested?
Existing and new compilation tests.

<!-- 
  If automated tests are included, mention it.
  If they are not, explain why and how the solution was tested.
-->

## Additional notes

<!-- Placeholder for any extra context regarding this contribution. -->

<!--
  When in doubt, and for support regarding contributions to a particular component of the compiler, 
  refer to [our contribution guide](https://github.com/scala/scala3/blob/main/CONTRIBUTING.md),
  and feel free to tag the maintainers listed there for the area(s) you are modifying.
-->
