### PR TITLE
Fix MSI installer reporting wrong Scala version on Windows

### DIFF
--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -12,6 +12,10 @@ name: Build the MSI Package
 
 on:
   workflow_call:
+    outputs:
+      version:
+        description: 'The developed Scala version (major.minor.patch) extracted from project/Build.scala'
+        value: ${{ jobs.build.outputs.version }}
 
 env:
   # Release only happends when triggering CI by pushing tag
@@ -20,6 +24,8 @@ env:
 jobs:
   build:
     runs-on: windows-latest
+    outputs:
+      version: ${{ steps.extract-version.outputs.version }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -27,6 +33,13 @@ jobs:
           distribution: 'adopt'
           java-version: 17
           cache: 'sbt'
+      - name: Extract Scala version
+        id: extract-version
+        shell: bash
+        run: |
+          version=$(sed -n 's/.*val developedVersion = "\(.*\)".*/\1/p' project/Build.scala)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Extracted Scala version: $version"
       - name: Build MSI package
         run: sbt 'dist-win-x86_64/Windows/packageBin'
       - name: Upload MSI Artifact

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -239,9 +239,7 @@ jobs:
    uses: ./.github/workflows/test-msi.yml
    needs: [build-msi-package]
    with:
-     # Ensure that version starts with prefix 3.
-     # In the future it can be adapted to compare with git tag or version set in the project/Build.scala
-     version: "3."
+     version: ${{ needs.build-msi-package.outputs.version }}
      java-version: 17
 
   build-sdk-package:

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -33,4 +33,4 @@ jobs:
           installers-regex: '\.msi$'
           release-tag     : ${{ inputs.version }}
           fork-user       : dottybot
-          token           : ${{ secrets.DOTTYBOT-WINGET-TOKEN }}
+          token           : ${{ secrets.DOTTYBOT-TOKEN }}

--- a/.github/workflows/test-msi.yml
+++ b/.github/workflows/test-msi.yml
@@ -44,6 +44,36 @@ jobs:
           Get-Content 'install.log'
           Add-Content $env:GITHUB_PATH "C:\Program Files (x86)\scala\bin"
 
+      # Verify that the MSI installed the expected file layout
+      - name: Verify installation layout
+        shell: cmd
+        run: |
+          echo Checking VERSION file...
+          if not exist "C:\Program Files (x86)\scala\VERSION" (
+            echo ERROR: VERSION file not found at install root
+            exit /b 1
+          )
+          type "C:\Program Files (x86)\scala\VERSION"
+
+          echo Checking scala-cli.exe...
+          if not exist "C:\Program Files (x86)\scala\libexec\scala-cli.exe" (
+            echo ERROR: scala-cli.exe not found in libexec
+            exit /b 1
+          )
+
+          echo Checking cli-common-platform.bat...
+          if not exist "C:\Program Files (x86)\scala\libexec\cli-common-platform.bat" (
+            echo ERROR: cli-common-platform.bat not found in libexec
+            exit /b 1
+          )
+
+          echo Checking maven2 directory...
+          if not exist "C:\Program Files (x86)\scala\maven2" (
+            echo ERROR: maven2 directory not found
+            exit /b 1
+          )
+          dir "C:\Program Files (x86)\scala\maven2" /b
+
       # Run tests to ensure the Scala Runner was installed and works
       - name: Test Scala Runner
         shell: pwsh
@@ -69,9 +99,23 @@ jobs:
             Write-Host "Invalid scaladoc version of MSI installed runner, expected ${{ inputs.version }}"
             Exit 1
           }
+
+      # Compile and run a trivial Scala program to verify the full toolchain:
+      #   scala.bat -> scala-cli.exe -> bundled compiler from maven2/ -> compile + run
+      # --server=false avoids starting a background Bloop server that would lock
+      # files and prevent msiexec /X from completing during uninstall.
+      - name: Smoke test - compile and run
+        shell: cmd
+        run: |
+          echo @main def test() = println("Hello from Scala") > test.scala
+          scala run --server=false test.scala
+          if not %ERRORLEVEL%==0 (
+            echo ERROR: Failed to compile and run test.scala
+            exit /b 1
+          )
+
       - name : Uninstall the `scala` package
         shell: pwsh
         run: |
           Start-Process 'msiexec.exe' -ArgumentList '/X "scala.msi" /L*V "uninstall.log" /qb' -Wait
           Get-Content 'uninstall.log'
-        

--- a/dist/bin/scala.bat
+++ b/dist/bin/scala.bat
@@ -12,18 +12,28 @@ for %%f in ("%~dp0.") do (
     set "_PROG_HOME=!_PROG_HOME:~0,-1!"
 )
 call "%_PROG_HOME%\libexec\common.bat"
