### PR TITLE
Bump Scala CLI to 1.12.5 (was 1.12.4) and Coursier to 2.1.25-M24 (was 2.1.25-M23

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -278,5 +278,5 @@ jobs:
         with:
           fetch-depth: 0
       - uses: coursier/cache-action@v8
-      - uses: VirtusLab/scala-cli-setup@v1.12.4
+      - uses: VirtusLab/scala-cli-setup@v1.12.5
       - run: scala-cli format --check

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -136,9 +136,9 @@ object Build {
   val mimaPreviousDottyVersion = "3.8.0"
 
   /** Version of Scala CLI to download */
-  val scalaCliLauncherVersion = "1.12.4"
+  val scalaCliLauncherVersion = "1.12.5"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
-  val coursierJarVersion = "2.1.25-M23"
+  val coursierJarVersion = "2.1.25-M24"
 
   object CompatMode {
     final val BinaryCompatible = 0


### PR DESCRIPTION
https://github.com/VirtusLab/scala-cli/releases/tag/v1.12.5
https://github.com/coursier/coursier/releases/tag/v2.1.25-M24

## How much have you relied on LLM-based tools in this contribution?
none

## How was the solution tested?
automated tests already exist
