### PR TITLE
bugfix: Fix issues in presentation compiler when using Scala JS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -854,7 +854,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
         val args = until(end, () => readTypeRef())
         if (sym == defn.ByNameParamClass2x) ExprType(args.head)
         else if (ctx.settings.scalajs.value && args.length == 2 &&
-            sym.owner == JSDefinitions.jsdefn.ScalaJSJSPackageClass && sym == JSDefinitions.jsdefn.PseudoUnionClass) {
+            sym.owner == JSDefinitions.jsdefn.ScalaJSJSPackageClass && sym.name == tpnme.raw.BAR) {
           // Treat Scala.js pseudo-unions as real unions, this requires a
           // special-case in erasure, see TypeErasure#eraseInfo.
           OrType(args(0), args(1), soft = false)

--- a/presentation-compiler/src/main/dotty/tools/pc/utils/InteractiveEnrichments.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/utils/InteractiveEnrichments.scala
@@ -121,24 +121,26 @@ object InteractiveEnrichments extends CommonMtagsEnrichments:
             )
           else pos
 
-        val pos1 =
-          if pos0.end > 0 && text(pos0.end - 1) == ',' then
-            pos0.withEnd(pos0.end - 1)
-          else pos0
-        val isBackticked =
-          text(pos1.start) == '`' &&
-            pos1.end > 0 &&
-            text(pos1.end - 1) == '`'
-        // when the old name contains backticks, the position is incorrect
-        val isOldNameBackticked = text(pos1.start) != '`' &&
-          pos1.start > 0 &&
-          text(pos1.start - 1) == '`' &&
-          text(pos1.end) == '`'
-        if isBackticked && forRename then
-          (pos1.withStart(pos1.start + 1).withEnd(pos1.end - 1), true)
-        else if isOldNameBackticked then
-          (pos1.withStart(pos1.start - 1).withEnd(pos1.end + 1), false)
-        else (pos1, false)
+        if !pos0.span.isCorrect(text) then (pos, false)
+        else
+          val pos1 =
+            if pos0.end > 0 && text(pos0.end - 1) == ',' then
+              pos0.withEnd(pos0.end - 1)
+            else pos0
+          val isBackticked =
+            text(pos1.start) == '`' &&
+              pos1.end > 0 &&
+              text(pos1.end - 1) == '`'
+          // when the old name contains backticks, the position is incorrect
+          val isOldNameBackticked = text(pos1.start) != '`' &&
+            pos1.start > 0 &&
+            text(pos1.start - 1) == '`' &&
+            text(pos1.end) == '`'
+          if isBackticked && forRename then
+            (pos1.withStart(pos1.start + 1).withEnd(pos1.end - 1), true)
+          else if isOldNameBackticked then
+            (pos1.withStart(pos1.start - 1).withEnd(pos1.end + 1), false)
+          else (pos1, false)
     end adjust
   end extension
 

--- a/presentation-compiler/test/dotty/tools/pc/base/BasePCSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/BasePCSuite.scala
@@ -42,7 +42,7 @@ abstract class BasePCSuite extends PcAssertions:
   )
 
   lazy val presentationCompiler: PresentationCompiler =
