### PR TITLE
Backport "Bump Scala CLI to 1.12.4 (was 1.12.3)" to 3.8.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -278,5 +278,5 @@ jobs:
         with:
           fetch-depth: 0
       - uses: coursier/cache-action@v8
-      - uses: VirtusLab/scala-cli-setup@v1.12.3
+      - uses: VirtusLab/scala-cli-setup@v1.12.4
       - run: scala-cli format --check

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -136,7 +136,7 @@ object Build {
   val mimaPreviousDottyVersion = "3.8.0"
 
   /** Version of Scala CLI to download */
-  val scalaCliLauncherVersion = "1.12.3"
+  val scalaCliLauncherVersion = "1.12.4"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
   val coursierJarVersion = "2.1.25-M23"
 


### PR DESCRIPTION
Backports #25434 to the 3.8.3-RC2.

PR submitted by the release tooling.
[skip ci]