### PR TITLE
Deprecation when inferring implicit from non-accessible companion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ metals.sbt
 .scala-build
 sbt-launch.jar
 
+.claude
+
 # Partest
 dotty.jar
 dotty-lib.jar

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1089,6 +1089,21 @@ trait Implicits:
       val res = implicitArgTree(defn.CanEqualClass.typeRef.appliedTo(ltp, rtp), span)
       implicits.println(i"CanEqual witness found for $ltp / $rtp: $res: ${res.tpe}")
 
+  // Deprecation warning if the implicit `result` is defined in a non-accessible object
+  private def warnIfImplicitFromInaccessibleCompanion(result: SearchSuccess, span: Span)(using Context): Unit =
+    val ref = result.ref
+    val owner = ref.symbol.owner
+    if owner.is(Module) then
+      val companion = owner.sourceModule
+      if companion.isOneOf(Private | Protected) then ref.prefix match
+        case companionRef: TermRef =>
+          val pre = companionRef.prefix
+          if !companion.isAccessibleFrom(pre) then
+            report.deprecationWarning(
+              em"Usage of implicit ${ref.symbol} defined in $companion, which is not accessible here. In Scala 3.10, this implicit will no longer be found.",
+              ctx.source.atSpan(span))
+        case _ =>
+
   /** Find an implicit parameter or conversion.
    *  @param pt              The expected type of the parameter or conversion.
    *  @param argument        If an implicit conversion is searched, the argument to which
@@ -1138,6 +1153,7 @@ trait Implicits:
               ctx.gadtState.restore(result.gstate)
             implicits.println(i"success: $result")
             implicits.println(i"committing ${result.tstate.constraint} yielding ${ctx.typerState.constraint} in ${ctx.typerState}")
+            warnIfImplicitFromInaccessibleCompanion(result, span)
             result
           case result: SearchFailure if result.isAmbiguous =>
             val deepPt = pt.deepenProto

--- a/tests/warn/i25347.check
+++ b/tests/warn/i25347.check
@@ -1,0 +1,4 @@
+-- Deprecation Warning: tests/warn/i25347.scala:17:18 ------------------------------------------------------------------
+17 |  def bar = O.foo(new i.C) // warn
+   |                  ^^^^^^^
+   |Usage of implicit given instance c2i defined in object C, which is not accessible here. In Scala 3.10, this implicit will no longer be found.

--- a/tests/warn/i25347.scala
+++ b/tests/warn/i25347.scala
@@ -1,0 +1,18 @@
+//> using options -deprecation -feature
+trait T {
+  object i {
+    class C
+    private object C {
+      import scala.language.implicitConversions
+      given c2i: Conversion[C, Int] = _ => 42
+    }
+  }
+}
+
+object O {
+  def foo(x: Int): String = "hi"
+}
+
+object P extends T {
+  def bar = O.foo(new i.C) // warn
+}


### PR DESCRIPTION
Implicits found in the companion object of a type should not be inferred if the companion object is not accessible.

Deprecation as a first step before actually changing implicit inference.

Ref https://github.com/scala/scala3/issues/25347

The PR to change inference is https://github.com/scala/scala3/pull/25367

## How much have your relied on LLM-based tools in this contribution?

I asked it to turn my existing PR into a deprecation and cleaned it up manually. It wrote the test case, I verified it works by removing `// warn` and adding an excess `// warn`.
