### PR TITLE
Inlines: decide sealing against original target, while using widened type as cast destination

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -623,17 +623,29 @@ object Inlines:
             val withAdjustedThisTypes = if call.symbol.is(Macro) then fixThisTypeModuleClassReferences(unpacked) else unpacked
             (call.tpe & withAdjustedThisTypes, withAdjustedThisTypes != unpacked)
           else (call.tpe, false)
+        // `target` might contain a method reference, which is an invalid cast target. Use its return type instead.
+        // see https://github.com/scala/scala3/issues/25091
         val resultType = target.widenIfUnstable
         if forceCast then
           // we need to force the cast for issues with ThisTypes, as ensureConforms will just
           // check subtyping and then choose not to cast, leaving the previous, incorrect type
           inlined.cast(resultType)
-        else
-          inlined.ensureConforms(resultType)
+        else if !(inlined.tpe <:< target) then
           // Make sure that the sealing with the declared type
           // is type correct. Without it we might get problems since the
           // expression's type is the opaque alias but the call's type is
           // the opaque type itself. An example is in pos/opaque-inline1.scala.
+          //
+          // Here we can't just use `inlined.ensureConforms(resultType)`:
+          // `target.widenIfUnstable` is an upper approximation of `target`,
+          // so a tree may conform to it while still not conforming to `target`.
+          // This can happen when widening drops path-/prefix-sensitive information
+          // (e.g. projected opaque-proxy types).
+          // We check conformance against the original `target`, but cast to the
+          // widened type to avoid NoType issues at erasure (see #25091, #25417).
+          inlined.cast(resultType)
+        else
+          inlined
     end expand
   end InlineCall
 end Inlines

--- a/tests/pos/i25417.scala
+++ b/tests/pos/i25417.scala
@@ -1,0 +1,24 @@
+import scala.compiletime.summonFrom
+
+trait Decoder[A]
+
+given Decoder[String] with {}
+
+trait Mirror[T]:
+  type IronType
+
+given [T](using mirror: Mirror[T], ev: Decoder[mirror.IronType]): Decoder[T] =
+  ev.asInstanceOf[Decoder[T]]
+
+object Foo:
+  opaque type T = String
+
+  inline given Mirror[T] with
+    type IronType = String
+
+inline def summonFooDecoder: Decoder[Foo.T] =
+  summonFrom {
+    case decodeA: Decoder[Foo.T] => decodeA
+  }
+
+val fooDecoder: Decoder[Foo.T] = summonFooDecoder

--- a/tests/pos/i25427.scala
+++ b/tests/pos/i25427.scala
@@ -1,0 +1,15 @@
+import scala.compiletime.summonInline
+
+trait MyEvidence[T]
+
+object Scope:
+  opaque type T = String
+
+  inline given MyEvidence[T] with {}
+
+inline def summonInlineNoOpProxy: MyEvidence[Scope.T] = summonInline[MyEvidence[Scope.T]]
+
+val smoke = (
+  summonInline[MyEvidence[Scope.T]],
+  summonInlineNoOpProxy,
+)


### PR DESCRIPTION
Fixes https://github.com/scala/scala3/issues/25417 fixes https://github.com/scala/scala3/issues/25427
Regression introduced by https://github.com/tanishiking/scala3/commit/816fc6cb34a2ee430ada1c40072a9635e0b673a5 (https://github.com/scala/scala3/pull/25111), which fixed https://github.com/scala/scala3/issues/25091.

Background:
- https://github.com/scala/scala3/issues/25091 showed that inline sealing could cast target contains  method-reference that results in `notype` at erasure.
- https://github.com/scala/scala3/pull/25111 fixed this by using `target.widenIfUnstable` to remove  method-reference from cast destination, and use it's return type instead.
- However, deciding adaptation against the widened type is too weak and could skip a required cast, and leak projected opaque-proxy types (https://github.com/scala/scala3/issues/25417).

For example:
```scala
import scala.compiletime.summonInline

trait MyEvidence[T]

object Scope:
  opaque type T = String
  inline given MyEvidence[T] with {}

inline def summonInlineNoOpProxy: MyEvidence[Scope.T] =
  summonInline[MyEvidence[Scope.T]]

val smoke = (
  summonInline[MyEvidence[Scope.T]],
  summonInlineNoOpProxy,
)
```

For `summonInline[MyEvidence[Scope.T]]`:

- `inlined.tpe`:
  `Scope.type{type T = String}#given_MyEvidence_T`
- `target` (before widening):
  `(Scope.given_MyEvidence_T : => Scope.given_MyEvidence_T)`
- `resultType = target.widenIfUnstable`:
  `Scope.given_MyEvidence_T`

Previously
- `inlined.tpe <:< resultType` hold, so adaptation is skipped.
- Therefore, no cast is inserted, inlined tree type remains`Scope.type{type T = String}#given_MyEvidence_T`
- This is seen as `MyEvidence[String]`
- Later typing fails for required `MyEvidence[Scope.T]` vs `MyEvidence[String]` (path dependence infor is dropped).

---

This commit fixes the problem by: decide whether adaptation is needed against original `target` (the real call-site contract), while using `target.widenIfUnstable` as a cast destination, so that https://github.com/scala/scala3/issues/25091 fix)

`target.widenIfUnstable` is an upper approximation of `target`. Conformance to widened type is weaker than conformance to original `target`.
Therefore adaptation-need must be checked against `target`, while widened type is used only as cast destination.
<!-- Fixes #XYZ (where XYZ is the issue number from the issue tracker) -->

<!-- TODO description of the change -->
<!-- Ideally should have a title like "Fix #XYZ: Short fix description" -->

<!--
  TODO first sign the CLA
  https://contribute.akka.io/cla/scala
-->

<!-- if the PR is still a WIP, create it as a draft PR (or convert it into one) -->

## How much have your relied on LLM-based tools in this contribution?

<!-- 
  State clearly in the pull request description, 
  whether LLM-based tools were used and to what extent 

  (extensively/moderately/minimally/not at all)
-->

<!--
  Refer to our [LLM usage policy](https://github.com/scala/scala3/blob/main/LLM_POLICY.md) for rules and guidelines
  regarding usage of LLM-based tools in contributions.
-->

Worked with GPT5.3-Codex

## How was the solution tested?

`testCompilation (i25091|i25417|i25427)`

<!-- 
  If automated tests are included, mention it.
  If they are not, explain why and how the solution was tested.
-->

## Additional notes

<!-- Placeholder for any extra context regarding this contribution. -->

<!--
  When in doubt, and for support regarding contributions to a particular component of the compiler, 
  refer to [our contribution guide](https://github.com/scala/scala3/blob/main/CONTRIBUTING.md),
  and feel free to tag the maintainers listed there for the area(s) you are modifying.
-->
