### PR TITLE
Match apply in PolyFunction for override

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -1074,7 +1074,11 @@ object CheckUnused:
       sym.canMatchInheritedSymbols && { // inline allOverriddenSymbols using owner.info or thisType
         val owner = sym.owner.asClass
         val base = if owner.classInfo.selfInfo != NoType then owner.thisType else owner.info
-        base.baseClasses.drop(1).iterator.exists(sym.overriddenSymbol(_).exists)
+        base.baseClasses.drop(1).iterator.exists: bc =>
+          if bc == defn.PolyFunctionClass then
+            sym.name == nme.apply
+          else
+            sym.overriddenSymbol(inClass = bc, siteClass = owner).exists
       }
     // pick the symbol the user wrote for purposes of tracking
     inline def userSymbol: Symbol=

--- a/tests/warn/i24665.scala
+++ b/tests/warn/i24665.scala
@@ -1,0 +1,5 @@
+//> using options -Werror -Wunused:all
+
+def method[A](f: [g[_]] => Unit => g[A]) = ()
+
+@main def main = method([g[_]] => (_: Unit) => null.asInstanceOf[g[Int]])


### PR DESCRIPTION
Fixes #24665 

The bug is LTS-only. This fix should backport cleanly.

## How much have your relied on LLM-based tools in this contribution?

0.0%

## How was the solution tested?

Developed first on scala/scala3-lts:lts-3.3 then cherry-picked.

## Additional notes

Glad he diagnosed it last year; not sure why he didn't submit a PR at the time, but probably because he had no idea how LTS was managed.

The bug was that when checking if a member is "effectively private", an `apply` method does not override any member of `PolyFunction`, which is a marker trait. The fix was to take any `apply` member with a `PolyFunction` parent as an override.