-if not %_EXITCODE%==0 goto end
+@rem Reset exit code: common.bat may fail if Java is not installed, but the native
+@rem Scala CLI launcher (scala-cli.exe) does not require Java. A missing Java error
+@rem will surface later only if the JVM-based launcher is used instead.
+set _EXITCODE=0
 
 @rem #########################################################################
 @rem ## Main
 
 call :setScalaOpts
 
+if not defined _SCALA_VERSION (
+    echo Error: Failed to extract Scala version from "%_PROG_HOME%\VERSION" 1>&2
+    set _EXITCODE=1
+    goto end
+)
+
 call "%_PROG_HOME%\libexec\cli-common-platform.bat"
 
-@rem SCALA_CLI_CMD_WIN is an array, set in cli-common-platform.bat.
-@rem WE NEED TO PASS '--skip-cli-updates' for JVM launchers but we actually don't need it for native launchers
-call %SCALA_CLI_CMD_WIN% "--prog-name" "scala" "--skip-cli-updates" "--cli-default-scala-version" "%_SCALA_VERSION%" "-r" "%MVN_REPOSITORY%" %*
+@rem SCALA_CLI_CMD_WIN is set by cli-common-platform.bat.
+@rem We use delayed expansion (!var!) and avoid 'call' to prevent double-expansion
+@rem of percent signs, which would corrupt %20 in the Maven repository URI.
+!SCALA_CLI_CMD_WIN! "--prog-name" "scala" "--skip-cli-updates" "--cli-default-scala-version" "!_SCALA_VERSION!" "-r" "!MVN_REPOSITORY!" %*
 
 if not %ERRORLEVEL%==0 ( set _EXITCODE=1& goto end )
 
@@ -34,29 +44,28 @@ goto end
 
 :setScalaOpts
 
-@REM sfind the index of the first colon in _PROG_HOME
-set "index=0"
-set "char=!_PROG_HOME:~%index%,1!"
-:findColon
-if not "%char%"==":" (
-  set /a "index+=1"
-  set "char=!_PROG_HOME:~%index%,1!"
-  goto :findColon
-)
-
 set "_SCALA_VERSION="
-set "MVN_REPOSITORY=file:///%_PROG_HOME:\=/%/maven2"
 
-@rem read for version:=_SCALA_VERSION in VERSION_FILE
-FOR /F "usebackq delims=" %%G IN ("%_PROG_HOME%\VERSION") DO (
-  SET "line=%%G"
-  IF "!line:~0,9!"=="version:=" (
-    SET "_SCALA_VERSION=!line:~9!"
-    GOTO :foundVersion
-  )
+@rem Read the VERSION file to extract the Scala version.
+@rem We use FOR /F with a 'type' command and delayed expansion (!_PROG_HOME!) so
+@rem that parentheses in the path (e.g. "C:\Program Files (x86)\scala") are not
+@rem present at parse time when cmd.exe matches the IN (...) / DO (...) blocks.
+@rem Unlike 'set /p', FOR /F correctly splits lines on both LF and CRLF.
+if not exist "%_PROG_HOME%\VERSION" goto :setMvnRepo
+for /f "delims=" %%G in ('type "!_PROG_HOME!\VERSION"') do (
+    set "_LINE=%%G"
+    if "!_LINE:~0,9!"=="version:=" (
+        set "_SCALA_VERSION=!_LINE:~9!"
+        goto :setMvnRepo
+    )
 )
 
-:foundVersion
+:setMvnRepo
+@rem Construct the local Maven repository URI.
+@rem Backslashes are converted to forward slashes; spaces are percent-encoded.
+set "_PROG_HOME_FWD=!_PROG_HOME:\=/!"
+set "MVN_REPOSITORY=file:///!_PROG_HOME_FWD: =%%20!/maven2"
+
 goto :eof
 
 @rem #########################################################################


### PR DESCRIPTION
The `FOR /F` loop in scala.bat seems to have silently failed to read the VERSION file when installed to paths with parentheses (e.g. `C:\Program Files (x86)`), likely causing `--cli-default-scala-version` to be empty and Scala CLI to fall back to its built-in default version. 
(this is likely why we have the mismatch between 3.8.2 compiler and 3.8.1 REPL in the linked WinGet PR)

Changes
- replaced `FOR /F` with `set /p`
- percent-encoded spaces in the maven2 local custom repo URI,
- prevented `common.bat` from failing when no Java is found (Scala CLI has fallbacks, so...)
- tightened MSI CI tests with file layout verification and a compile smoke test 

## How much have you relied on LLM-based tools in this contribution?
extensively, Cursor + Claude 

## How was the solution tested?
a whole bunch of automatic tests for the MSI included

## Additional notes
- https://github.com/microsoft/winget-pkgs/pull/350014#issuecomment-4093573288
- https://github.com/scala/scala3/issues/22184

[test_msi]
