### PR TITLE
Make result types of hoisted superArg defs InferredTypes

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -826,6 +826,10 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       CaseDef(tree: Tree)(pat, guard, body)
     override def Try(tree: Try)(expr: Tree = tree.expr, cases: List[CaseDef] = tree.cases, finalizer: Tree = tree.finalizer)(using Context): Try =
       Try(tree: Tree)(expr, cases, finalizer)
+
+    def TypeTree(tree: Tree)(inferred: Boolean)(using Context): TypeTree = tree match
+      case tree: TypeTree if tree.isInferred == inferred => tree
+      case _ => finalize(tree, tpd.TypeTree(tree.tpe, inferred))
   }
 
   class TimeTravellingTreeCopier extends TypedTreeCopier {

--- a/compiler/src/dotty/tools/dotc/transform/HoistSuperArgs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/HoistSuperArgs.scala
@@ -12,6 +12,7 @@ import core.Decorators.*
 import collection.mutable
 import ast.Trees.*
 import core.NameKinds.SuperArgName
+import config.Feature
 
 import core.Decorators.*
 
@@ -134,7 +135,7 @@ class HoistSuperArgs extends MiniPhase with IdentityDenotTransformer { thisPhase
       arg match {
         case _ if arg.existsSubTree(needsHoist) =>
           val superMeth = newSuperArgMethod(arg.tpe)
-          val superArgDef = DefDef(superMeth, prefss => {
+          var superArgDef = DefDef(superMeth, prefss => {
             val paramSyms = prefss.flatten.map(pref =>
               if pref.isType then pref.tpe.typeSymbol else pref.symbol)
             val tmap = new TreeTypeMap(
@@ -158,6 +159,9 @@ class HoistSuperArgs extends MiniPhase with IdentityDenotTransformer { thisPhase
               })
             tmap(arg).changeOwnerAfter(constr, superMeth, thisPhase)
           })
+          if Feature.ccEnabled then
+            superArgDef =
+              cpy.DefDef(superArgDef)(tpt = cpy.TypeTree(superArgDef.tpt)(inferred = true))
           superArgDefs += superArgDef
           def termParamRefs(tp: Type, params: List[Symbol]): List[List[Tree]] = tp match {
             case tp: PolyType =>

--- a/tests/pos-custom-args/captures/i25525.scala
+++ b/tests/pos-custom-args/captures/i25525.scala
@@ -1,0 +1,12 @@
+import language.experimental.captureChecking
+
+class Data
+
+class Parent(
+    name: String,
+    op: () => Unit
+)
+
+class Child(
+    op: Data^
+) extends Parent("abab", () => (op: Unit))


### PR DESCRIPTION
Make result types of hoisted superArg defs InferredTypes under cc. 

Fixes #25525

## How much have your relied on LLM-based tools in this contribution?

no use
