### PR TITLE
Backport "Don't enable compact annotations under 2.13." to 3.8.3

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
+++ b/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
@@ -47,7 +47,7 @@ enum SourceVersion:
   def enablesBetterFors(using Context) = isAtLeast(`3.8`) || (isAtLeast(`3.7`) && isPreviewEnabled)
   /** See PR #23441 and tests/neg/i23435-min */
   def enablesDistributeAnd = !isAtLeast(`future`)
-  def enablesCompactAnnotation = isAtLeast(`3.9`)
+  def enablesCompactAnnotation = isAtLeast(`3.9`) && this != `2.13`
 
   def requiresNewSyntax = isAtLeast(future)
 


### PR DESCRIPTION
Backports #25419 to the 3.8.3-RC2.

PR submitted by the release tooling.
[skip ci]