### PR TITLE
Observe outdent also for type cases and type blocks in quotes

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2015,6 +2015,7 @@ object Parsers {
     def typeBlockStat(): Tree =
       val mods = defAnnotsMods(BitSet())
       val tdef = typeDefOrDcl(in.offset, in.skipToken(mods))
+      in.observeOutdented()
       if in.token == SEMI then in.nextToken()
       if in.isNewLine then in.nextToken()
       tdef
@@ -3290,6 +3291,7 @@ object Parsers {
       }
       CaseDef(pat, EmptyTree, atSpan(accept(ARROW)) {
         val t = rejectWildcardType(typ())
+        in.observeOutdented()
         if in.token == SEMI then in.nextToken()
         newLinesOptWhenFollowedBy(CASE)
         t

--- a/tests/pos/i25513.scala
+++ b/tests/pos/i25513.scala
@@ -1,0 +1,5 @@
+type Foo[A, B] = (
+  (A, B) match
+    case (Int, Int) => (A, B),
+  A
+)


### PR DESCRIPTION
These are analogous to statement sequences

Fixes #25513
