### PR TITLE
Fix incorrect rewrite of `expr _` when expr has a function type

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Migrations.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Migrations.scala
@@ -62,14 +62,15 @@ trait Migrations:
       case blockEndingInClosure(_, _, _) =>
       case _ =>
         val recovered = typed(qual)(using ctx.fresh.setExploreTyperState())
-        val msg = OnlyFunctionsCanBeFollowedByUnderscore(recovered.tpe.widen, tree)
-        report.errorOrMigrationWarning(msg, tree.srcPos, mv.Scala2to3)
-        if mv.Scala2to3.needsPatch then
-          // Under -rewrite, patch `x _` to `(() => x)`
-          msg.actions
-            .headOption
-            .foreach(Rewrites.applyAction)
-          return typed(untpd.Function(Nil, qual), pt)
+        if !defn.isFunctionType(recovered.tpe.widen) then
+          val msg = OnlyFunctionsCanBeFollowedByUnderscore(recovered.tpe.widen, tree)
+          report.errorOrMigrationWarning(msg, tree.srcPos, mv.Scala2to3)
+          if mv.Scala2to3.needsPatch then
+            // Under -rewrite, patch `x _` to `(() => x)`
+            msg.actions
+              .headOption
+              .foreach(Rewrites.applyAction)
+            return typed(untpd.Function(Nil, qual), pt)
     }
     nestedCtx.typerState.commit()
 
@@ -80,6 +81,8 @@ trait Migrations:
         functionPrefixSuffix(vparams.length)
       case Block(ValDef(_, _, _) :: Nil, Block(DefDef(_, vparams :: Nil, _, _) :: Nil, _: Closure)) =>
         functionPrefixSuffix(vparams.length)
+      case _ if defn.isFunctionType(res.tpe.widen) =>
+        ("", "")
       case _ =>
         ("(() => ", ")")
     }

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -90,6 +90,8 @@ class CompilationTests {
       compileFile("tests/rewrites/implicit-to-given.scala", defaultOptions.and("-rewrite", "-Yimplicit-to-given")),
       compileFile("tests/rewrites/i22792.scala", defaultOptions.and("-rewrite")),
       compileFile("tests/rewrites/i23449.scala", defaultOptions.and("-rewrite", "-source:3.4-migration")),
+      compileFile("tests/rewrites/i24103.scala", defaultOptions.and("-rewrite", "-source:3.4-migration")),
+      compileFile("tests/rewrites/i24103b.scala", defaultOptions.and("-rewrite", "-source:3.4-migration")),
       compileFile("tests/rewrites/i24213.scala", defaultOptions.and("-rewrite", "-source:3.4-migration")),
     )).checkRewrites()
   }

--- a/tests/rewrites/i24103.check
+++ b/tests/rewrites/i24103.check
@@ -1,0 +1,11 @@
+abstract class IndexedTraversal_[I, S, T, A, B]:
+  final def overF[F[_]](f: ((A, I)) => F[B])(s: S): F[T] = ???
+
+type Id[A] = A
+
+trait IndexedTraversalLaws[I, S, A]:
+  def indexedTraversal: IndexedTraversal_[I, S, S, A, A]
+
+  def consistentFoci(s: S, f: (A, I) => A, g: (A, I) => A) =
+    (indexedTraversal.overF[Id](f.tupled) compose indexedTraversal.overF[Id](g.tupled))(s)
+    ???

--- a/tests/rewrites/i24103.scala
+++ b/tests/rewrites/i24103.scala
@@ -1,0 +1,12 @@
+abstract class IndexedTraversal_[I, S, T, A, B]:
+  final def overF[F[_]](f: ((A, I)) => F[B])(s: S): F[T] = ???
+
+type Id[A] = A
+
+trait IndexedTraversalLaws[I, S, A] {
+  def indexedTraversal: IndexedTraversal_[I, S, S, A, A]
+
+  def consistentFoci(s: S, f: (A, I) => A, g: (A, I) => A) =
+    (indexedTraversal.overF[Id](f.tupled) _ compose indexedTraversal.overF[Id](g.tupled))(s)
+    ???
+}

--- a/tests/rewrites/i24103b.check
+++ b/tests/rewrites/i24103b.check
@@ -1,0 +1,6 @@
+object Test:
+  def foo(x: Int): Int => Int = y => x + y
+  def bar(x: Int): Int => Int = y => x * y
+
+  def test(s: Int): Int =
+    (foo(1) compose bar(2))(s)

--- a/tests/rewrites/i24103b.scala
+++ b/tests/rewrites/i24103b.scala
@@ -1,0 +1,8 @@
+object Test {
+  def foo(x: Int): Int => Int = y => x + y
+  def bar(x: Int): Int => Int = y => x * y
+
+  def test(s: Int): Int = {
+    (foo(1) _ compose bar(2))(s)
+  }
+}


### PR DESCRIPTION
When the expression already has a function type, `expr _` is just redundant eta-expansion. The rewriter was incorrectly wrapping it in `(() => expr)`, changing the type and breaking compilation.

Now we skip the `OnlyFunctionsCanBeFollowedByUnderscore` error for function-typed expressions and just remove the trailing `_` instead.

Fixes #24103.

## How much have your relied on LLM-based tools in this contribution?

Extensively; Claude Opus 4.6 investigated and fixed the issue on its own. I reviewed and applied minor modifications.

## How was the solution tested?

Two new rewrite tests `tests/rewrites/i24103.scala` and `tests/rewrites/i24103b.scala`.