### PR TITLE
Fix capture checking doc links in language.scala

### DIFF
--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -90,14 +90,14 @@ private[scala] object language:
 
     /** Experimental support for capture checking; implies support for pureFunctions
      *
-     *  @see [[https://nightly.scala-lang.org/docs/reference/experimental/capture-checking/]]
+     *  @see [[https://docs.scala-lang.org/scala3/reference/experimental/capture-checking/index.html]]
      */
     @compileTimeOnly("`captureChecking` can only be used at compile time in import statements")
     object captureChecking
 
     /** Experimental support for separation checking; requires captureChecking also to be enabled.
      *
-     *  @see [[https://nightly.scala-lang.org/docs/reference/experimental/capture-checking/]]
+     *  @see [[https://docs.scala-lang.org/scala3/reference/experimental/capture-checking/index.html]]
      */
     @compileTimeOnly("`separationChecking` can only be used at compile time in import statements")
     object separationChecking


### PR DESCRIPTION
Update @see links for captureChecking and separationChecking to point to the correct capture-checking documentation URL.


## How much have your relied on LLM-based tools in this contribution?

Nope

## How was the solution tested?

Entering the link in the browser

