### PR TITLE
Backport "Bump Scala CLI to v1.12.3 (was v1.12.2)" to 3.8.3

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -136,7 +136,7 @@ object Build {
   val mimaPreviousDottyVersion = "3.8.0"
 
   /** Version of Scala CLI to download */
-  val scalaCliLauncherVersion = "1.12.2"
+  val scalaCliLauncherVersion = "1.12.3"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
   val coursierJarVersion = "2.1.25-M23"
 


### PR DESCRIPTION
Backports #25365 to the 3.8.3-RC2.

PR submitted by the release tooling.
[skip ci]