### PR TITLE
Value discard checks inline call for exemption

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -5280,11 +5280,15 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
 
   // Check if the tree was ascribed to `Unit` explicitly to silence the warning.
   private def withDiscardWarnable(tree: tpd.Tree)(op: (tpd.Tree) => Unit)(using Context): Unit =
-    val warnable = tree match
-      case inlined: Inlined => inlined.expansion
-      case tree => tree
-    if !isThisTypeResult(warnable) && !isAscribedToUnit(warnable) then
-      op(warnable)
+    def exempt(tree: tpd.Tree): Boolean = isThisTypeResult(tree) || isAscribedToUnit(tree)
+    def recur(tree: tpd.Tree): Unit = tree match
+      case tree: Inlined =>
+        if !exempt(tree.call) then
+          recur(tree.expansion)
+      case tree =>
+        if !exempt(tree) then
+          op(tree)
+    recur(tree)
 
   /** Types the body Scala 2 macro declaration `def f = macro <body>` */
   protected def typedScala2MacroBody(call: untpd.Tree)(using Context): Tree =

--- a/tests/warn/i25553.scala
+++ b/tests/warn/i25553.scala
@@ -1,0 +1,16 @@
+//> using options -Werror -Wvalue-discard
+
+trait BaseKyoDataTest:
+  type Assertion
+  def assertionSuccess: Assertion
+  transparent inline def typeCheck(inline code: String): Assertion = assertionSuccess
+  def pendingUntilFixed(f: => Unit): Unit = f
+
+  def test(): Unit =
+    pendingUntilFixed {
+      typeCheck("Abort.run(Abort.fail(new Test[Int]))"): Unit
+    }
+
+object Test extends BaseKyoDataTest:
+  type Assertion = Int
+  def assertionSuccess: Assertion = 1


### PR DESCRIPTION
Fixes #25553 

Check inline call for exemption before considering the inline expansion.

This means the expansion did not "inherit" the attachment at the call. Should it?