### PR TITLE
Automatically assign dependabot PRs to `scala/infrastructure-maintainers`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,16 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    assignees:
-      - hamzaremmal
     reviewers:
-      - hamzaremmal
+      - scala/infrastructure-maintainers
   - package-ecosystem: bundler
     directory: '/docs/_spec'
     schedule:
       interval: weekly
-    assignees:
-      - hamzaremmal
     reviewers:
-      - hamzaremmal
-      
+      - scala/infrastructure-maintainers


### PR DESCRIPTION
cc @scala/infrastructure-maintainers 

The `assignees` field is left empty, as you can't assign PRs to teams (and I don't think we should hard-code a single person. Especially as that person would likely have to be me 🙃 

## How much have your relied on LLM-based tools in this contribution?
I guess I let Claude check the dependabot reference and use the team name in the correct syntax.
I'm just that lazy.
So extensively? 🤣 

## How was the solution tested?
The only way to test it is to merge it to `main`.

## Additional notes
- https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
