### PR TITLE
Use `readAllBytes` instead of `ByteArrayOutputStream`

### DIFF
--- a/sjs-compiler-tests/test/scala/dotty/tools/dotc/JSRun.scala
+++ b/sjs-compiler-tests/test/scala/dotty/tools/dotc/JSRun.scala
@@ -54,16 +54,7 @@ object JSRun:
         ""
       case Some(stream) =>
         try
-          val result = new java.io.ByteArrayOutputStream()
-          val buffer = new Array[Byte](1024)
-          while ({
-            val len = stream.read(buffer)
-            len >= 0 && {
-              result.write(buffer, 0, len)
-              true
-            }
-          }) ()
-          new String(result.toByteArray(), StandardCharsets.UTF_8)
+          new String(stream.readAllBytes(), StandardCharsets.UTF_8)
         finally
           stream.close()
   end readStreamFully


### PR DESCRIPTION
https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/io/InputStream.html#readAllBytes()

`InputStream` has `readAllBytes` method since JDK 9.


<!-- Fixes #XYZ (where XYZ is the issue number from the issue tracker) -->

<!-- TODO description of the change -->
<!-- Ideally should have a title like "Fix #XYZ: Short fix description" -->

<!--
  TODO first sign the CLA
  https://contribute.akka.io/cla/scala
-->

<!-- if the PR is still a WIP, create it as a draft PR (or convert it into one) -->

## How much have your relied on LLM-based tools in this contribution?

No

<!-- 
  State clearly in the pull request description, 
  whether LLM-based tools were used and to what extent 

  (extensively/moderately/minimally/not at all)
-->

<!--
  Refer to our [LLM usage policy](https://github.com/scala/scala3/blob/main/LLM_POLICY.md) for rules and guidelines
  regarding usage of LLM-based tools in contributions.
-->

## How was the solution tested?

<!-- 
  If automated tests are included, mention it.
  If they are not, explain why and how the solution was tested.
-->

## Additional notes

<!-- Placeholder for any extra context regarding this contribution. -->

<!--
  When in doubt, and for support regarding contributions to a particular component of the compiler, 
  refer to [our contribution guide](https://github.com/scala/scala3/blob/main/CONTRIBUTING.md),
  and feel free to tag the maintainers listed there for the area(s) you are modifying.
-->