-    val myclasspath: Seq[Path] = TestResources.classpath
+    val myclasspath: Seq[Path] = TestResources.classpath ++ additionalClasspath
     val scalacOpts = scalacOptions(myclasspath)
     val search = new MockSymbolSearch(
       testingWorkspaceSearch,
@@ -80,6 +80,7 @@ abstract class BasePCSuite extends PcAssertions:
 
   protected def scalacOptions(classpath: Seq[Path]): Seq[String] =
     immutable.Seq.empty
+  protected def additionalClasspath: Seq[Path] = Nil
   protected def mockEntries: MockEntries = new MockEntries {}
 
   def params(code: String, filename: String = "A.scala"): (String, Int) =

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/ScalaJSCompletionsSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/ScalaJSCompletionsSuite.scala
@@ -1,0 +1,58 @@
+package dotty.tools.pc.tests.completion
+
+import java.net.URI
+import java.nio.file.Path
+
+import scala.meta.internal.jdk.CollectionConverters.*
+import scala.meta.internal.metals.EmptyCancelToken
+import scala.meta.pc.CancelToken
+import scala.meta.pc.VirtualFileParams
+
+import dotty.tools.pc.RawScalaPresentationCompiler
+import dotty.tools.pc.base.BaseCompletionSuite
+import dotty.tools.pc.base.TestResources
+import dotty.tools.pc.tests.buildinfo.BuildInfo
+import dotty.tools.pc.utils.PcAssertions
+
+import org.junit.Test
+
+class ScalaJSCompletionsSuite extends BaseCompletionSuite {
+
+  override protected def scalacOptions(classpath: Seq[Path]): Seq[String] = List("-scalajs")
+
+  override protected def additionalClasspath: Seq[Path] = BuildInfo.ideTestsScalaJSClasspath.map(_.toPath)
+
+  @Test def plainScalaJS =
+    check(
+      """
+        |object ChatApp:
+        |  private def connectWebSocket() =
+        |    scala.scalajs.js.@@
+        |    ???
+        |""".stripMargin,
+      """
+        |WrappedArray[A](elems: A*): WrappedArray[A]
+        |WrappedSet[A](elems: A*): WrappedSet[A]
+        |AggregateError(errors: scala.scalajs.js.Iterable[Any], message: String = ...): AggregateError
+        |Array[A](items: A*): scala.scalajs.js.Array[A]
+        |""".stripMargin,
+      topLines = Some(4)
+    )
+
+  @Test def scalajsDom =
+    check(
+      """
+        |
+        |import org.scalajs.dom
+        |import org.scalajs.dom.WebSocket
+        |
+        |object ChatApp:
+        |  private def connectWebSocket() =
+        |    val newws = WebSocket(???)
+        |    dom.window.onbeforeunload@@ = _ => newws.close()
+        |""".stripMargin,
+      """
+        |onbeforeunload: scala.scalajs.js.Function1[BeforeUnloadEvent, ?] 
+        |""".stripMargin
+    )
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -168,6 +168,7 @@ object Build {
   val ideTestsCompilerVersion = taskKey[String]("Compiler version to use in IDE tests")
   val ideTestsCompilerArguments = taskKey[Seq[String]]("Compiler arguments to use in IDE tests")
   val ideTestsDependencyClasspath = taskKey[Seq[File]]("Dependency classpath to use in IDE tests")
+  val ideTestsScalaJSClasspath = taskKey[Seq[File]]("Scala.js dependency classpath to use in IDE tests")
 
   val fetchScalaJSSource = taskKey[File]("Fetch the sources of Scala.js")
 
@@ -2030,10 +2031,20 @@ object Build {
         val dottyLib = (`scala-library-bootstrapped` / Compile / classDirectory).value
         testCasesLib :: dottyLib :: Nil
       },
+      ideTestsScalaJSClasspath := {
+        val externalJSCommonDeps = (`scaladoc-js-common`  / Compile / externalDependencyClasspath).value
+        println(externalJSCommonDeps)
+        val scalaJSCommonDom = findArtifact(externalJSCommonDeps, "scalajs-dom_sjs1_3")
+        val externalJSDeps = (`scala-library-sjs` / Compile / externalDependencyClasspath).value
+        val scalaJSLibrary = findArtifact(externalJSDeps, "scalajs-library_2.13")
+        val scalaJSJavalib = findArtifact(externalJSDeps, "scalajs-javalib")
+        val scalaJSScalalib = (`scala-library-sjs` / Compile / packageBin).value
+        scalaJSLibrary :: scalaJSJavalib :: scalaJSScalalib :: scalaJSCommonDom :: Nil
+      },
       Compile / buildInfoPackage := "dotty.tools.pc.buildinfo",
       Compile / buildInfoKeys := Seq(scalaVersion),
       Test / buildInfoPackage := "dotty.tools.pc.tests.buildinfo",
-      Test / buildInfoKeys := Seq(scalaVersion, ideTestsDependencyClasspath)
+      Test / buildInfoKeys := Seq(scalaVersion, ideTestsDependencyClasspath, ideTestsScalaJSClasspath)
     ) ++ BuildInfoPlugin.buildInfoScopedSettings(Compile) ++
       BuildInfoPlugin.buildInfoScopedSettings(Test) ++
       BuildInfoPlugin.buildInfoDefaultSettings


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/8236 and https://github.com/scala/scala3/issues/25447

Avoid loading the | scala JS symbol altogether as suggested.

<!-- Fixes #XYZ (where XYZ is the issue number from the issue tracker) -->

<!-- TODO description of the change -->
<!-- Ideally should have a title like "Fix #XYZ: Short fix description" -->

<!--
  TODO first sign the CLA
  https://contribute.akka.io/cla/scala
-->

<!-- if the PR is still a WIP, create it as a draft PR (or convert it into one) -->

## How much have your relied on LLM-based tools in this contribution?

It wrote parts of the tests and suggested some improvements.

## How was the solution tested?

Added tests specific to Scala JS

## Additional notes

<!-- Placeholder for any extra context regarding this contribution. -->

<!--
  When in doubt, and for support regarding contributions to a particular component of the compiler, 
  refer to [our contribution guide](https://github.com/scala/scala3/blob/main/CONTRIBUTING.md),
  and feel free to tag the maintainers listed there for the area(s) you are modifying.
-->
