### PR TITLE
Don't automatically insert OUTDENT before COMMA

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -725,22 +725,24 @@ object Scanners {
           offset = next.offset
           token = INDENT
 
-    def isEnclosedInParens(r: Region): Boolean = r match
-      case r: Indented => isEnclosedInParens(r.outer)
-      case _: InParens => true
-      case _ => false
-
     /** Insert an <outdent> token if next token closes an indentation region.
-     *  Exception: continue if indentation region belongs to a `match` and next token is `case`.
+     *  or next token is a comma and we expect a comma in an outer region.
+     *  Exception: continue if indentation region belongs to a `match` or `catch1
+     *  and next token is `case`.
      */
     def observeOutdented(): Unit = currentRegion match
-      case r: Indented
-      if !r.isOutermost
-         && closingRegionTokens.contains(token)
-         && !(token == CASE && r.prefix == MATCH)
-         && next.token == EMPTY  // can be violated for ill-formed programs, e.g. neg/i12605.scala
-      =>
-        insert(OUTDENT, offset)
+      case r: Indented if !r.isOutermost =>
+        if closingRegionTokens.contains(token)
+            && !(token == CASE && r.prefix == MATCH)
+            && next.token == EMPTY
+          ||
+            token == COMMA
+            && r.outer.commasExpectedInEnclosing
+            && nextNext.token == EMPTY
+        then
+          //if next.token != EMPTY then
+          //  println(i"NOT inserting outdent in front of $this, ${next.token}, ${r.prefix}")
+          insert(OUTDENT, offset)
       case _ =>
 
     def peekAhead() =
@@ -777,21 +779,17 @@ object Scanners {
           peekAhead()
           if (token != ELSE) reset()
         case COMMA =>
-          currentRegion match
-            case r: Indented if isEnclosedInParens(r.outer) =>
-              insert(OUTDENT, offset)
-            case _ =>
-              peekAhead()
-              if isAfterLineEnd
-                 && currentRegion.commasExpected
-                 && (token == RPAREN || token == RBRACKET || token == RBRACE || token == OUTDENT)
-              then
-                // encountered a trailing comma
-                // reset only the lastOffset
-                // so that the tree's span is correct
-                lastOffset = prev.lastOffset
-              else
-                reset()
+          peekAhead()
+          if isAfterLineEnd
+              && currentRegion.commasExpected
+              && (token == RPAREN || token == RBRACKET || token == RBRACE || token == OUTDENT)
+          then
+            // encountered a trailing comma
+            // reset only the lastOffset
+            // so that the tree's span is correct
+            lastOffset = prev.lastOffset
+          else
+            reset()
         case ARROW =>
           currentRegion match
           case r: Indented if r.outer.isInstanceOf[InCase] =>
@@ -1679,6 +1677,11 @@ object Scanners {
       res
 
     def commasExpected = myCommasExpected
+
+    def commasExpectedInEnclosing: Boolean =
+      commasExpected || this.match
+        case r: Indented => r.outer.commasExpectedInEnclosing
+        case _ => false
 
     def toList: List[Region] =
       this :: (if outer == null then Nil else outer.toList)

--- a/tests/pos/i22528.scala
+++ b/tests/pos/i22528.scala
@@ -1,0 +1,8 @@
+trait Bar
+trait Baz
+
+def f =
+  identity(
+    locally:
+      trait Foo extends Bar, Baz
+  )


### PR DESCRIPTION
Don't automatically insert OUTDENT before COMMA

(when enclosed in parentheses). Do it instead as part of
observeOutdented when we look at a separator or terminator
of a statement sequence.

This needs 2-token looahead since a comma always uses one lookahead
to determine whether it's a comma at end of line and we need to sometimes
insert an OUTDENT before the comma.

Fixes #22528 