### PR TITLE
Fix protected constructor access checks

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -947,7 +947,7 @@ object SymDenotations {
         if !cls.exists then
           pre.termSymbol.isPackageObject && accessWithin(pre.termSymbol.owner)
         else {
-          val isConstructorAccessOK = isConstructor && ctx.owner.isConstructor
+          val isConstructorAccessOK = isConstructor && ctx.owner.isPrimaryConstructor
           // allow accesses to types from arbitrary subclasses fixes #4737
           // don't perform this check for static members
           isType || pre.derivesFrom(cls) || isConstructorAccessOK || owner.is(ModuleClass)

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -1415,6 +1415,29 @@ trait Checking {
         case Apply(fn, _) => checkLegalConstructorCall(fn, call, "")
         case _ =>
       }
+
+      // Check that super call arguments don't contain `new` expressions
+      // accessing protected constructors. The super call itself is allowed
+      // (via isConstructorAccessOK in isProtectedAccessOK), but nested `new`
+      // expressions in its arguments should not benefit from that exception.
+      // Since ctx.owner here is the class (not the constructor),
+      // isConstructorAccessOK is automatically false, giving the correct check.
+      def collectArgs(tree: Tree): List[Tree] = tree match
+        case Apply(fn, args) => args ++ collectArgs(fn)
+        case TypeApply(fn, _) => collectArgs(fn)
+        case _ => Nil
+      for arg <- collectArgs(call) do
+        arg.foreachSubTree:
+          case sel @ tpd.Select(nw: tpd.New, nme.CONSTRUCTOR) =>
+            val constrSym = sel.symbol
+            if constrSym.is(Protected)
+              && !constrSym.isAccessibleFrom(nw.tpe, superAccess = false)
+            then
+              report.error(
+                em"""${constrSym} cannot be accessed as a member of ${nw.tpe} from ${caller}.
+                    |  protected ${constrSym} can only be accessed from ${caller} or one of its subclasses.""",
+                nw.srcPos)
+          case _ =>
     }
 
   /** Check that `tpt` does not define a higher-kinded type */

--- a/tests/neg/i25442/protected-constructors.scala
+++ b/tests/neg/i25442/protected-constructors.scala
@@ -1,0 +1,28 @@
+package protectedCtors
+
+class A protected (x: Int)
+
+// Protected constructor in super call arguments (transitive parent)
+class B(a: A) extends A(a.hashCode)
+class C extends B(new A(1)) // error
+
+// Protected constructor in own parent's arguments
+class D protected (x: Any)
+class E extends D(new D(1)) // error
+
+// Mixed visibility constructors
+class F protected (x: Int) {
+  def this() = this(0) // public secondary
+}
+class G(f: F) extends F(f.hashCode)
+class H extends G(new F())   // ok: public secondary in super args
+class J extends G(new F(1))  // error: protected primary in super args
+
+// new in primary constructor body
+class K extends A(42) {
+  val k = new A(1) // error
+}
+
+// Lambda in super call arguments
+class M(f: () => A) extends A(1)
+class N extends M(() => new A(2)) // error

--- a/tests/neg/i25442/test.scala
+++ b/tests/neg/i25442/test.scala
@@ -5,4 +5,5 @@ class I protected (x: Int) {
 class M protected () extends I(42) {
   def t1 = new M()   // ok
   def t2 = new I(42) // error
+  def this(x: Int) = { this(); new I(x) } // error
 }

--- a/tests/pos/i25442.scala
+++ b/tests/pos/i25442.scala
@@ -1,0 +1,18 @@
+package protectedCtorsPos
+
+class A protected (x: Int)
+
+// Super calls are allowed
+class B extends A(42)
+
+// Inner class extending protected parent
+class C extends A(42) {
+  class Inner extends A(1)
+}
+
+// Mixed visibility: public secondary constructor is accessible
+class D protected (x: Int) {
+  def this() = this(0)
+}
+class E(d: D) extends D(d.hashCode)
+class F extends E(new D())


### PR DESCRIPTION
Refine isConstructorAccessOK to check isPrimaryConstructor instead of isConstructor. This rejects `new Parent(x)` in secondary constructors, which was incorrectly allowed because ctx.owner.isConstructor was true for both primary (super call) and secondary constructors.

Add a post-hoc check in checkParentCall that walks super call arguments and rejects protected constructor accesses within them. This handles cases like `extends B(new A(1))` where A has a protected constructor and is a direct or transitive parent. The check leverages the fact that ctx.owner is the class (not the constructor) in checkParentCall, so isConstructorAccessOK is naturally false.

Covers more cases than https://github.com/scala/scala3/pull/25511

## How much have your relied on LLM-based tools in this contribution?

I used Claude to point me to places in the compiler that are involved in this check.

## How was the solution tested?

Added some more subtle test cases and compared against Scala 2.13 behavior. 

## Additional notes

I first tried an alternative approach that fine-tunes the context for a constructor-call argument in `def argCtx` in `Applications.scala`, because in the case of, say, `extends A(new A(1))`, the context owner for the argument `new A(1)` will also be the primary constructor, so just checking for `isPrimaryConstructor` isn't granular enough. However, tweaking `argCtx` for this specific situation resulted in a massive amount of compiler tests failing. So the current approach is checking the arguments of super calls in `checkParentCall` within `Checking`.