### PR TITLE
Fix crash when processing path dependent context functions using HKTs

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -955,6 +955,13 @@ object ProtoTypes {
     }
   }
 
+  def containsTypeParamRef(tp: Type)(using Context): Boolean =
+    tp.stripped match {
+      case tr: TypeParamRef => true
+      case AppliedType(_, args) => args.exists(containsTypeParamRef)
+      case _ => false
+    }
+
   /** Approximate occurrences of parameter types and uninstantiated typevars
    *  by wildcard types.
    */
@@ -962,7 +969,9 @@ object ProtoTypes {
     tp match {
     case tp: NamedType => // default case, inlined for speed
       val isPatternBoundTypeRef = tp.isInstanceOf[TypeRef] && tp.symbol.isPatternBound
+      val isImplicitTermRef = tp.isInstanceOf[TermRef] && tp.symbol.maybeOwner.isAnonymousFunction && tp.symbol.isParamOrAccessor && tp.symbol.is(Flags.Given) && containsTypeParamRef(tp.superType)
       if (isPatternBoundTypeRef) WildcardType(tp.underlying.bounds)
+      else if (isImplicitTermRef) wildApprox(tp.underlying, theMap, seen, internal)
       else if (tp.symbol.isStatic || (tp.prefix `eq` NoPrefix)) tp
       else tp.derivedSelect(wildApprox(tp.prefix, theMap, seen, internal))
     case tp @ AppliedType(tycon, args) =>

--- a/tests/neg/i25500.scala
+++ b/tests/neg/i25500.scala
@@ -1,0 +1,7 @@
+trait A[B[_]]:
+  type C
+
+def apply[D[_]](other: (a: A[D]) ?=> a.C): Any = ???
+
+def main =
+  apply(()) // error

--- a/tests/pos/i25500.scala
+++ b/tests/pos/i25500.scala
@@ -1,0 +1,13 @@
+trait A[B[_]]:
+  type C
+
+object A:
+  given A[Option]:
+    type C = Option[Int]
+
+  def apply[E[_], F](e: E[F])(using a: A[E]): a.C = ???
+
+def apply[D[_]](other: (a: A[D]) ?=> a.C): Any = ???
+
+def main =
+  apply(A(Option(5)))


### PR DESCRIPTION
<!-- Fixes #XYZ (where XYZ is the issue number from the issue tracker) -->

Fixes #25500

<!-- TODO description of the change -->
<!-- Ideally should have a title like "Fix #XYZ: Short fix description" -->

I've adjusted the wildApprox function to dive down into TermRefs when they are parameters of an anonymous function.

<!--
  TODO first sign the CLA
  https://contribute.akka.io/cla/scala
-->

<!-- if the PR is still a WIP, create it as a draft PR (or convert it into one) -->

## How much have your relied on LLM-based tools in this contribution?

  not at all

<!--
  Refer to our [LLM usage policy](https://github.com/scala/scala3/blob/main/LLM_POLICY.md) for rules and guidelines
  regarding usage of LLM-based tools in contributions.
-->

## How was the solution tested?

pos and neg tests with the issue, and test + community build

<!-- 
  If automated tests are included, mention it.
  If they are not, explain why and how the solution was tested.
-->

## Additional notes

Not sure if this is the fix that you would want

<!-- Placeholder for any extra context regarding this contribution. -->

<!--
  When in doubt, and for support regarding contributions to a particular component of the compiler, 
  refer to [our contribution guide](https://github.com/scala/scala3/blob/main/CONTRIBUTING.md),
  and feel free to tag the maintainers listed there for the area(s) you are modifying.
-->
