### PR TITLE
Check protected parent constructor accesses only occurs in child constructors

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -946,10 +946,12 @@ object SymDenotations {
         val cls = owner.enclosingSubClass
         if !cls.exists then
           pre.termSymbol.isPackageObject && accessWithin(pre.termSymbol.owner)
-        else
+        else {
+          val isConstructorAccessOK = isConstructor && ctx.owner.isConstructor
           // allow accesses to types from arbitrary subclasses fixes #4737
           // don't perform this check for static members
-          isType || pre.derivesFrom(cls) || isConstructor || owner.is(ModuleClass)
+          isType || pre.derivesFrom(cls) || isConstructorAccessOK || owner.is(ModuleClass)
+        }
       end isProtectedAccessOK
 
       if pre eq NoPrefix then true

--- a/tests/neg/i25442/test.scala
+++ b/tests/neg/i25442/test.scala
@@ -1,0 +1,8 @@
+class I protected (x: Int) {
+  protected def f = x
+}
+
+class M protected () extends I(42) {
+  def t1 = new M()   // ok
+  def t2 = new I(42) // error
+}


### PR DESCRIPTION
Fixes #25442.

Currently, protected parent class constructor calls that occur outside of their subclass constructors are not properly checked. So it possible to call a parent constructor in any method of subclass. This change checks that such accesses only occur inside subclass constructors. 

No LLM-based tools were used.

negative test case from issue included.