### PR TITLE
fix: import resolution for Java

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -343,11 +343,16 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         imp.importSym.info match
           case ImportType(expr) =>
             val pre = expr.tpe
-            val denot0 = pre.memberBasedOnFlags(name, required, excluded)
+            def findMember(excluded: FlagSet) =
+              if ctx.isJava then
+                ctx.javaFindMember(name, pre, lookInCompanion = true, required, excluded)
+              else
+                pre.memberBasedOnFlags(name, required, excluded)
+            val denot0 = findMember(excluded)
             var accessibleDenot = denot0.accessibleFrom(pre)(using refctx)
             if !accessibleDenot.exists && denot0.hasAltWith(_.symbol.is(Private)) then
-              accessibleDenot = pre.memberBasedOnFlags(name, required, excluded | Private)
-                .accessibleFrom(pre)(using refctx)
+              accessibleDenot =
+                findMember(excluded | Private).accessibleFrom(pre)(using refctx)
             // Pass refctx so that any errors are reported in the context of the
             // reference instead of the context of the import scope
             if accessibleDenot.exists then

--- a/tests/pos/i18530/Code.java
+++ b/tests/pos/i18530/Code.java
@@ -1,0 +1,11 @@
+package bug.code;
+
+import bug.actions.Smart.Action;
+
+import java.util.ArrayDeque;
+
+public class Code {
+    public static class Variable {
+        public ArrayDeque<Action> actions = new ArrayDeque<Action>();
+    }
+}

--- a/tests/pos/i18530/Smart.java
+++ b/tests/pos/i18530/Smart.java
@@ -1,0 +1,7 @@
+package bug.actions;
+
+public class Smart {
+    public abstract class Action {
+
+    }
+}

--- a/tests/pos/i18530/Test.scala
+++ b/tests/pos/i18530/Test.scala
@@ -1,0 +1,3 @@
+object Test {
+  val v = new bug.code.Code.Variable()
+}

--- a/tests/pos/i18531/Code.java
+++ b/tests/pos/i18531/Code.java
@@ -1,0 +1,8 @@
+package bug.code;
+
+import static bug.code.Symbol.*;
+
+public class Code {
+    public void constant(LoadableConstant c) {
+    }
+}

--- a/tests/pos/i18531/Constant.java
+++ b/tests/pos/i18531/Constant.java
@@ -1,0 +1,6 @@
+package bug.code;
+
+public interface Constant {
+    interface LoadableConstant extends Constant {
+    }
+}

--- a/tests/pos/i18531/Symbol.java
+++ b/tests/pos/i18531/Symbol.java
@@ -1,0 +1,4 @@
+package bug.code;
+
+public abstract class Symbol implements Constant {
+}

--- a/tests/pos/i18531/Test.scala
+++ b/tests/pos/i18531/Test.scala
@@ -1,0 +1,3 @@
+object Test {
+  val c = new bug.code.Code()
+}


### PR DESCRIPTION
Fixes #18530 
Fixes #18531

## Summary

### 18530

For `import bug.actions.Smart.Action` method `memberBasedOnFlags` looked for `Action` in `object Smart()`, thus generating an error.

```scala
package bug.actions {
  object Smart() {}
  class Smart private[this](x$1: scala.Unit) extends Object {
    def <init>() = _root_.scala.Predef.???
    object Action() {}
    abstract class Action private[this](x$1: scala.Unit) extends Object {
      def <init>() = _root_.scala.Predef.???
    }
  }
}
```

### 18531

For `import static bug.code.Symbol.*`, `memberBasedOnFlags` looked for `LoadableConstant` in `object Symbol`, but `LoadableConstant` is a static member of `Constant`, inherited by `Symbol` through `class Symbol extends Constant`.

```scala
package bug.code {
  object Constant() {
    <static> object LoadableConstant() {}
    <static> trait LoadableConstant() extends Constant {}
  }
  trait Constant() extends Object {}
}
```

```scala
package bug.code {
  object Symbol() {}
  abstract class Symbol private[this](x$1: scala.Unit) extends Object, Constant
     {
    def <init>() = _root_.scala.Predef.???
  }
}
```

## How much have your relied on LLM-based tools in this contribution?

Minimally - just to pinpoint the location of the problem

## How was the solution tested?

`tests/pos/i18530` and `tests/pos/i18531` added. Also verified manually in VS Code.
