### PR TITLE
Port stdlib scalacheck

### DIFF
--- a/library/test/scala/ArrayProperties.scala
+++ b/library/test/scala/ArrayProperties.scala
@@ -1,0 +1,69 @@
+package scala
+
+import scala.reflect.ClassTag
+import org.scalacheck.*
+import Prop.*
+import Gen.*
+import Arbitrary.*
+import util.*
+import Buildable.*
+import scala.util.Random
+
+object ArrayProps extends Properties("Array") {
+  implicit def arbArray[T](implicit a: Arbitrary[T], m: ClassTag[T]): Arbitrary[Array[T]] =
+    Arbitrary(containerOf[List,T](arbitrary[T]) map (_.toArray))
+
+  val arrGen: Gen[Array[?]] = oneOf(
+    arbitrary[Array[Int]],
+    arbitrary[Array[Array[Int]]],
+    arbitrary[Array[List[String]]],
+    arbitrary[Array[String]],
+    arbitrary[Array[Boolean]],
+    arbitrary[Array[AnyVal]]
+  )
+
+  // inspired by #1857 and #2352
+  property("eq/ne") = forAll(arrGen, arrGen) { (c1, c2) =>
+    (c1 eq c2) || (c1 ne c2)
+  }
+
+  // inspired by #2299
+  def smallInt = choose(1, 10)
+  property("ofDim") = forAll(smallInt, smallInt, smallInt) { (i1, i2, i3) =>
+    val arr = Array.ofDim[String](i1, i2, i3)
+    val flattened = arr.flatten.flatten
+    flattened.length == i1 * i2 * i3
+  }
+
+  property("range") = forAll(
+    Gen.choose(-1000, 1000),
+    Gen.choose(-1000, 1000),
+    Gen.oneOf(Gen.choose(1, 100), Gen.choose(-100, -1)),
+  ) { (start, end, step) =>
+    Array.range(start, end, step).toList == List.range(start, end, step)
+  }
+
+  property("iterate") = forAll(
+    implicitly[Arbitrary[Int]].arbitrary,
+    Gen.choose(-10, 100),
+    implicitly[Arbitrary[Int => Int]].arbitrary,
+  ) { (start, len, f) =>
+    Array.iterate(start, len)(f).toList == List.iterate(start, len)(f)
+  }
+
+  property("fill") = forAll(
+    Gen.choose(-10, 100),
+  ) { len =>
+    val xs = Vector.fill(len)(Random.nextInt())
+    val i = xs.iterator
+    Array.fill(len)(i.next()).toVector == xs
+  }
+
+  property("tabulate") = forAll(
+    Gen.choose(-10, 100),
+    implicitly[Arbitrary[Int => Int]].arbitrary,
+  ) { (len, f) =>
+    Array.tabulate(len)(f).toList == List.tabulate(len)(f)
+  }
+
+}

--- a/library/test/scala/NaNProps.scala
+++ b/library/test/scala/NaNProps.scala
@@ -1,0 +1,132 @@
+package scala
+
+import org.scalacheck.*
+import Gen.*
+import Prop.*
+
+object NaNProps extends Properties("NaN-Ordering") {
+
+  val specFloats: Gen[Float] = oneOf(
+    Float.MaxValue,
+    Float.MinPositiveValue,
+    Float.MinValue,
+    Float.NaN,
+    Float.NegativeInfinity,
+    Float.PositiveInfinity,
+    -0.0f,
+    +0.0f
+  )
+
+  property("Float min") = forAll(specFloats, specFloats) { (d1, d2) => {
+      val mathmin = math.min(d1, d2)
+      val numericmin = d1 min d2
+      mathmin == numericmin || mathmin.isNaN && numericmin.isNaN
+    }
+  }
+
+  property("Float max") = forAll(specFloats, specFloats) { (d1, d2) => {
+      val mathmax = math.max(d1, d2)
+      val numericmax = d1 max d2
+      mathmax == numericmax || mathmax.isNaN && numericmax.isNaN
+    }
+  }
+
+  val numFloat = implicitly[Numeric[Float]]
+
+  property("Float lt") = forAll(specFloats, specFloats) { (d1, d2) => numFloat.lt(d1, d2) == d1 < d2 }
+
+  property("Float lteq") = forAll(specFloats, specFloats) { (d1, d2) => numFloat.lteq(d1, d2) == d1 <= d2 }
+
+  property("Float gt") = forAll(specFloats, specFloats) { (d1, d2) => numFloat.gt(d1, d2) == d1 > d2 }
+
+  property("Float gteq") = forAll(specFloats, specFloats) { (d1, d2) => numFloat.gteq(d1, d2) == d1 >= d2 }
+
+  property("Float equiv") = forAll(specFloats, specFloats) { (d1, d2) => numFloat.equiv(d1, d2) == (d1 == d2) }
+
+  property("Float reverse.min") = forAll(specFloats, specFloats) { (d1, d2) => {
+      val mathmax = math.max(d1, d2)
+      val numericmin = numFloat.reverse.min(d1, d2)
+      mathmax == numericmin || mathmax.isNaN && numericmin.isNaN
+    }
+  }
+
+  property("Float reverse.max") = forAll(specFloats, specFloats) { (d1, d2) => {
+      val mathmin = math.min(d1, d2)
+      val numericmax = numFloat.reverse.max(d1, d2)
+      mathmin == numericmax || mathmin.isNaN && numericmax.isNaN
+    }
+  }
+
+  property("Float reverse.lt") = forAll(specFloats, specFloats) { (d1, d2) => numFloat.reverse.lt(d1, d2) == d2 < d1 }
+
+  property("Float reverse.lteq") = forAll(specFloats, specFloats) { (d1, d2) => numFloat.reverse.lteq(d1, d2) == d2 <= d1 }
+
+  property("Float reverse.gt") = forAll(specFloats, specFloats) { (d1, d2) => numFloat.reverse.gt(d1, d2) == d2 > d1 }
+
+  property("Float reverse.gteq") = forAll(specFloats, specFloats) { (d1, d2) => numFloat.reverse.gteq(d1, d2) == d2 >= d1 }
+
+  property("Float reverse.equiv") = forAll(specFloats, specFloats) { (d1, d2) => numFloat.reverse.equiv(d1, d2) == (d1 == d2) }
+
+
+  val specDoubles: Gen[Double] = oneOf(
+    Double.MaxValue,
+    Double.MinPositiveValue,
+    Double.MinValue,
+    Double.NaN,
+    Double.NegativeInfinity,
+    Double.PositiveInfinity,
+    -0.0,
+    +0.0
+  )
+
+  // ticket #5104
+  property("Double min") = forAll(specDoubles, specDoubles) { (d1, d2) => {
+    val mathmin = math.min(d1, d2)
+    val numericmin = d1 min d2
+    mathmin == numericmin || mathmin.isNaN && numericmin.isNaN
+  }
+  }
+
+  property("Double max") = forAll(specDoubles, specDoubles) { (d1, d2) => {
+    val mathmax = math.max(d1, d2)
+    val numericmax = d1 max d2
+    mathmax == numericmax || mathmax.isNaN && numericmax.isNaN
+  }
+  }
+
+  val numDouble = implicitly[Numeric[Double]]
+
+  property("Double lt") = forAll(specDoubles, specDoubles) { (d1, d2) => numDouble.lt(d1, d2) == d1 < d2 }
+
+  property("Double lteq") = forAll(specDoubles, specDoubles) { (d1, d2) => numDouble.lteq(d1, d2) == d1 <= d2 }
+
+  property("Double gt") = forAll(specDoubles, specDoubles) { (d1, d2) => numDouble.gt(d1, d2) == d1 > d2 }
+
+  property("Double gteq") = forAll(specDoubles, specDoubles) { (d1, d2) => numDouble.gteq(d1, d2) == d1 >= d2 }
+
+  property("Double equiv") = forAll(specDoubles, specDoubles) { (d1, d2) => numDouble.equiv(d1, d2) == (d1 == d2) }
+
+  property("Double reverse.min") = forAll(specDoubles, specDoubles) { (d1, d2) => {
+    val mathmax = math.max(d1, d2)
+    val numericmin = numDouble.reverse.min(d1, d2)
+    mathmax == numericmin || mathmax.isNaN && numericmin.isNaN
+  }
+  }
+
+  property("Double reverse.max") = forAll(specDoubles, specDoubles) { (d1, d2) => {
+    val mathmin = math.min(d1, d2)
+    val numericmax = numDouble.reverse.max(d1, d2)
+    mathmin == numericmax || mathmin.isNaN && numericmax.isNaN
+  }
+  }
+
+  property("Double reverse.lt") = forAll(specDoubles, specDoubles) { (d1, d2) => numDouble.reverse.lt(d1, d2) == d2 < d1 }
+
+  property("Double reverse.lteq") = forAll(specDoubles, specDoubles) { (d1, d2) => numDouble.reverse.lteq(d1, d2) == d2 <= d1 }
+
+  property("Double reverse.gt") = forAll(specDoubles, specDoubles) { (d1, d2) => numDouble.reverse.gt(d1, d2) == d2 > d1 }
+
+  property("Double reverse.gteq") = forAll(specDoubles, specDoubles) { (d1, d2) => numDouble.reverse.gteq(d1, d2) == d2 >= d1 }
+
+  property("Double reverse.equiv") = forAll(specDoubles, specDoubles) { (d1, d2) => numDouble.reverse.equiv(d1, d2) == (d1 == d2) }
+}

--- a/library/test/scala/OptionProps.scala
+++ b/library/test/scala/OptionProps.scala
@@ -1,0 +1,328 @@
+package scala
+
+import org.scalacheck.Prop
+import org.scalacheck.Properties
+import org.scalacheck.Prop.AnyOperators
+
+/**
+ * Property tests for code in [[scala.Option]]'s documentation.
+ */
+object OptionProps extends Properties("scala.Option") {
+
+  property("map") = {
+    Prop.forAll { (option: Option[Int], i: Int) =>
+      val f: Function1[Int,Int] = (_ => i)
+      option.map(f(_)) ?= {
+        option match {
+          case Some(x) => Some(f(x))
+          case None    => None
+        }
+      }
+    }
+  }
+
+  property("flatMap") = {
+    Prop.forAll { (option: Option[Int], i: Int) =>
+      val f: Function1[Int,Option[Int]] = (_ => Some(i))
+      option.flatMap(f(_)) ?= {
+        option match {
+          case Some(x) => f(x)
+          case None    => None
+        }
+      }
+    }
+  }
+
+  property("flatten") = {
+    Prop.forAll { (optionOfOption: Option[Option[Int]]) =>
+      optionOfOption.flatten ?= {
+        optionOfOption match {
+          case Some(Some(i)) => Some(i)
+          case _             => None
+        }
+      }
+    }
+  }
+
+  property("foreach") = {
+    Prop.forAll { (option: Option[Int], unit: Unit) =>
+      val proc: Function1[Int,Unit] = (_ => unit)
+      option.foreach(proc(_)) ?= {
+        option match {
+          case Some(x) => proc(x)
+          case None    => ()
+        }
+      }
+    }
+  }
+
+  property("fold") = {
+    Prop.forAll { (option: Option[Int], i: Int, y: Int) =>
+      val f: Function1[Int,Int] = (_ => i)
+      option.fold(y)(f(_)) ?= {
+        option match {
+          case Some(x) => f(x)
+          case None    => y
+        }
+      }
+    }
+  }
+
+  property("foldLeft") = {
+    Prop.forAll { (option: Option[Int], i: Int, y: Int) =>
+      val f: Function2[Int,Int,Int] = ((_, _) => i)
+      option.foldLeft(y)(f(_, _)) ?= {
+        option match {
+          case Some(x) => f(y, x)
+          case None    => y
+        }
+      }
+    }
+  }
+
+  property("foldRight") = {
+    Prop.forAll { (option: Option[Int], i: Int, y: Int) =>
+      val f: Function2[Int,Int,Int] = ((_, _) => i)
+      option.foldRight(y)(f(_, _)) ?= {
+        option match {
+          case Some(x) => f(x, y)
+          case None    => y
+        }
+      }
+    }
+  }
+
+  property("collect") = {
+    Prop.forAll { (option: Option[Int], i: Int) =>
+      val pf: PartialFunction[Int,Int] = {
+        case x if x > 0 => i
+      }
+      option.collect(pf) ?= {
+        option match {
+          case Some(x) if pf.isDefinedAt(x) => Some(pf(x))
+          case _                            => None
+        }
+      }
+    }
+  }
+
+  property("isDefined") = {
+    Prop.forAll { (option: Option[Int]) =>
+      option.isDefined ?= {
+        option match {
+          case Some(_) => true
+          case None    => false
+        }
+      }
+    }
+  }
+
+  property("isEmpty") = {
+    Prop.forAll { (option: Option[Int]) =>
+      option.isEmpty ?= {
+        option match {
+          case Some(_) => false
+          case None    => true
+        }
+      }
+    }
+  }
+
+  property("nonEmpty") = {
+    Prop.forAll { (option: Option[Int]) =>
+      option.nonEmpty ?= {
+        option match {
+          case Some(_) => true
+          case None    => false
+        }
+      }
+    }
+  }
+
+  property("orElse") = {
+    Prop.forAll { (option: Option[Int], y: Option[Int]) =>
+      option.orElse(y) ?= {
+        option match {
+          case Some(x) => Some(x)
+          case None    => y
+        }
+      }
+    }
+  }
+
+  property("getOrElse") = {
+    Prop.forAll { (option: Option[Int], y: Int) =>
+      option.getOrElse(y) ?= {
+        option match {
+          case Some(x) => x
+          case None    => y
+        }
+      }
+    }
+  }
+
+  property("get") = {
+    Prop.forAll { (option: Option[Int]) =>
+      Prop.iff[Option[Int]](option, {
+        case Some(x) =>
+          option.get ?= {
+            option match {
+              case Some(y) => y
+              case None    => throw new Exception
+            }
+          }
+        case None =>
+          Prop.throws(classOf[Exception]) {
+            option.get
+          }
+      })
+    }
+  }
+
+  property("orNull") = {
+    Prop.forAll { (option: Option[String]) =>
+      option.orNull ?= {
+        option match {
+          case Some(s) => s
+          case None    => null
+        }
+      }
+    }
+  }
+
+  property("filter") = {
+    Prop.forAll { (option: Option[Int], bool: Boolean) =>
+      val pred: Function1[Int,Boolean] = (_ => bool)
+      option.filter(pred(_)) ?= {
+        option match {
+          case Some(x) if pred(x) => Some(x)
+          case _                  => None
+        }
+      }
+    }
+  }
+
+  property("filterNot") = {
+    Prop.forAll { (option: Option[Int], bool: Boolean) =>
+      val pred: Function1[Int,Boolean] = (_ => bool)
+      option.filterNot(pred(_)) ?= {
+        option match {
+          case Some(x) if !pred(x) => Some(x)
+          case _                   => None
+        }
+      }
+    }
+  }
+
+  property("exists") = {
+    Prop.forAll { (option: Option[Int], bool: Boolean) =>
+      val pred: Function1[Int,Boolean] = (_ => bool)
+      option.exists(pred(_)) ?= {
+        option match {
+          case Some(x) => pred(x)
+          case None    => false
+        }
+      }
+    }
+  }
+
+  property("forall") = {
+    Prop.forAll { (option: Option[Int], bool: Boolean) =>
+      val pred: Function1[Int,Boolean] = (_ => bool)
+      option.forall(pred(_)) ?= {
+        option match {
+          case Some(x) => pred(x)
+          case None    => true
+        }
+      }
+    }
+  }
+
+  property("contains") = {
+    Prop.forAll { (option: Option[Int], y: Int) =>
+      option.contains(y) ?= {
+        option match {
+          case Some(x) => x == y
+          case None    => false
+        }
+      }
+    }
+  }
+
+  property("size") = {
+    Prop.forAll { (option: Option[Int]) =>
+      option.size ?= {
+        option match {
+          case Some(x) => 1
+          case None    => 0
+        }
+      }
+    }
+  }
+
+  property("zip") = {
+    Prop.forAll { (option1: Option[Int], option2: Option[Int]) =>
+      option1.zip(option2) ?= {
+        (option1, option2) match {
+          case (Some(x), Some(y)) => Some((x, y))
+          case _                  => None
+        }
+      }
+    }
+  }
+
+  property("unzip") = {
+    Prop.forAll { (option: Option[(Int, Int)]) =>
+      option.unzip ?= {
+        option match {
+          case Some((x, y)) => (Some(x), Some(y))
+          case _            => (None,    None)
+        }
+      }
+    }
+  }
+
+  property("unzip3") = {
+    Prop.forAll { (option: Option[(Int, Int, Int)]) =>
+      option.unzip3 ?= {
+        option match {
+          case Some((x, y, z)) => (Some(x), Some(y), Some(z))
+          case _               => (None,    None,    None)
+        }
+      }
+    }
+  }
+
+  property("toList") = {
+    Prop.forAll { (option: Option[Int]) =>
+      option.toList ?= {
+        option match {
+          case Some(x) => List(x)
+          case None    => Nil
+        }
+      }
+    }
+  }
+
+  property("toRight") = {
+    Prop.forAll { (option: Option[Int], i: Int) =>
+      option.toRight(i) ?= {
+        option match {
+          case Some(x) => scala.util.Right(x)
+          case None    => scala.util.Left(i)
+        }
+      }
+    }
+  }
+
+  property("toLeft") = {
+    Prop.forAll { (option: Option[Int], i: Int) =>
+      option.toLeft(i) ?= {
+        option match {
+          case Some(x) => scala.util.Left(x)
+          case None    => scala.util.Right(i)
+        }
+      }
+    }
+  }
+}

--- a/library/test/scala/PrimitiveEqualityProps.scala
+++ b/library/test/scala/PrimitiveEqualityProps.scala
@@ -1,0 +1,31 @@
+package scala
+
+import org.scalacheck.*
+import Prop.*
+import Gen.*
+
+object PrimitiveEqualityProps extends Properties("==") {
+  def equalObjectsEqualHashcodes(x: Any, y: Any) = (x != y) || (x == y && x.## == y.##)
+
+  // ticket #2087
+  property("short/char") = forAll { (x: Short) =>
+    val ch: Char = x.toChar
+    (x == ch) == (ch == x)
+  }
+
+  property("symmetry") = forAll { (x: AnyVal, y: AnyVal) => (x == y) == (y == x) }
+  property("transitivity") = forAll { (x: AnyVal, y: AnyVal, z: AnyVal) => x != y || y != z || x == z }
+
+  property("##") = forAll { (x: Short) =>
+    val anyvals = List[Any](x.toByte, x.toChar, x, x.toInt, x.toLong, x.toFloat, x.toDouble, BigInt(x), BigDecimal(x))
+    val shortAndLarger = anyvals.drop(2)
+
+    (anyvals.lazyZip(anyvals) forall equalObjectsEqualHashcodes) &&
+    (shortAndLarger.lazyZip(shortAndLarger) forall (_ == _)) &&
+    (shortAndLarger.lazyZip(shortAndLarger) forall ((x, y) => (x: Any) == (y: Any)))
+  }
+  property("## 2") = forAll { (dv: Double) =>
+    val fv = dv.toFloat
+    (fv != dv) || (fv.## == dv.##)
+  }
+}

--- a/library/test/scala/StringProps.scala
+++ b/library/test/scala/StringProps.scala
@@ -1,0 +1,21 @@
+package scala
+
+import org.scalacheck.*
+
+object StringProps extends Properties("String") {
+  property("startsWith") = Prop.forAll((a: String, b: String) => (a+b).startsWith(a))
+
+  property("endsWith") = Prop.forAll((a: String, b: String) => (a+b).endsWith(b))
+
+  property("concat") = Prop.forAll((a: String, b: String) =>
+    (a+b).length >= a.length && (a+b).length >= b.length
+  )
+
+  property("substring") = Prop.forAll((a: String, b: String) =>
+    (a+b).substring(a.length) == b
+  )
+
+  property("substring") = Prop.forAll((a: String, b: String, c: String) =>
+    (a+b+c).substring(a.length, a.length+b.length) == b
+  )
+}

--- a/library/test/scala/collection/FloatFormatTest.scala
+++ b/library/test/scala/collection/FloatFormatTest.scala
@@ -1,0 +1,111 @@
+package scala.collection
+
+import scala.util.Try
+import org.scalacheck.{Arbitrary, Gen, Properties}
+import org.scalacheck.Prop.*
+
+object FloatFormatTest extends Properties("FloatFormat") {
+
+  import StringParsers._
+
+  val genDec = for {
+    sign <- Gen.oneOf("", "+", "-")
+    int <- Gen.numStr
+    dot <- Gen.oneOf("", ".")
+    frac <- Gen.numStr
+  } yield sign + int + dot + frac
+
+  val genHexChar = Gen.oneOf(
+    Gen.numChar,
+    Gen.choose('a', 'f'),
+    Gen.choose('A', 'F')
+  )
+
+  val genHexString = for {
+    hexstring <- Gen.listOf(genHexChar).map(_.mkString)
+    prefix <- Gen.oneOf("0x", "0X")
+  } yield prefix + hexstring
+
+  val genHex = for {
+    sign <- Gen.oneOf("", "+", "-")
+    int <- genHexString
+    dot <- Gen.oneOf("", ".")
+    frac <- genHexString
+  } yield sign + int + dot + frac
+
+  val genDecOrHex = Gen.oneOf(genDec, genHex)
+
+  val genWSChar = Gen.const(' ')
+
+  val genWS = Gen.listOf(genWSChar).map(_.mkString)
+
+  val genExpSign = Gen.oneOf("", "e", "E", "p", "P")
+
+  val genSuffix = Gen.oneOf("", "f", "F", "d", "D")
+
+  val anystring: Gen[String] = Arbitrary.arbString.arbitrary
+
+  val genPossibleFloatString = {
+    val parts = List(genWS, genDecOrHex, genExpSign, genDecOrHex, genSuffix, genWS)
+    genBogifiedString(parts)
+  }
+
+  val genNanInf = for {
+    ws <- genWS
+    signum <- Gen.oneOf("", "+", "-")
+    nanInf <- Gen.oneOf("NaN", "Infinity")
+    wse <- genWS
+  } yield  ws + signum + nanInf + wse
+
+  val genPlausibleFloatString = for {
+    ws <- genWS
+    dec <- genDecOrHex
+    exp <- genExpSign
+    dec2 <- genDecOrHex
+    suffix <- genSuffix
+    wse <- genWS
+  } yield ws + dec + exp + dec2 + suffix + wse
+
+  def genBogifiedString(parts: List[Gen[String]]): Gen[String] = {
+    val wrong: Gen[String] = {
+      parts match {
+        case head :: tail => Gen.oneOf(anystring, head, tail*)
+        case Nil => anystring
+      }
+    }
+    
+    val bogoparts: List[Gen[String]] = parts.map(right =>
+      Gen.frequency(
+        1 -> wrong,
+        10 -> right
+      ))
+    
+    import scala.jdk.CollectionConverters._
+    Gen.sequence(bogoparts).map(_.asScala.mkString)
+  }
+
+  //compare NaN equal
+  def deq(l: Option[Double], r: Option[Double]): Boolean = (l, r) match {
+    case (Some(ll), Some(rr)) if ll.isNaN && rr.isNaN => true
+    case (ll, rr) => ll == rr
+  }
+
+  property("for all strings (plausible examples) str.toDoubleOption == Try(str.toDouble).toOption") = forAll(genPlausibleFloatString) {
+    str => deq(str.toDoubleOption, Try(str.toDouble).toOption)
+  }
+
+  property("for all strings (possible examples) str.toDoubleOption == Try(str.toDouble).toOption") = forAll(genPossibleFloatString) { 
+    str => deq(str.toDoubleOption, Try(str.toDouble).toOption)
+  }
+
+  property("for all strings (random strings) str.toDoubleOption == Try(str.toDouble).toOption") = forAll{ (str: String) =>
+    deq(str.toDoubleOption, Try(str.toDouble).toOption)
+  }
+
+  property("double.toString is a valid float format") = forAll{ (d: Double) => checkFloatFormat(d.toString)}
+
+  property("nan and infinity toDouble == toDoubleOption.get") = forAll(genNanInf){ (str: String) =>
+    deq(str.toDoubleOption, Try(str.toDouble).toOption)
+  }
+
+}

--- a/library/test/scala/collection/IndexOfSliceTest.scala
+++ b/library/test/scala/collection/IndexOfSliceTest.scala
@@ -1,0 +1,32 @@
+package scala.collection
+
+import scala.collection.immutable.{LazyList, Nil}
+import org.scalacheck.{Arbitrary, Gen, Properties}
+import org.scalacheck.Prop.*
+
+object IndexOfSliceTest extends Properties("indexOfSlice") {
+
+  // The default arbitrary[Seq[Int]] picks only one Seq implementation.
+  // Here we explicitly list all the implementations we want to test
+  @annotation.nowarn("msg=type WrappedArray")
+  val genDifferentSeqs =
+    Gen.oneOf[Seq[Int]](
+      Arbitrary.arbitrary[collection.immutable.List[Int]],
+      Arbitrary.arbitrary[collection.immutable.Vector[Int]],
+      Arbitrary.arbitrary[collection.immutable.ArraySeq[Int]],
+      Arbitrary.arbitrary[collection.mutable.ListBuffer[Int]],
+      Arbitrary.arbitrary[collection.mutable.ArrayBuffer[Int]],
+      Arbitrary.arbitrary[collection.mutable.WrappedArray[Int]]
+    )
+
+  property("indexOfSlice(Nil) == 0") =
+    forAll(genDifferentSeqs) { (seq: Seq[Int]) =>
+      seq.indexOfSlice(Nil) == 0 && seq.indexOfSlice(LazyList.empty) == 0
+    }
+
+  property("indexOfSlice(Nil, from = size + 1) == -1") =
+    forAll(genDifferentSeqs) { (seq: Seq[Int]) =>
+      seq.indexOfSlice(Nil, from = seq.size + 1) == -1
+    }
+
+}

--- a/library/test/scala/collection/IntegralParseTest.scala
+++ b/library/test/scala/collection/IntegralParseTest.scala
@@ -1,0 +1,292 @@
+package scala.collection
+
+import scala.util.Try
+import org.scalacheck.{Gen, Properties, Shrink}
+import org.scalacheck.Prop.*
+
+object NumericStringGenerators {
+
+  val nearOverflowByteUpper = {
+    val lower: Int = Byte.MaxValue.toInt / 10
+    val upper: Int = Byte.MaxValue.toInt * 20
+    Gen.choose(lower, upper).map(_.toString)
+  }
+
+  val nearOverflowByteLower = {
+    val upper: Int = Byte.MinValue.toInt / 10
+    val lower: Int = Byte.MinValue.toInt * 20
+    Gen.choose(lower, upper).map(_.toString)
+  }
+
+  val nearOverflowShortUpper = {
+    val lower: Int = Short.MaxValue.toInt / 10
+    val upper: Int = Short.MaxValue.toInt * 20
+    Gen.choose(lower, upper).map(_.toString)
+  }
+
+
+  val nearOverflowShortLower = {
+    val upper: Int = Short.MinValue.toInt / 10
+    val lower: Int = Short.MinValue.toInt * 20
+    Gen.choose(lower, upper).map(_.toString)
+  }
+
+  val nearOverflowIntUpper = {
+    val lower: Long = Int.MaxValue.toLong / 10
+    val upper: Long = Int.MaxValue.toLong * 20
+    Gen.choose(lower, upper).map(_.toString)
+  }
+
+  val nearOverflowIntLower = {
+    val upper: Long = Int.MinValue.toLong / 10
+    val lower: Long = Int.MinValue.toLong * 20
+    Gen.choose(lower, upper).map(_.toString)
+  }
+
+  val nearOverflowLongUpper = {
+    val base = (Long.MaxValue / 10).toString
+    for {
+      end <- Gen.choose(0, 200)
+    } yield base + end.toString
+  }
+
+  val nearOverflowLongLower = {
+    val base = (Long.MinValue / 10).toString
+    for {
+      end <- Gen.choose(0, 200)
+    } yield base + end.toString
+  }
+
+  val overflowByteUpper = Gen.choose(Byte.MaxValue.toInt + 1, Short.MaxValue.toInt).map(_.toString)
+  val overflowByteLower = Gen.choose(Short.MinValue.toInt, Byte.MinValue.toInt - 1).map(_.toString)
+  val overflowShortUpper = Gen.choose(Short.MaxValue.toInt + 1, Int.MaxValue).map(_.toString)
+  val overflowShortLower = Gen.choose(Int.MinValue, Short.MinValue.toInt - 1).map(_.toString)
+  val overflowIntUpper = Gen.choose(Int.MaxValue.toLong + 1, Long.MaxValue).map(_.toString)
+  val overflowIntLower = Gen.choose(Long.MinValue, Int.MinValue.toLong - 1).map(_.toString)
+
+  val validBytes = 
+    for {
+      byte <- Gen.choose(Byte.MinValue, Byte.MaxValue)
+      zeroes <- Gen.listOf(Gen.const('0')).map(_.mkString)
+      signum <- if (byte > 0) Gen.oneOf(List("+", "")) else if (byte == 0) Gen.oneOf(List("+", "", "-")) else Gen.const("-")
+    } yield {
+      val numbers = if (byte >= 0) byte.toString else byte.toString.substring(1)
+      signum + zeroes + numbers
+    }
+
+  val validShorts = 
+    for {
+      short <- Gen.choose(Short.MinValue, Short.MaxValue)
+      zeroes <- Gen.listOf(Gen.const('0')).map(_.mkString)
+      signum <- if (short > 0) Gen.oneOf(List("+", "")) else if (short == 0) Gen.oneOf(List("+", "", "-")) else Gen.const("-")
+    } yield {
+      val numbers = if (short >= 0) short.toString else short.toString.substring(1)
+      signum + zeroes + numbers
+    }
+
+  val validInts = 
+    for {
+      int <- Gen.choose(Int.MinValue, Int.MaxValue)
+      zeroes <- Gen.listOf(Gen.const('0')).map(_.mkString)
+      signum <-if (int > 0) Gen.oneOf(List("+", "")) else if (int == 0) Gen.oneOf(List("+", "", "-")) else Gen.const("-")
+    } yield {
+      val numbers = if (int >= 0) int.toString else int.toString.substring(1)
+      signum + zeroes + numbers
+    }
+
+  val validLongs = 
+    for {
+      long <- Gen.choose(Long.MinValue, Long.MaxValue)
+      zeroes <- Gen.listOf(Gen.const('0')).map(_.mkString)
+      signum <- if (long > 0) Gen.oneOf(List("+", "")) else if (long == 0) Gen.oneOf(List("+", "", "-")) else Gen.const("-")
+    } yield {
+      val numbers = if (long >= 0) long.toString else long.toString.substring(1)
+      signum + zeroes + numbers
+    }
+    
+
+  val digitsByValue = {
+    val allnumbers = (Char.MinValue to Char.MaxValue).filter(ch => java.lang.Character.isDigit(ch))
+    allnumbers.groupBy(n => java.lang.Character.digit(n, 10))
+  }
+
+  def nonStandardNumbers(numeric: String) = {
+    val listOfGens: List[Gen[Char]] = numeric.toList.map(ch => {
+      val n = java.lang.Character.digit(ch, 10)
+      if (n >= 0) Gen.oneOf(digitsByValue(n))
+      else Gen.const(ch)
+    })
+
+    import scala.jdk.CollectionConverters._
+
+    val sequenced = Gen.sequence(listOfGens)
+    sequenced.map(_.asScala.mkString)
+  }
+
+}
+
+object IntegralParseTest extends Properties("ParseX") {
+
+
+  implicit val noShrink: Shrink[String] = Shrink.shrinkAny
+  import NumericStringGenerators._
+
+  //Byte
+  property("nearUpperByte") = forAll(nearOverflowByteUpper){ 
+    (bytestring: String) => bytestring.toByteOption == Try(java.lang.Byte.parseByte(bytestring)).toOption
+  }
+
+  property("nearUpperByteNonstandard") = forAll(nearOverflowByteUpper.flatMap(nonStandardNumbers)){ 
+    (bytestring: String) => bytestring.toByteOption == Try(java.lang.Byte.parseByte(bytestring)).toOption
+  }
+
+  property("nearLowerByte") = forAll(nearOverflowByteLower){ 
+    (bytestring: String) => bytestring.toByteOption == Try(java.lang.Byte.parseByte(bytestring)).toOption
+  }
+
+  property("nearLowerByteNonstandard") = forAll(nearOverflowByteLower.flatMap(nonStandardNumbers)){ 
+    (bytestring: String) => bytestring.toByteOption == Try(java.lang.Byte.parseByte(bytestring)).toOption
+  }
+
+  property("overflowByteUpper") = forAll(overflowByteUpper){ 
+    (bytestring: String) => bytestring.toByteOption == None
+  }
+
+  property("overflowByteLower") = forAll(overflowByteLower){ 
+    (bytestring: String) => bytestring.toByteOption == None
+  }
+
+  property("validBytes") = forAll(validBytes){
+    (bytestring: String) => {
+      val parsed = bytestring.toByteOption
+      parsed.isDefined &&
+      parsed == Some(java.lang.Byte.parseByte(bytestring))
+    }
+  }
+
+  property("validBytesNonstandard") = forAll(validBytes.flatMap(nonStandardNumbers)){
+    (bytestring: String) => {
+      val parsed = bytestring.toByteOption
+      parsed.isDefined &&
+      parsed == Some(java.lang.Byte.parseByte(bytestring))
+    }
+  }
+
+  //Short
+
+  property("nearUpperShort") = forAll(nearOverflowShortUpper){ 
+    (shortstring: String) => shortstring.toShortOption == Try(java.lang.Short.parseShort(shortstring)).toOption
+  }
+
+  property("nearUpperShortNonstandard") = forAll(nearOverflowShortUpper.flatMap(nonStandardNumbers)){ 
+    (shortstring: String) => shortstring.toShortOption == Try(java.lang.Short.parseShort(shortstring)).toOption
+  }
+
+  property("nearLowerShort") = forAll(nearOverflowShortLower){ 
+    (shortstring: String) => shortstring.toShortOption == Try(java.lang.Short.parseShort(shortstring)).toOption
+  }
+
+  property("nearLowerShortNonstandard") = forAll(nearOverflowShortLower.flatMap(nonStandardNumbers)){ 
+    (shortstring: String) => shortstring.toShortOption == Try(java.lang.Short.parseShort(shortstring)).toOption
+  }
+
+  property("overflowShortUpper") = forAll(overflowShortUpper){ 
+    (shortstring: String) => shortstring.toShortOption == None
+  }
+
+  property("overflowShortLower") = forAll(overflowShortLower){ 
+    (shortstring: String) => shortstring.toShortOption == None
+  }
+
+  property("validShorts") = forAll(validShorts){
+    (shortstring: String) => {
+      val parsed = shortstring.toShortOption
+      parsed.isDefined &&
+      parsed == Some(java.lang.Short.parseShort(shortstring))
+    }
+  }
+
+  property("validShortsNonstandard") = forAll(validShorts.flatMap(nonStandardNumbers)){
+    (shortstring: String) => {
+      val parsed = shortstring.toShortOption
+      parsed.isDefined &&
+      parsed == Some(java.lang.Short.parseShort(shortstring))
+    }
+  }
+
+  //Int
+
+  property("nearUpperInt") = forAll(nearOverflowIntUpper){ 
+    (intstring: String) => intstring.toIntOption == Try(java.lang.Integer.parseInt(intstring)).toOption
+  }
+
+  property("nearUpperIntNonstandard") = forAll(nearOverflowIntUpper.flatMap(nonStandardNumbers)){ 
+    (intstring: String) => intstring.toIntOption == Try(java.lang.Integer.parseInt(intstring)).toOption
+  }
+
+  property("nearLowerInt") = forAll(nearOverflowIntLower){ 
+    (intstring: String) => intstring.toIntOption == Try(java.lang.Integer.parseInt(intstring)).toOption
+  }
+
+  property("nearLowerIntNonstandard") = forAll(nearOverflowIntLower.flatMap(nonStandardNumbers)){ 
+    (intstring: String) => intstring.toIntOption == Try(java.lang.Integer.parseInt(intstring)).toOption
+  }
+
+  property("overflowIntUpper") = forAll(overflowIntUpper){ 
+    (intstring: String) => intstring.toIntOption == None
+  }
+
+  property("overflowIntLower") = forAll(overflowIntLower){ 
+    (intstring: String) => intstring.toIntOption == None
+  }
+
+  property("validInts") = forAll(validInts){
+    (intstring: String) => {
+      val parsed = intstring.toIntOption
+      parsed.isDefined &&
+      parsed == Some(java.lang.Integer.parseInt(intstring))
+    }
+  }
+
+  property("validIntsNonstandard") = forAll(validInts.flatMap(nonStandardNumbers)){
+    (intstring: String) => {
+      val parsed = intstring.toIntOption
+      parsed.isDefined &&
+      parsed == Some(java.lang.Integer.parseInt(intstring))
+    }
+  }
+
+  //long
+  property("nearUpperLong") = forAll(nearOverflowLongUpper){ 
+    (longstring: String) => longstring.toLongOption == Try(java.lang.Long.parseLong(longstring)).toOption
+  }
+
+  property("nearUpperLongNonstandard") = forAll(nearOverflowLongUpper.flatMap(nonStandardNumbers)){ 
+    (longstring: String) => longstring.toLongOption == Try(java.lang.Long.parseLong(longstring)).toOption
+  }
+
+  property("nearLowerLong") = forAll(nearOverflowLongLower){ 
+    (longstring: String) => longstring.toLongOption == Try(java.lang.Long.parseLong(longstring)).toOption
+  }
+
+  property("nearLowerLongNonstandard") = forAll(nearOverflowLongLower.flatMap(nonStandardNumbers)){ 
+    (longstring: String) => longstring.toLongOption == Try(java.lang.Long.parseLong(longstring)).toOption
+  }
+
+  property("validLongs") = forAll(validLongs){
+    (longstring: String) => {
+      val parsed = longstring.toLongOption
+      parsed.isDefined &&
+      parsed == Some(java.lang.Long.parseLong(longstring))
+    }
+  }
+
+  property("validLongsNonstandard") = forAll(validLongs.flatMap(nonStandardNumbers)){
+    (longstring: String) => {
+      val parsed = longstring.toLongOption
+      parsed.isDefined &&
+      parsed == Some(java.lang.Long.parseLong(longstring))
+    }
+  }
+
+} 

--- a/library/test/scala/collection/IterableProps.scala
+++ b/library/test/scala/collection/IterableProps.scala
@@ -1,0 +1,18 @@
+package scala.collection
+
+import org.scalacheck.*
+import Prop.*
+import Gen.*
+
+object IterableProps extends Properties("Iterable.scanLeft") {
+  property("scanLeft") = forAll { (xs: List[Int], z: Int) => {
+    val sums = xs.scanLeft(z)(_ + _)
+    (xs.size == 0) || sums.zip(sums.tail).map(x => x._2 - x._1) == xs
+  }}
+}
+
+
+
+
+
+

--- a/library/test/scala/collection/IteratorProperties.scala
+++ b/library/test/scala/collection/IteratorProperties.scala
@@ -1,0 +1,54 @@
+package scala.collection
+
+import org.scalacheck.{Arbitrary, Gen, Properties, Prop}
+import org.scalacheck.Prop.{forAll, propBoolean}
+
+object IteratorProperties extends Properties("Iterator") {
+
+  val smallInteger = Gen.choose(0,50)
+
+  class SimpleIterable[A](underlying: Iterable[A]) extends Iterable[A] {
+    def iterator: Iterator[A] = {
+      val it = underlying.iterator
+      new Iterator[A] {
+        override def hasNext: Boolean = it.hasNext
+        override def next(): A = it.next()
+      }
+    }
+  }
+
+  property("take") = check(_ take _)
+  property("takeRight") = check((it, n) => it match {
+    case it: Iterable[Int] => it.takeRight(n)
+    case it: Iterator[Int] => View.takeRightIterator(it, n)
+    case x                 => throw new MatchError(x)
+  })
+  property("drop") = check(_ drop _)
+  property("dropRight") = check((it, n) => it match {
+    case it: Iterable[Int] => it.dropRight(n)
+    case it: Iterator[Int] => View.dropRightIterator(it, n)
+    case x                 => throw new MatchError(x)
+  })
+  property("patch") = check((it, n) => it match {
+    case it: Iterable[Int] => it.iterator.patch(1, Iterator.empty, n)
+    case it: Iterator[Int] => it.patch(1, Iterator.empty, n)
+    case x                 => throw new MatchError(x)
+  })
+
+  def check(f: (IterableOnceOps[Int, IterableOnce, IterableOnce[Int]], Int) => IterableOnce[Int]): Prop = forAll(Arbitrary.arbitrary[Seq[Int]], smallInteger) { (s: Seq[Int], n: Int) =>
+    val indexed = s.toIndexedSeq // IndexedSeqs and their Iterators have a knownSize
+    val simple = new SimpleIterable(s) // SimpleIterable and its Iterator don't
+    val lazyList = LazyList.from(s) // Lazy
+    val indexed1 = f(indexed, n).iterator.to(Seq)
+    val indexed2 = f(indexed.iterator, n).iterator.to(Seq)
+    val simple1 = f(simple, n).iterator.to(Seq)
+    val simple2 = f(simple.iterator, n).iterator.to(Seq)
+    val stream1 = f(lazyList, n).iterator.to(Seq)
+    val stream2 = f(lazyList.iterator, n).iterator.to(Seq)
+    (indexed1 == indexed2) :| s"indexed: $indexed1 != $indexed2" &&
+      (simple1 == simple2) :| s"simple: $simple1 != $simple2" &&
+      (stream1 == stream2) :| s"stream: $stream1 != $stream2" &&
+      (simple1 == indexed2) :| s"simple vs indexed: $simple1 != $indexed2" &&
+      (stream1 == indexed2) :| s"stream vs indexed: $stream1 != $indexed2"
+  }
+}

--- a/library/test/scala/collection/MapViewProperties.scala
+++ b/library/test/scala/collection/MapViewProperties.scala
@@ -1,0 +1,48 @@
+package scala.collection
+
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Prop.forAll
+import org.scalacheck.*
+
+object MapViewProperties extends Properties("MapView") {
+
+  type K = Int
+  type V = Int
+  type T = (K, V)
+
+  val x = MapView.from(List(1 -> ""))
+
+  property("filter behaves like Map.filter") = forAll { (m: Map[K, V], p: ((K, V)) => Boolean, isFlipped: Boolean) =>
+    if (isFlipped)
+      m.filterNot(p) == m.view.filterNot(p).toMap
+    else
+      m.filter(p) == m.view.filter(p).toMap
+  }
+
+  property("concat behaves like Map.concat") = forAll { (m0: Map[K, V], m1: Map[K, V]) =>
+    val strictStrict = m0 concat m1
+    val strictView = m0 concat m1.view
+    val viewStrict = (m0.view concat m1).toMap
+    val viewView = (m0.view concat m1.view).toMap
+
+    strictStrict == strictView &&
+    strictView == viewStrict &&
+    viewStrict == viewView
+  }
+  property("++ behaves like Map.++") = forAll { (m0: Map[K, V], m1: Map[K, V]) =>
+    val strictStrict = m0 ++ m1
+    val strictView = m0 ++ m1.view
+    val viewStrict = (m0.view ++ m1).toMap
+    val viewView = (m0.view ++ m1.view).toMap
+
+    strictStrict == strictView &&
+      strictView == viewStrict &&
+      viewStrict == viewView
+  }
+  property("partition behaves like Map.partition") = forAll { (m: Map[K, V], p: ((K, V)) => Boolean) =>
+    val strict = m.partition(p)
+    val (viewA, viewB) = m.view.partition(p)
+    strict == (viewA.toMap, viewB.toMap)
+  }
+
+}

--- a/library/test/scala/collection/StringOpsProps.scala
+++ b/library/test/scala/collection/StringOpsProps.scala
@@ -1,0 +1,36 @@
+
+package scala.collection
+
+import java.io.{BufferedReader, StringReader}
+
+import org.scalacheck.{Gen, Properties}, Gen.{oneOf, listOf}
+import org.scalacheck.Prop.*
+
+import scala.jdk.CollectionConverters._
+
+object StringOpsProps extends Properties("StringOps") {
+
+  val lineChar: Gen[Char] = oneOf('X', '\r', '\n')
+
+  val line = listOf(lineChar).map(_.mkString)
+
+  property("linesIterator tracks BufferedReader.lines") = forAll(line) { s =>
+    val r = new BufferedReader(new StringReader(s))
+
+    s.linesIterator.sameElements(r.lines.iterator.asScala)
+  }
+
+  property("linesIterator returns stripped lines") = forAll(line) { s =>
+    s.linesIterator.sameElements(s.linesWithSeparators.map(_.stripLineEnd))
+  }
+
+  property("stripped lines are shorter except maybe last") = forAll(line) { s =>
+    val stripped = s.linesIterator.toList
+    val lines    = s.linesWithSeparators.toList
+    val zipped   = stripped.zip(lines)
+    def shorter  = zipped.init.forall { case (strip, ln) => strip.length < ln.length }
+    def maybe    = zipped.last match { case (strip, ln) => strip.length <= ln.length }
+
+    stripped.length == lines.length && (lines.isEmpty || shorter && maybe)
+  }
+}

--- a/library/test/scala/collection/ViewProperties.scala
+++ b/library/test/scala/collection/ViewProperties.scala
@@ -1,0 +1,57 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection
+
+import org.scalacheck.*
+import org.scalacheck.Prop.*
+
+import scala.collection.mutable.ListBuffer
+
+object ViewProperties extends Properties("View") {
+
+  type Elem = Int
+  type SomeSeqOps = SeqOps[Elem, Iterable, Iterable[Elem]]
+
+  private def expectedPatch(seq: SomeSeqOps, from: Int, other: Iterable[Elem], replaced: Int): Seq[Elem] = {
+    val (prefix, suffix) = seq.splitAt(from)
+    ListBuffer.empty[Elem] ++= prefix ++= other ++= suffix.drop(replaced)
+  }
+
+  property("`SeqOps#patch(...)` (i.e. `iterableFactory.from(View.Patched(...))`) correctness") = {
+    // we use `mutable.ArraySeq` because it uses the default `patch`
+    // implementation, rather than one from `StrictOptimisedSeqOps`
+    forAll { (seq: mutable.ArraySeq[Elem], from: Int, other: Iterable[Elem], replaced: Int) =>
+      val expected = expectedPatch(seq, from, other, replaced)
+      val patchedWithIterable = seq.patch(from, other, replaced)
+      val patchedWithIterableOnce = seq.patch(from, other.iterator, replaced)
+
+      // we don't need to use `sameElements` like below, because
+      // both `expected` and patched are `Seq` this time
+      ((expected =? patchedWithIterable) :| "`patch(_, Iterable, _)` is performed correctly") &&
+        ((expected =? patchedWithIterableOnce) :| "`patch(_, IterableOnce, _)` is performed correctly")
+    }
+  }
+
+
+  property("`SeqOps#view.patch(...)` (i.e. `View.Patched` used directly) correctness and consistency") =
+    forAll { (seq: Seq[Elem], from: Int, other: Iterable[Elem], replaced: Int) =>
+      val expected = expectedPatch(seq, from, other, replaced)
+      val patchedWithIterable = seq.view.patch(from, other, replaced)
+      val patchedWithIterableOnce = seq.view.patch(from, other.iterator, replaced)
+
+      (expected.sameElements(patchedWithIterable) :| "`patch(_, Iterable, _)` is performed correctly") &&
+        (expected.sameElements(patchedWithIterable) :| "`view.patch(_, Iterable, _)` remains the same after multiple iterations") &&
+        (expected.sameElements(patchedWithIterableOnce) :| "`patch(_, IterableOnce, _)` is performed correctly") &&
+        (expected.sameElements(patchedWithIterableOnce) :| "`view.patch(_, IterableOnce, _)` remains the same after multiple iterations")
+    }
+}

--- a/library/test/scala/collection/concurrent/ConcurrentTrieMapProps.scala
+++ b/library/test/scala/collection/concurrent/ConcurrentTrieMapProps.scala
@@ -1,0 +1,250 @@
+package scala.collection.concurrent
+
+import org.scalacheck.*
+import org.scalacheck.Prop.*
+import org.scalacheck.Gen.*
+import collection.*
+import collection.concurrent.TrieMap
+import java.util.concurrent.*
+import scala.jdk.CollectionConverters.*
+
+import scala.language.reflectiveCalls
+import annotation.unused
+
+import scala.compiletime.uninitialized
+
+case class Wrap(i: Int) {
+  override def hashCode = i // * 0x9e3775cd
+}
+
+
+/** A check mainly oriented towards checking snapshot correctness.
+ */
+object ConcurrentTrieMapProps extends Properties("concurrent.TrieMap") {
+
+  /* generators */
+
+  val sizes = choose(0, 200000)
+
+  val threadCounts = choose(2, 16)
+
+  val threadCountsAndSizes = for {
+    p <- threadCounts
+    sz <- sizes
+  } yield (p, sz)
+
+
+  /* helpers */
+
+  class MyThread1[T](idx: Int, body: Int => T) extends Thread {
+    setName("ParThread-" + idx)
+    private var res: T = uninitialized
+
+    override def run(): Unit = {
+      res = body(idx)
+    }
+
+    def result = {
+      this.join()
+      res
+    }
+  }
+
+  def inParallel[T](totalThreads: Int)(body: Int => T): Seq[T] = {
+    val threads = for (idx <- 0 until totalThreads) yield new MyThread1[T](idx, body)
+
+    threads.foreach(_.start())
+    threads.map(_.result)
+  }
+
+  class MyThread2[T](body: => T) extends Thread {
+    setName("SpawnThread")
+    private var res: T = uninitialized
+
+    override def run(): Unit = {
+      res = body
+    }
+
+    def result = res
+  }
+
+  def spawn[T](body: => T): {def get: T} = {
+    val t = new MyThread2[T](body)
+    t.start()
+    new {
+      def get: T = {
+        t.join()
+        t.result
+      }
+    }
+  }
+
+  def elementRange(threadIdx: Int, totalThreads: Int, totalElems: Int): Range = {
+    val sz = totalElems
+    val idx = threadIdx
+    val p = totalThreads
+    val start = (sz / p) * idx + math.min(idx, sz % p)
+    val elems = (sz / p) + (if (idx < sz % p) 1 else 0)
+    val end = start + elems
+    (start until end)
+  }
+
+  def hasGrown[K, V](last: Map[K, V], current: Map[K, V]) = {
+    (last.size <= current.size) && {
+      last forall {
+        case (k, v) => current.get(k) == Some(v)
+      }
+    }
+  }
+
+  object err {
+    var buffer = new StringBuilder
+
+    def println(a: AnyRef) = buffer.append(a.toString).append("\n")
+
+    def clear() = buffer.clear()
+
+    def flush() = {
+      Console.out.println(buffer)
+      clear()
+    }
+  }
+
+
+  /* properties */
+
+  property("concurrent growing snapshots") = forAll(threadCounts, sizes) {
+    (numThreads, numElems) =>
+      val p = 3 //numThreads
+      val sz = 102 //numElems
+      val ct = new TrieMap[Wrap, Int]
+
+      // checker
+      @unused val checker = spawn {
+        def check(last: Map[Wrap, Int], iterationsLeft: Int): Boolean = {
+          val current = ct.readOnlySnapshot()
+          if (!hasGrown(last, current)) false
+          else if (current.size >= sz) true
+          else if (iterationsLeft < 0) false
+          else check(current, iterationsLeft - 1)
+        }
+
+        check(ct.readOnlySnapshot(), 500)
+      }
+
+      // fillers
+      inParallel(p) {
+        idx =>
+          elementRange(idx, p, sz) foreach (i => ct.update(Wrap(i), i))
+      }
+
+      // wait for checker to finish
+      val growing = true //checker.get
+
+      val ok = growing && ((0 until sz) forall {
+        case i => ct.get(Wrap(i)) == Some(i)
+      })
+
+      ok
+  }
+
+  property("update") = forAll(sizes) {
+    (n: Int) =>
+      val ct = new TrieMap[Int, Int]
+      for (i <- 0 until n) ct(i) = i
+      (0 until n) forall {
+        case i => ct(i) == i
+      }
+  }
+
+  property("concurrent update") = forAll(threadCountsAndSizes) {
+    case (p, sz) =>
+      val ct = new TrieMap[Wrap, Int]
+
+      inParallel(p) {
+        idx =>
+          for (i <- elementRange(idx, p, sz)) ct(Wrap(i)) = i
+      }
+
+      (0 until sz) forall {
+        case i => ct(Wrap(i)) == i
+      }
+  }
+
+
+  property("concurrent remove") = forAll(threadCounts, sizes) {
+    (p, sz) =>
+      val ct = new TrieMap[Wrap, Int]
+      for (i <- 0 until sz) ct(Wrap(i)) = i
+
+      inParallel(p) {
+        idx =>
+          for (i <- elementRange(idx, p, sz)) ct.remove(Wrap(i))
+      }
+
+      (0 until sz) forall {
+        case i => ct.get(Wrap(i)) == None
+      }
+  }
+
+
+  property("concurrent putIfAbsent") = forAll(threadCounts, sizes) {
+    (p, sz) =>
+      val ct = new TrieMap[Wrap, Int]
+
+      val results = inParallel(p) {
+        idx =>
+          elementRange(idx, p, sz) find (i => ct.putIfAbsent(Wrap(i), i) != None)
+      }
+
+      (results forall (_ == None)) && ((0 until sz) forall {
+        case i => ct.get(Wrap(i)) == Some(i)
+      })
+  }
+
+  property("concurrent getOrElseUpdate") = forAll(threadCounts, sizes) {
+    (p, sz) =>
+      val totalInserts = new java.util.concurrent.atomic.AtomicInteger
+      val ct = new TrieMap[Wrap, String]
+
+      @unused val results = inParallel(p) {
+        idx =>
+          (0 until sz) foreach {
+            i =>
+              val v = ct.getOrElseUpdate(Wrap(i), s"$idx:$i")
+              if (v == s"$idx:$i") totalInserts.incrementAndGet()
+          }
+      }
+
+      (totalInserts.get == sz) && ((0 until sz) forall {
+        case i => ct(Wrap(i)).split(":")(1).toInt == i
+      })
+  }
+
+  property("concurrent getOrElseUpdate insertions") = forAll(threadCounts, sizes) {
+    (p, sz) =>
+      val chm = new ConcurrentHashMap[Wrap, Int]().asScala
+
+      val results = inParallel(p) {
+        idx =>
+          for (i <- 0 until sz) yield chm.getOrElseUpdate(new Wrap(i), idx)
+      }
+
+      val resultSets = for (i <- 0 until sz) yield results.map(_(i)).toSet
+      val largerThanOne = resultSets.zipWithIndex.find(_._1.size != 1)
+      val allThreadsAgreeOnWhoInserted = {
+        largerThanOne == None
+      } :| s"$p threads agree on who inserted [disagreement (differentResults, position) = $largerThanOne]"
+
+      allThreadsAgreeOnWhoInserted
+  }
+}
+
+
+
+
+
+
+
+
+

--- a/library/test/scala/collection/convert/WrapperProperties.scala
+++ b/library/test/scala/collection/convert/WrapperProperties.scala
@@ -1,0 +1,22 @@
+
+package scala.collection.convert
+
+import org.scalacheck.Properties
+import org.scalacheck.Prop.*
+
+import scala.collection.immutable
+
+
+object WrapperProperties extends Properties("Wrappers") {
+
+  property("JSetWrapper#filterInPlace(p)") = forAll { (hs: immutable.HashSet[Int], p: Int => Boolean) =>
+    val expected: collection.Set[Int] = hs.filter(p)
+    val actual: collection.Set[Int] = {
+      val jset = new java.util.HashSet[Int]()
+      hs.foreach(jset.add)
+      new JavaCollectionWrappers.JSetWrapper(jset)
+    }.filterInPlace(p)
+    actual ?= expected
+  }
+
+}

--- a/library/test/scala/collection/immutable/BitSetProperties.scala
+++ b/library/test/scala/collection/immutable/BitSetProperties.scala
@@ -1,0 +1,59 @@
+package scala.collection.immutable
+
+import org.scalacheck.*
+import org.scalacheck.Prop.*
+import Gen.*
+
+object BitSetProperties extends Properties("immutable.BitSet") {
+
+  // the top of the range shouldn't be too high, else we may not get enough overlap
+  implicit val arbitraryBitSet: Arbitrary[BitSet] = Arbitrary(
+    oneOf(
+      const(BitSet()),
+      oneOf(0 to 100).map(i => BitSet(i)),
+      listOfN(200, oneOf(0 to 10000)).map(_.to(BitSet))
+    )
+  )
+
+  property("min") = forAll { (bs: BitSet) =>
+    bs.nonEmpty ==> (bs.min ?= bs.toList.min)
+  }
+  property("min reverse") = forAll { (bs: BitSet) =>
+    bs.nonEmpty ==> (bs.min(using Ordering.Int.reverse) ?= bs.toList.min(using Ordering.Int.reverse))
+  }
+
+  property("max") = forAll { (bs: BitSet) =>
+    bs.nonEmpty ==> (bs.max ?= bs.toList.max)
+  }
+
+  property("max reverse") = forAll { (bs: BitSet) =>
+    bs.nonEmpty ==> (bs.max(using Ordering.Int.reverse) ?= bs.toList.max(using Ordering.Int.reverse))
+  }
+
+  property("diff bitSet") = forAll { (left: BitSet, right: BitSet) =>
+    (left.diff(right): Set[Int]) ?= left.to(HashSet).diff(right.to(HashSet))
+  }
+  property("diff hashSet") = forAll { (left: BitSet, right: BitSet) =>
+    (left.diff(right.to(HashSet)) : Set[Int]) ?= left.to(HashSet).diff(right.to(HashSet))
+  }
+
+  property("filter") = forAll { (bs: BitSet) =>
+    bs.filter(_ % 2 == 0) ?= bs.toList.filter(_ % 2 == 0).to(BitSet)
+  }
+  property("filterNot") = forAll { (bs: BitSet) =>
+    bs.filterNot(_ % 2 == 0) ?= bs.toList.filterNot(_ % 2 == 0).to(BitSet)
+  }
+
+  property("partition") = forAll { (bs: BitSet) =>
+    val p = (i: Int) => i % 2 == 0
+    val (left, right) = bs.partition(p)
+    (left ?= bs.filter(p)) && (right ?= bs.filterNot(p))
+  }
+
+  property("iteratorFrom") = forAll(
+    listOfN(200, oneOf(0 to 10000)).map(_.to(Set)),
+    Gen.chooseNum[Int](0, 10000)) { (xs: Set[Int], start: Int) =>
+    val bs = xs.to(BitSet)
+    bs.iteratorFrom(start).to(Set) ?= xs.filter(_ >= start)
+  }
+}

--- a/library/test/scala/collection/immutable/ImmutableChampHashMapProperties.scala
+++ b/library/test/scala/collection/immutable/ImmutableChampHashMapProperties.scala
@@ -1,0 +1,373 @@
+package scala.collection.immutable
+
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Prop.*
+import org.scalacheck.*
+
+import scala.collection.Hashing
+
+object ImmutableChampHashMapProperties extends Properties("HashMap") {
+
+  type K = Int
+  type V = Int
+  type T = (K, V)
+
+  property("convertToScalaMapAndCheckSize") = forAll { (input: HashMap[K, V]) =>
+    convertToScalaMapAndCheckSize(input)
+  }
+
+  private def convertToScalaMapAndCheckSize(input: HashMap[K, V]) = HashMap.from(input).size == input.size
+
+  property("convertToScalaMapAndCheckHashCode") = forAll { (input: HashMap[K, V]) =>
+    convertToScalaMapAndCheckHashCode(input)
+  }
+
+  private def convertToScalaMapAndCheckHashCode(input: HashMap[K, V]) =
+    HashMap.from(input).hashCode == input.hashCode
+
+  property("convertToScalaMapAndCheckEquality") = forAll { (input: HashMap[K, V]) =>
+    input == HashMap.from(input) && HashMap.from(input) == input
+  }
+
+  property("input.equals(duplicate)") = forAll { (inputMap: HashMap[K, V]) =>
+    val builder = HashMap.newBuilder[K, V]
+    inputMap.foreach(builder.addOne)
+
+    val duplicateMap = builder.result()
+    inputMap == duplicateMap
+  }
+
+  property("checkSizeAfterInsertAll") = forAll { (inputValues: HashMap[K, V]) =>
+    val testMap = HashMap.empty[K, V] ++ inputValues
+    inputValues.size == testMap.size
+  }
+
+  property("containsAfterInsert") = forAll { (inputValues: HashMap[K, V]) =>
+    val testMap = HashMap.empty[K, V] ++ inputValues
+    inputValues.forall { case (key, value) => testMap.get(key).contains(value) }
+  }
+
+  property("iterator equals reverseIterator.reverse()") = forAll { (input: HashMap[K, V]) =>
+    val xs: List[(K, V)] = input.iterator
+      .foldLeft(List.empty[(K, V)])((list: List[(K, V)], item: (K, V)) => list prepended item)
+
+    val ys: List[(K, V)] = input.reverseIterator
+      .foldLeft(List.empty[(K, V)])((list: List[(K, V)], item: (K, V)) => list appended item)
+
+    xs == ys
+  }
+
+  property("building element-wise is the same as in bulk") = forAll { (seq: Seq[(K, V)]) =>
+    val xs = (HashMap.newBuilder[K, V] ++= seq).result()
+    val ys = {
+      val b = HashMap.newBuilder[K, V]
+      seq.foreach(b += _)
+      b.result()
+    }
+    var zs = HashMap.empty[K, V]
+    seq.foreach(zs += _)
+
+    xs == ys && xs == zs
+  }
+
+  property("adding elems twice to builder is the same as adding them once") = forAll { (seq: Seq[(K, V)]) =>
+    val b = HashMap.newBuilder[K, V].addAll(seq)
+    b.result() == b.addAll(seq).result()
+  }
+
+  property("(xs ++ ys).toMap == xs.toMap ++ ys.toMap") = forAll { (xs: Seq[(K, V)],ys: Seq[(K, V)]) =>
+    (xs ++ ys).toMap ?= xs.toMap ++ ys.toMap
+  }
+
+  property("HashMapBuilder produces the same Map as MapBuilder") = forAll { (xs: Seq[(K, V)]) =>
+    Map.newBuilder[K, V].addAll(xs).result() == HashMap.newBuilder[K, V].addAll(xs).result()
+  }
+  property("HashMapBuilder does not mutate after releasing") = forAll { (xs: Seq[(K, V)], ys: Seq[(K, V)], single: (K, V), addSingleFirst: Boolean) =>
+    val b = HashMap.newBuilder[K, V].addAll(xs)
+
+    val hashMapA = b.result()
+
+    val cloneOfA: Map[K, V] = hashMapA.foldLeft(Map.empty[K, V])(_ + _)
+
+    if (addSingleFirst) {
+      b.addOne(single)
+      b.addAll(ys)
+    } else {
+      b.addAll(ys)
+      b.addOne(single)
+    }
+
+    (b.result().size >= hashMapA.size) && hashMapA == cloneOfA
+  }
+  property("Map does not mutate after releasing") = forAll { (xs: Seq[(K, V)], ys: Seq[(K, V)], single: (K, V), addSingleFirst: Boolean) =>
+    val b = Map.newBuilder[K, V].addAll(xs)
+
+    val mapA = b.result()
+
+    val cloneOfA: Map[K, V] = mapA.foldLeft(Map.empty[K, V])(_ + _)
+
+    if (addSingleFirst) {
+      b.addOne(single)
+      b.addAll(ys)
+    } else {
+      b.addAll(ys)
+      b.addOne(single)
+    }
+
+    (b.result().size >= mapA.size) && mapA == cloneOfA
+  }
+
+  property("calling result() twice returns the same instance") = forAll { (xs: Seq[(K, V)]) =>
+    val mb = Map.newBuilder[K, V].addAll(xs)
+    val hmb = HashMap.newBuilder[K, V].addAll(xs)
+    (mb.result() eq mb.result()) && (hmb.result() eq hmb.result())
+  }
+
+  property("transform(f) == map { (k, v) => (k, f(k, v)) }") = forAll { (xs: HashMap[K, V], f: (K, V) => String) =>
+    xs.transform(f) == xs.map{ case (k, v) => (k, f(k, v)) }
+  }
+
+  property("xs.transform((_, v) => v) eq xs") = forAll { (xs: HashMap[K, String]) =>
+    xs.transform((_, v) => v) eq xs
+  }
+
+  property("left.merged(right) { select left } is the same as right concat left") =
+    forAll { (left: HashMap[K, V], right: HashMap[K, V]) =>
+      left.merged(right)((left, _) => left) ?= right.concat(left)
+    }
+  property("left.merged(right) { select right } is the same as left concat right") =
+    forAll { (left: HashMap[K, V], right: HashMap[K, V]) =>
+      left.merged(right)((_, right) => right) ?= left.concat(right)
+    }
+  property("merged passes through all key-values in either map that aren't in the other") =
+    forAll { (left: HashMap[K, V], right: HashMap[K, V], mergedValue: V) =>
+      val onlyInLeft = left.filter { case (k, _) => !right.contains(k) }
+      val onlyInRight = right.filter { case (k, _) => !left.contains(k) }
+
+      val merged = left.merged(right){ case (_, (k, _)) => k -> mergedValue }
+
+      onlyInLeft.forall{ case (k, v) => merged.get(k).contains(v) } &&
+      onlyInRight.forall{ case (k, v) => merged.get(k).contains(v) }
+    }
+
+  property("merged results in a merged value for all keys that appear in both maps") =
+    forAll { (left: HashMap[K, V], right: HashMap[K, V], mergedValue: V) =>
+      val intersected = left.filter { case (k, _) => right.contains(k) }
+
+      val merged = left.merged(right){ case (_, (k, _)) => k -> mergedValue }
+
+      intersected.forall { case (k, _) => merged.get(k).contains(mergedValue) }
+    }
+
+  property("merged with a null merge function is equal to concatenation") =
+    forAll { (left: HashMap[K, V], right: HashMap[K, V]) =>
+      left.merged(right)(null.asInstanceOf[((K, V), (K, V)) => (K, V)]) == right.concat(left)
+    }
+
+  property("merged specification") =
+    forAll { (left: HashMap[K, V], right: HashMap[K, V], mergef: ((K, V), (K, V))=> (K, V)) =>
+      // A key-by-key specification of the behavior of merged, for case where mergef != null
+      val keysOnlyInLeft: Set[K] = left.keySet -- right.keySet
+      val keysOnlyInRight: Set[K] = right.keySet -- left.keySet
+      val keysInBoth: Set[K] = left.keySet intersect right.keySet
+
+      val resultsOfMergeFunctionByOriginalKey: Map[K, (K, V)] = {
+        val rightKVsByKey: Map[K, (K, V)] = right.iterator.map { case kv@(k, _) => k -> kv }.toMap
+        keysInBoth.iterator.map(k => k -> mergef((k, left(k)), rightKVsByKey(k))).toMap
+      }
+
+      val resultsOfMergeFunctionByNewKey: Map[K, List[V]] = resultsOfMergeFunctionByOriginalKey.valuesIterator.toList.groupMap(_._1)(_._2)
+
+      val allKeys = keysOnlyInLeft.concat(keysOnlyInRight.iterator.concat(resultsOfMergeFunctionByNewKey.keys))
+
+      val merged = left.merged(right)(mergef)
+
+      keysOnlyInLeft.iterator.map { leftKey =>
+        Prop(merged.get(leftKey).contains(left(leftKey)) || resultsOfMergeFunctionByNewKey.contains(leftKey))
+          .label(s"Key $leftKey from left(and not right) must be found in merged, or overwritten by the merge function")
+      }.concat(
+        keysOnlyInRight.iterator.map { rightKey =>
+          Prop(merged.get(rightKey).contains(right(rightKey)) || resultsOfMergeFunctionByNewKey.contains(rightKey))
+            .label(s"Key $right from right(and not left) must be found in merged, or overwritten by the merge function")
+        }
+      ).concat(
+        keysInBoth.iterator.map { key =>
+
+          val (newKey, _) = resultsOfMergeFunctionByOriginalKey(key)
+          Prop(merged.get(newKey).exists { mergedValue =>
+            resultsOfMergeFunctionByNewKey(newKey).contains(mergedValue) || // the resulting value could have come from the merge function
+              left.get(newKey).contains(mergedValue) || // or it could have been from left
+              right.get(newKey).contains(mergedValue) //                             ... or right
+          })
+            .label(
+              s"""Key $key found in left and right, so its merged form ($newKey) must exist in the resulting map, with the value derived from either:
+                 |1) this or an other invocation of mergef
+                 |2) a value existing in left
+                 |3) a value existing in right""".stripMargin)
+        }
+      ).concat(
+        merged.keysIterator.map ( k => Prop(allKeys.contains(k)).label(s"Key $k in merged should not be present"))
+      )
+      .foldLeft(
+        Prop(merged.size <= keysInBoth.size + keysOnlyInLeft.size + keysOnlyInRight.size)
+          .label("A merged hashmap mustn't have greater size than leftOnlyKeys + rightOnlyKeys + collidingKeys"))(_ && _)
+    }
+
+  property("rootnode hashCode should be sum of key improved hashcodes") = forAll { (seq: Seq[(K, V)]) =>
+    val distinct = seq.distinctBy(_._1)
+    val expectedHash = distinct.map(_._1.hashCode).map(Hashing.improve).sum
+    val b = HashMap.newBuilder[K, V]
+    distinct.foreach(b.addOne)
+    b.result().rootNode.cachedJavaKeySetHashCode == expectedHash
+  }
+
+  property("xs.toList.filter(p).toMap == xs.filter(p)") = forAll { (xs: HashMap[Int, Int], flipped: Boolean) =>
+    val p: ((Int, Int)) => Boolean = { case (k, v) => k * v >= 0} // "key and value are the same sign"
+    xs.toList.filterImpl(p, flipped).toMap == xs.filterImpl(p, flipped)
+  }
+
+  property("xs.filter(p) retains all elements that pass `p`, and only those") =
+    forAll { (xs: HashMap[Int, Int], p: ((Int, Int)) => Boolean, flipped: Boolean) =>
+      xs.filterImpl(p, flipped) == {
+        val builder = HashMap.newBuilder[Int, Int]
+        xs.foreach (kv => if (p(kv) != flipped) builder.addOne(kv))
+        builder.result()
+      }
+  }
+
+  property("xs.filter(p) does not perform any hashes") =
+    forAll { (xs: HashMap[Int, Int], p: ((Int, Int)) => Boolean, flipped: Boolean) =>
+      // container which tracks the number of times its hashCode() is called
+      case class Container(inner: Int) {
+        var timesHashed = 0
+        override def hashCode(): Int = {
+          timesHashed += 1
+          inner.hashCode()
+        }
+      }
+
+      val ys: HashMap[Container, Int] = xs.map { case (k, v) => Container(k) -> v }
+      @annotation.unused val zs = ys.filterImpl( { case (k, v) => p((k.inner, v))}, flipped)
+
+      ys.forall(_._1.timesHashed <= 1)
+     }
+
+  property("xs.removeAll(ys) == xs.filterNot(kv => ys.toSet.contains(kv._1))") = forAll { (xs: HashMap[K, V], ys: Iterable[K]) =>
+    val ysSet = ys.toSet
+    xs.removedAll(ys) == xs.filterNot { case (k, _) => ysSet.contains(k) }
+  }
+  property("concat(HashMap)") = forAll { (left: HashMap[Int, Int], right: HashMap[Int, Int]) =>
+    val expected: collection.Map[Int, Int] = left concat right
+    val actual: collection.Map[Int, Int] = (left.toSeq ++ right.toSeq).to(HashMap)
+
+    actual ?= expected
+  }
+
+  property("concat(mutable.HashMap)") = forAll { (left: HashMap[Int, Int], right: HashMap[Int, Int]) =>
+    val expected: collection.Map[Int, Int] = left concat right
+    val actual: collection.Map[Int, Int] = left.concat(right.to(collection.mutable.HashMap.mapFactory))
+    actual ?= expected
+  }
+  property("concat(Vector)") = forAll { (left: HashMap[Int, Int], right: Vector[(Int, Int)]) =>
+    val expected: collection.Map[Int, Int] = left.mapFactory.newBuilder.addAll(left).addAll(right).result()
+    val actual: collection.Map[Int, Int] = left.concat(right)
+    actual ?= expected
+  }
+  property("removedAll(HashSet)") = forAll { (left: HashMap[Int, Int], right: HashSet[Int]) =>
+    val expected: collection.Map[Int, Int] = left.view.filterKeys(!right.contains(_)).toMap
+    val actual: collection.Map[Int, Int] = left -- right
+    actual ?= expected
+  }
+  property("removedAll(mutable.HashSet)") = forAll { (left: HashMap[Int, Int], right: HashSet[Int]) =>
+    val expected: collection.Map[Int, Int] = left -- right
+    val actual: collection.Map[Int, Int] = left -- right.to(collection.mutable.HashSet)
+    actual ?= expected
+  }
+  property("removedAll(Vector)") = forAll { (left: HashMap[Int, Int], right: Vector[Int]) =>
+    val expected: collection.Map[Int, Int] = left.view.filterKeys(!right.contains(_)).toMap
+    val actual: collection.Map[Int, Int] = left -- right
+    actual ?= expected
+  }
+
+  property("hm.removedAll(list) == list.foldLeft(hm)(_ - _)") = forAll { (hm: HashMap[K, V], l: List[K]) =>
+    hm.removedAll(l) ?= l.foldLeft(hm)(_ - _)
+  }
+
+  property("hm.removedAll(list) does not mutate hm") = forAll { (hm: HashMap[K, V], l: List[K]) =>
+    val clone = hm.to(List).to(HashMap)
+    hm.removedAll(l)
+    hm ?= clone
+  }
+  property("hm.concat(list) == list.foldLeft(hm)(_ + _)") = forAll { (hm: HashMap[K, V], l: List[(K, V)]) =>
+    hm.concat(l) ?= l.foldLeft(hm)((m, tuple) => m + tuple)
+  }
+
+  property("hm.concat(list) does not mutate hm") = forAll { (hm: HashMap[K, V], l: List[(K, V)]) =>
+    val clone = hm.to(List).to(HashMap)
+    hm.concat(l)
+    hm ?= clone
+  }
+
+  property("hm.concat(mutable.HashMap) == list.foldLeft(hm)(_ + _)") = forAll { (hm: HashMap[K, V], l: List[(K, V)]) =>
+    val mhm = l.to(collection.mutable.HashMap)
+    hm.concat(mhm) ?= mhm.foldLeft(hm)((m, tuple) => m + tuple)
+  }
+
+  property("hm.concat(mutable.HashMap) does not mutate hm or the mutable.HashMap") = forAll { (hm: HashMap[K, V], l: List[(K, V)]) =>
+    val clone = hm.to(List).to(HashMap)
+    val mhm = l.to(collection.mutable.HashMap)
+    hm.concat(mhm)
+    (hm ?= clone).label("hm is unmutated") &&
+      ((mhm : collection.Map[K, V]) ?= l.to(HashMap)).label("mhm is unmutated")
+  }
+
+  property("hm.removedAll(hashSet) == hashSet.foldLeft(this)(_ - _)") = forAll { (hm: HashMap[K, V], hs: HashSet[K]) =>
+    hm.removedAll(hs) ?= hs.foldLeft(hm)(_ - _)
+  }
+  property("hm.removedAll(hashSet) does not mutate hm") = forAll { (hm: HashMap[K, V], hs: HashSet[K]) =>
+    val clone = hm.to(List).to(HashMap)
+    hm.removedAll(hs)
+    hm ?= clone
+  }
+  property("hm.removedAll(mutable.hashSet) == hashSet.foldLeft(this)(_ - _)") = forAll { (hm: HashMap[K, V], hs: HashSet[K]) =>
+    val mhs = hs.to(collection.mutable.HashSet)
+    hm.removedAll(mhs) ?= mhs.foldLeft(hm)(_ - _)
+  }
+  property("hm.removedAll(mutable.hashSet) does not mutate hm or the mutable.hashSet") = forAll { (hm: HashMap[K, V], hs: HashSet[K]) =>
+    val clone = hm.to(List).to(HashMap)
+    val mhs = hs.to(collection.mutable.HashSet)
+    hm.removedAll(mhs)
+    (hm ?= clone).label("hm is unmutated") &&
+      ((mhs : collection.Set[K]) ?= hs).label("mhs is unmutated")
+  }
+
+  property("xs.keySet + k == xs.map(_._1).to(Set) + k") = forAll { (hm: HashMap[K, V], k: K) =>
+    (hm.keySet + k) ?= (hm.map((kv: (K, V)) => kv._1).to(Set) + k)
+  }
+  property("xs.keySet - k == xs.map(_._1).to(Set) - k") = forAll { (hm: HashMap[K, V], k: K) =>
+    (hm.keySet - k) ?= (hm.map((kv: (K, V)) => kv._1).to(Set) - k)
+  }
+  property("xs.keySet removedAll ys == xs.map(_._1).to(Set) removedAll ys") = forAll { (hm: HashMap[K, V], ys: List[K]) =>
+    (hm.keySet.removedAll(ys) ?= hm.map((kv: (K, V)) => kv._1).to(Set).removedAll(ys)).label("RemovedAll(List)") &&
+      (hm.keySet.removedAll(ys.toSet) ?= hm.map((kv: (K, V)) => kv._1).to(Set).removedAll(ys)).label("RemovedAll(Set)")
+  }
+  property("xs.keySet filter p == xs.map(_._1).to(Set) filter p") = forAll { (hm: HashMap[K, V], p: K => Boolean) =>
+    hm.keySet.filter(p) ?= hm.to(List).map(_._1).to(Set).filter(p)
+  }
+
+  property("xs.keySet filterNot p == xs.map(_._1).to(Set) filterNot p") = forAll { (hm: HashMap[K, V], p: K => Boolean) =>
+    hm.keySet.filterNot(p) ?= hm.to(List).map(_._1).to(Set).filterNot(p)
+  }
+  property("xs.keySet ks == xs.map(_._1).to(Set) concat ks") = forAll { (hm: HashMap[K, V], ks: List[K]) =>
+    hm.keySet.concat(ks) ?= hm.to(List).map(_._1).to(Set).concat(ks)
+  }
+  property("xs.keySet diff ks == xs.map(_._1).to(Set) diff ks") = forAll { (hm: HashMap[K, V], ks: Set[K]) =>
+    hm.keySet.diff(ks) ?= hm.to(List).map(_._1).to(Set).diff(ks)
+  }
+
+  property("xs.removed(key) eq xs when !xs.contains(key)") = forAll { (hm: HashMap[K, V], key: K) =>
+    Prop(!hm.contains(key)).label("HashMap does not contain key") ==>
+      Prop(hm.removed(key) eq hm).label("hashMap.removed(key) eq hashMap")
+  }
+
+}

--- a/library/test/scala/collection/immutable/ImmutableChampHashSetProperties.scala
+++ b/library/test/scala/collection/immutable/ImmutableChampHashSetProperties.scala
@@ -1,0 +1,379 @@
+package scala.collection.immutable
+
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Prop.*
+import org.scalacheck.*
+
+object ImmutableChampHashSetProperties extends Properties("immutable.HashSet") {
+
+  type K = Int
+
+  private def doSubtract(one: HashSet[K], two: HashSet[K]) = {
+    one.foldLeft(HashSet.empty[K])((result, elem) => if (two contains elem) result else result + elem)
+  }
+
+  private def doIntersect(one: HashSet[K], two: HashSet[K]) = {
+    one.foldLeft(HashSet.empty[K])((result, elem) => if (two contains elem) result + elem else result)
+  }
+
+  property("convertToScalaSetAndCheckSize") = forAll { (input: HashSet[K]) =>
+    convertToScalaSetAndCheckSize(input)
+  }
+
+  private def convertToScalaSetAndCheckSize(input: HashSet[K]) =
+    HashSet.from(input).size == input.size
+
+  property("convertToScalaSetAndCheckHashCode") = forAll { (input: HashSet[K]) =>
+    convertToScalaSetAndCheckHashCode(input)
+  }
+
+  private def convertToScalaSetAndCheckHashCode(input: HashSet[K]) =
+    HashSet.from(input).hashCode == input.hashCode
+
+  property("convertToScalaSetAndCheckEquality") = forAll { (input: HashSet[K]) =>
+    input == HashSet.from(input) && HashSet.from(input) == input
+  }
+
+  property("input.equals(duplicate)") = forAll { (inputSet: HashSet[K]) =>
+    val builder = HashSet.newBuilder[K]
+    inputSet.foreach(builder.addOne)
+
+    val duplicateSet = builder.result()
+    inputSet == duplicateSet
+  }
+
+  property("checkSizeAfterInsertAll") = forAll { (inputValues: HashSet[K]) =>
+    val testSet = HashSet.empty[K] ++ inputValues
+    inputValues.size == testSet.size
+  }
+
+  property("containsAfterInsert") = forAll { (inputValues: HashSet[K]) =>
+    val testSet = HashSet.empty[K] ++ inputValues
+    inputValues.forall(testSet.contains)
+  }
+
+  property("notContainedAfterInsertRemove") = forAll { (input: HashSet[K], item: K) =>
+    !(input + item - item).contains(item)
+  }
+
+  property("intersectIdentityReference") = forAll { (inputShared: HashSet[K]) =>
+    inputShared == inputShared.intersect(inputShared)
+  }
+
+  property("intersectIdentityStructural") = forAll { (inputShared: HashSet[K]) =>
+    val builder = HashSet.newBuilder[K]
+    inputShared.foreach(builder.addOne)
+
+    val duplicateSet = builder.result()
+    inputShared == inputShared.intersect(duplicateSet)
+  }
+
+  property("intersect") = forAll { (inputOne: HashSet[K], inputTwo: HashSet[K], inputShared: HashSet[K]) =>
+    val oneWithoutShared = doSubtract(doSubtract(inputOne, inputShared), inputTwo)
+    val twoWithoutShared = doSubtract(doSubtract(inputTwo, inputShared), inputOne)
+
+    val oneWithShared = inputOne ++ inputShared
+    val twoWithShared = inputTwo ++ inputShared
+    val intersectedWithShared = oneWithShared.intersect(twoWithShared)
+
+    val predicate1 = inputShared.forall(intersectedWithShared.contains)
+    val predicate2 = !intersectedWithShared.exists(oneWithoutShared.contains)
+    val predicate3 = !intersectedWithShared.exists(twoWithoutShared.contains)
+
+    predicate1 && predicate2 && predicate3
+  }
+
+  property("intersectMaintainsSizeAndHashCode") = forAll { (inputOne: HashSet[K], inputTwo: HashSet[K], inputShared: HashSet[K]) =>
+    val oneWithShared = inputOne ++ inputShared
+    val twoWithShared = inputTwo ++ inputShared
+    val intersectedWithShared = oneWithShared.intersect(twoWithShared)
+
+    convertToScalaSetAndCheckSize(intersectedWithShared) && convertToScalaSetAndCheckHashCode(intersectedWithShared)
+  }
+
+  property("intersectEqualToDefaultImplementation") = forAll { (inputOne: HashSet[K], inputTwo: HashSet[K], inputShared: HashSet[K]) =>
+    val oneWithShared = inputOne ++ inputShared
+    val twoWithShared = inputTwo ++ inputShared
+
+    val intersectNative = oneWithShared.intersect(twoWithShared)
+    val intersectDefault = doIntersect(oneWithShared, twoWithShared)
+
+    intersectDefault =? intersectNative
+  }
+
+  property("intersectIdentityMostlyReference") = forAll { (input: HashSet[K], key: K) =>
+    val inputCopy = if (input.contains(key)) input - key + key else input + key - key
+
+    input == input.intersect(inputCopy) && inputCopy.intersect(input) == input
+  }
+
+  property("unionIdentityReference") = forAll { (inputShared: HashSet[K]) =>
+    inputShared == inputShared.union(inputShared)
+  }
+
+  property("unionIdentityMostlyReference") = forAll { (input: HashSet[K], key: K) =>
+    val inputCopy = if (input.contains(key)) input - key + key else input + key - key
+
+    input == input.union(inputCopy) && inputCopy.union(input) == input
+  }
+
+  property("unionIdentityStructural") = forAll { (inputShared: HashSet[K]) =>
+    val builder = HashSet.newBuilder[K]
+    inputShared.foreach(builder.addOne)
+
+    val duplicateSet = builder.result()
+    inputShared == inputShared.union(duplicateSet)
+  }
+
+  property("union") = forAll { (inputOne: HashSet[K], inputTwo: HashSet[K]) =>
+    val unioned = inputOne.intersect(inputTwo)
+
+    unioned.forall(inputOne.contains) && unioned.forall(inputTwo.contains)
+  }
+
+  property("unionMaintainsSizeAndHashCode") = forAll { (inputOne: HashSet[K], inputTwo: HashSet[K]) =>
+    val unioned = inputOne.union(inputTwo)
+
+    convertToScalaSetAndCheckSize(unioned) && convertToScalaSetAndCheckHashCode(unioned)
+  }
+
+  property("unionEqualToDefaultImplementation") = forAll { (inputOne: HashSet[K], inputTwo: HashSet[K]) =>
+    inputOne ++ inputTwo == inputOne.union(inputTwo)
+  }
+
+  property("subtract") = forAll { (inputOne: HashSet[K], inputTwo: HashSet[K]) =>
+    val subtracted = inputOne.diff(inputTwo)
+
+    subtracted.forall(inputOne.contains) && !subtracted.exists(inputTwo.contains)
+  }
+
+  property("subtractMaintainsSizeAndHashCode") = forAll { (inputOne: HashSet[K], inputTwo: HashSet[K]) =>
+    val subtracted = inputOne.diff(inputTwo)
+    convertToScalaSetAndCheckSize(subtracted) && convertToScalaSetAndCheckHashCode(subtracted)
+  }
+
+  property("subtractIdentityReference") = forAll { (inputShared: HashSet[K]) =>
+    HashSet.empty[K] == inputShared.diff(inputShared)
+  }
+
+  property("subtractIdentityMostlyReference") = forAll { (input: HashSet[K], key: K) =>
+    val inputCopy = if (input.contains(key)) input - key + key else input + key - key
+
+    input.diff(inputCopy).isEmpty && inputCopy.diff(input).isEmpty
+  }
+
+  property("subtractIdentityStructural") = forAll { (inputShared: HashSet[K]) =>
+    val builder = HashSet.newBuilder[K]
+    inputShared.foreach(builder.addOne)
+
+    val duplicateSet = builder.result()
+    HashSet.empty[K] == inputShared.diff(duplicateSet)
+  }
+
+  property("subtract") = forAll { (inputOne: HashSet[K], inputTwo: HashSet[K], inputShared: HashSet[K]) =>
+    val oneWithoutShared = inputOne diff inputShared diff inputTwo
+    val twoWithoutShared = inputTwo diff inputShared diff inputOne
+
+    val oneWithShared = inputOne ++ inputShared
+    val twoWithShared = inputTwo ++ inputShared
+    val subtractedWithShared = oneWithShared diff twoWithShared
+
+    val predicate1 = !inputShared.exists(subtractedWithShared.contains)
+    val predicate2 = subtractedWithShared.forall(oneWithoutShared.contains)
+    val predicate3 = !subtractedWithShared.exists(twoWithoutShared.contains)
+
+    predicate1 && predicate2 && predicate3
+  }
+
+  property("subtractMaintainsSizeAndHashCode") = forAll { (inputOne: HashSet[K], inputTwo: HashSet[K], inputShared: HashSet[K]) =>
+    val oneWithShared = inputOne ++ inputShared
+    val twoWithShared = inputTwo ++ inputShared
+    val subtractedWithShared = oneWithShared diff twoWithShared
+
+    convertToScalaSetAndCheckSize(subtractedWithShared) && convertToScalaSetAndCheckHashCode(subtractedWithShared)
+  }
+
+  property("subtractEqualToDefaultImplementation") = forAll { (inputOne: HashSet[K], inputTwo: HashSet[K], inputShared: HashSet[K]) =>
+    val oneWithShared = inputOne ++ inputShared
+    val twoWithShared = inputTwo ++ inputShared
+
+    val subtractNative = oneWithShared diff twoWithShared
+    val subtractDefault = doSubtract(oneWithShared, twoWithShared)
+
+    subtractDefault == subtractNative
+  }
+
+  property("iterator equals reverseIterator.reverse()") = forAll { (input: HashSet[K]) =>
+    val xs: List[K] = input.iterator
+      .foldLeft(List.empty[K])((list: List[K], item: K) => list prepended item)
+
+    val ys: List[K] = input.reverseIterator
+      .foldLeft(List.empty[K])((list: List[K], item: K) => list appended item)
+
+    xs == ys
+  }
+
+  property("smaller subsetOf larger") = forAll { (inputSet: HashSet[K]) =>
+    if (inputSet.isEmpty) {
+      true
+    } else {
+      val randomSamples = scala.util.Random.nextInt(inputSet.size)
+      val randomIndices = ArraySeq.fill(randomSamples)(scala.util.Random.nextInt(inputSet.size))
+
+      val inputArray = inputSet.toArray
+      val smallerSet = HashSet.from(randomIndices.map(inputArray).toSet)
+
+      smallerSet.subsetOf(inputSet)
+    }
+  }
+
+  property("building element-wise is the same as in bulk") = forAll { (seq: Seq[K]) =>
+    val xs = (HashSet.newBuilder[K] ++= seq).result()
+    val ys = {
+      val b = HashSet.newBuilder[K]
+      seq.foreach(b += _)
+      b.result()
+    }
+    var zs = HashSet.empty[K]
+    seq.foreach(zs += _)
+    xs == ys && xs == zs
+  }
+  property("adding elems twice to builder is the same as adding them once") = forAll { (seq: Seq[K]) =>
+    val b = HashSet.newBuilder[K].addAll(seq)
+    b.result() == b.addAll(seq).result()
+  }
+  property("(xs ++ ys).toSet == xs.toSet ++ ys.toSet") = forAll { (xs: Seq[K],ys: Seq[K]) =>
+    (xs ++ ys).toSet =? xs.toSet ++ ys.toSet
+  }
+  property("HashSetBuilder produces the same Set as SetBuilder") = forAll { (xs: Seq[K]) =>
+    HashSet.newBuilder[K].addAll(xs).result() =? HashSet.newBuilder[K].addAll(xs).result()
+  }
+  property("HashSetBuilder does not mutate after releasing") = forAll { (xs: Seq[K], ys: Seq[K], single: K, addSingleFirst: Boolean) =>
+    val b = HashSet.newBuilder[K].addAll(xs)
+    val hashSetA = b.result()
+    val cloneOfA: Set[K] = hashSetA.foldLeft(Set.empty[K])(_ + _)
+    if (addSingleFirst) {
+      b.addOne(single)
+      b.addAll(ys)
+    } else {
+      b.addAll(ys)
+      b.addOne(single)
+    }
+    Prop(b.result().size >= hashSetA.size) && ((hashSetA: Set[K]) ?= (cloneOfA: Set[K]))
+  }
+  property("Set does not mutate after releasing") = forAll { (xs: Seq[K], ys: Seq[K], single: K, addSingleFirst: Boolean) =>
+    val b = Set.newBuilder[K].addAll(xs)
+    val setA = b.result()
+    val cloneOfA: Set[K] = setA.foldLeft(Set.empty[K])(_ + _)
+    if (addSingleFirst) {
+      b.addOne(single)
+      b.addAll(ys)
+    } else {
+      b.addAll(ys)
+      b.addOne(single)
+    }
+    (b.result().size >= setA.size) && setA == cloneOfA
+  }
+  property("calling result() twice returns the same instance") = forAll { (xs: Seq[K]) =>
+    val mb = Set.newBuilder[K].addAll(xs)
+    val hmb = Set.newBuilder[K].addAll(xs)
+    (mb.result() eq mb.result()) && (hmb.result() eq hmb.result())
+  }
+
+  property("xs.toList.toSet == xs") = forAll { (xs: Set[K]) =>
+    xs.toList.toSet == xs
+  }
+
+  property("(xs - elem) == xs.toList.filterNot(_ == elem).toSet") = forAll { (xs: Set[K], elem: K) =>
+    (xs - elem) == xs.toList.filterNot(_ == elem).toSet
+  }
+
+  property("(xs + elem) == (xs.toList :+ elem).toSet") = forAll { (xs: Set[K], elem: K) =>
+    (xs + elem) == (xs.toList :+ elem).toSet
+  }
+  property("xs -- range == xs -- range.toSet") = forAll { (xs: Set[Int], rangeMax: Int) =>
+    val range = 1 to (rangeMax % 10000)
+    xs -- range == xs -- range.toSet
+  }
+
+  property("concat(mutable.HashSet)") = forAll { (left: HashSet[Int], right: HashSet[Int]) =>
+    val expected: collection.Set[Int] = left concat right
+    val actual: collection.Set[Int] = left.concat(right.to(collection.mutable.HashSet))
+    actual ?= expected
+  }
+  property("concat(Vector)") = forAll { (left: HashSet[Int], right: Vector[Int]) =>
+    val expected: collection.Set[Int] = left.iterableFactory.newBuilder[Int].addAll(left).addAll(right).result()
+    val actual: collection.Set[Int] = left.concat(right)
+    actual ?= expected
+  }
+  property("removedAll(HashSet)") = forAll { (left: HashSet[Int], right: HashSet[Int]) =>
+    val expected: collection.Set[Int] = left.filter(!right.contains(_))
+    val actual: collection.Set[Int] = left -- right
+    actual ?= expected
+  }
+  property("removedAll(mutable.HashSet)") = forAll { (left: HashSet[Int], right: HashSet[Int]) =>
+    val expected: collection.Set[Int] = left -- right
+    val actual: collection.Set[Int] = left -- right.to(collection.mutable.HashSet)
+    actual ?= expected
+  }
+
+  property("removedAll(Vector)") = forAll { (left: HashSet[Int], right: Vector[Int]) =>
+    val expected: collection.Set[Int] = left.filter(!right.contains(_))
+    val actual: collection.Set[Int] = left -- right
+    actual ?= expected
+  }
+  property("(xs.filter(p) == xs.toList.filter(p).toSet") = forAll { (xs: HashSet[Int]) =>
+    val isEven = (i: Int) => i % 2 == 0
+    xs.toList.filter(isEven).toSet =? xs.filter(isEven)
+  }
+  property("(xs.filterNot(p) == xs.toList.filterNot(p).toSet") = forAll { (xs: HashSet[Int]) =>
+    val isEven = (i: Int) => i % 2 == 0
+    xs.toList.filterNot(isEven).toSet =? xs.filterNot(isEven)
+  }
+
+  property("xs ++ list == list.foldLeft(xs)(_ + _)") = forAll { (xs: HashSet[Int], list: List[Int]) =>
+    xs.concat(list) ?= list.foldLeft(xs)(_ + _)
+  }
+
+
+  property("hs.concat(list) does not mutate hs") = forAll { (hs: HashSet[K], l: List[K]) =>
+    val clone = hs.to(List).to(HashSet)
+    hs.concat(l)
+    hs ?= clone
+  }
+  property("hs.concat(mutable.HashSet) does not mutate hs or the mutable.HashSet") = forAll { (hs: HashSet[K], l: List[K]) =>
+    val mhs: collection.Set[K] = l.to(collection.mutable.HashSet)
+    val clone = hs.to(List).to(HashSet)
+    hs.concat(mhs)
+    hs ?= clone
+  }
+  property("hs.concat(mutable.HashSet)") = forAll { (hs: HashSet[K], l: List[K]) =>
+    val mhs: collection.Set[K] = l.to(collection.mutable.HashSet)
+    hs.concat(mhs) ?= mhs.foldLeft(hs)(_ + _)
+  }
+
+  property("hs.union(hashSet) does not mutate hs") = forAll { (hs: HashSet[K], hs2: HashSet[K]) =>
+    val clone = hs.to(List).to(HashSet)
+    hs.union(hs2)
+    hs ?= clone
+  }
+  property("hs.removedAll(list) does not mutate hs") = forAll { (hs: HashSet[K], l: List[K]) =>
+    val clone = hs.to(List).to(HashSet)
+    hs.removedAll(l)
+    hs ?= clone
+  }
+  property("hs.diff(hashSet) does not mutate hs") = forAll { (hs: HashSet[K], hs2: HashSet[K]) =>
+    val clone = hs.to(List).to(HashSet)
+    hs.diff(hs2)
+    hs ?= clone
+  }
+  property("hs.removedAll(hashSet) does not mutate hs") = forAll { (hs: HashSet[K], hs2: HashSet[K]) =>
+    val clone = hs.to(List).to(HashSet)
+    hs.removedAll(hs2)
+    hs ?= clone
+  }
+  property("t11551") = forAll { (x: HashSet[AnyVal], y: HashSet[AnyVal]) =>
+    val z = x ++ y
+    z.size ?= z.toList.toSet.size
+  }
+}

--- a/library/test/scala/collection/immutable/ListMapBuilderProperties.scala
+++ b/library/test/scala/collection/immutable/ListMapBuilderProperties.scala
@@ -1,0 +1,58 @@
+package scala.collection.immutable
+
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Prop.*
+import org.scalacheck.*
+import org.scalacheck.Gen.*
+
+object ListMapBuilderProperties extends Properties("immutable.ListMapBuilder") {
+
+  type K = Int
+  type V = Int
+
+
+  sealed trait Transform
+
+  object Transform {
+    case class AddOne(kv: (K, V)) extends Transform
+    case class AddAllList(kvs: List[(K, V)]) extends Transform
+    case class AddAllMap(kvs: Map[K, V]) extends Transform
+    case object Clear extends Transform
+  }
+
+  val transformGen: Gen[List[Transform]] =
+    listOf(oneOf(
+      Arbitrary.arbitrary[(K, V)].map(Transform.AddOne.apply),
+      Arbitrary.arbitrary[List[(K, V)]].map(Transform.AddAllList.apply),
+      Arbitrary.arbitrary[Map[K, V]].map(Transform.AddAllMap.apply),
+      const(Transform.Clear)
+    ))
+
+  def interpret(transforms: Seq[Transform], builder: () => collection.mutable.Builder[(K, V), Map[K, V]]): Map[K, V] =
+    transforms.foldLeft(builder()) {
+      case (b, Transform.AddOne(kv)) => b.addOne(kv)
+      case (b, Transform.AddAllList(kvs)) => b.addAll(kvs)
+      case (b, Transform.AddAllMap(kvs)) => b.addAll(kvs)
+      case (b, Transform.Clear) => b.clear(); b
+    }.result()
+
+
+  property("Multiple transforms on ListMapBuilder give same result as HashMapBuilder") =
+    forAll(transformGen) { (transforms: Seq[Transform]) =>
+      interpret(transforms, () => ListMap.newBuilder) ?= interpret(transforms, () => HashMap.newBuilder)
+  }
+
+  property("Builder is reusable") = forAll(transformGen, transformGen) { (transformsA: Seq[Transform], transformsB: Seq[Transform]) =>
+    val listMapBuilder = ListMap.newBuilder[K, V]
+    val firstListMap = interpret(transformsA, () => listMapBuilder)
+    val secondListMap = interpret(transformsB, () => listMapBuilder)
+
+    val hmMapBuilder = HashMap.newBuilder[K, V]
+    val firstHashMap = interpret(transformsA, () => hmMapBuilder)
+    val secondHashMap = interpret(transformsB, () => hmMapBuilder)
+
+    (firstListMap ?= firstHashMap).label("First Maps") &&
+      (secondListMap ?= secondHashMap).label("Second Maps")
+  }
+
+}

--- a/library/test/scala/collection/immutable/ListMapProperties.scala
+++ b/library/test/scala/collection/immutable/ListMapProperties.scala
@@ -1,0 +1,23 @@
+package scala.collection.immutable
+
+import org.scalacheck.*
+import Prop.*
+
+object ListMapProperties extends Properties("immutable.ListMap") {
+
+  type K = Int
+  type V = Int
+  type T = (K, V)
+
+  property("from(linkedHashMap) == from(linkedHashMap.toList)") = forAll { (m: Map[K, V]) =>
+    val lhm = m.to(collection.mutable.LinkedHashMap)
+    ListMap.from(lhm) ?= ListMap.from(lhm.toList)
+  }
+
+  property("from(map) == from(map.toList)") = forAll { (m: Map[K, V]) =>
+    ListMap.from(m) ?= ListMap.from(m.toList)
+  }
+  property("from(map.view) == from(map)") = forAll { (m: Map[K, V]) =>
+    ListMap.from(m.view) ?= ListMap.from(m)
+  }
+}

--- a/library/test/scala/collection/immutable/ListProperties.scala
+++ b/library/test/scala/collection/immutable/ListProperties.scala
@@ -1,0 +1,64 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.immutable
+
+import org.scalacheck.Prop.*
+import org.scalacheck.Gen.*
+import org.scalacheck.*
+import org.scalacheck.Arbitrary.arbitrary
+
+import scala.collection.mutable.{ArrayBuffer, ListBuffer}
+import scala.collection.{IterableFactory, View, mutable}
+
+object ListProperties extends Properties("immutable.List") {
+
+  val iterableGen: Gen[collection.Iterable[Int]] =
+    for {
+      data <- Gen.listOf(Arbitrary.arbInt.arbitrary)
+      factory <- Gen.oneOf[IterableFactory[collection.Iterable]](
+        List, Vector, ArrayBuffer, mutable.ArrayDeque, Queue, ListBuffer, View
+      )
+    } yield factory.from(data)
+
+
+  val iterableOnceGen: Gen[() => IterableOnce[Int]] =
+    Gen.oneOf(iterableGen.map(it => () => it), iterableGen.map(it => () => it.iterator))
+
+  property("list1 ::: list2 == list1.toVector.prependedAll(list2)") = forAll { (list1: List[Int], list2: List[Int]) =>
+    (list1.prependedAll(list2): Seq[Int]) ?= list1.toVector.prependedAll(list2)
+  }
+  property("list1.prependedAll(iterableOnce) == list1.toVector.prependedAll(iterableOnce)") =
+    forAll(arbitrary[List[Int]], iterableOnceGen){ (list1, it) =>
+      (list1.prependedAll(it()): Seq[Int]) ?= list1.toVector.prependedAll(it())
+  }
+
+  property("List.from(iterableOnce) == Vector.from(iterableOnce)") =
+    forAll(iterableOnceGen) { it =>
+      (List.from(it()): Seq[Int]) ?= Vector.from(it())
+    }
+
+  def sorted(xs: List[Int]) = xs.sortWith(_ < _)
+
+  property("concat size") = forAll { (l1: List[Int], l2: List[Int]) => (l1.size + l2.size) == (l1 ::: l2).size }
+  property("reverse") = forAll { (l1: List[Int]) => l1.reverse.reverse == l1 }
+  property("toSet") = forAll { (l1: List[Int]) => sorted(l1.toSet.toList) sameElements sorted(l1).distinct }
+  // property("flatten") = forAll { (xxs: List[List[Int]]) => xxs.flatten.length == (xxs map (_.length) sum) }
+  property("startsWith/take") = forAll { (xs: List[Int], count: Int) => xs startsWith (xs take count) }
+  property("endsWith/takeRight") = forAll { (xs: List[Int], count: Int) => xs endsWith (xs takeRight count) }
+  property("fill") = forAll(choose(1, 100)) { count =>
+    forAll { (x: Int) =>
+      val xs = List.fill(count)(x)
+      (xs.length == count) && (xs.distinct == List(x))
+    }
+  }
+}

--- a/library/test/scala/collection/immutable/MapProperties.scala
+++ b/library/test/scala/collection/immutable/MapProperties.scala
@@ -1,0 +1,116 @@
+package scala.collection.immutable
+
+import org.scalacheck.Properties
+
+import org.scalacheck.Arbitrary.arbInt
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
+import org.scalacheck.commands.Commands
+
+import scala.collection.mutable
+import scala.util.{Success, Try}
+
+object MapProperties extends Properties("immutable.Map builder implementations"){
+
+  type K = String
+  type V = String
+  type T = (K, V)
+
+  property("ListMap builder stateful testing") = new MapBuilderStateProperties(HashMap.empty[K, V], ListMap.newBuilder[K, V]).property()
+  property("SortedMap builder stateful testing") = new MapBuilderStateProperties(ListMap.empty[K, V], SortedMap.newBuilder[K, V]).property()
+  property("HashMap builder stateful testing") = new MapBuilderStateProperties(ListMap.empty[K, V], HashMap.newBuilder[K, V]).property()
+  property("Map builder stateful testing") = new MapBuilderStateProperties(ListMap.empty[K, V], Map.newBuilder[K, V]).property()
+  property("VectorMap builder stateful testing") = new MapBuilderStateProperties(ListMap.empty[K, V], VectorMap.newBuilder[K, V]).property()
+  property("IntMap builder stateful testing") = new MapBuilderStateProperties(ListMap.empty[Int, Long], IntMap.newBuilder[Long]).property()
+  property("LongMap builder stateful testing") = new MapBuilderStateProperties(ListMap.empty[Long, Int], LongMap.newBuilder[Int]).property()
+
+}
+
+/** Generic stateful property testing for maps
+  *
+  * Usage: {{{
+  *   class MyMapProperties extends Properties("my.Map") {
+  *
+  *      property("MyMapProperties builder stateful testing") =
+  *        new MapBuilderStateProperties[K, V, ListMap, MyMap](ListMap, MyMap).property() &&
+  *        new MapBuilderStateProperties[K, V, Map, MyMap](Map, MyMap).property() &&
+  *        new MapBuilderStateProperties[K, V, VectorMap, MyMap](VectorMap, MyMap).property()
+  *   }
+  * }}}
+  *
+  * @param newEmptyControlMap Produce a new empty control map. This map is assumed to be correct.
+  *                       That is, it is assumed it can immutably append/concatenate properly.
+  *                       It's a good idea to cross validate against two or more control maps.
+  * @param newBuilder produce a new builder of the map under test
+  *
+  * @param tupleGen  gen for the key-values of this map
+  * @tparam K type of the Key
+  * @tparam V type of the Value
+  * @tparam ControlMap the type of the control map implementation
+  * @tparam M the type of map under test
+  */
+class MapBuilderStateProperties[K, V, ControlMap <: Map[K, V], M <: Map[K, V]](
+  newEmptyControlMap: => ControlMap,
+  newBuilder: => mutable.Builder[(K, V), M])(implicit tupleGen: Arbitrary[(K, V)]) extends Commands {
+
+  override type State = ControlMap
+  override type Sut = mutable.Builder[(K, V), M]
+
+  override def genInitialState: Gen[ControlMap] = newEmptyControlMap
+
+  override def canCreateNewSut(
+                                newState: State,
+                                initSuts: scala.Iterable[State],
+                                runningSuts: scala.Iterable[mutable.Builder[(K, V), M]]) = true
+
+  override def newSut(state: ControlMap) = newBuilder.addAll(state)
+
+  override def destroySut(sut: mutable.Builder[(K, V), M]): Unit = ()
+
+  override def initialPreCondition(state: ControlMap) = state.isEmpty
+
+  override def genCommand(state: State) = {
+    import Gen._
+    oneOf(
+      const(Clear),
+      const(Result),
+      arbInt.arbitrary.map(SizeHint.apply),
+      tupleGen.arbitrary.map(AddOne.apply),
+      listOf(tupleGen.arbitrary).map(AddAll.apply)
+    )
+  }
+
+  case object Clear extends UnitCommand {
+    override def postCondition(state: ControlMap, success: Boolean) = success
+    override def run(sut: mutable.Builder[(K, V), M]) = sut.clear()
+    override def nextState(state: ControlMap) = newEmptyControlMap
+    override def preCondition(state: ControlMap) = true
+  }
+  case object Result extends Command {
+    override type Result = M
+    override def postCondition(state: ControlMap, result: Try[Result]) = result == Success(state)
+    override def run(sut: mutable.Builder[(K, V), M]) = sut.result()
+    override def nextState(state: ControlMap) = state
+    override def preCondition(state: ControlMap) = true
+  }
+  case class SizeHint(size: Int) extends UnitCommand {
+    override def postCondition(state: ControlMap, success: Boolean) = success
+    override def run(sut: mutable.Builder[(K, V), M]) = sut.sizeHint(size)
+    override def nextState(state: ControlMap) = state
+    override def preCondition(state: ControlMap) = true
+  }
+  case class AddOne(elem: (K, V)) extends UnitCommand {
+    override def postCondition(state: ControlMap, success: Boolean) = success
+    override def run(sut: mutable.Builder[(K, V), M]) = sut.addOne(elem)
+    override def nextState(state: ControlMap) =
+      state.updated(elem._1, elem._2).asInstanceOf[ControlMap]
+    override def preCondition(state: ControlMap) = true
+  }
+  case class AddAll(elems: Seq[(K, V)]) extends UnitCommand {
+    override def postCondition(state: ControlMap, success: Boolean) = success
+    override def run(sut: mutable.Builder[(K, V), M]) = sut.addAll(elems)
+    override def nextState(state: ControlMap) =
+      state.concat(elems).asInstanceOf[ControlMap]
+    override def preCondition(state: ControlMap) = true
+  }
+}

--- a/library/test/scala/collection/immutable/NumericRangeProperties.scala
+++ b/library/test/scala/collection/immutable/NumericRangeProperties.scala
@@ -1,0 +1,56 @@
+package scala
+package collection.immutable
+
+import org.scalacheck.*
+
+import scala.util.Try
+
+class NumericRangeProperties extends Properties("immutable.NumericRange") {
+  import Prop._
+  import NumericRangeProperties._
+
+  property("same length when take and drop with a specific amount (Byte)") = forAll { (r: NumericRange[Byte], amount: Int) =>
+    Try(r.length).isSuccess ==> {
+      r.take(amount).length + r.drop(amount).length == r.length
+    }
+  }
+
+  property("same length when take and drop with a specific amount (Short)") = forAll { (r: NumericRange[Short], amount: Int) =>
+    Try(r.length).isSuccess ==> {
+      r.take(amount).length + r.drop(amount).length == r.length
+    }
+  }
+
+  property("same length when take and drop with a specific amount (Int)") = forAll { (r: NumericRange[Int], amount: Int) =>
+    Try(r.length).isSuccess ==> {
+      r.take(amount).length + r.drop(amount).length == r.length
+    }
+  }
+
+  // This is commented intentionally, because of a bug in NumericRange.count,
+  // which makes the length unstable for property based testing:
+  // e.g., NumericRange(1L, -9223372036854775808L, -1L).length == 1
+//  property("same length when take and drop with a specific amount (Long)") = forAll { (r: NumericRange[Long], amount: Int) =>
+//    Try(r.length).isSuccess ==> {
+//      r.take(amount).length + r.drop(amount).length == r.length
+//    }
+//  }
+
+  property("same length when take and drop with a specific amount (BigInt)") = forAll { (r: NumericRange[BigInt], amount: Int) =>
+    Try(r.length).isSuccess ==> {
+      r.take(amount).length + r.drop(amount).length == r.length
+    }
+  }
+}
+
+object NumericRangeProperties {
+  private implicit def arbitraryNumericRange[T](implicit num: Integral[T], tGen: Arbitrary[T]): Arbitrary[NumericRange[T]] =
+    Arbitrary(
+      for {
+        start <- tGen.arbitrary
+        end <- tGen.arbitrary
+        step <- tGen.arbitrary filterNot (num.equiv(_, num.zero))
+        incl  <- Gen.oneOf(true, false)
+      } yield if (incl) NumericRange.inclusive(start, end, step) else NumericRange(start, end, step)
+    )
+}

--- a/library/test/scala/collection/immutable/QueueProperties.scala
+++ b/library/test/scala/collection/immutable/QueueProperties.scala
@@ -1,0 +1,69 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.immutable
+
+
+import org.scalacheck.*
+import Prop.*
+
+import scala.collection.{IterableFactory, View, mutable}
+import scala.collection.mutable.{ArrayBuffer, ListBuffer}
+
+object QueueProperties extends Properties("immutable.Queue") {
+
+  val iterableGen: Gen[collection.Iterable[Int]] =
+    for {
+      data <- Gen.listOf(Arbitrary.arbInt.arbitrary)
+      factory <-
+      Gen.oneOf[IterableFactory[collection.Iterable]](
+        List, Vector, ArrayBuffer, mutable.ArrayDeque, Queue, ListBuffer, View
+      )
+    } yield factory.from(data)
+
+  property("(Queue.from(list1) ++ list2).apply(i) == (list1 ++ list2).apply(i)") = {
+
+    val testCases = for {
+      list1 <- Gen.listOf(Arbitrary.arbInt.arbitrary)
+      list2 <- Gen.listOf(Arbitrary.arbInt.arbitrary)
+      length = list1.length + list2.length
+      if length > 0
+      i <- Gen.choose(0, length - 1)
+    } yield (list1, list2, i)
+
+    // we do not shrink because shrinking will result in empty lists which will result in exceptions thrown in apply
+    forAllNoShrink(testCases) { case (list1, list2, i) =>
+      val left = Queue.from(list1).concat(list2)
+      left.apply(i) ?= list1.concat(list2).apply(i)
+    }
+  }
+  property("queue.concat(iterable) == list.concat(iterable)") = {
+    val testCases = for {
+      list1 <- Gen.listOf(Arbitrary.arbInt.arbitrary)
+      list2 <- Gen.listOf(Arbitrary.arbInt.arbitrary)
+      iterable: collection.Iterable[Int] <- iterableGen
+    } yield (list1, list2, iterable)
+
+    forAll(testCases) { case (list1, list2, iterable) =>
+      val result = list1.concat(list2).appendedAll(iterable)
+      ((Queue.from(list1).concat(list2).concat(iterable): Seq[Int]) ?= result).label("concat") &&
+        ((Queue.from(list1).appendedAll(list2).appendedAll(iterable): Seq[Int]) ?= result).label("appendedAll") &&
+        ((Queue.from(list1).enqueueAll(list2).enqueueAll(iterable): Seq[Int]) ?= result).label("enqueueAll")
+    }
+  }
+
+  property("Queue.from(iterable) == List.from(iterable)") = {
+    forAll(iterableGen) { it =>
+      (Queue.from(it): Seq[Int]) ?= List.from(it)
+    }
+  }
+}

--- a/library/test/scala/collection/immutable/RangeProperties.scala
+++ b/library/test/scala/collection/immutable/RangeProperties.scala
@@ -1,0 +1,76 @@
+package scala
+package collection.immutable
+
+import org.scalacheck.*
+
+class RangeProperties extends Properties("immutable.Range") {
+  import Prop._
+  import RangeProperties._
+
+  property("indexOf") = forAll { (r: Range, i: Int) =>
+    r.indexOf(i) == r.toVector.indexOf(i)
+  }
+
+  property("indexOf with start") = forAll { (r: Range, start: Int, i: Int) =>
+    r.indexOf(i, start) == r.toVector.indexOf(i, start)
+  }
+
+  property("lastIndexOf") = forAll { (r: Range, i: Int) =>
+    r.lastIndexOf(i) == r.toVector.lastIndexOf(i)
+  }
+
+  property("lastIndexOf with end") = forAll { (r: Range, end: Int, i: Int) =>
+    r.lastIndexOf(i, end) == r.toVector.lastIndexOf(i, end)
+  }
+
+  property("sorted") = forAll { (r: Range) =>
+    r.sorted.toVector == r.toVector.sorted
+  }
+
+  property("sorted backwards") = forAll { (r: Range) =>
+    r.sorted(using Ordering.Int.reverse).toVector == r.toVector.sorted(using Ordering.Int.reverse)
+  }
+
+  property("sameElements") = forAll { (r: Range, s: Range) =>
+    r.sameElements(s) == r.toVector.sameElements(s.toVector)
+  }
+
+  property("sameElements reflexive") = forAll { (r: Range) =>
+    r sameElements r
+  }
+
+  property("sameElements neg init") = forAll { (r: Range) =>
+    !r.isEmpty ==> !r.sameElements(r.init)
+  }
+
+  property("sameElements neg tail") = forAll { (r: Range) =>
+    !r.isEmpty ==> !r.sameElements(r.tail)
+  }
+
+  property("sameElements neg empty/non-empty") = forAll { (r1: Range, r2: Range) =>
+    (r1.isEmpty != r2.isEmpty) ==> !r1.sameElements(r2)
+  }
+
+  property("sameElements with different clusivity") = forAll { (r: Range) =>
+    !r.isEmpty ==> {
+      val oneFurther = if (r.step > 0) 1 else -1
+      if (r.isInclusive) r.sameElements(r.start until (r.end + oneFurther) by r.step)
+      else r.sameElements(r.start to (r.end - oneFurther) by r.step)
+    }
+  }
+
+}
+
+object RangeProperties {
+  final val MinInt = -128
+  final val MaxInt = 127
+
+  implicit val arbitraryRange: Arbitrary[Range] = Arbitrary(for {
+    start <- Gen.choose(MinInt, MaxInt)
+    step  <- Gen.choose(MinInt, MaxInt) filter (_ != 0)
+    end   <- Gen.choose(MinInt, MaxInt)
+    incl  <- Gen.oneOf(true, false)
+    r      = (if (incl) start to end else start until end) by step
+  } yield r)
+
+}

--- a/library/test/scala/collection/immutable/RangeProps.scala
+++ b/library/test/scala/collection/immutable/RangeProps.scala
@@ -1,0 +1,277 @@
+package scala.collection.immutable
+
+import org.scalacheck.*
+import Prop.*
+import Gen.*
+import Arbitrary.*
+
+class Counter(r: Range) {
+  var cnt = 0L
+  var last: Option[Int] = None
+  val str = "Range["+r.start+", "+r.end+", "+r.step+(if (r.isInclusive) "]" else ")")
+  def apply(x: Int) = {
+    cnt += 1L
+    if (cnt % 500000000L == 0L) {
+      println(f"Working: $str $cnt%d $x%d")
+    }
+    if (cnt > (Int.MaxValue.toLong + 1) * 2) {
+      val msg = s"Count exceeds maximum possible for an Int Range: $str"
+      println(msg) // exception is likely to be eaten by an out of memory error
+      sys error msg
+    }
+    if ((r.step > 0 && last.exists(_ > x)) || (r.step < 0 && last.exists(_ < x))) {
+      val msg = f"Range $str wrapped: $x%d ${last.toString}"
+      println(msg) // exception is likely to be eaten by an out of memory error
+      sys error msg
+    }
+    last = Some(x)
+  }
+}
+
+abstract class RangeProps(kind: String) extends Properties("Range "+kind) {
+  def myGen: Gen[Range]
+
+  def genReasonableSizeRange = oneOf(genArbitraryRange, genBoundaryRange)
+
+  def genArbitraryRange = for {
+    start <- choose(Int.MinValue, Int.MaxValue)
+    end <- choose(Int.MinValue, Int.MaxValue)
+    step <- choose(-Int.MaxValue, Int.MaxValue)
+  } yield Range(start, end, if (step == 0) 100 else step)
+
+  def genBoundaryRange = for {
+    boundary <- oneOf(Int.MinValue, -1, 0, 1, Int.MaxValue)
+    isStart <- arbitrary[Boolean]
+    size <- choose(1, 100)
+    step <- choose(1, 101)
+  } yield {
+    val signum = if (boundary == 0) 1 else boundary.sign
+    if (isStart) Range(boundary, boundary - size * boundary.sign, - step * signum)
+    else         Range(boundary - size * boundary.sign, boundary, step * signum)
+  }
+
+
+  def genSmallRange = for {
+    start <- choose(-100, 100)
+    end <- choose(-100, 100)
+    step <- choose(1, 1)
+  } yield if (start < end) Range(start, end, step) else Range(start, end, -step)
+
+  def genRangeByOne = oneOf(genRangeOpenByOne, genRangeClosedByOne)
+
+  def genRangeOpenByOne = for {
+    r <- oneOf(genSmallRange, genBoundaryRange)
+    if (r.end.toLong - r.start.toLong).abs <= 10000000L
+  } yield if (r.start < r.end) Range(r.start, r.end) else Range(r.end, r.start)
+
+  def genRangeClosedByOne = for (r <- genRangeOpenByOne) yield r.start to r.end
+
+  def str(r: Range) = "Range["+r.start+", "+r.end+", "+r.step+(if (r.isInclusive) "]" else ")")
+
+  def expectedSize(r: Range): Long = if (r.isInclusive) {
+    (r.end.toLong - r.start.toLong < 0, r.step < 0) match {
+      case (true, true) | (false, false) => (r.end.toLong - r.start.toLong).abs / r.step.abs.toLong + 1L
+      case _ => if (r.start == r.end) 1L else 0L
+    }
+  } else {
+    (r.end.toLong - r.start.toLong < 0, r.step < 0) match {
+      case (true, true) | (false, false) => (
+        (r.end.toLong - r.start.toLong).abs / r.step.abs.toLong
+        + (if ((r.end.toLong - r.start.toLong).abs % r.step.abs.toLong > 0L) 1L else 0L)
+      )
+      case _ => 0L
+    }
+  }
+
+  def within(r: Range, x: Int) = if (r.step > 0)
+    r.start <= x && (if (r.isInclusive) x <= r.end else x < r.end)
+  else
+    r.start >= x && (if (r.isInclusive) x >= r.end else x > r.end)
+
+  def multiple(r: Range, x: Int) = (x.toLong - r.start) % r.step == 0
+
+  property("foreach.step") = forAllNoShrink(myGen) { r =>
+    var allValid = true
+    val cnt = new Counter(r)
+    r foreach { x => cnt(x)
+      allValid &&= multiple(r, x)
+    }
+    allValid :| str(r)
+  }
+
+  property("foreach.inside.range") = forAll(myGen) { r =>
+    var allValid = true
+    val cnt = new Counter(r)
+    r foreach { x => cnt(x)
+      allValid &&= within(r, x)
+    }
+    allValid :| str(r)
+  }
+
+  property("foreach.visited.size") = forAll(myGen) { r =>
+    var visited = 0L
+    val cnt = new Counter(r)
+    r foreach { x => cnt(x)
+      visited += 1L
+    }
+    (visited == expectedSize(r)) :| str(r)
+  }
+
+  property("sum") = forAll(myGen) { r =>
+    val rSum = r.sum
+    val expected = r.length match {
+      case 0 => 0
+      case 1 => r.head
+      case x if x < 1000 => 
+        // Explicit sum, to guard against having the same mistake in both the
+        // range implementation and test implementation of sum formula.
+        // (Yes, this happened before.)
+        var i = r.head
+        var s = 0L
+        var n = x
+        while (n > 0) {
+          s += i
+          i += r.step
+          n -= 1
+        }
+        s.toInt
+      case _ =>
+        // Make sure head + last doesn't overflow!
+        ((r.head.toLong + r.last) * r.length  / 2).toInt
+    }
+
+    (rSum == expected) :| str(r)
+  }
+
+/* checks that sum respects custom Numeric */
+  property("sumCustomNumeric") = forAll(myGen) { r =>
+    val mod = 65536
+    object mynum extends Numeric[Int] {
+        def plus(x: Int, y: Int): Int = (x + y) % mod
+        override def zero = 0
+
+        def fromInt(x: Int): Int = ???
+        def parseString(str: String) = ???
+        def minus(x: Int, y: Int): Int = ???
+        def negate(x: Int): Int = ???
+        def times(x: Int, y: Int): Int = ???
+        def toDouble(x: Int): Double = ???
+        def toFloat(x: Int): Float = ???
+        def toInt(x: Int): Int = ((x % mod) + mod * 2) % mod
+        def toLong(x: Int): Long = ???
+        def compare(x: Int, y: Int): Int = ???
+      }
+
+    val rSum = r.sum(mynum)
+    val expected = mynum.toInt(r.sum)
+
+    (rSum == expected) :| str(r)
+  }
+
+
+  property("length") = forAll(myGen suchThat (r => expectedSize(r).toInt == expectedSize(r))) { r =>
+    (r.length == expectedSize(r)) :| str(r)
+  }
+
+  property("isEmpty") = forAll(myGen suchThat (r => expectedSize(r).toInt == expectedSize(r))) { r =>
+    (r.isEmpty == (expectedSize(r) == 0L)) :| str(r)
+  }
+
+  property("contains") = forAll(myGen, arbInt.arbitrary) { (r, x) =>
+    ((within(r, x) && multiple(r, x)) == r.contains(x)) :| str(r)+": "+x
+  }
+
+  property("take") = forAll(myGen suchThat (r => expectedSize(r).toInt == expectedSize(r)), arbInt.arbitrary) { (r, x) =>
+    val t = r take x
+    (t.size == (0 max x min r.size) && t.start == r.start && t.step == r.step) :| str(r)+" / "+str(t)+": "+x
+  }
+
+  property("init") = forAll(myGen suchThat (r => expectedSize(r).toInt == expectedSize(r))) { r =>
+    (r.size == 0) || {
+      val t = r.init
+      (t.size + 1 == r.size) && (t.isEmpty || t.head == r.head)
+    }
+  }
+
+  property("takeWhile") = forAll(myGen suchThat (r => expectedSize(r).toInt == expectedSize(r)), arbInt.arbitrary) { (r, x) =>
+    val t = (if (r.step > 0) r takeWhile (_ <= x) else r takeWhile(_ >= x))
+    if (r.size == 0) {
+      (t.size == 0) :| str(r)+" / "+str(t)+": "+x
+    } else {
+      val t2 = (if (r.step > 0) Range(r.start, x min r.last, r.step).inclusive else Range(r.start, x max r.last, r.step).inclusive)
+      (t.start == r.start && t.size == t2.size && t.step == r.step) :| str(r)+" / "+str(t)+" / "+str(t2)+": "+x
+    }
+  }
+
+  property("tails") = forAll(myGen) { r =>
+    (r.size < 1024) ==> { r.tails.toList == r.toList.tails.toList }
+  }
+
+  property("inits") = forAll(myGen) { r =>
+    (r.size < 1024) ==> { r.inits.toList == r.toList.inits.toList }
+  }
+
+  property("reverse.toSet.equal") = forAll(myGen) { r =>
+    val reversed = r.reverse
+    val aresame = r.toSet == reversed.toSet
+    if (!aresame) {
+      println(str(r))
+      println(r)
+      println(reversed)
+      println(r.toSet)
+      println(reversed.toSet)
+    }
+    aresame :| str(r)
+  }
+
+  property("grouped") = forAllNoShrink(
+    myGen,
+    Gen.posNum[Int],
+  ) { (r, size) =>
+    r.grouped(size).toSeq == r.toList.grouped(size).toSeq
+  }
+}
+
+object NormalRangeTest extends RangeProps("normal") {
+  override def myGen = genReasonableSizeRange
+  def genOne = for {
+    start <- arbitrary[Int]
+    end <- arbitrary[Int]
+    if (start.toLong - end.toLong).abs < Int.MaxValue.toLong
+  } yield Range(start, end, if (start < end) 1 else - 1)
+  property("by 1.size + 1 == inclusive.size") = forAll(genOne) { r =>
+    (r.size + 1 == r.inclusive.size) :| str(r)
+  }
+}
+
+object InclusiveRangeTest extends RangeProps("inclusive") {
+  override def myGen = for (r <- genReasonableSizeRange) yield r.inclusive
+}
+
+object ByOneRangeTest extends RangeProps("byOne") {
+  override def myGen = genRangeByOne
+}
+
+object InclusiveByOneRangeTest extends RangeProps("inclusiveByOne") {
+  override def myGen = for (r <- genRangeByOne) yield r.inclusive
+}
+
+object SmallValuesRange extends RangeProps("smallValues") {
+  override def myGen = genSmallRange
+}
+
+object TooLargeRange extends Properties("Too Large Range") {
+  val genTooLargeStart = for {
+    start <- choose(-Int.MinValue, 0)
+  } yield start
+
+  property("Too large range throws exception") = forAll(genTooLargeStart) { start =>
+    try   {
+      val r = Range.inclusive(start, Int.MaxValue, 1)
+      val l = r.length
+      println("how here? length = " + l + ", r = " + r.toString)
+      false
+    }
+    catch { case _: IllegalArgumentException => true }
+  }
+}

--- a/library/test/scala/collection/immutable/RedBlackTreeProps.scala
+++ b/library/test/scala/collection/immutable/RedBlackTreeProps.scala
@@ -1,0 +1,434 @@
+package scala.collection.immutable
+
+import collection.immutable.{RedBlackTree => RB}
+import org.scalacheck._
+import Prop._
+import Gen._
+
+/*
+Properties of a Red & Black Tree:
+
+A node is either red or black.
+The root is black. (This rule is used in some definitions and not others. Since the
+root can always be changed from red to black but not necessarily vice versa this
+rule has little effect on analysis.)
+All leaves are black.
+Both children of every red node are black.
+Every simple path from a given node to any of its descendant leaves contains the same number of black nodes.
+*/
+
+abstract class RedBlackTreeTest(tname: String) extends Properties(tname) with RedBlackTreeInvariants[String, Int] {
+  def minimumSize = 0
+  def maximumSize = 5
+
+  import RB._
+
+  def nodeAt[A](tree: Tree[String, A] | Null, n: Int): Option[(String, A)] = if (n < iterator(tree).size && n >= 0)
+    Some(iterator(tree).drop(n).next())
+  else
+    None
+
+  def treeContains[A](tree: Tree[String, A] | Null, key: String) = iterator(tree).map(_._1) contains key
+
+  def height(tree: Tree[?, ?] | Null): Int = if (tree eq null) 0 else (1 + math.max(height(tree.nn.left), height(tree.nn.right)))
+
+  def mkTree(level: Int, parentIsBlack: Boolean = false, label: String = ""): Gen[Tree[String, Int]] =
+    if (level == 0) {
+      const(null.asInstanceOf[Tree[String, Int]])
+    } else {
+      for {
+        oddOrEven <- choose(0, 2)
+        tryRed = oddOrEven.sample.get % 2 == 0 // work around arbitrary[Boolean] bug
+        isRed = parentIsBlack && tryRed
+        nextLevel = if (isRed) level else level - 1
+        left <- mkTree(nextLevel, !isRed, label + "L")
+        right <- mkTree(nextLevel, !isRed, label + "R")
+      } yield {
+        if (isRed)
+          RB.RedTree(label + "N", 0, left, right)
+        else
+          RB.BlackTree(label + "N", 0, left, right)
+      }
+    }
+
+  def genTree = for {
+    depth <- choose(minimumSize, maximumSize + 1)
+    tree <- mkTree(depth)
+  } yield tree
+
+  type ModifyParm
+  def genParm(tree: Tree[String, Int]): Gen[ModifyParm]
+  def modify(tree: Tree[String, Int] | Null, parm: ModifyParm): Tree[String, Int] | Null
+
+  def genInput: Gen[(Tree[String, Int], ModifyParm, Tree[String, Int] | Null)] = for {
+    tree <- genTree
+    parm <- genParm(tree)
+  } yield (tree, parm, validate(modify(tree, parm)))
+
+  def setup(invariant: Tree[String, Int] | Null => Boolean): Prop = forAll(genInput) { case (tree, parm, newTree) =>
+    invariant(newTree)
+  }
+
+  implicit def ordering: Ordering[String] = Ordering.String
+}
+
+trait RedBlackTreeInvariants[K, V] {
+  self: Properties =>
+
+  import RB._
+
+  object RedTree {
+    def unapply[A, B](t: Tree[A, B] | Null) = if ((t ne null) && t.isRed) Some((t.key, t.value, t.left, t.right)) else None
+  }
+  object BlackTree {
+    def unapply[A, B](t: Tree[A, B] | Null) = if ((t ne null) && t.isBlack) Some((t.key, t.value, t.left, t.right)) else None
+  }
+
+  implicit def ordering: Ordering[K]
+
+  def rootIsBlack[A](t: Tree[K, V] | Null) = isBlack(t)
+
+  def areAllLeavesBlack[A](t: Tree[K, V] | Null): Boolean = t match {
+    case null => isBlack(t)
+    case ne => List(ne.left, ne.right).forall(areAllLeavesBlack)
+  }
+
+  def areRedNodeChildrenBlack[A](t: Tree[K, V] | Null): Boolean = t match {
+    case RedTree(_, _, left, right) => List(left, right).forall(t => isBlack(t) && areRedNodeChildrenBlack(t))
+    case BlackTree(_, _, left, right) => List(left, right).forall(areRedNodeChildrenBlack)
+    case null => true
+  }
+
+  def blackNodesToLeaves[A](t: Tree[K, V] | Null): List[Int] = t match {
+    case null => List(1)
+    case BlackTree(_, _, left, right) => List(left, right).flatMap(blackNodesToLeaves).map(_ + 1)
+    case RedTree(_, _, left, right) => List(left, right).flatMap(blackNodesToLeaves)
+  }
+
+  def areBlackNodesToLeavesEqual[A](t: Tree[K, V] | Null): Boolean = t match {
+    case null => true
+    case ne =>
+      (
+        blackNodesToLeaves(ne).distinct.size == 1
+          && areBlackNodesToLeavesEqual(ne.left)
+          && areBlackNodesToLeavesEqual(ne.right)
+        )
+  }
+
+  def orderIsPreserved[A](t: Tree[K, V] | Null): Boolean =
+    iterator(t) zip iterator(t).drop(1) forall { case (x, y) => ordering.compare(x._1, y._1) < 0 }
+
+  def setup(invariant: Tree[K, V] | Null => Boolean): Prop
+
+  property("root is black") = setup(rootIsBlack)
+  property("all leaves are black") = setup(areAllLeavesBlack)
+  property("children of red nodes are black") = setup(areRedNodeChildrenBlack)
+  property("black nodes are balanced") = setup(areBlackNodesToLeavesEqual)
+  property("ordering of keys is preserved") = setup(orderIsPreserved)
+}
+
+object TestInsert extends RedBlackTreeTest("RedBlackTree.insert") {
+  import RB._
+
+  override type ModifyParm = Int
+  override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = choose(0, iterator(tree).size + 1)
+  override def modify(tree: Tree[String, Int] | Null, parm: ModifyParm): Tree[String, Int] | Null = update(tree, generateKey(tree, parm), 0, overwrite = true)
+
+  def generateKey(tree: Tree[String, Int] | Null, parm: ModifyParm): String = nodeAt(tree, parm) match {
+    case Some((key, _)) => key.init.mkString + "MN"
+    case None => nodeAt(tree, parm - 1) match {
+      case Some((key, _)) => key.init.mkString + "RN"
+      case None  => "N"
+    }
+  }
+
+  property("update adds elements") = forAll(genInput) { case (tree, parm, newTree) =>
+    treeContains(newTree, generateKey(tree, parm))
+  }
+}
+
+object TestModify extends RedBlackTreeTest("RedBlackTree.modify") {
+  import RB._
+
+  def newValue = 1
+  override def minimumSize = 1
+  override type ModifyParm = Int
+  override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = choose(0, iterator(tree).size)
+  override def modify(tree: Tree[String, Int] | Null, parm: ModifyParm): Tree[String, Int] | Null = nodeAt(tree, parm) map {
+    case (key, _) => update(tree, key, newValue, overwrite = true)
+  } getOrElse tree
+
+  property("update modifies values") = forAll(genInput) { case (tree, parm, newTree) =>
+    nodeAt(tree,parm) forall { case (key, _) =>
+      iterator(newTree) contains (key, newValue)
+    }
+  }
+}
+
+object TestDelete extends RedBlackTreeTest("RedBlackTree.delete") {
+  import RB._
+
+  override def minimumSize = 1
+  override type ModifyParm = Int
+  override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = choose(0, iterator(tree).size)
+  override def modify(tree: Tree[String, Int] | Null, parm: ModifyParm): Tree[String, Int] | Null = nodeAt(tree, parm) map {
+    case (key, _) => delete(tree, key)
+  } getOrElse tree
+
+  property("delete removes elements") = forAll(genInput) { case (tree, parm, newTree) =>
+    nodeAt(tree, parm) forall { case (key, _) =>
+      !treeContains(newTree, key)
+    }
+  }
+}
+
+object TestRange extends RedBlackTreeTest("RedBlackTree.range") {
+  import RB._
+
+  override type ModifyParm = (Option[Int], Option[Int])
+  override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = for {
+    from <- choose(0, iterator(tree).size)
+    to <- choose(0, iterator(tree).size) suchThat (from <= _)
+    optionalFrom <- oneOf(Some(from), None, Some(from)) // Double Some(n) to get around a bug
+    optionalTo <- oneOf(Some(to), None, Some(to)) // Double Some(n) to get around a bug
+  } yield (optionalFrom, optionalTo)
+
+  override def modify(tree: Tree[String, Int] | Null, parm: ModifyParm): Tree[String, Int] | Null = {
+    val from = parm._1 flatMap (nodeAt(tree, _) map (_._1))
+    val to = parm._2 flatMap (nodeAt(tree, _) map (_._1))
+    rangeImpl(tree, from, to)
+  }
+
+  property("range boundaries respected") = forAll(genInput) { case (tree, parm, newTree) =>
+    val from = parm._1 flatMap (nodeAt(tree, _) map (_._1))
+    val to = parm._2 flatMap (nodeAt(tree, _) map (_._1))
+    ("lower boundary" |: (from forall ( key => keysIterator(newTree) forall (key.<=)))) &&
+    ("upper boundary" |: (to forall ( key => keysIterator(newTree) forall (key.>))))
+  }
+
+  property("range returns all elements") = forAll(genInput) { case (tree, parm, newTree) =>
+    val from = parm._1 flatMap (nodeAt(tree, _) map (_._1))
+    val to = parm._2 flatMap (nodeAt(tree, _) map (_._1))
+    val filteredTree = (keysIterator(tree)
+      .filter(key => from forall (key >= _))
+      .filter(key => to forall (key < _))
+      .toList)
+    filteredTree == keysIterator(newTree).toList
+  }
+}
+
+object TestDrop extends RedBlackTreeTest("RedBlackTree.drop") {
+  import RB._
+
+  override type ModifyParm = Int
+  override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = choose(0, iterator(tree).size)
+  override def modify(tree: Tree[String, Int] | Null, parm: ModifyParm): Tree[String, Int] | Null = drop(tree, parm)
+
+  property("drop") = forAll(genInput) { case (tree, parm, newTree) =>
+    iterator(tree).drop(parm).toList == iterator(newTree).toList
+  }
+}
+
+object TestTail extends RedBlackTreeTest("RedBlackTree.tail") {
+  import RB._
+
+  override type ModifyParm = Int
+  override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = choose(0, 0)
+  override def modify(tree: Tree[String, Int] | Null, parm: ModifyParm): Tree[String, Int] | Null =
+    if(tree eq null) null else tail(tree)
+
+  property("tail") = forAll(genInput) { case (tree, parm, newTree) =>
+    iterator(tree).drop(1).toList == iterator(newTree).toList
+  }
+}
+
+object TestInit extends RedBlackTreeTest("RedBlackTree.init") {
+  import RB._
+
+  override type ModifyParm = Int
+  override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = choose(0, 0)
+  override def modify(tree: Tree[String, Int] | Null, parm: ModifyParm): Tree[String, Int] | Null =
+    if(tree eq null) null else init(tree)
+
+  property("tail") = forAll(genInput) { case (tree, parm, newTree) =>
+    iterator(tree).toList.dropRight(1) == iterator(newTree).toList
+  }
+}
+
+object TestTake extends RedBlackTreeTest("RedBlackTree.take") {
+  import RB._
+
+  override type ModifyParm = Int
+  override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = choose(0, iterator(tree).size)
+  override def modify(tree: Tree[String, Int] | Null, parm: ModifyParm): Tree[String, Int] | Null = take(tree, parm)
+
+  property("take") = forAll(genInput) { case (tree, parm, newTree) =>
+    iterator(tree).take(parm).toList == iterator(newTree).toList
+  }
+
+  property("degenerateTree") =
+    forAll(Gen.listOfN(10000, Gen.posNum[Int])) { items =>
+      items.zipWithIndex.foldLeft(scala.collection.immutable.TreeMap.empty[Int, String]) {
+        case (collection, (key, index)) if index % 2 == 0 =>
+          (collection + (key -> "foobar")).take(10)
+        case (collection, (key, _)) => (collection - key).take(10)
+      }
+      true
+    }
+}
+
+object TestSlice extends RedBlackTreeTest("RedBlackTree.slice") {
+  import RB._
+
+  override type ModifyParm = (Int, Int)
+  override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = for {
+    from <- choose(0, iterator(tree).size)
+    to <- choose(from, iterator(tree).size)
+  } yield (from, to)
+  override def modify(tree: Tree[String, Int] | Null, parm: ModifyParm): Tree[String, Int] | Null = slice(tree, parm._1, parm._2)
+
+  property("slice") = forAll(genInput) { case (tree, parm, newTree) =>
+    iterator(tree).slice(parm._1, parm._2).toList == iterator(newTree).toList
+  }
+}
+
+object TestFromOrderedKeys extends Properties("RedBlackTree.fromOrderedKeys") with RedBlackTreeInvariants[Int, Null] {
+  import RB._
+
+  def modify(s: Set[Int]): Tree[Int, Null] | Null = {
+    val xs = s.toIndexedSeq.sorted
+    fromOrderedKeys(xs.iterator, xs.size)
+  }
+
+  property("fromOrderedKeys") = forAll { (s: Set[Int]) =>
+    s.toIndexedSeq.sorted == keysIterator(modify(s)).toIndexedSeq
+  }
+
+  def setup(invariant: Tree[Int, Null] | Null => Boolean) = forAll { (s: Set[Int]) =>
+    invariant(modify(s))
+  }
+
+  implicit def ordering: Ordering[Int] = Ordering.Int
+}
+
+object TestFromOrderedEntries extends Properties("RedBlackTree.fromOrderedEntries") with RedBlackTreeInvariants[Int, String] {
+  import RB._
+
+  def modify(s: Set[Int]): Tree[Int, String] | Null = {
+    val xs = s.toIndexedSeq.sorted.map(i => (i, i.toString))
+    fromOrderedEntries(xs.iterator, xs.size)
+  }
+
+  property("fromOrderedKeys") = forAll { (s: Set[Int]) =>
+    s.toIndexedSeq.sorted.map(i => (i, i.toString)) == iterator(modify(s)).toIndexedSeq
+  }
+
+  def setup(invariant: Tree[Int, String] | Null => Boolean) = forAll { (s: Set[Int]) =>
+    invariant(modify(s))
+  }
+
+  implicit def ordering: Ordering[Int] = Ordering.Int
+}
+
+abstract class BulkTest(pName: String) extends RedBlackTreeTest(pName) {
+  import RB._
+
+  override type ModifyParm = Tree[String, Int] | Null
+  override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = genTree
+  override def modify(tree: Tree[String, Int] | Null, parm: ModifyParm): Tree[String, Int] | Null = treeOp(tree, parm)
+
+  def treeOp(t1: Tree[String, Int] | Null, t2: Tree[String, Int] | Null): Tree[String, Int] | Null
+  def setOp(s1: Set[(String, Int)], s2: Set[(String, Int)]): Set[(String, Int)]
+
+  // Using our own setup here because genTree can't minimize - great when it works but useless when it fails
+  // and you have to debug it
+
+  def gen(l1: List[Int], l2: List[Int]) = {
+    var t1: Tree[String, Int] | Null = null
+    l1.foreach { i => t1 = update(t1, ""+i, i, overwrite = false) }
+    var t2: Tree[String, Int] | Null = null
+    l2.foreach { i => t2 = update(t2, ""+i, i, overwrite = false) }
+    val t3 = validate(modify(t1, t2))
+    (t1, t2, t3)
+  }
+
+  override def setup(invariant: Tree[String, Int] | Null => Boolean) = forAll { (l1: List[Int], l2: List[Int]) =>
+    val (t1, t2, t3) = gen(l1, l2)
+    invariant(t3)
+  }
+
+  property(pName) = forAll { (l1: List[Int], l2: List[Int]) =>
+    val (t1, t2, t3) = gen(l1, l2)
+    setOp(iterator(t1).toSet, iterator(t2).toSet).toList.sorted == iterator(t3).toList
+  }
+}
+
+object TestUnion extends BulkTest("RedBlackTree.union") {
+  import RB._
+  def treeOp(t1: Tree[String, Int] | Null, t2: Tree[String, Int] | Null): Tree[String, Int] | Null = union(t1, t2)
+  def setOp(s1: Set[(String, Int)], s2: Set[(String, Int)]): Set[(String, Int)] = s1.union(s2)
+}
+
+object TestIntersect extends BulkTest("RedBlackTree.intersect") {
+  import RB._
+  def treeOp(t1: Tree[String, Int] | Null, t2: Tree[String, Int] | Null): Tree[String, Int] | Null = intersect(t1, t2)
+  def setOp(s1: Set[(String, Int)], s2: Set[(String, Int)]): Set[(String, Int)] = s1.intersect(s2)
+}
+
+object TestDifference extends BulkTest("RedBlackTree.difference") {
+  import RB._
+  def treeOp(t1: Tree[String, Int] | Null, t2: Tree[String, Int] | Null): Tree[String, Int] | Null = difference(t1, t2)
+  def setOp(s1: Set[(String, Int)], s2: Set[(String, Int)]): Set[(String, Int)] = s1.diff(s2)
+}
+
+object TestFilter extends RedBlackTreeTest("RedBlackTree.filterEntries") {
+  import RB._
+
+  override type ModifyParm = Int
+  override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = choose(0, 0)
+  override def modify(tree: Tree[String, Int] | Null, parm: ModifyParm): Tree[String, Int] | Null =
+    filterEntries[String, Int](tree, (k, _) => k.hashCode % 2 == 0)
+
+  property("filter") = forAll(genInput) { case (tree, parm, newTree) =>
+    iterator(tree).filter(t => t._1.hashCode % 2 == 0).toList == iterator(newTree).toList
+  }
+}
+
+object TestPartitionLeft extends RedBlackTreeTest("RedBlackTree.partitionKeysLeft") {
+  import RB._
+
+  override type ModifyParm = Int
+  override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = choose(0, 0)
+  override def modify(tree: Tree[String, Int] | Null, parm: ModifyParm): Tree[String, Int] | Null =
+    partitionEntries[String, Int](tree, (k, v) => k.hashCode % 2 == 0)._1
+
+  property("partition") = forAll(genInput) { case (tree, parm, newTree) =>
+    iterator(tree).filter(t => t._1.hashCode % 2 == 0).toList == iterator(newTree).toList
+  }
+}
+
+object TestPartitionRight extends RedBlackTreeTest("RedBlackTree.partitionKeysRight") {
+  import RB._
+
+  override type ModifyParm = Int
+  override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = choose(0, 0)
+  override def modify(tree: Tree[String, Int] | Null, parm: ModifyParm): Tree[String, Int] | Null =
+    partitionEntries[String, Int](tree, (k, v) => k.hashCode % 2 == 0)._2
+
+  property("partition") = forAll(genInput) { case (tree, parm, newTree) =>
+    iterator(tree).filter(t => t._1.hashCode % 2 != 0).toList == iterator(newTree).toList
+  }
+}
+
+object TestTransform extends RedBlackTreeTest("RedBlackTree.transform") {
+  import RB._
+
+  override type ModifyParm = Int
+  override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = choose(0, count(tree))
+  override def modify(tree: Tree[String, Int] | Null, parm: ModifyParm): Tree[String, Int] | Null =
+    transform[String, Int, Int](tree, (k, v) => if(v < parm) v else v+1)
+
+  property("transform") = forAll(genInput) { case (tree, parm, newTree) =>
+    iterator(tree).toList.map { case (k, v) => if(v < parm) (k, v) else (k, v+1) } == iterator(newTree).toList
+  }
+}

--- a/library/test/scala/collection/immutable/SeqMapProps.scala
+++ b/library/test/scala/collection/immutable/SeqMapProps.scala
@@ -1,0 +1,41 @@
+package scala.collection.immutable
+
+import org.scalacheck.*
+import Arbitrary.arbitrary
+import Prop.*
+import Gen.*
+
+object SeqMapProps extends Properties("SeqMap") {
+
+  property("overrides stringPrefix") = {
+    new SeqMap[Int, String] {
+      def removed(key: Int): SeqMap[Int, String] = ???
+      def updated[V1 >: String](key: Int, value: V1): SeqMap[Int, V1] = ???
+      override def get(key: Int): Option[String] = ???
+      override def iterator: Iterator[(Int, String)] = Iterator(1 -> "hi")
+    }.toString == "SeqMap(1 -> hi)"
+  }
+
+  property("ordering") = forAll { (m: Map[Int, Int]) =>
+    val list = m.toList
+    val sm = SeqMap.from(list)
+    val iter = sm.iterator
+    iter.toList == list
+  }
+
+  property("ordering append") = forAll(arbitrary[Map[Int,Int]] suchThat (_.size > 1))
+    { (m: Map[Int, Int]) =>
+      val (m1, m2) = m.splitAt(m.size / 2)
+      val first = m1.toList
+      val second = m2.toList
+      (SeqMap.from(first) ++ second).iterator.toList == first ++ second
+  }
+
+  property("ordering on withDefault") = forAll(arbitrary[Map[Int,Int]] suchThat (_.size > 1))
+    { (m: Map[Int, Int]) =>
+      val (m1, m2) = m.splitAt(m.size / 2)
+      val first = m1.toList
+      val second = m2.toList
+      (SeqMap.from(first).withDefaultValue(1) ++ second).iterator.toList == first ++ second
+  }
+}

--- a/library/test/scala/collection/immutable/SeqProperties.scala
+++ b/library/test/scala/collection/immutable/SeqProperties.scala
@@ -1,0 +1,96 @@
+package scala.collection.immutable
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
+import org.scalacheck.commands.Commands
+
+import scala.collection.mutable
+import scala.util.{Success, Try}
+import org.scalacheck.Properties
+
+@annotation.nowarn("cat=deprecation&msg=Stream")
+object SeqProperties extends Properties("immutable.Seq builder implementations"){
+
+  type A = Int
+
+  property("Seq builder stateful testing") = new SeqBuilderStateProperties(Seq.newBuilder[A]).property()
+  property("List builder stateful testing") = new SeqBuilderStateProperties(List.newBuilder[A]).property()
+  property("ArraySeq builder stateful testing") = new SeqBuilderStateProperties(ArraySeq.newBuilder[A]).property()
+  property("Queue builder stateful testing") = new SeqBuilderStateProperties(Queue.newBuilder[A]).property()
+  property("IndexedSeq builder stateful testing") = new SeqBuilderStateProperties(IndexedSeq.newBuilder[A]).property()
+  property("Stream builder stateful testing") = new SeqBuilderStateProperties(Stream.newBuilder[A]).property()
+  property("Vector builder stateful testing") = new SeqBuilderStateProperties(Vector.newBuilder[A]).property()
+  property("WrappedString builder stateful testing") = new SeqBuilderStateProperties(WrappedString.newBuilder).property()
+
+}
+
+
+/** Generic stateful property testing for Seq builders
+  *
+  * Usage: {{{
+  *   class MyCollectionProperties extends Properties("my.Collection") {
+  *      property("MyCollection builder stateful testing") =
+  *        new SeqBuilderStateProperties(MySeq.newBuilder[A]).property() &&
+  *   }
+  * }}}
+  * @param arbA  gen for the elements of the Seq
+  * @tparam To the type of Seq under test
+  */
+class SeqBuilderStateProperties[A: Arbitrary, To <: Seq[A]](newBuilder: => mutable.Builder[A, To])(implicit arbA: Arbitrary[A]) extends Commands {
+
+  override type State = Seq[A]
+  override type Sut = mutable.Builder[A, To]
+
+  import Gen._
+  val commandGen = Gen.oneOf(
+    const(Clear),
+    const(Result),
+    choose(0, 10000).map(SizeHint(_)),
+    arbA.arbitrary.map(a => AddOne(a)),
+    listOf(arbA.arbitrary).map(a => AddAll(a))
+  )
+
+  override def genInitialState: Gen[State] = newBuilder.result()
+
+  override def canCreateNewSut(newState: State, initSuts: scala.Iterable[State], runningSuts: scala.Iterable[Sut]) = true
+
+  override def newSut(state: State): mutable.Builder[A, To] = newBuilder.addAll(state)
+
+  override def destroySut(sut: Sut): Unit = ()
+
+  override def initialPreCondition(state: State) = state.isEmpty
+
+  override def genCommand(state: State): Gen[Command] = commandGen
+
+  case object Clear extends UnitCommand {
+    override def postCondition(state: State, success: Boolean) = success
+    override def run(sut: Sut) = sut.clear()
+    override def nextState(state: State) = Vector.empty
+    override def preCondition(state: State) = true
+  }
+  case object Result extends Command {
+    override type Result = State
+    override def postCondition(state: State, result: Try[Result]) = result.map(_.toVector) == Success(state.toVector)
+    override def run(sut: Sut) = sut.result().toVector
+    override def nextState(state: State) = state
+    override def preCondition(state: State) = true
+  }
+  case class SizeHint(size: Int) extends UnitCommand {
+    override def postCondition(state: State, success: Boolean) = success
+    override def run(sut: Sut) = sut.sizeHint(size)
+    override def nextState(state: State) = state
+    override def preCondition(state: State) = true
+  }
+  case class AddOne(elem: A) extends UnitCommand {
+    override def postCondition(state: State, success: Boolean) = success
+    override def run(sut: Sut) = sut.addOne(elem)
+    override def nextState(state: State) = state.appended(elem)
+    override def preCondition(state: State) = true
+  }
+  case class AddAll(elems: scala.collection.immutable.Seq[A]) extends UnitCommand {
+    override def postCondition(state: State, success: Boolean) = success
+    override def run(sut: Sut) = sut.addAll(elems)
+    override def nextState(state: State) = state.appendedAll(elems)
+    override def preCondition(state: State) = true
+  }
+}

--- a/library/test/scala/collection/immutable/SetProperties.scala
+++ b/library/test/scala/collection/immutable/SetProperties.scala
@@ -1,0 +1,93 @@
+package scala.collection.immutable
+
+import org.scalacheck.{Arbitrary, Gen, Properties, Shrink}
+import org.scalacheck.commands.Commands
+
+import scala.collection.mutable
+import scala.util.{Success, Try}
+
+@annotation.nowarn("cat=deprecation&msg=Stream")
+object SetProperties extends Properties("immutable.Set builder implementations") {
+
+  type A = Int
+
+  property("Set builder stateful testing") = new SetBuilderStateProperties(Set.newBuilder[A]).property()
+  property("HashSet builder stateful testing") = new SetBuilderStateProperties(HashSet.newBuilder[A]).property()
+  property("ListSet builder stateful testing") = new SetBuilderStateProperties(ListSet.newBuilder[A]).property()
+  property("SortedSet builder stateful testing") = new SetBuilderStateProperties(SortedSet.newBuilder[A]).property()
+  property("TreeSet builder stateful testing") = new SetBuilderStateProperties(TreeSet.newBuilder[A]).property()
+}
+
+
+/** Generic stateful property testing for Set builders
+  *
+  * Usage: {{{
+  *   class MyCollectionProperties extends Properties("my.Collection") {
+  *      property("MyCollection builder stateful testing") =
+  *        new SetBuilderStateProperties(MySet.newBuilder[A]).property() &&
+  *   }
+  * }}}
+  * @param arbA  gen for the elements of the Set
+  * @tparam To the type of Set under test
+  */
+class SetBuilderStateProperties[A, To <: Set[A]](newBuilder: => mutable.Builder[A, To])(implicit arbA: Arbitrary[A]) extends Commands {
+
+  override type State = Set[A]
+  override type Sut = mutable.Builder[A, To]
+
+  override def genInitialState: Gen[State] = Set.empty[A]
+
+  override def canCreateNewSut(newState: State, initSuts: scala.Iterable[State], runningSuts: scala.Iterable[Sut]) = true
+
+  override def newSut(state: State): mutable.Builder[A, To] = newBuilder.addAll(state)
+
+  override def destroySut(sut: Sut): Unit = ()
+
+  override def initialPreCondition(state: State) = state.isEmpty
+
+  import Gen._
+  lazy val _genCommand = Gen.oneOf(
+    const(Clear),
+    const(Result),
+    choose(0, 10000).map(SizeHint(_)),
+    arbA.arbitrary.map(a => AddOne(a)),
+    listOf(arbA.arbitrary).map(a => AddAll(a))
+  )
+
+  override def genCommand(state: State): Gen[Command] = _genCommand
+
+  @annotation.nowarn("cat=deprecation&msg=Stream")
+  override def shrinkState = Shrink.apply[State]( set => set.to(Stream).map(set - _) )
+
+  case object Clear extends UnitCommand {
+    override def postCondition(state: State, success: Boolean) = success
+    override def run(sut: Sut) = sut.clear()
+    override def nextState(state: State) = Set.empty
+    override def preCondition(state: State) = true
+  }
+  case object Result extends Command {
+    override type Result = State
+    override def postCondition(state: State, result: Try[Result]) = result == Success(state)
+    override def run(sut: Sut) = sut.result()
+    override def nextState(state: State) = state
+    override def preCondition(state: State) = true
+  }
+  case class SizeHint(size: Int) extends UnitCommand {
+    override def postCondition(state: State, success: Boolean) = success
+    override def run(sut: Sut) = sut.sizeHint(size)
+    override def nextState(state: State) = state
+    override def preCondition(state: State) = true
+  }
+  case class AddOne(elem: A) extends UnitCommand {
+    override def postCondition(state: State, success: Boolean) = success
+    override def run(sut: Sut) = sut.addOne(elem)
+    override def nextState(state: State) = state + elem
+    override def preCondition(state: State) = true
+  }
+  case class AddAll(elems: scala.collection.immutable.Seq[A]) extends UnitCommand {
+    override def postCondition(state: State, success: Boolean) = success
+    override def run(sut: Sut) = sut.addAll(elems)
+    override def nextState(state: State) = state ++ elems
+    override def preCondition(state: State) = true
+  }
+}

--- a/library/test/scala/collection/immutable/TreeMapProps.scala
+++ b/library/test/scala/collection/immutable/TreeMapProps.scala
@@ -1,0 +1,175 @@
+package scala.collection.immutable
+
+import org.scalacheck.*
+import Prop.*
+import Gen.*
+import Arbitrary.*
+import util.*
+import Buildable.*
+
+object TreeMapProps extends Properties("TreeMap") {
+  def genTreeMap[A: {Arbitrary, Ordering}, B: Arbitrary]: Gen[TreeMap[A, B]] =
+    for {
+      keys <- listOf(arbitrary[A])
+      values <- listOfN(keys.size, arbitrary[B])
+    } yield TreeMap(keys zip values*)
+  implicit def arbTreeMap[A : {Arbitrary, Ordering}, B : Arbitrary]: Arbitrary[TreeMap[A, B]] = Arbitrary(genTreeMap[A, B])
+
+  property("foreach/iterator consistency") = forAll { (subject: TreeMap[Int, String]) =>
+    val it = subject.iterator
+    var consistent = true
+    subject.foreach { element =>
+      consistent &&= it.hasNext && element == it.next()
+    }
+    consistent
+  }
+
+  property("worst-case tree height is iterable") = forAll(choose(0, 10), arbitrary[Boolean]) { (n: Int, even: Boolean) =>
+    /*
+     * According to "Ralf Hinze. Constructing red-black trees" [https://www.cs.ox.ac.uk/ralf.hinze/publications/#P5]
+     * you can construct a skinny tree of height 2n by inserting the elements [1 .. 2^(n+1) - 2] and a tree of height
+     * 2n+1 by inserting the elements [1 .. 3 * 2^n - 2], both in reverse order.
+     *
+     * Since we allocate a fixed size buffer in the iterator (based on the tree size) we need to ensure
+     * it is big enough for these worst-case trees.
+     */
+    val highest = if (even) (1 << (n+1)) - 2 else 3*(1 << n) - 2
+    val values = (1 to highest).reverse
+    val subject = TreeMap(values zip values*)
+    val it = subject.iterator
+    try { while (it.hasNext) it.next(); true } catch { case _: Throwable => false }
+  }
+
+  property("sorted") = forAll { (subject: TreeMap[Int, String]) => (subject.size >= 3) ==> {
+    subject.zip(subject.tail).forall { case (x, y) => x._1 < y._1 }
+  }}
+
+  property("contains all") = forAll { (arr: List[(Int, String)]) =>
+    val subject = TreeMap(arr*)
+    arr.map(_._1).forall(subject.contains)
+  }
+
+  property("size") = forAll { (elements: List[(Int, Int)]) =>
+    val subject = TreeMap(elements*)
+    elements.map(_._1).distinct.size == subject.size
+  }
+
+  property("toSeq") = forAll { (elements: List[(Int, Int)]) =>
+    val subject = TreeMap(elements*)
+    elements.map(_._1).distinct.sorted == subject.toSeq.map(_._1)
+  }
+
+  property("head") = forAll { (elements: List[Int]) => elements.nonEmpty ==> {
+    val subject = TreeMap(elements zip elements*)
+    elements.min == subject.head._1
+  }}
+
+  property("last") = forAll { (elements: List[Int]) => elements.nonEmpty ==> {
+    val subject = TreeMap(elements zip elements*)
+    elements.max == subject.last._1
+  }}
+
+  property("minAfter") = forAll { (elements: List[Int]) => elements.nonEmpty ==> {
+    val half = elements.take(elements.size / 2)
+    val subject = TreeMap((half zip half)*)
+    elements.forall { e =>
+      val temp = subject.rangeFrom(e)
+      if (temp.isEmpty) subject.minAfter(e).isEmpty
+      else subject.minAfter(e).get == temp.min
+    }
+  }}
+
+  property("maxBefore") = forAll { (elements: List[Int]) => elements.nonEmpty ==> {
+    val half = elements.take(elements.size / 2)
+    val subject = TreeMap((half zip half)*)
+    elements.forall { e =>
+      val temp = subject.rangeUntil(e)
+      if (temp.isEmpty) subject.maxBefore(e).isEmpty
+      else subject.maxBefore(e).get == temp.max
+    }
+  }}
+
+  property("head/tail identity") = forAll { (subject: TreeMap[Int, String]) => subject.nonEmpty ==> {
+    subject == (subject.tail + subject.head)
+  }}
+
+  property("init/last identity") = forAll { (subject: TreeMap[Int, String]) => subject.nonEmpty ==> {
+    subject == (subject.init + subject.last)
+  }}
+
+  property("take") = forAll { (subject: TreeMap[Int, String]) =>
+    val n = choose(0, subject.size).sample.get
+    n == subject.take(n).size && subject.take(n).forall(elt => subject.get(elt._1) == Some(elt._2))
+  }
+
+  property("drop") = forAll { (subject: TreeMap[Int, String]) =>
+    val n = choose(0, subject.size).sample.get
+    (subject.size - n) == subject.drop(n).size && subject.drop(n).forall(elt => subject.get(elt._1) == Some(elt._2))
+  }
+
+  property("take/drop identity") = forAll { (subject: TreeMap[Int, String]) =>
+    val n = choose(-1, subject.size + 1).sample.get
+    subject == subject.take(n) ++ subject.drop(n)
+  }
+
+  property("splitAt") = forAll { (subject: TreeMap[Int, String]) =>
+    val n = choose(-1, subject.size + 1).sample.get
+    val (prefix, suffix) = subject.splitAt(n)
+    prefix == subject.take(n) && suffix == subject.drop(n)
+  }
+
+  def genSliceParms = for {
+    tree <- genTreeMap[Int, String]
+    from <- choose(0, tree.size)
+    until <- choose(from, tree.size)
+  } yield (tree, from, until)
+
+  property("slice") = forAll(genSliceParms) { case (subject, from, until) =>
+    val slice = subject.slice(from, until)
+    slice.size == until - from && subject.toSeq == subject.take(from).toSeq ++ slice ++ subject.drop(until)
+  }
+
+  property("takeWhile") = forAll { (subject: TreeMap[Int, String]) =>
+    val result = subject.takeWhile(_._1 < 0)
+    result.forall(_._1 < 0) && result == subject.take(result.size)
+  }
+
+  property("dropWhile") = forAll { (subject: TreeMap[Int, String]) =>
+    val result = subject.dropWhile(_._1 < 0)
+    result.forall(_._1 >= 0) && result == subject.takeRight(result.size)
+  }
+
+  property("span identity") = forAll { (subject: TreeMap[Int, String]) =>
+    val (prefix, suffix) = subject.span(_._1 < 0)
+    prefix.forall(_._1 < 0) && suffix.forall(_._1 >= 0) && subject == prefix ++ suffix
+  }
+
+  property("from is inclusive") = forAll { (subject: TreeMap[Int, String]) => subject.nonEmpty ==> {
+    val n = choose(0, subject.size - 1).sample.get
+    val from = subject.drop(n).firstKey
+    subject.rangeFrom(from).firstKey == from && subject.rangeFrom(from).forall(_._1 >= from)
+  }}
+
+  property("to is inclusive") = forAll { (subject: TreeMap[Int, String]) => subject.nonEmpty ==> {
+    val n = choose(0, subject.size - 1).sample.get
+    val to = subject.drop(n).firstKey
+    subject.rangeTo(to).lastKey == to && subject.rangeTo(to).forall(_._1 <= to)
+  }}
+
+  property("until is exclusive") = forAll { (subject: TreeMap[Int, String]) => subject.size > 1 ==> {
+    val n = choose(1, subject.size - 1).sample.get
+    val until = subject.drop(n).firstKey
+    subject.rangeUntil(until).lastKey == subject.take(n).lastKey && subject.rangeUntil(until).forall(_._1 <= until)
+  }}
+
+  property("remove single") = forAll { (subject: TreeMap[Int, String]) => subject.nonEmpty ==> {
+    val key = oneOf(subject.keys.toSeq).sample.get
+    val removed = subject - key
+    subject.contains(key) && !removed.contains(key) && subject.size - 1 == removed.size
+  }}
+
+  property("remove all") = forAll { (subject: TreeMap[Int, String]) =>
+    val result = subject.foldLeft(subject)((acc, elt) => acc - elt._1)
+    result.isEmpty
+  }
+}

--- a/library/test/scala/collection/immutable/TreeSeqMapProps.scala
+++ b/library/test/scala/collection/immutable/TreeSeqMapProps.scala
@@ -1,0 +1,28 @@
+package scala.collection.immutable
+
+import org.scalacheck.*
+import Prop.*
+
+object TreeSeqMapProps extends Properties("TreeSeqMap") {
+  property("transitive test") = {
+    val x = TreeSeqMap(1 -> 2, 3 -> 4)
+    val y = Map(1 -> 2, 3 -> 4)
+    val z = TreeSeqMap(3 -> 4, 1 -> 2)
+    x == y && y == z && x == z
+  }
+
+  property("shuffle") = forAll { (m: Map[Int, Int]) =>
+    val asSeq = Seq.from(m)
+    val vm1 = TreeSeqMap.from(asSeq)
+    val vm2 = TreeSeqMap.from(scala.util.Random.shuffle(asSeq))
+    vm1 == vm2
+  }
+
+  property("notEqual") = forAll { (m1: Map[Int, Int], m2: Map[Int, Int]) =>
+    m1 != m2 ==> {
+      val vm1 = TreeSeqMap.from(m1)
+      val vm2 = TreeSeqMap.from(m2)
+      vm1 != vm2
+    }
+  }
+}

--- a/library/test/scala/collection/immutable/TreeSetProps.scala
+++ b/library/test/scala/collection/immutable/TreeSetProps.scala
@@ -1,0 +1,175 @@
+package scala.collection.immutable
+
+import org.scalacheck.*
+import Prop.*
+import Gen.*
+import Arbitrary.*
+
+object TreeSetProps extends Properties("TreeSet") {
+  def genTreeSet[A: {Arbitrary, Ordering}]: Gen[TreeSet[A]] =
+    for {
+      elements <- listOf(arbitrary[A])
+    } yield TreeSet(elements*)
+  implicit def arbTreeSet[A : {Arbitrary, Ordering}]: Arbitrary[TreeSet[A]] = Arbitrary(genTreeSet)
+
+  property("foreach/iterator consistency") = forAll { (subject: TreeSet[Int]) =>
+    val it = subject.iterator
+    var consistent = true
+    subject.foreach { element =>
+      consistent &&= it.hasNext && element == it.next()
+    }
+    consistent
+  }
+
+  property("worst-case tree height is iterable") = forAll(choose(0, 10), arbitrary[Boolean]) { (n: Int, even: Boolean) =>
+    /*
+     * According to "Ralf Hinze. Constructing red-black trees" [https://www.cs.ox.ac.uk/ralf.hinze/publications/#P5]
+     * you can construct a skinny tree of height 2n by inserting the elements [1 .. 2^(n+1) - 2] and a tree of height
+     * 2n+1 by inserting the elements [1 .. 3 * 2^n - 2], both in reverse order.
+     *
+     * Since we allocate a fixed size buffer in the iterator (based on the tree size) we need to ensure
+     * it is big enough for these worst-case trees.
+     */
+    val highest = if (even) (1 << (n+1)) - 2 else 3*(1 << n) - 2
+    val values = (1 to highest).reverse
+    val subject = TreeSet(values*)
+    val it = subject.iterator
+    try { while (it.hasNext) it.next(); true } catch { case _: Throwable => false }
+  }
+
+  property("sorted") = forAll { (subject: TreeSet[Int]) => (subject.size >= 3) ==> {
+    subject.zip(subject.tail).forall { case (x, y) => x < y }
+  }}
+
+  property("contains all") = forAll { (elements: List[Int]) =>
+    val subject = TreeSet(elements*)
+    elements.forall(subject.contains)
+  }
+
+  property("size") = forAll { (elements: List[Int]) =>
+    val subject = TreeSet(elements*)
+    elements.distinct.size == subject.size
+  }
+
+  property("toSeq") = forAll { (elements: List[Int]) =>
+    val subject = TreeSet(elements*)
+    elements.distinct.sorted == subject.toSeq
+  }
+
+  property("head") = forAll { (elements: List[Int]) => elements.nonEmpty ==> {
+    val subject = TreeSet(elements*)
+    elements.min == subject.head
+  }}
+
+  property("last") = forAll { (elements: List[Int]) => elements.nonEmpty ==> {
+    val subject = TreeSet(elements*)
+    elements.max == subject.last
+  }}
+
+  property("minAfter") = forAll { (elements: List[Int]) => elements.nonEmpty ==> {
+    val half = elements.take(elements.size / 2)
+    val subject = TreeSet(half*)
+    elements.forall{e => {
+      val temp = subject.rangeFrom(e)
+      if (temp.isEmpty) subject.minAfter(e).isEmpty
+      else subject.minAfter(e).get == temp.min
+    }}
+  }}
+
+  property("maxBefore") = forAll { (elements: List[Int]) => elements.nonEmpty ==> {
+    val half = elements.take(elements.size / 2)
+    val subject = TreeSet(half*)
+    elements.forall{e => {
+      val temp = subject.rangeFrom(e)
+      if (temp.isEmpty) subject.minAfter(e).isEmpty
+      else subject.minAfter(e).get == temp.min
+    }}
+  }}
+
+  property("head/tail identity") = forAll { (subject: TreeSet[Int]) => subject.nonEmpty ==> {
+    subject == (subject.tail + subject.head)
+  }}
+
+  property("init/last identity") = forAll { (subject: TreeSet[Int]) => subject.nonEmpty ==> {
+    subject == (subject.init + subject.last)
+  }}
+
+  property("take") = forAll { (subject: TreeSet[Int]) =>
+    val n = choose(0, subject.size).sample.get
+    n == subject.take(n).size && subject.take(n).forall(subject.contains)
+  }
+
+  property("drop") = forAll { (subject: TreeSet[Int]) =>
+    val n = choose(0, subject.size).sample.get
+    (subject.size - n) == subject.drop(n).size && subject.drop(n).forall(subject.contains)
+  }
+
+  property("take/drop identity") = forAll { (subject: TreeSet[Int]) =>
+    val n = choose(-1, subject.size + 1).sample.get
+    subject == subject.take(n) ++ subject.drop(n)
+  }
+
+  property("splitAt") = forAll { (subject: TreeSet[Int]) =>
+    val n = choose(-1, subject.size + 1).sample.get
+    val (prefix, suffix) = subject.splitAt(n)
+    prefix == subject.take(n) && suffix == subject.drop(n)
+  }
+
+  def genSliceParms = for {
+    tree <- genTreeSet[Int]
+    from <- choose(0, tree.size)
+    until <- choose(from, tree.size)
+  } yield (tree, from, until)
+
+  property("slice") = forAll(genSliceParms) { case (subject, from, until) =>
+    val slice = subject.slice(from, until)
+    slice.size == until - from && subject.toSeq == subject.take(from).toSeq ++ slice ++ subject.drop(until)
+  }
+
+  property("takeWhile") = forAll { (subject: TreeSet[Int]) =>
+    val result = subject.takeWhile(_ < 0)
+    result.forall(_ < 0) && result == subject.take(result.size)
+  }
+
+  property("dropWhile") = forAll { (subject: TreeSet[Int]) =>
+    val result = subject.dropWhile(_ < 0)
+    result.forall(_ >= 0) && result == subject.takeRight(result.size)
+  }
+
+  property("span identity") = forAll { (subject: TreeSet[Int]) =>
+    val (prefix, suffix) = subject.span(_ < 0)
+    prefix.forall(_ < 0) && suffix.forall(_ >= 0) && subject == prefix ++ suffix
+  }
+
+  property("from is inclusive") = forAll { (subject: TreeSet[Int]) => subject.nonEmpty ==> {
+    val n = choose(0, subject.size - 1).sample.get
+    val from = subject.drop(n).firstKey
+    subject.rangeFrom(from).firstKey == from && subject.rangeFrom(from).forall(_ >= from)
+  }}
+
+  property("to is inclusive") = forAll { (subject: TreeSet[Int]) => subject.nonEmpty ==> {
+    val n = choose(0, subject.size - 1).sample.get
+    val to = subject.drop(n).firstKey
+    subject.rangeTo(to).lastKey == to && subject.rangeTo(to).forall(_ <= to)
+  }}
+
+  property("until is exclusive") = forAll { (subject: TreeSet[Int]) => subject.size > 1 ==> {
+    val n = choose(1, subject.size - 1).sample.get
+    val until = subject.drop(n).firstKey
+    subject.rangeUntil(until).lastKey == subject.take(n).lastKey && subject.rangeUntil(until).forall(_ <= until)
+  }}
+
+  property("remove single") = forAll { (subject: TreeSet[Int]) => subject.nonEmpty ==> {
+    val element = oneOf(subject.toSeq).sample.get
+    val removed = subject - element
+    subject.contains(element) && !removed.contains(element) && subject.size - 1 == removed.size
+  }}
+
+  property("remove all") = forAll { (subject: TreeSet[Int]) =>
+    val result = subject.foldLeft(subject)((acc, elt) => acc - elt)
+    result.isEmpty
+  }
+
+  property("ordering must not be null") =
+    throws(classOf[NullPointerException])(TreeSet.empty[Int](using null.asInstanceOf[Ordering[Int]]))
+}

--- a/library/test/scala/collection/immutable/VectorMapProperties.scala
+++ b/library/test/scala/collection/immutable/VectorMapProperties.scala
@@ -1,0 +1,146 @@
+package scala.collection.immutable
+
+import org.scalacheck.*
+import Prop.*
+import Gen.*
+import commands.Commands
+
+import scala.util.Try
+
+object VectorMapProperties extends Properties("immutable.VectorMap") {
+
+  type K = Int
+  type V = Int
+  type T = (K, V)
+
+  property("internal underlying index match") = forAll { (m: Map[K, V]) =>
+    !m.isEmpty ==> {
+      val vm = VectorMap.from(m)
+      val last = vm.keys.last
+      vm.fields(vm.underlying(last)._1) == last
+    }
+  }
+
+  property("internal underlying and keys length") = forAll { (m: Map[K, V]) => {
+      val vm = VectorMap.from(m)
+      vm.underlying.size == vm.keys.length
+    }
+  }
+
+  property("internal underlying and index are consistent after removal") = forAll { (m: Map[K, V]) =>
+    m.size >= 3 ==> {
+      val v       = Vector.from(m)
+      val random  = v(new scala.util.Random().nextInt(v.size))
+      val vm      = VectorMap.from(v)
+      val removed = vm - random._1
+      ("all map keys are located at the specified indices in the vector" |:
+        removed.underlying.forall { case (k, (s, v)) => removed.fields(s) == k }) &&
+        ("all elements in the vector are in the map with the correct associated indices" |:
+          removed.fields.zipWithIndex.forall {
+            case (k: K, s) => removed.underlying(k)._1 == s
+            case _         => true
+          })
+    }
+  }
+
+  property("repeatedly removing to empty is empty at end") = forAll { (m: Map[K, V]) => {
+      var vm = VectorMap.from(m)
+      val sz1 = vm.size
+      for (k <- vm.keys) vm = vm.removed(k)
+      val sz2 = vm.size
+      for (n <- 0 until sz1) vm = vm + (n -> n)
+      val sz3 = vm.size
+      for (k <- vm.keys) vm = vm.removed(k)
+      vm.size == 0 && sz2 == 0 && sz3 == sz1
+    }
+  }
+
+  property("nullable types for keys and values") = forAll { (m: Map[String, String]) => {
+      val vm = VectorMap.from(m)
+      vm.underlying.size == vm.keys.length
+    }
+  }
+
+  property("internal underlying init size of non empty is consistent with original size and keys init size") = forAll { (m: Map[K, V]) =>
+    m.size >= 1 ==> {
+      val vm = VectorMap.from(m)
+      val sz = vm.size - 1
+      vm.underlying.init.size == sz && vm.keys.init.size == sz
+    }
+  }
+
+  property("vectorMap.last == vectorMap.toList.last, after some operations") = {
+    //After vectorMap.updated(key, value), removed(key), tail, and init, verify if vectorMap.last == vectorMap.toList.last is satisfied.
+    object VectorMapCommandsChecker extends Commands {
+      //Perform the same operation on both maps and keep them in the same state.
+      override type State = SeqMap[K, V]
+      override type Sut = VectorMap[K, V]
+
+      override def canCreateNewSut(newState: SeqMap[K, V], initSuts: scala.Iterable[SeqMap[K, V]], runningSuts: scala.Iterable[VectorMap[K, V]]): Boolean = true
+      override def destroySut(sut: VectorMap[K, V]): Unit = ()
+      override def newSut(state: SeqMap[K, V]): VectorMap[K, V] = VectorMap.from(state)
+      override def initialPreCondition(state: SeqMap[K, V]): Boolean = true
+      override def genInitialState: Gen[SeqMap[K, V]] = implicitly[Arbitrary[Map[K, V]]].arbitrary.map(m => SeqMap.from(m))
+      override def genCommand(state: State): Gen[VectorMapCommandsChecker.Command] = {
+        if (state.isEmpty) {
+          append(state)
+        }else {
+          Gen.oneOf(removeRandom(state), updateRandom(state), append(state), tail(state), init(state))
+        }
+      }
+
+      def removeRandom(vm: State): Gen[Remove] = Gen.delay{
+        val random = new scala.util.Random()
+        const(Remove(random.shuffle(vm.keysIterator).next()))
+      }
+      def updateRandom(vm: State): Gen[Update] = Gen.delay{
+        val random = new scala.util.Random()
+        val key = random.shuffle(vm.keysIterator).next()
+        const(Update(key, key))
+      }
+      def append(state: State): Gen[Update] = Gen.delay {
+        if (state.isEmpty) const(Update(1, 1))
+        else {
+          val max = state.maxBy(_._1)
+          const(Update(max._1 + 1, max._1 + 1))
+        }
+      }
+      def tail(state: State): Gen[Tail.type] = {
+        const(Tail)
+      }
+      def init(state: State): Gen[Init.type ] = {
+        const(Init)
+      }
+
+      case class Remove(key: K) extends Command {
+        override type Result = Sut
+        override def run(sut: VectorMap[K, V]): VectorMap[K, V] = sut.removed(key)
+        override def nextState(state: State): State = state.removed(key)
+        override def preCondition(state: State): Boolean = true
+        override def postCondition(state: State, result: Try[VectorMap[K, V]]): Prop = result.map(_.lastOption) == result.map(_.toList.lastOption)
+      }
+      case class Update(key: K, value: V) extends Command {
+        override type Result = Sut
+        override def run(sut: VectorMap[K, V]): VectorMap[K, V] = sut.updated(key, value)
+        override def nextState(state: State): State = state.updated(key, value)
+        override def preCondition(state: State): Boolean = true
+        override def postCondition(state: State, result: Try[VectorMap[K, V]]): Prop = result.map(_.last) == result.map(_.toList.last)
+      }
+      case object Tail extends Command {
+        override type Result = Sut
+        override def run(sut: VectorMap[K, V]): VectorMap[K, V] = sut.tail
+        override def nextState(state: State): State = state.tail
+        override def preCondition(state: State): Boolean = true
+        override def postCondition(state: State, result: Try[VectorMap[K, V]]): Prop = result.map(_.lastOption) == result.map(_.toList.lastOption)
+      }
+      case object Init extends Command {
+        override type Result = Sut
+        override def run(sut: VectorMap[K, V]): VectorMap[K, V] = sut.init
+        override def nextState(state: State): State = state.init
+        override def preCondition(state: State): Boolean = true
+        override def postCondition(state: State, result: Try[VectorMap[K, V]]): Prop = result.map(_.lastOption) == result.map(_.toList.lastOption)
+      }
+    }
+    VectorMapCommandsChecker.property()
+  }
+}

--- a/library/test/scala/collection/immutable/VectorMapProps.scala
+++ b/library/test/scala/collection/immutable/VectorMapProps.scala
@@ -1,0 +1,28 @@
+package scala.collection.immutable
+
+import org.scalacheck.*
+import Prop.*
+
+object VectorMapProps extends Properties("VectorMap") {
+  property("transitive test") = {
+    val x = VectorMap(1 -> 2, 3 -> 4)
+    val y = Map(1 -> 2, 3 -> 4)
+    val z = VectorMap(3 -> 4, 1 -> 2)
+    x == y && y == z && x == z
+  }
+
+  property("shuffle") = forAll { (m: Map[Int, Int]) =>
+    val asSeq = Seq.from(m)
+    val vm1 = VectorMap.from(asSeq)
+    val vm2 = VectorMap.from(scala.util.Random.shuffle(asSeq))
+    vm1 == vm2
+  }
+
+  property("notEqual") = forAll { (m1: Map[Int, Int], m2: Map[Int, Int]) =>
+    m1 != m2 ==> {
+      val vm1 = VectorMap.from(m1)
+      val vm2 = VectorMap.from(m2)
+      vm1 != vm2
+    }
+  }
+}

--- a/library/test/scala/collection/immutable/WrappedStringProperties.scala
+++ b/library/test/scala/collection/immutable/WrappedStringProperties.scala
@@ -1,0 +1,72 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.immutable
+
+import org.scalacheck.*
+
+class WrappedStringProperties extends Properties("immutable.WrappedString") {
+  import Prop._
+  import WrappedStringProperties._
+
+  property("indexOf") = forAll { (s: WrappedString, c: Char) =>
+    s.indexOf(c) == s.toString.indexOf(c)
+  }
+
+  property("indexOf with start") = forAll { (s: WrappedString, start: Int, c: Char) =>
+    start < s.size ==> (s.indexOf(c, start) == s.toString.indexOf(c, start))
+  }
+
+  property("indexOf") = forAll { (s: WrappedString, c: Char) =>
+    s.lastIndexOf(c) == s.toString.lastIndexOf(c)
+  }
+
+  property("indexOf with end") = forAll { (s: WrappedString, end: Int, c: Char) =>
+    end < s.size ==> (s.lastIndexOf(c, end) == s.toString.lastIndexOf(c, end))
+  }
+
+  property("sameElements") = forAll { (s: WrappedString, o: WrappedString) =>
+    s.sameElements(o) == (s.toString == o.toString)
+  }
+
+  property("sameElements reflexive") = forAll { (s: WrappedString) =>
+    s sameElements s
+  }
+
+  property("sameElements neg init") = forAll { (s: WrappedString) =>
+    !s.isEmpty ==> !s.sameElements(s.init)
+  }
+
+  property("sameElements neg tail") = forAll { (s: WrappedString) =>
+    !s.isEmpty ==> !s.sameElements(s.tail)
+  }
+
+  property("sameElements neg sizes") = forAll { (s: WrappedString, o: WrappedString) =>
+    (s.size != o.size) ==> !s.sameElements(o)
+  }
+
+}
+
+object WrappedStringProperties {
+
+  implicit val arbitraryWrappedString: Arbitrary[WrappedString] = Arbitrary {
+    for {
+      isAlpha <- Gen.oneOf(false, true)
+      charGen  = if (isAlpha) Gen.alphaChar else Arbitrary.arbChar.arbitrary
+      size    <- Gen.chooseNum(0, 4)
+      chars   <- Gen.listOfN(size, charGen)
+    } yield wrapString(new String(chars.toArray))
+  }
+
+  implicit val arbitraryChar: Arbitrary[Char] = Arbitrary(Gen.alphaNumChar)
+
+}

--- a/library/test/scala/collection/mutable/ArrayBufferProperties.scala
+++ b/library/test/scala/collection/mutable/ArrayBufferProperties.scala
@@ -1,0 +1,39 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.mutable
+
+import org.scalacheck.*
+import org.scalacheck.Prop.*
+
+object ArrayBufferProperties extends Properties("mutable.ArrayBuffer") {
+
+  type Elem = Int
+
+  property("view consistency after modifications") = forAll { (buf: ArrayBuffer[Elem]) =>
+    def check[U](op: ArrayBuffer[Elem] => U): Prop = {
+      val b    = buf.clone()
+      val view = b.view
+      op(b) // modifies the buffer
+      b.sameElements(view)
+    }
+
+    val spaceForMoreElems = buf.sizeIs <= (Int.MaxValue / 2 - 101)
+
+    (check(_.clear()) :| "_.clear()") &&
+      (check(_.dropRightInPlace(1)) :| "_.dropRightInPlace(1)") &&
+      (check(_.dropInPlace(1)) :| "_.dropInPlace(1)") &&
+      (spaceForMoreElems ==> (check(_ ++= (1 to 100)) :| "_ ++= (1 to 100)")) &&
+      (spaceForMoreElems ==> (check(_.prependAll(1 to 100)) :| "_.prependAll(1 to 100)")) &&
+      ((!buf.isEmpty && spaceForMoreElems) ==> (check(_.insertAll(1, 1 to 100)) :| "_.insertAll(1, 1 to 100)"))
+  }
+}

--- a/library/test/scala/collection/mutable/ArrayOpsProperties.scala
+++ b/library/test/scala/collection/mutable/ArrayOpsProperties.scala
@@ -1,0 +1,112 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.mutable
+
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Prop.*
+import org.scalacheck.*
+
+object ArrayOpsProperties extends Properties("ArrayOps") {
+  type E = Int
+
+  private def showArray[A](array: Array[A]): String = array.mkString("Array(", ",", ")")
+
+  property("left.copyToArray(right) == min(left.length, right.length)") = forAll{ (left: Array[E], right: Array[E]) =>
+    val returned = left.copyToArray(right)
+    s"left.length: ${left.length}, right.length: ${right.length}" |:
+      (returned ?= math.min(left.length, right.length))
+  }
+
+  property("left.copyToArray(right, start) returns min of (left.length, right.length - start)") =
+    forAll(Arbitrary.arbitrary[Array[E]], Arbitrary.arbitrary[Array[E]], Gen.chooseNum[Int](0, 10000)) {
+      (left: Array[E], right: Array[E], start: Int) =>
+        val returned = left.copyToArray(right, start)
+        s"left.length: ${left.length}, right.length: ${right.length}" |:
+          (returned ?= (left.length min (right.length - start).max(0)))
+    }
+
+  property("left.copyToArray(right, start, len) returns min of (left.length, right.length - start, len)") =
+    forAll(Arbitrary.arbitrary[Array[E]], Arbitrary.arbitrary[Array[E]], Gen.chooseNum[Int](0, 10000), Gen.chooseNum[Int](0, 10000)) {
+      (left: Array[E], right: Array[E], start: Int, len: Int) =>
+        val returned = left.copyToArray(right, start, len)
+        s"left.length: ${left.length}, right.length: ${right.length}" |:
+          (returned ?= (left.length min (right.length - start).max(0) min len.max(0)))
+    }
+
+
+  property("left.copyToArray(right) copies min(left.length, right.length) to right") = forAll{ (left: Array[E], right: Array[E]) =>
+
+    left.copyToArray(right)
+
+    val prefix = left.take(left.length min right.length)
+
+    s"left: ${showArray(left)}, right: ${showArray(right)}" |: (Prop(left.startsWith(prefix)) && right.startsWith(prefix))
+  }
+
+  property("left.copyToArray(right, start) copies min of (left.length, right.length - start) to right") =
+    forAll(Arbitrary.arbitrary[Array[E]], Arbitrary.arbitrary[Array[E]], Gen.chooseNum[Int](0, 10000)) {
+      (left: Array[E], right: Array[E], start: Int) =>
+        left.copyToArray(right, start)
+
+        val prefix = left.take(left.length min (right.length - start).max(0))
+
+        s"left: ${showArray(left)}, right: ${showArray(right)}, prefix: ${showArray(prefix)}" |:
+          (Prop(left.startsWith(prefix)) && right.drop(start).startsWith(prefix))
+    }
+
+  property("left.copyToArray(right, start, len) copies min of (left.length, right.length - start, len) to right") =
+    forAll(
+      Arbitrary.arbitrary[Array[E]],
+      Arbitrary.arbitrary[Array[E]],
+      Gen.chooseNum[Int](0, 10000),
+      Gen.chooseNum[Int](0, 10000)) {
+      (left: Array[E], right: Array[E], start: Int, len) =>
+        left.copyToArray(right, start)
+
+        val prefix = left.take(left.length min (right.length - start).max(0) min len.max(0))
+
+        s"left: ${showArray(left)}, right: ${showArray(right)}, prefix: ${showArray(prefix)}" |:
+          (Prop(left.startsWith(prefix)) && right.drop(start).startsWith(prefix))
+    }
+
+  property("left.copyToArray(right) does not modify left") = forAll{ (left: Array[E], right: Array[E]) =>
+    val beforeSeq = left.toList
+    left.copyToArray(right)
+    val afterSeq = left.toList
+    s"before: $beforeSeq, after: $afterSeq" |: (afterSeq ?= beforeSeq)
+  }
+
+  property("left.copyToArray(right, start) does not modify left") =
+    forAll(Arbitrary.arbitrary[Array[E]], Arbitrary.arbitrary[Array[E]], Gen.chooseNum[Int](0, 10000)) {
+      (left: Array[E], right: Array[E], start: Int) =>
+        val beforeSeq = left.toList
+        left.copyToArray(right, start)
+        val afterSeq = left.toList
+        s"before: $beforeSeq, after: $afterSeq" |: (afterSeq ?= beforeSeq)
+    }
+  property("left.copyToArray(right, start, len) does not modify left") =
+    forAll(
+      Arbitrary.arbitrary[Array[E]],
+      Arbitrary.arbitrary[Array[E]],
+      Gen.chooseNum[Int](0, 10000),
+      Gen.chooseNum[Int](0, 10000)
+    ) {
+      (left: Array[E], right: Array[E], start: Int, len: Int) =>
+        val beforeSeq = left.toList
+        left.copyToArray(right, start, len)
+        val afterSeq = left.toList
+        s"before: $beforeSeq, after: $afterSeq" |: (afterSeq ?= beforeSeq)
+    }
+
+}
+

--- a/library/test/scala/collection/mutable/BitSetProperties.scala
+++ b/library/test/scala/collection/mutable/BitSetProperties.scala
@@ -1,0 +1,73 @@
+package scala.collection.mutable
+
+import org.scalacheck.*
+import org.scalacheck.Prop.*
+import Gen.*
+
+object BitSetProperties extends Properties("mutable.BitSet") {
+
+  // the top of the range shouldn't be too high, else we may not get enough overlap
+  implicit val arbitraryBitSet: Arbitrary[BitSet] = Arbitrary(
+    oneOf(
+      const(BitSet()),
+      oneOf(0 to 100).map(i => BitSet(i)),
+      listOfN(200, oneOf(0 to 10000)).map(_.to(BitSet))
+    )
+  )
+
+  /** the max number to include in generated BitSets */
+  val highestNum = 15000
+
+  implicit val nonNegativeRange: Arbitrary[Range] = Arbitrary(
+    for {
+      start <- chooseNum(0, highestNum)
+      end <- chooseNum(start, highestNum)
+      by <- oneOf(-1, 1, 5)
+    } yield start to end by by
+  )
+
+  property("diff") = forAll { (left: BitSet, right: BitSet) =>
+    (left.diff(right): Set[Int]) ?= left.to(HashSet).diff(right.to(HashSet))
+  }
+  property("diff hashSet") = forAll { (left: BitSet, right: BitSet) =>
+    (left.diff(right.to(HashSet)): Set[Int]) ?= left.to(HashSet).diff(right.to(HashSet))
+  }
+  property("filter") = forAll { (bs: BitSet) =>
+    bs.filter(_ % 2 == 0) ?= bs.toList.filter(_ % 2 == 0).to(BitSet)
+  }
+  property("filterNot") = forAll { (bs: BitSet) =>
+    bs.filterNot(_ % 2 == 0) ?= bs.toList.filterNot(_ % 2 == 0).to(BitSet)
+  }
+  property("filterInPlace") = forAll { (bs: BitSet) =>
+    val list = bs.toList
+    bs.filterInPlace(_ % 2 == 0) ?= list.filter(_ % 2 == 0).to(BitSet)
+  }
+  property("partition") = forAll { (bs: BitSet) =>
+    val p = (i: Int) => i % 2 == 0
+    val (left, right) = bs.partition(p)
+    (left ?= bs.filter(p)) && (right ?= bs.filterNot(p))
+  }
+
+
+  property("addAll(Range)") = forAll{ (bs: BitSet, range: Range) =>
+    val bsClone1 = bs.clone()
+    val bsClone2 = bs.clone()
+    range.foreach(bsClone2.add)
+    bsClone1.addAll(range) ?= bsClone2
+  }
+
+  property("subsetOf(BitSet) equivalent to slow implementation") = forAll{ (left: BitSet, right: BitSet) =>
+    (Prop(left.subsetOf(right)) ==> left.forall(right)) &&
+      (Prop(left.forall(right)) ==> Prop(left.subsetOf(right)))
+  }
+
+  property("left subsetOf (left union right) && right subsetOf (left union right)") = forAll{ (left: BitSet, right: BitSet) =>
+    val leftUnionRight = left concat right
+    left.subsetOf(leftUnionRight) && right.subsetOf(leftUnionRight)
+  }
+
+  property("range") = forAll{ (bs: BitSet, range: Range) =>
+    bs.range(range.start, range.end) ?= bs.filter(b => b >= range.start && b < range.end)
+  }
+
+}

--- a/library/test/scala/collection/mutable/BuilderProperties.scala
+++ b/library/test/scala/collection/mutable/BuilderProperties.scala
@@ -1,0 +1,75 @@
+package scala.collection.mutable
+
+class BuilderProperties
+
+import org.scalacheck.Arbitrary.arbInt
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
+import org.scalacheck.commands.Commands
+
+import scala.collection.mutable
+import scala.util.{Success, Try}
+
+/** Generic stateful property testing for builders
+  */
+class SeqBuilderStateProperties[A: Arbitrary, To <: Seq[A]](newBuilder: => mutable.Builder[A, To])(arbA: Arbitrary[A]) extends Commands {
+
+  override type State = List[A]
+  override type Sut = mutable.Builder[A, To]
+
+  override def genInitialState: Gen[State] = Nil
+
+  override def canCreateNewSut(
+    newState: State,
+    initSuts: scala.Iterable[State],
+    runningSuts: scala.Iterable[Sut]) = true
+
+  override def newSut(state: State) = newBuilder.addAll(state)
+
+  override def destroySut(sut: Sut): Unit = ()
+
+  override def initialPreCondition(state: State) = state.isEmpty
+
+  override def genCommand(state: State): Gen[Command] = {
+    import Gen._
+    Gen.oneOf(
+      const(Clear),
+      const(Result),
+      arbInt.arbitrary.map(SizeHint.apply),
+      arbA.arbitrary.map(a => AddOne(a)),
+      listOf(arbA.arbitrary).map(a => AddAll(a))
+    )
+  }
+
+  case object Clear extends UnitCommand {
+    override def postCondition(state: State, success: Boolean) = success
+    override def run(sut: Sut) = sut.clear()
+    override def nextState(state: State) = Nil
+    override def preCondition(state: State) = true
+  }
+  case object Result extends Command {
+    override type Result = To
+    override def postCondition(state: State, result: Try[Result]) = result == Success(state.reverse)
+    override def run(sut: Sut) = sut.result()
+    override def nextState(state: State) = state
+    override def preCondition(state: State) = true
+  }
+  case class SizeHint(size: Int) extends UnitCommand {
+    override def postCondition(state: State, success: Boolean) = success
+    override def run(sut: Sut) = sut.sizeHint(size)
+    override def nextState(state: State) = state
+    override def preCondition(state: State) = true
+  }
+  case class AddOne(elem: A) extends UnitCommand {
+    override def postCondition(state: State, success: Boolean) = success
+    override def run(sut: Sut) = sut.addOne(elem)
+    override def nextState(state: State) = elem :: state
+    override def preCondition(state: State) = true
+  }
+  case class AddAll(elems: scala.collection.immutable.Seq[A]) extends UnitCommand {
+    override def postCondition(state: State, success: Boolean) = success
+    override def run(sut: Sut) = sut.addAll(elems)
+    override def nextState(state: State) = state.prependedAll(elems)
+    override def preCondition(state: State) = true
+  }
+}

--- a/library/test/scala/collection/mutable/HashMapProperties.scala
+++ b/library/test/scala/collection/mutable/HashMapProperties.scala
@@ -1,0 +1,41 @@
+package scala.collection.mutable
+
+import org.scalacheck.*
+import org.scalacheck.Prop.*
+
+import scala.collection.immutable
+
+object HashMapProperties extends Properties("mutable.HashMap") {
+
+  property("addAll(immutable.HashMap)") = forAll { (left: immutable.HashMap[Int, Int], right: immutable.HashMap[Int, Int]) =>
+    val expected: collection.Map[Int, Int] = left concat right
+    val actual: collection.Map[Int, Int] = left.to(HashMap).addAll(right)
+
+    actual ?= expected
+  }
+  property("addAll(mutable.HashMap)") = forAll { (left: immutable.HashMap[Int, Int], right: immutable.HashMap[Int, Int]) =>
+    val expected: collection.Map[Int, Int] = left concat right
+    val actual: collection.Map[Int, Int] = left.to(HashMap).addAll(right.to(HashMap.mapFactory))
+    actual ?= expected
+  }
+  property("addAll(Vector)") = forAll { (left: immutable.HashMap[Int, Int], right: Vector[(Int, Int)]) =>
+    val expected: collection.Map[Int, Int] = left concat right
+    val actual: collection.Map[Int, Int] = left.to(HashMap).addAll(right)
+    actual ?= expected
+  }
+  property("subtractAll(immutable.HashSet)") = forAll { (left: immutable.HashMap[Int, Int], right: immutable.HashSet[Int]) =>
+    val expected: collection.Map[Int, Int] = left -- right
+    val actual: collection.Map[Int, Int] = left.to(HashMap).subtractAll(right.to(HashSet))
+    actual ?= expected
+  }
+  property("subtractAll(mutable.HashSet)") = forAll { (left: immutable.HashMap[Int, Int], right: immutable.HashSet[Int]) =>
+    val expected: collection.Map[Int, Int] = left -- right
+    val actual: collection.Map[Int, Int] = left.to(HashMap).subtractAll(right.to(HashSet))
+    actual ?= expected
+  }
+  property("subtractAll(Vector)") = forAll { (left: immutable.HashMap[Int, Int], right: Vector[Int]) =>
+    val expected: collection.Map[Int, Int] = left -- right
+    val actual: collection.Map[Int, Int] = left.to(HashMap).subtractAll(right.to(Vector))
+    actual ?= expected
+  }
+}

--- a/library/test/scala/collection/mutable/HashSetProperties.scala
+++ b/library/test/scala/collection/mutable/HashSetProperties.scala
@@ -1,0 +1,52 @@
+package scala.collection.mutable
+
+import org.scalacheck.*
+import org.scalacheck.Prop.*
+import scala.collection.immutable
+
+object HashSetProperties extends Properties("mutable.HashSet") {
+
+  property("filterInPlace(p)") = forAll { (hs: immutable.HashSet[Int], p: Int => Boolean) =>
+    val expected: collection.Set[Int] = hs.filter(p)
+    val actual: collection.Set[Int] = hs.to(HashSet).filterInPlace(p)
+    actual ?= expected
+  }
+  property("filterInPlace(_ => true)") = forAll { (hs: immutable.HashSet[Int]) =>
+    val actual: collection.Set[Int] = hs.to(HashSet).filterInPlace(_ => true)
+    actual ?= hs
+  }
+  property("filterInPlace(_ => false)") = forAll { (hs: immutable.HashSet[Int]) =>
+    val actual: collection.Set[Int] = hs.to(HashSet).filterInPlace(_ => false)
+    actual ?= Set.empty
+  }
+  property("addAll(immutable.HashSet)") = forAll { (left: immutable.HashSet[Int], right: immutable.HashSet[Int]) =>
+    val expected: collection.Set[Int] = left union right
+    val actual: collection.Set[Int] = left.to(HashSet).addAll(right)
+    actual ?= expected
+  }
+  property("addAll(mutable.HashSet)") = forAll { (left: immutable.HashSet[Int], right: immutable.HashSet[Int]) =>
+    val expected: collection.Set[Int] = left union right
+    val actual: collection.Set[Int] = left.to(HashSet).addAll(right.to(HashSet))
+    actual ?= expected
+  }
+  property("addAll(Vector)") = forAll { (left: immutable.HashSet[Int], right: immutable.HashSet[Int]) =>
+    val expected: collection.Set[Int] = left union right
+    val actual: collection.Set[Int] = left.to(HashSet).addAll(right.to(Vector))
+    actual ?= expected
+  }
+  property("subtractAll(immutable.HashSet)") = forAll { (left: immutable.HashSet[Int], right: immutable.HashSet[Int]) =>
+    val expected: collection.Set[Int] = left diff right
+    val actual: collection.Set[Int] = left.to(HashSet).subtractAll(right)
+    actual ?= expected
+  }
+  property("subtractAll(immutable.HashSet)") = forAll { (left: immutable.HashSet[Int], right: immutable.HashSet[Int]) =>
+    val expected: collection.Set[Int] = left diff right
+    val actual: collection.Set[Int] = left.to(HashSet).subtractAll(right.to(HashSet))
+    actual ?= expected
+  }
+  property("subtractAll(immutable.Vector)") = forAll { (left: immutable.HashSet[Int], right: immutable.HashSet[Int]) =>
+    val expected: collection.Set[Int] = left diff right
+    val actual: collection.Set[Int] = left.to(HashSet).subtractAll(right.to(Vector))
+    actual ?= expected
+  }
+}

--- a/library/test/scala/collection/mutable/LinkedHashMapProperties.scala
+++ b/library/test/scala/collection/mutable/LinkedHashMapProperties.scala
@@ -1,0 +1,15 @@
+package scala.collection.mutable
+
+import org.scalacheck.Prop.*
+import org.scalacheck.Properties
+
+import scala.annotation.nowarn
+
+object LinkedHashMapProperties extends Properties("mutable.LinkedHashMap") {
+  property("-- retains order") = forAll { (lhm: LinkedHashMap[Int, Int], els: collection.immutable.Set[Int]) =>
+    @nowarn("cat=deprecation")
+    val actual = (lhm -- els).toList.map(_._1)
+    val expected = lhm.toList.map(_._1).filterNot(els)
+    actual ?= expected
+  }
+}

--- a/library/test/scala/collection/mutable/LinkedHashSetProperties.scala
+++ b/library/test/scala/collection/mutable/LinkedHashSetProperties.scala
@@ -1,0 +1,15 @@
+package scala.collection.mutable
+
+import org.scalacheck.Prop.*
+import org.scalacheck.Properties
+
+import scala.annotation.nowarn
+
+object LinkedHashSetProperties extends Properties("mutable.LinkedHashSet") {
+  property("-- retains order") = forAll { (lhs: LinkedHashSet[Int], els: collection.immutable.Set[Int]) =>
+    @nowarn("cat=deprecation")
+    val actual = (lhs -- els).toList
+    val expected = lhs.toList.filterNot(els)
+    actual ?= expected
+  }
+}

--- a/library/test/scala/collection/mutable/MapProperties.scala
+++ b/library/test/scala/collection/mutable/MapProperties.scala
@@ -1,0 +1,55 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.mutable
+
+import org.scalacheck.*
+import org.scalacheck.Prop.*
+import org.scalacheck.Arbitrary.arbitrary
+import Gen.*
+
+object MapProperties extends Properties("mutable.Map") {
+
+  type K = Int
+  type V = Int
+
+  /** returns a map that certainly does not override `filterInPlace` implementation */
+  def testMap(elems: collection.immutable.Map[K, V]): Map[K, V] = new Map[K, V] {
+    override protected def className: String = "TestMap"
+    private var _elems = elems
+    override def get(key: K): Option[V] = _elems.get(key)
+    override def subtractOne(elem: K): this.type = { _elems -= elem; this }
+    override def iterator: Iterator[(K, V)] = _elems.iterator
+    override def addOne(elem: (K, V)): this.type = { _elems += elem; this }
+  }
+
+  @annotation.nowarn("cat=deprecation&msg=ListMap")
+  implicit val arbMap: Arbitrary[Map[K, V]] =
+    Arbitrary {
+      for {
+        elems <- arbitrary[collection.immutable.HashMap[K, V]]
+        map <- oneOf(
+          elems.to(HashMap),
+          elems.to(TreeMap),
+          elems.to(LinkedHashMap),
+          elems.to(ListMap),
+          testMap(elems)
+        )
+      } yield map.asInstanceOf[Map[K, V]]
+    }
+
+  property("filterInPlace(p)") = forAll { (map: Map[K, V], p: (K, V) => Boolean) =>
+    val expected: collection.Map[K, V] = map.to(collection.immutable.HashMap).filter(p.tupled)
+    map.filterInPlace(p)
+    (map: collection.Map[K, V]) ?= expected
+  }
+}

--- a/library/test/scala/collection/mutable/MutablePriorityQueue.scala
+++ b/library/test/scala/collection/mutable/MutablePriorityQueue.scala
@@ -1,0 +1,103 @@
+package scala.collection.mutable
+
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Prop.*
+import org.scalacheck.*
+
+object MutablePriorityQueueTest extends Properties("PriorityQueue") {
+  type E = Int // the element type used for most/all tests
+
+  def checkInvariant[A](pq: PriorityQueue[A])(implicit ord: Ordering[A]): Boolean = {
+    // The ordering invariant in the heap is that parent >= child.
+    // A child at index i has a parent at index i/2 in the priority
+    // queue's internal array.  However, that array is padded with
+    // an extra slot in front so that the first real element is at
+    // index 1.  The vector below is not padded, so subtract 1 from
+    // every index.
+    import ord._
+    val vec = pq.toVector // elements in same order as pq's internal array
+    2 until pq.size forall { i => vec(i/2-1) >= vec(i-1) }
+  }
+
+  property("newBuilder (in companion)") = forAll { (list: List[E]) =>
+    val builder = PriorityQueue.newBuilder[E]
+    for (x <- list) builder += x
+    val pq = builder.result()
+    checkInvariant(pq) &&
+    pq.dequeueAll == list.sorted.reverse
+  }
+
+  property("to[PriorityQueue]") = forAll { (list: List[E]) =>
+    val pq = list.to(PriorityQueue)
+    checkInvariant(pq) &&
+    pq.dequeueAll == list.sorted.reverse
+  }
+
+  property("apply (in companion)") = forAll { (list: List[E]) =>
+    val pq = PriorityQueue.apply(list*)
+    checkInvariant(pq) &&
+    pq.dequeueAll == list.sorted.reverse
+  }
+
+  property("size, isEmpty") = forAll { (list: List[E]) =>
+    val pq = PriorityQueue(list*)
+    pq.size == list.size && pq.isEmpty == list.isEmpty
+  }
+
+  property("+=") = forAll { (x: E, list: List[E]) =>
+    val pq = PriorityQueue(list*)
+    pq += x
+    checkInvariant(pq) &&
+    pq.dequeueAll == (x :: list).sorted.reverse
+  }
+
+  property("++= on empty") = forAll { (list: List[E]) =>
+    val pq = PriorityQueue.empty[E]
+    pq ++= list
+    checkInvariant(pq) &&
+    pq.dequeueAll == list.sorted.reverse
+  }
+
+  property("++=") = forAll { (list1: List[E], list2: List[E]) =>
+    val pq = PriorityQueue(list1*)
+    pq ++= list2
+    checkInvariant(pq) &&
+    pq.dequeueAll == (list1 ++ list2).sorted.reverse
+  }
+
+  property("reverse") = forAll { (list: List[E]) =>
+    val pq = PriorityQueue(list*).reverse
+    checkInvariant(pq)(using implicitly[Ordering[E]].reverse) &&
+    pq.dequeueAll == list.sorted
+  }
+
+  property("reverse then ++=") = forAll { (list: List[E]) =>
+    val pq = PriorityQueue.empty[E].reverse ++= list
+    checkInvariant(pq)(using implicitly[Ordering[E]].reverse) &&
+    pq.dequeueAll == list.sorted
+  }
+
+  property("reverse then +=") = forAll { (x: E, list: List[E]) =>
+    val pq = PriorityQueue(list*).reverse += x
+    checkInvariant(pq)(using implicitly[Ordering[E]].reverse) &&
+    pq.dequeueAll == (x +: list).sorted
+  }
+
+  property("clone") = forAll { (list: List[E]) =>
+    val pq = PriorityQueue(list*)
+    val c = pq.clone()
+    (pq ne c) &&
+    checkInvariant(c) &&
+    c.dequeueAll == pq.dequeueAll
+  }
+
+  property("dequeue") = forAll { (list: List[E]) =>
+    list.nonEmpty ==> {
+      val pq = PriorityQueue(list*)
+      val x = pq.dequeue()
+      checkInvariant(pq) &&
+      x == list.max && pq.dequeueAll == list.sorted.reverse.tail
+    }
+  }
+
+}

--- a/library/test/scala/collection/mutable/MutablePriorityQueueProps.scala
+++ b/library/test/scala/collection/mutable/MutablePriorityQueueProps.scala
@@ -1,0 +1,103 @@
+package scala.collection.mutable
+
+import org.scalacheck.*
+import Prop.*
+import Arbitrary.*
+
+object MutablePriorityQueueProps extends Properties("PriorityQueue") {
+  type E = Int // the element type used for most/all tests
+
+  def checkInvariant[A](pq: PriorityQueue[A])(implicit ord: Ordering[A]): Boolean = {
+    // The ordering invariant in the heap is that parent >= child.
+    // A child at index i has a parent at index i/2 in the priority
+    // queue's internal array.  However, that array is padded with
+    // an extra slot in front so that the first real element is at
+    // index 1.  The vector below is not padded, so subtract 1 from
+    // every index.
+    import ord._
+    val vec = pq.toVector // elements in same order as pq's internal array
+    2 until pq.size forall { i => vec(i/2-1) >= vec(i-1) }
+  }
+
+  property("newBuilder (in companion)") = forAll { (list: List[E]) =>
+    val builder = PriorityQueue.newBuilder[E]
+    for (x <- list) builder += x
+    val pq = builder.result()
+    checkInvariant(pq) &&
+    pq.dequeueAll == list.sorted.reverse
+  }
+
+  property("to[PriorityQueue]") = forAll { (list: List[E]) =>
+    val pq = list.to(PriorityQueue)
+    checkInvariant(pq) &&
+    pq.dequeueAll == list.sorted.reverse
+  }
+
+  property("apply (in companion)") = forAll { (list: List[E]) =>
+    val pq = PriorityQueue.apply(list*)
+    checkInvariant(pq) &&
+    pq.dequeueAll == list.sorted.reverse
+  }
+
+  property("size, isEmpty") = forAll { (list: List[E]) =>
+    val pq = PriorityQueue(list*)
+    pq.size == list.size && pq.isEmpty == list.isEmpty
+  }
+
+  property("+=") = forAll { (x: E, list: List[E]) =>
+    val pq = PriorityQueue(list*)
+    pq += x
+    checkInvariant(pq) &&
+    pq.dequeueAll == (x :: list).sorted.reverse
+  }
+
+  property("++= on empty") = forAll { (list: List[E]) =>
+    val pq = PriorityQueue.empty[E]
+    pq ++= list
+    checkInvariant(pq) &&
+    pq.dequeueAll == list.sorted.reverse
+  }
+
+  property("++=") = forAll { (list1: List[E], list2: List[E]) =>
+    val pq = PriorityQueue(list1*)
+    pq ++= list2
+    checkInvariant(pq) &&
+    pq.dequeueAll == (list1 ++ list2).sorted.reverse
+  }
+
+  property("reverse") = forAll { (list: List[E]) =>
+    val pq = PriorityQueue(list*).reverse
+    checkInvariant(pq)(using implicitly[Ordering[E]].reverse) &&
+    pq.dequeueAll == list.sorted
+  }
+
+  property("reverse then ++=") = forAll { (list: List[E]) =>
+    val pq = PriorityQueue.empty[E].reverse ++= list
+    checkInvariant(pq)(using implicitly[Ordering[E]].reverse) &&
+    pq.dequeueAll == list.sorted
+  }
+
+  property("reverse then +=") = forAll { (x: E, list: List[E]) =>
+    val pq = PriorityQueue(list*).reverse += x
+    checkInvariant(pq)(using implicitly[Ordering[E]].reverse) &&
+    pq.dequeueAll == (x +: list).sorted
+  }
+
+  property("clone") = forAll { (list: List[E]) =>
+    val pq = PriorityQueue(list*)
+    val c = pq.clone()
+    (pq ne c) &&
+    checkInvariant(c) &&
+    c.dequeueAll == pq.dequeueAll
+  }
+
+  property("dequeue") = forAll { (list: List[E]) =>
+    list.nonEmpty ==> {
+      val pq = PriorityQueue(list*)
+      val x = pq.dequeue()
+      checkInvariant(pq) &&
+      x == list.max && pq.dequeueAll == list.sorted.reverse.tail
+    }
+  }
+
+}

--- a/library/test/scala/collection/mutable/MutableTreeMap.scala
+++ b/library/test/scala/collection/mutable/MutableTreeMap.scala
@@ -1,0 +1,357 @@
+package scala.collection.mutable
+
+import java.io.*
+
+import org.scalacheck.*
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Prop.forAll
+
+import scala.collection.{BuildFrom, immutable, mutable}
+import scala.util.Try
+import scala.collection.mutable.{RedBlackTree => RB}
+
+trait Generators {
+
+  def genRedBlackTree[A: {Arbitrary, Ordering}, B: Arbitrary]: Gen[RB.Tree[A, B]] = {
+    import org.scalacheck.Gen._
+    for { entries <- listOf(arbitrary[(A, B)]) } yield {
+      val tree = RB.Tree.empty[A, B]
+      entries.foreach { case (k, v) => RB.insert(tree, k, v) }
+      tree
+    }
+  }
+
+  // Note: in scalacheck 1.12.2 tree maps can be automatically generated without the need for custom
+  // machinery
+  def genTreeMap[A: {Arbitrary, Ordering}, B: Arbitrary]: Gen[mutable.TreeMap[A, B]] = {
+    import org.scalacheck.Gen._
+    for {
+      keys <- listOf(arbitrary[A])
+      values <- listOfN(keys.size, arbitrary[B])
+    } yield mutable.TreeMap(keys zip values*)
+  }
+
+  implicit def arbRedBlackTree[A: {Arbitrary, Ordering}, B: Arbitrary]: Arbitrary[RB.Tree[A,B]] = Arbitrary(genRedBlackTree[A, B])
+  implicit def arbTreeMap[A: {Arbitrary, Ordering}, B: Arbitrary]: Arbitrary[mutable.TreeMap[A,B]] = Arbitrary(genTreeMap[A, B])
+}
+
+object RedBlackTreeProperties extends Properties("mutable.RedBlackTree") with Generators {
+  type K = String
+  type V = Int
+
+  property("initial invariants") = forAll { (tree: RB.Tree[K, V]) =>
+    RB.isValid(tree)
+  }
+
+  property("insert") = forAll { (tree: RB.Tree[K, V], entries: Seq[(K, V)]) =>
+    entries.foreach { case (k, v) => RB.insert(tree, k, v) }
+    RB.isValid(tree) && entries.toMap.forall { case (k, v) => RB.get(tree, k) == Some(v) }
+  }
+
+  property("delete") = forAll { (tree: RB.Tree[K, V], ks: Seq[K]) =>
+    ks.foreach { k => RB.delete(tree, k) }
+    RB.isValid(tree) && ks.toSet.forall { k => RB.get(tree, k) == None }
+  }
+
+  property("insert & delete") = forAll { (tree: RB.Tree[K, V], ops: Seq[Either[(K, V), K]]) =>
+    ops.foreach {
+      case Left((k, v)) => RB.insert(tree, k, v)
+      case Right(k) => RB.delete(tree, k)
+    }
+    RB.isValid(tree)
+  }
+
+  property("min") = forAll { (entries: Seq[(K, V)]) =>
+    val tree = RB.Tree.empty[K, V]
+    entries.foreach { case (k, v) => RB.insert(tree, k, v) }
+    RB.min(tree) == (if (entries.isEmpty) None else Some(entries.toMap.min))
+  }
+
+  property("max") = forAll { (entries: Seq[(K, V)]) =>
+    val tree = RB.Tree.empty[K, V]
+    entries.foreach { case (k, v) => RB.insert(tree, k, v) }
+    RB.max(tree) == (if (entries.isEmpty) None else Some(entries.toMap.max))
+  }
+}
+
+object MutableTreeMapProperties extends Properties("mutable.TreeMap") with Generators {
+  type K = String
+  type V = Int
+
+  property("get, contains") = forAll { (allEntries: Map[K, V]) =>
+    val entries = allEntries.take(allEntries.size / 2)
+
+    val map = mutable.TreeMap[K, V]()
+    map ++= entries
+
+    allEntries.forall { case (k, v) =>
+      map.contains(k) == entries.contains(k) &&
+        map.get(k) == entries.get(k)
+    }
+  }
+
+  property("size, isEmpty") = forAll { (entries: Map[K, V]) =>
+    val map = mutable.TreeMap[K, V]()
+    map ++= entries
+    map.size == entries.size && map.isEmpty == entries.isEmpty
+  }
+
+  property("+=") = forAll { (map: mutable.TreeMap[K, V], k: K, v: V) =>
+    val oldSize = map.size
+    val containedKeyBefore = map.contains(k)
+    val newExpectedSize = if(containedKeyBefore) oldSize else oldSize + 1
+
+    map += (k -> v)
+    map.contains(k) && map.get(k) == Some(v) && map.size == newExpectedSize
+  }
+
+  property("++=") = forAll { (map: mutable.TreeMap[K, V], entries: Seq[(K, V)]) =>
+    val oldEntries = map.toMap
+    map ++= entries
+    (oldEntries ++ entries).forall { case (k, v) => map.get(k) == Some(v) }
+  }
+
+  property("-=") = forAll { (map: mutable.TreeMap[K, V], k: K) =>
+    val oldSize = map.size
+    val containedKeyBefore = map.contains(k)
+    val newExpectedSize = if(containedKeyBefore) oldSize - 1 else oldSize
+
+    map -= k
+    !map.contains(k) && map.get(k) == None && map.size == newExpectedSize
+  }
+
+  property("--=") = forAll { (map: mutable.TreeMap[K, V], ks: Seq[K]) =>
+    val oldElems = map.toList
+    map --= ks
+    val deletedElems = ks.toSet
+    oldElems.forall { case (k, v) => map.get(k) == (if(deletedElems(k)) None else Some(v)) }
+  }
+
+  property("iterator") = forAll { (entries: Map[K, V]) =>
+    val map = mutable.TreeMap[K, V]()
+    map ++= entries
+
+    map.iterator.toSeq == entries.toSeq.sorted
+  }
+
+  property("iteratorFrom") = forAll { (entries: Map[K, V], k: K) =>
+    val map = mutable.TreeMap[K, V]()
+    map ++= entries
+
+    map.iteratorFrom(k).toSeq == entries.view.filterKeys(_ >= k).toSeq.sorted
+  }
+
+  property("keysIteratorFrom") = forAll { (entries: Map[K, V], k: K) =>
+    val map = mutable.TreeMap[K, V]()
+    map ++= entries
+
+    map.keysIteratorFrom(k).toSeq == entries.keysIterator.filter(_ >= k).toSeq.sorted
+  }
+
+  property("valuesIteratorFrom") = forAll { (entries: Map[K, V], k: K) =>
+    val map = mutable.TreeMap[K, V]()
+    map ++= entries
+
+    map.valuesIteratorFrom(k).toSeq == entries.view.filterKeys(_ >= k).toSeq.sorted.map(_._2)
+  }
+
+  property("headOption") = forAll { (map: mutable.TreeMap[K, V]) =>
+    map.headOption == Try(map.iterator.next()).toOption
+  }
+
+  property("lastOption") = forAll { (map: mutable.TreeMap[K, V]) =>
+    map.lastOption == Try(map.iterator.max).toOption
+  }
+
+  property("minAfter") = forAll { (allEntries: Map[K, V]) =>
+    val entries = allEntries.take(allEntries.size / 2)
+
+    val map = mutable.TreeMap[K, V]()
+    map ++= entries
+
+    allEntries.forall { case (k, v) =>
+      map.minAfter(k) == map.rangeImpl(Some(k), None).headOption
+    }
+  }
+
+  property("maxBefore") = forAll { (allEntries: Map[K, V]) =>
+    val entries = allEntries.take(allEntries.size / 2)
+
+    val map = mutable.TreeMap[K, V]()
+    map ++= entries
+
+    allEntries.forall { case (k, v) =>
+      map.maxBefore(k) == map.rangeImpl(None, Some(k)).lastOption
+    }
+  }
+
+  property("clear") = forAll { (map: mutable.TreeMap[K, V]) =>
+    map.clear()
+    map.isEmpty && map.size == 0
+  }
+
+  property("serializable") = forAll { (map: mutable.TreeMap[K, V]) =>
+    val bytesOut = new ByteArrayOutputStream()
+    val out = new ObjectOutputStream(bytesOut)
+    out.writeObject(map)
+    val bytes = bytesOut.toByteArray
+
+    val in = new ObjectInputStream(new ByteArrayInputStream(bytes))
+    val sameMap = in.readObject().asInstanceOf[mutable.TreeMap[K, V]]
+    map.iterator.toSeq == sameMap.iterator.toSeq
+  }
+
+  property("same behavior as immutable.TreeMap") = forAll { (ops: Seq[Either[(K, V), K]]) =>
+    var imap = immutable.TreeMap[K, V]()
+    val mmap = mutable.TreeMap[K, V]()
+
+    ops.foreach {
+      case Left((k, v)) => imap += k -> v; mmap += k -> v
+      case Right(k) => imap -= k; mmap -= k
+    }
+
+    imap.toList == mmap.toList
+  }
+}
+
+object MutableTreeMapProjectionProperties extends Properties("mutable.TreeMapProjection") with Generators {
+  type K = String
+  type V = Int
+
+  private val ord = implicitly[Ordering[K]]
+
+  def in(key: K, from: Option[K], until: Option[K]) =
+    from.fold(true)(_ <= key) && until.fold(true)(_ > key)
+
+  def entriesInView[This <: IterableOnce[(K, V)], That](entries: This, from: Option[K], until: Option[K])(implicit bf: BuildFrom[This, (K, V), That]) = {
+    (bf.newBuilder(entries) ++= entries.iterator.filter { case (k, _) => in(k, from, until) }).result()
+  }
+
+  property("get, contains") = forAll { (allEntries: Map[K, V], from: Option[K], until: Option[K]) =>
+    val entries = allEntries.take(allEntries.size / 2)
+
+    val map = mutable.TreeMap[K, V]()
+    map ++= entries
+
+    val mapView = map.rangeImpl(from, until)
+    allEntries.forall { case (k, v) =>
+      mapView.contains(k) == (in(k, from, until) && entries.contains(k)) &&
+        mapView.get(k) == (if(in(k, from, until)) entries.get(k) else None)
+    }
+  }
+
+  property("size, isEmpty") = forAll { (entries: Map[K, V], from: Option[K], until: Option[K]) =>
+    val map = mutable.TreeMap[K, V]()
+    map ++= entries
+
+    val mapView = map.rangeImpl(from, until)
+    mapView.size == entriesInView(entries, from, until).size &&
+      mapView.isEmpty == !entries.exists { kv => in(kv._1, from, until) }
+  }
+
+  property("+=") = forAll { (map: mutable.TreeMap[K, V], k: K, v: V, from: Option[K], until: Option[K]) =>
+    val oldSize = map.size
+    val containedKeyBefore = map.contains(k)
+    val newExpectedSize = if(containedKeyBefore) oldSize else oldSize + 1
+    val isInRange = in(k, from, until)
+
+    val mapView = map.rangeImpl(from, until)
+    mapView += (k -> v)
+
+    map.contains(k) && map.get(k) == Some(v) && map.size == newExpectedSize &&
+      mapView.contains(k) == isInRange &&
+      mapView.get(k) == (if(isInRange) Some(v) else None)
+  }
+
+  property("++=") = forAll { (map: mutable.TreeMap[K, V], entries: Seq[(K, V)], from: Option[K], until: Option[K]) =>
+    val mapView = map.rangeImpl(from, until)
+    mapView ++= entries
+    entries.toMap.forall { case (k, v) =>
+      map.get(k) == Some(v) &&
+        mapView.get(k) == (if (in(k, from, until)) Some(v) else None)
+    }
+  }
+
+  property("-=") = forAll { (map: mutable.TreeMap[K, V], k: K, from: Option[K], until: Option[K]) =>
+    val oldSize = map.size
+    val containedKeyBefore = map.contains(k)
+    val newExpectedSize = if(containedKeyBefore) oldSize - 1 else oldSize
+
+    val mapView = map.rangeImpl(from, until)
+    mapView -= k
+
+    !map.contains(k) && map.get(k) == None && map.size == newExpectedSize &&
+      !mapView.contains(k) &&
+      mapView.get(k) == None
+  }
+
+  property("--=") = forAll { (map: mutable.TreeMap[K, V], ks: Seq[K], from: Option[K], until: Option[K]) =>
+    val mapView = map.rangeImpl(from, until)
+    mapView --= ks
+    ks.toSet.forall { k => map.get(k) == None && mapView.get(k) == None }
+  }
+
+  property("iterator") = forAll { (entries: Map[K, V], from: Option[K], until: Option[K]) =>
+    val map = mutable.TreeMap[K, V]()
+    map ++= entries
+
+    val mapView = map.rangeImpl(from, until)
+    mapView.iterator.toSeq == entriesInView(entries, from, until).toSeq.sorted
+  }
+
+  property("iteratorFrom") = forAll { (entries: Map[K, V], k: K, from: Option[K], until: Option[K]) =>
+    val map = mutable.TreeMap[K, V]()
+    map ++= entries
+
+    val mapView = map.rangeImpl(from, until)
+    val newLower = Some(from.fold(k)(ord.max(_, k)))
+    mapView.iteratorFrom(k).toSeq == entriesInView(entries, newLower, until).toSeq.sorted
+  }
+
+  property("keysIteratorFrom") = forAll { (entries: Map[K, V], k: K, from: Option[K], until: Option[K]) =>
+    val map = mutable.TreeMap[K, V]()
+    map ++= entries
+
+    val mapView = map.rangeImpl(from, until)
+    val newLower = Some(from.fold(k)(ord.max(_, k)))
+    mapView.keysIteratorFrom(k).toSeq == entriesInView(entries, newLower, until).toSeq.sorted.map(_._1)
+  }
+
+  property("valuesIteratorFrom") = forAll { (entries: Map[K, V], k: K, from: Option[K], until: Option[K]) =>
+    val map = mutable.TreeMap[K, V]()
+    map ++= entries
+
+    val mapView = map.rangeImpl(from, until)
+    val newLower = Some(from.fold(k)(ord.max(_, k)))
+    mapView.valuesIteratorFrom(k).toSeq == entriesInView(entries, newLower, until).toSeq.sorted.map(_._2)
+  }
+
+  property("headOption") = forAll { (map: mutable.TreeMap[K, V], from: Option[K], until: Option[K]) =>
+    val mapView = map.rangeImpl(from, until)
+    mapView.headOption == Try(entriesInView(map.iterator, from, until).next()).toOption
+  }
+
+  property("lastOption") = forAll { (map: mutable.TreeMap[K, V], from: Option[K], until: Option[K]) =>
+    val mapView = map.rangeImpl(from, until)
+    mapView.lastOption == Try(entriesInView(map.iterator, from, until).max).toOption
+  }
+
+  property("clear") = forAll { (map: mutable.TreeMap[K, V], from: Option[K], until: Option[K]) =>
+    val mapView = map.rangeImpl(from, until)
+    mapView.clear()
+    map.isEmpty && mapView.isEmpty && map.size == 0 && mapView.size == 0
+  }
+
+  property("serializable") = forAll { (map: mutable.TreeMap[K, V], from: Option[K], until: Option[K]) =>
+    val mapView = map.rangeImpl(from, until)
+
+    val bytesOut = new ByteArrayOutputStream()
+    val out = new ObjectOutputStream(bytesOut)
+    out.writeObject(mapView)
+    val bytes = bytesOut.toByteArray
+
+    val in = new ObjectInputStream(new ByteArrayInputStream(bytes))
+    val sameMapView = in.readObject().asInstanceOf[mutable.TreeMap[K, V]]
+    mapView.iterator.toSeq == sameMapView.iterator.toSeq
+  }
+}

--- a/library/test/scala/collection/mutable/MutableTreeSet.scala
+++ b/library/test/scala/collection/mutable/MutableTreeSet.scala
@@ -1,0 +1,220 @@
+package scala.collection.mutable
+
+import java.io.*
+
+import org.scalacheck.*
+import org.scalacheck.Arbitrary.*
+import org.scalacheck.Prop.forAll
+
+import scala.collection.{BuildFrom, immutable, mutable}
+import scala.util.Try
+
+object MutableTreeSetProperties extends Properties("mutable.TreeSet") {
+  type K = String
+
+  property("size, isEmpty") = forAll { (elems: Set[K]) =>
+    val set = mutable.TreeSet[K]()
+    set ++= elems
+    set.size == elems.size && set.isEmpty == elems.isEmpty
+  }
+
+  property("+=") = forAll { (set: mutable.TreeSet[K], k: K) =>
+    val oldSize = set.size
+    val containedKeyBefore = set.contains(k)
+    val newExpectedSize = if(containedKeyBefore) oldSize else oldSize + 1
+
+    set += k
+    set.contains(k) && set.size == newExpectedSize
+  }
+
+  property("++=") = forAll { (set: mutable.TreeSet[K], ks: Seq[K]) =>
+    val oldElems = set.toList
+    set ++= ks
+    (oldElems ++ ks).forall(set.contains)
+  }
+
+  property("-=") = forAll { (set: mutable.TreeSet[K], k: K) =>
+    val oldSize = set.size
+    val containedKeyBefore = set.contains(k)
+    val newExpectedSize = if(containedKeyBefore) oldSize - 1 else oldSize
+
+    set -= k
+    !set.contains(k) && set.size == newExpectedSize
+  }
+
+  property("--=") = forAll { (set: mutable.TreeSet[K], ks: Seq[K]) =>
+    val oldElems = set.toList
+    set --= ks
+    val deletedElems = ks.toSet
+    oldElems.forall { e => set.contains(e) == !deletedElems(e) }
+  }
+
+  property("iterator") = forAll { (ks: Set[K]) =>
+    val set = mutable.TreeSet[K]()
+    set ++= ks
+
+    set.iterator.toSeq == ks.toSeq.sorted
+  }
+
+  property("iteratorFrom, keysIteratorFrom") = forAll { (ks: Set[K], k: K) =>
+    val set = mutable.TreeSet[K]()
+    set ++= ks
+
+    set.iteratorFrom(k).toSeq == ks.filter(_ >= k).toSeq.sorted
+  }
+
+  property("headOption") = forAll { (set: mutable.TreeSet[K]) =>
+    set.headOption == Try(set.iterator.next()).toOption
+  }
+
+  property("lastOption") = forAll { (set: mutable.TreeSet[K]) =>
+    set.lastOption == Try(set.iterator.max).toOption
+  }
+
+  property("minAfter") = forAll { (set: mutable.TreeSet[K]) =>
+    val half = set.take(set.size / 2)
+    set.forall { x =>
+      half.minAfter(x) == half.rangeImpl(Some(x), None).headOption
+    }
+  }
+
+  property("maxBefore") = forAll { (set: mutable.TreeSet[K]) =>
+    val half = set.take(set.size / 2)
+    set.forall { x =>
+      half.maxBefore(x) == half.rangeImpl(None, Some(x)).lastOption
+    }
+  }
+
+  property("clear") = forAll { (set: mutable.TreeSet[K]) =>
+    set.clear()
+    set.isEmpty && set.size == 0
+  }
+
+  property("serializable") = forAll { (set: mutable.TreeSet[K]) =>
+    val bytesOut = new ByteArrayOutputStream()
+    val out = new ObjectOutputStream(bytesOut)
+    out.writeObject(set)
+    val bytes = bytesOut.toByteArray
+
+    val in = new ObjectInputStream(new ByteArrayInputStream(bytes))
+    val sameSet = in.readObject().asInstanceOf[mutable.TreeSet[K]]
+    set.iterator.toSeq == sameSet.iterator.toSeq
+  }
+
+  property("same behavior as immutable.TreeMap") = forAll { (ops: Seq[Either[K, K]]) =>
+    var iset = immutable.TreeSet[K]()
+    val mset = mutable.TreeSet[K]()
+
+    ops.foreach {
+      case Left(k) => iset += k; mset += k
+      case Right(k) => iset -= k; mset -= k
+    }
+
+    iset.toList == mset.toList
+  }
+}
+
+object MutableTreeSetProjectionProperties extends Properties("mutable.TreeSetProjection") {
+  type K = String
+
+  private val ord = implicitly[Ordering[K]]
+
+  def in(key: K, from: Option[K], until: Option[K]) =
+    from.fold(true)(_ <= key) && until.fold(true)(_ > key)
+
+  def keysInView[This <: IterableOnce[K], That](keys: This, from: Option[K], until: Option[K])(implicit bf: BuildFrom[This, K, That]) = {
+    (bf.newBuilder(keys) ++= keys.iterator.filter(in(_, from, until))).result()
+  }
+
+  property("size, isEmpty") = forAll { (keys: Set[K], from: Option[K], until: Option[K]) =>
+    val map = mutable.TreeSet[K]()
+    map ++= keys
+
+    val mapView = map.rangeImpl(from, until)
+    mapView.size == keysInView(keys, from, until).size &&
+      mapView.isEmpty == !keys.exists(in(_, from, until))
+  }
+
+  property("+=") = forAll { (set: mutable.TreeSet[K], k: K, from: Option[K], until: Option[K]) =>
+    val oldSize = set.size
+    val containedKeyBefore = set.contains(k)
+    val newExpectedSize = if(containedKeyBefore) oldSize else oldSize + 1
+    val isInRange = in(k, from, until)
+
+    val setView = set.rangeImpl(from, until)
+    setView += k
+
+    set.contains(k) && set.size == newExpectedSize && setView.contains(k) == isInRange
+  }
+
+  property("++=") = forAll { (set: mutable.TreeSet[K], ks: Seq[K], from: Option[K], until: Option[K]) =>
+    val setView = set.rangeImpl(from, until)
+    setView ++= ks
+    ks.toSet.forall { k =>
+      set.contains(k) && setView.contains(k) == in(k, from, until)
+    }
+  }
+
+  property("-=") = forAll { (set: mutable.TreeSet[K], k: K, from: Option[K], until: Option[K]) =>
+    val oldSize = set.size
+    val containedKeyBefore = set.contains(k)
+    val newExpectedSize = if(containedKeyBefore) oldSize - 1 else oldSize
+
+    val setView = set.rangeImpl(from, until)
+    setView -= k
+
+    !set.contains(k) && set.size == newExpectedSize && !setView.contains(k)
+  }
+
+  property("--=") = forAll { (set: mutable.TreeSet[K], ks: Seq[K], from: Option[K], until: Option[K]) =>
+    val setView = set.rangeImpl(from, until)
+    setView --= ks
+    ks.toSet.forall { k => !set.contains(k) && !setView.contains(k) }
+  }
+
+  property("iterator") = forAll { (ks: Set[K], from: Option[K], until: Option[K]) =>
+    val set = mutable.TreeSet[K]()
+    set ++= ks
+
+    val setView = set.rangeImpl(from, until)
+    setView.iterator.toSeq == keysInView(ks, from, until).toSeq.sorted
+  }
+
+  property("iteratorFrom, keysIteratorFrom") = forAll { (ks: Set[K], k: K, from: Option[K], until: Option[K]) =>
+    val set = mutable.TreeSet[K]()
+    set ++= ks
+
+    val setView = set.rangeImpl(from, until)
+    val newLower = Some(from.fold(k)(ord.max(_, k)))
+    setView.iteratorFrom(k).toSeq == keysInView(ks, newLower, until).toSeq.sorted
+  }
+
+  property("headOption") = forAll { (set: mutable.TreeSet[K], from: Option[K], until: Option[K]) =>
+    val setView = set.rangeImpl(from, until)
+    setView.headOption == Try(keysInView(set.iterator, from, until).next()).toOption
+  }
+
+  property("lastOption") = forAll { (set: mutable.TreeSet[K], from: Option[K], until: Option[K]) =>
+    val setView = set.rangeImpl(from, until)
+    setView.lastOption == Try(keysInView(set.iterator, from, until).max).toOption
+  }
+
+  property("clear") = forAll { (set: mutable.TreeSet[K], from: Option[K], until: Option[K]) =>
+    val setView = set.rangeImpl(from, until)
+    setView.clear()
+    set.isEmpty && setView.isEmpty && set.size == 0 && setView.size == 0
+  }
+
+  property("serializable") = forAll { (set: mutable.TreeSet[K], from: Option[K], until: Option[K]) =>
+    val setView = set.rangeImpl(from, until)
+
+    val bytesOut = new ByteArrayOutputStream()
+    val out = new ObjectOutputStream(bytesOut)
+    out.writeObject(setView)
+    val bytes = bytesOut.toByteArray
+
+    val in = new ObjectInputStream(new ByteArrayInputStream(bytes))
+    val sameSetView = in.readObject().asInstanceOf[mutable.TreeSet[K]]
+    setView.iterator.toSeq == sameSetView.iterator.toSeq
+  }
+}

--- a/library/test/scala/collection/mutable/RedBlackTree.scala
+++ b/library/test/scala/collection/mutable/RedBlackTree.scala
@@ -1,0 +1,211 @@
+package scala.collection.mutable
+
+import collection.mutable.{RedBlackTree => RB}
+import org.scalacheck.*
+import Prop.*
+import Gen.*
+
+/*
+Properties of a Red & Black Tree:
+
+A node is either red or black.
+The root is black. (This rule is used in some definitions and not others. Since the
+root can always be changed from red to black but not necessarily vice-versa this
+rule has little effect on analysis.)
+All leaves are black.
+Both children of every red node are black.
+Every simple path from a given node to any of its descendant leaves contains the same number of black nodes.
+*/
+
+abstract class RedBlackTreeTest(tname: String) extends Properties(tname) with RedBlackTreeInvariants[String, Int] {
+  def minimumSize = 0
+  def maximumSize = 5
+
+  import RB.*
+
+  def nodeAt[A](tree: Tree[String, A], n: Int): Option[(String, A)] = if (n < iterator(tree).size && n >= 0)
+    Some(iterator(tree).drop(n).next())
+  else
+    None
+
+  def treeContains[A](tree: Tree[String, A], key: String) = iterator(tree).map(_._1) contains key
+
+  def height(node: Node[?, ?] | Null): Int = if node eq null then 0 else (1 + math.max(height(node.nn.left), height(node.nn.right)))
+
+  def RedTree[A, B](k: A, v: B, l: Tree[A, B], r: Tree[A, B]): Tree[A, B] = {
+    val n = new Node(k, v, red = true, l.root, r.root, null)
+    if(l.root ne null) l.root.nn.parent = n
+    if(r.root ne null) r.root.nn.parent = n
+    new Tree(n, l.size + r.size + 1)
+  }
+
+  def BlackTree[A, B](k: A, v: B, l: Tree[A, B], r: Tree[A, B]): Tree[A, B] = {
+    val n = new Node(k, v, red = false, l.root, r.root, null)
+    if(l.root ne null) l.root.nn.parent = n
+    if(r.root ne null) r.root.nn.parent = n
+    new Tree(n, l.size + r.size + 1)
+  }
+
+  def mkTree(level: Int, parentIsBlack: Boolean = false, label: String = ""): Gen[Tree[String, Int]] =
+    if (level == 0) {
+      const(new Tree(null, 0))
+    } else {
+      for {
+        oddOrEven <- choose(0, 2)
+        tryRed = oddOrEven.sample.get % 2 == 0 // work around arbitrary[Boolean] bug
+        isRed = parentIsBlack && tryRed
+        nextLevel = if (isRed) level else level - 1
+        left <- mkTree(nextLevel, !isRed, label + "L")
+        right <- mkTree(nextLevel, !isRed, label + "R")
+      } yield {
+        if (isRed)
+          RedTree(label + "N", 0, left, right)
+        else
+          BlackTree(label + "N", 0, left, right)
+      }
+    }
+
+  def genTree = for {
+    depth <- choose(minimumSize, maximumSize + 1)
+    tree <- mkTree(depth)
+  } yield tree
+
+  type ModifyParm
+  def genParm(tree: Tree[String, Int]): Gen[ModifyParm]
+  def modify(tree: Tree[String, Int], parm: ModifyParm): Unit
+
+  def genInput: Gen[(Tree[String, Int], ModifyParm, Tree[String, Int])] = for {
+    tree <- genTree
+    parm <- genParm(tree)
+  } yield (tree, parm, { val c = tree.treeCopy(); modify(c, parm); c })
+
+  def setup(invariant: Tree[String, Int] => Boolean): Prop = forAll(genInput) { case (tree, parm, newTree) =>
+    invariant(newTree)
+  }
+
+  implicit def ordering: Ordering[String] = Ordering.String
+}
+
+trait RedBlackTreeInvariants[K, V] {
+  self: Properties =>
+
+  import RB._
+
+  implicit def ordering: Ordering[K]
+
+  def rootIsBlack(t: Tree[K, V]) = isBlack(t.root)
+
+  def areAllLeavesBlack(t: Tree[K, V]): Boolean = areAllLeavesBlack(t.root)
+
+  def areAllLeavesBlack(n: Node[K, V] | Null): Boolean = n match {
+    case null => isBlack(n)
+    case ne => List(ne.left, ne.right).forall(areAllLeavesBlack)
+  }
+
+  def areRedNodeChildrenBlack(t: Tree[K, V]): Boolean = areRedNodeChildrenBlack(t.root)
+
+  def areRedNodeChildrenBlack(n: Node[K, V] | Null): Boolean = n match {
+    case null => true
+    case n if n.red => List(n.left, n.right).forall(t => isBlack(t) && areRedNodeChildrenBlack(t))
+    case n => List(n.left, n.right).forall(areRedNodeChildrenBlack)
+  }
+
+  def blackNodesToLeaves(n: Node[K, V] | Null): List[Int] = n match {
+    case null => List(1)
+    case n if n.red => List(n.left, n.right).flatMap(blackNodesToLeaves)
+    case n => List(n.left, n.right).flatMap(blackNodesToLeaves).map(_ + 1)
+  }
+
+  def areBlackNodesToLeavesEqual(t: Tree[K, V]): Boolean = areBlackNodesToLeavesEqual(t.root)
+
+  def areBlackNodesToLeavesEqual(n: Node[K, V] | Null): Boolean = n match {
+    case null => true
+    case ne =>
+      blackNodesToLeaves(ne).distinct.size == 1 &&
+        areBlackNodesToLeavesEqual(ne.left) &&
+        areBlackNodesToLeavesEqual(ne.right)
+  }
+
+  def orderIsPreserved(t: Tree[K, V]): Boolean =
+    iterator(t) zip iterator(t).drop(1) forall { case (x, y) => ordering.compare(x._1, y._1) < 0 }
+
+  def sizeIsConsistent(t: Tree[K, V]): Boolean =
+    size(t) == size(t.root)
+
+  def setup(invariant: Tree[K, V] => Boolean): Prop
+
+  property("root is black") = setup(rootIsBlack)
+  property("all leaves are black") = setup(areAllLeavesBlack)
+  property("children of red nodes are black") = setup(areRedNodeChildrenBlack)
+  property("black nodes are balanced") = setup(areBlackNodesToLeavesEqual)
+  property("ordering of keys is preserved") = setup(orderIsPreserved)
+  property("size is consistent") = setup(sizeIsConsistent)
+}
+
+object TestInsert extends RedBlackTreeTest("RedBlackTree.insert") {
+  import RB._
+
+  override type ModifyParm = Int
+  override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = choose(0, iterator(tree).size + 1)
+  override def modify(tree: Tree[String, Int], parm: ModifyParm): Unit = insert(tree, generateKey(tree, parm), 0)
+
+  def generateKey(tree: Tree[String, Int], parm: ModifyParm): String = nodeAt(tree, parm) match {
+    case Some((key, _)) => key.init.mkString + "MN"
+    case None => nodeAt(tree, parm - 1) match {
+      case Some((key, _)) => key.init.mkString + "RN"
+      case None  => "N"
+    }
+  }
+
+  property("update adds elements") = forAll(genInput) { case (tree, parm, newTree) =>
+    treeContains(newTree, generateKey(tree, parm))
+  }
+}
+
+object TestModify extends RedBlackTreeTest("RedBlackTree.modify") {
+  import RB._
+
+  def newValue = 1
+  override def minimumSize = 1
+  override type ModifyParm = Int
+  override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = choose(0, iterator(tree).size)
+  override def modify(tree: Tree[String, Int], parm: ModifyParm): Unit = nodeAt(tree, parm) foreach {
+    case (key, _) => insert(tree, key, newValue)
+  }
+
+  property("update modifies values") = forAll(genInput) { case (tree, parm, newTree) =>
+    nodeAt(tree,parm) forall { case (key, _) =>
+      iterator(newTree) contains (key, newValue)
+    }
+  }
+}
+
+object TestDelete extends RedBlackTreeTest("RedBlackTree.delete") {
+  import RB._
+
+  override def minimumSize = 1
+  override type ModifyParm = Int
+  override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = choose(0, iterator(tree).size)
+  override def modify(tree: Tree[String, Int], parm: ModifyParm): Unit = nodeAt(tree, parm) foreach {
+    case (key, _) => delete(tree, key)
+  }
+
+  property("delete removes elements") = forAll(genInput) { case (tree, parm, newTree) =>
+    nodeAt(tree, parm) forall { case (key, _) =>
+      !treeContains(newTree, key)
+    }
+  }
+}
+
+object TestTransform extends RedBlackTreeTest("RedBlackTree.transform") {
+  import RB._
+
+  override type ModifyParm = Int
+  override def genParm(tree: Tree[String, Int]): Gen[ModifyParm] = choose(0, size(tree))
+  override def modify(tree: Tree[String, Int], parm: ModifyParm): Unit =
+    transform[String, Int](tree, (k, v) => if(v < parm) v else v+1)
+
+  property("transform") = forAll(genInput) { case (tree, parm, newTree) =>
+    iterator(tree).toList.map { case (k, v) => if(v < parm) (k, v) else (k, v+1) } == iterator(newTree).toList
+  }
+}

--- a/library/test/scala/collection/mutable/SetProperties.scala
+++ b/library/test/scala/collection/mutable/SetProperties.scala
@@ -1,0 +1,53 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.mutable
+
+import org.scalacheck.*
+import org.scalacheck.Prop.*
+import org.scalacheck.Arbitrary.arbitrary
+import Gen.*
+
+object SetProperties extends Properties("mutable.Set") {
+
+  type Elem = Int
+
+  /** returns a set that certainly does not override `filterInPlace` implementation */
+  def testSet(elems: collection.immutable.Set[Elem]): Set[Elem] = new Set[Elem] {
+    override protected def className: String = "TestSet"
+    private var _elems = elems
+    override def iterator: Iterator[Elem] = _elems.iterator
+    override def clear(): Unit = _elems = collection.immutable.Set.empty
+    override def subtractOne(elem: Elem): this.type = { _elems -= elem; this }
+    override def addOne(elem: Elem): this.type = { _elems += elem; this }
+    override def contains(elem: Elem): Boolean = { _elems.contains(elem) }
+  }
+
+  implicit val arbSet: Arbitrary[Set[Elem]] =
+    Arbitrary {
+      for {
+        elems <- arbitrary[collection.immutable.HashSet[Elem]]
+        set <- oneOf(
+          elems.to(HashSet),
+          elems.to(TreeSet),
+          elems.to(LinkedHashSet),
+          testSet(elems)
+        )
+      } yield set.asInstanceOf[Set[Elem]]
+    }
+
+  property("filterInPlace(p)") = forAll { (set: Set[Elem], p: Elem => Boolean) =>
+    val expected: collection.Set[Elem] = set.to(collection.immutable.HashSet).filter(p)
+    set.filterInPlace(p)
+    (set: collection.Set[Elem]) ?= expected
+  }
+}

--- a/library/test/scala/collection/mutable/TreeSetProps.scala
+++ b/library/test/scala/collection/mutable/TreeSetProps.scala
@@ -1,0 +1,66 @@
+package scala.collection.mutable
+
+import org.scalacheck.Prop.{forAll, throws}
+import org.scalacheck.Properties
+import org.scalacheck.Gen
+
+object TreeSetProps extends Properties("Mutable TreeSet") {
+
+  val generator = Gen.listOfN(1000, Gen.chooseNum(0, 1000))
+
+  val denseGenerator = Gen.listOfN(1000, Gen.chooseNum(0, 200))
+
+  property("Insertion doesn't allow duplicates values.") = forAll(generator) { (s: List[Int]) =>
+    {
+      val t = TreeSet[Int](s*)
+      t == s.toSet
+    }
+  }
+
+  property("Verification of size method validity") = forAll(generator) { (s: List[Int]) =>
+    {
+      val t = TreeSet[Int](s*)
+      for (a <- s) {
+        t -= a
+      }
+      t.size == 0
+    }
+  }
+
+  property("All inserted elements are removed") = forAll(generator) { (s: List[Int]) =>
+    {
+      val t = TreeSet[Int](s*)
+      for (a <- s) {
+        t -= a
+      }
+      t == Set()
+    }
+  }
+
+  property("Elements are sorted.") = forAll(generator) { (s: List[Int]) =>
+    {
+      val t = TreeSet[Int](s*)
+      t.toList == s.distinct.sorted
+    }
+  }
+
+  property("Implicit CanBuildFrom resolution succeeds as well as the \"same-result-type\" principle.") =
+    forAll(generator) { (s: List[Int]) =>
+      {
+        val t = TreeSet[Int](s*)
+        val t2 = t.map(_ * 2)
+        t2.isInstanceOf[TreeSet[Int]]
+      }
+    }
+
+  property("A view doesn't expose off bounds elements") = forAll(denseGenerator) { (s: List[Int]) =>
+    {
+      val t = TreeSet[Int](s*)
+      val view = t.rangeImpl(Some(50), Some(150))
+      view.filter(_ < 50) == Set[Int]() && view.filter(_ >= 150) == Set[Int]()
+    }
+  }
+
+  property("ordering must not be null") =
+    throws(classOf[NullPointerException])(TreeSet.empty[Int](using null.asInstanceOf[Ordering[Int]]))
+}

--- a/library/test/scala/collection/mutable/UnrolledBufferProps.scala
+++ b/library/test/scala/collection/mutable/UnrolledBufferProps.scala
@@ -1,0 +1,26 @@
+package scala.collection.mutable
+
+import org.scalacheck.*
+import Prop.*
+import Gen.*
+
+object UnrolledBufferProps extends Properties("UnrolledBuffer") {
+
+  property("concat size") = forAll { (l1: List[Int], l2: List[Int]) =>
+    val u1 = new UnrolledBuffer[Int]
+    u1 ++= l1
+    val u2 = new UnrolledBuffer[Int]
+    u2 ++= l2
+    val totalsz = u1.size + u2.size
+    u1 concat u2
+    totalsz == u1.size
+  }
+
+  property("adding") = forAll { (l: List[Int]) =>
+    val u = new UnrolledBuffer[Int]
+    u ++= l
+    u == l
+  }
+
+}
+

--- a/library/test/scala/concurrent/duration/DurationProps.scala
+++ b/library/test/scala/concurrent/duration/DurationProps.scala
@@ -1,0 +1,74 @@
+package scala.concurrent.duration
+
+import org.scalacheck.*
+import Prop.*
+import Gen.*
+import Arbitrary.*
+import math.*
+import concurrent.duration.Duration.fromNanos
+
+object DurationProps extends Properties("Division of Duration by Long") {
+
+  val weightedLong =
+    frequency(
+      1 -> choose(-128L, 127L),
+      1 -> (arbitrary[Byte] map (_.toLong << 8)),
+      1 -> (arbitrary[Byte] map (_.toLong << 16)),
+      1 -> (arbitrary[Byte] map (_.toLong << 24)),
+      1 -> (arbitrary[Byte] map (_.toLong << 32)),
+      1 -> (arbitrary[Byte] map (_.toLong << 40)),
+      1 -> (arbitrary[Byte] map (_.toLong << 48)),
+      1 -> (choose(-127L, 127L) map (_ << 56))
+    )
+
+  val genTwoSmall = for {
+    a <- weightedLong
+    b <- choose(-(Long.MaxValue / max(1, abs(a))), Long.MaxValue / max(1, abs(a)))
+  } yield (a, b)
+
+  val genTwoLarge = for {
+    a <- weightedLong
+    b <- arbitrary[Long] suchThat (b => abs(b) > Long.MaxValue / max(1, abs(a)))
+  } yield (a, b)
+
+  val genClose = for {
+    a <- weightedLong
+    if a != 0
+    center = Long.MaxValue / a
+    b <-
+      if (center - 10 < center + 10) choose(center - 10,  center + 10)
+      else choose(center + 10,  center - 10) // deal with overflow if abs(a) == 1
+  } yield (a, b)
+
+  val genBorderline =
+    frequency(
+      1 -> (Long.MinValue, 0L),
+      1 -> (Long.MinValue, 1L),
+      1 -> (Long.MinValue, -1L),
+      1 -> (0L, Long.MinValue),
+      1 -> (1L, Long.MinValue),
+      1 -> (-1L, Long.MinValue),
+      90 -> genClose
+    )
+
+  def mul(a: Long, b: Long): Long = {
+    (fromNanos(a) * b).toNanos
+  }
+
+  property("without overflow") = forAll(genTwoSmall) { case (a, b) =>
+    a * b == mul(a, b)
+  }
+
+  property("with overflow") = forAll(genTwoLarge) { case (a, b) =>
+    try { mul(a, b); false } catch { case _: IllegalArgumentException => true }
+  }
+
+  property("on overflow edge cases") = forAll(genBorderline) { case (a, b) =>
+    val shouldFit =
+      a != Long.MinValue && // must fail due to illegal duration length
+      (b != Long.MinValue || a == 0) && // Long factor may only be MinValue if the duration is zero, otherwise the result will be illegal
+      (abs(b) <= Long.MaxValue / max(1, abs(a))) // check the rest against the “safe” division method
+    try { mul(a, b); shouldFit }
+    catch { case _: IllegalArgumentException => !shouldFit }
+  }
+}

--- a/library/test/scala/jdk/AccumulatorProps.scala
+++ b/library/test/scala/jdk/AccumulatorProps.scala
@@ -1,0 +1,104 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.jdk
+
+import org.scalacheck.{Arbitrary, Properties}
+import Arbitrary.arbitrary
+import org.scalacheck.Prop.forAll
+
+object AccumulatorProps extends Properties("Accumulators") {
+  property("IntAccumulatorConvert") = forAll(
+    arbitrary[Seq[Int]]
+  ) { xs =>
+    val acc: IntAccumulator = Accumulator(xs*)
+    acc.toList == xs &&
+      acc.stepper.iterator.toList == xs &&
+      acc.toArray.toList == xs &&
+      acc.to(List) == xs &&
+      acc.iterator.toList == xs
+  }
+
+  property("IntAccumulatorDrain") = forAll(
+    arbitrary[Seq[Int]],
+    arbitrary[Seq[Int]]
+  ) { (xs1, xs2) =>
+    val acc1: IntAccumulator = Accumulator(xs1*)
+    val acc2: IntAccumulator = Accumulator(xs2*)
+    acc1.drain(acc2)
+    acc1.sameElements(Iterator.concat(xs1, xs2))
+  }
+
+  property("LongAccumulatorConvert") = forAll(
+    arbitrary[Seq[Long]]
+  ) { xs =>
+    val acc: LongAccumulator = Accumulator(xs*)
+    acc.toList == xs &&
+      acc.stepper.iterator.toList == xs &&
+      acc.toArray.toList == xs &&
+      acc.to(List) == xs &&
+      acc.iterator.toList == xs
+  }
+
+  property("LongAccumulatorDrain") = forAll(
+    arbitrary[Seq[Long]],
+    arbitrary[Seq[Long]]
+  ) { (xs1, xs2) =>
+    val acc1: LongAccumulator = Accumulator(xs1*)
+    val acc2: LongAccumulator = Accumulator(xs2*)
+    acc1.drain(acc2)
+    acc1.sameElements(Iterator.concat(xs1, xs2))
+  }
+
+  property("DoubleAccumulatorConvert") = forAll(
+    arbitrary[Seq[Double]]
+  ) { xs =>
+    val acc: DoubleAccumulator = Accumulator(xs*)
+    acc.toList == xs &&
+      acc.stepper.iterator.toList == xs &&
+      acc.toArray.toList == xs &&
+      acc.to(List) == xs &&
+      acc.iterator.toList == xs
+  }
+
+  property("DoubleAccumulatorDrain") = forAll(
+    arbitrary[Seq[Double]],
+    arbitrary[Seq[Double]]
+  ) { (xs1, xs2) =>
+    val acc1: DoubleAccumulator = Accumulator(xs1*)
+    val acc2: DoubleAccumulator = Accumulator(xs2*)
+    acc1.drain(acc2)
+    acc1 sameElements Iterator.concat(xs1, xs2)
+  }
+
+  property("AnyAccumulatorConvert") = forAll(
+    arbitrary[Seq[String]]
+  ) { xs =>
+    val acc: AnyAccumulator[String] = Accumulator(xs*)
+    acc.toList == xs &&
+      acc.stepper.iterator.toList == xs &&
+      acc.toArray.toList == xs &&
+      acc.to(List) == xs &&
+      acc.iterator.toList == xs
+  }
+
+  property("AnyAccumulatorDrain") = forAll(
+    arbitrary[Seq[String]],
+    arbitrary[Seq[String]]
+  ) { (xs1, xs2) =>
+    val acc1: AnyAccumulator[String] = Accumulator(xs1*)
+    val acc2: AnyAccumulator[String] = Accumulator(xs2*)
+    acc1.drain(acc2)
+    acc1.sameElements(Iterator.concat(xs1, xs2))
+  }
+
+}

--- a/library/test/scala/math/BigIntProperties.scala
+++ b/library/test/scala/math/BigIntProperties.scala
@@ -1,0 +1,149 @@
+package scala.math
+
+import org.scalacheck.{Properties, Gen, Arbitrary}
+import Arbitrary.arbitrary
+import org.scalacheck.Prop.*
+import java.math.BigInteger
+import java.lang.Character
+import scala.annotation.nowarn
+import scala.util.Random
+
+object BigIntProperties extends Properties("BigInt") {
+
+  val positiveNumberString: Gen[String] = for {
+    firstDigit <- Gen.choose('1', '9')
+    nDigits <- Gen.choose(0, 30)
+    digits <- Gen.listOfN(nDigits, Gen.choose('0', '9'))
+  } yield firstDigit +: digits.mkString
+
+  val negativeNumberString: Gen[String] = positiveNumberString.map("-" + _)
+
+  val nonZeroNumberString: Gen[String] = Gen.oneOf(positiveNumberString, negativeNumberString)
+
+  val numberString: Gen[String] = Gen.frequency(1 -> "0", 10 -> positiveNumberString, 10 -> negativeNumberString)
+
+  val bigInteger: Gen[BigInteger] = numberString.map(new BigInteger(_))
+
+  val positiveBigInteger: Gen[BigInteger] = positiveNumberString.map(new BigInteger(_))
+
+  val nonZeroBigInteger: Gen[BigInteger] = nonZeroNumberString.map(new BigInteger(_))
+
+  val bigInt: Gen[BigInt] = numberString.map(BigInt(_))
+
+  val nonZeroSignum: Gen[Int] = Gen.oneOf(-1, 1)
+
+  val byteArray: Gen[Array[Byte]] = Gen.containerOf[Array, Byte](arbitrary[Byte])
+
+  val radix: Gen[Int] = Gen.choose(Character.MIN_RADIX, Character.MAX_RADIX)
+
+  val stringAndRadix: Gen[(String, Int)] = for {
+    rdx <- radix
+    firstDigit <- Gen.choose(1, rdx - 1).map(Character.forDigit(_, rdx))
+    nDigits <- Gen.choose(0, 30)
+    digits <- Gen.listOfN(nDigits, Gen.choose(0, rdx - 1).map(i => Character.forDigit(i, rdx)))
+  } yield (firstDigit +: digits.mkString, rdx)
+
+  val shift: Gen[Int] = for {
+    sign <- Gen.oneOf(-1, 1)
+    size <- Gen.size
+  } yield sign * size
+
+  val bitIndex: Gen[Int] = Gen.size
+
+  val smallExponent: Gen[Int] = Gen.choose(0, 10)
+  val exponent: Gen[Int] = Gen.choose(0, Int.MaxValue)
+
+  val relativelyPrimePositiveBigIntegers: Gen[(BigInteger, BigInteger)] = for {
+    x <- positiveBigInteger
+    y <- positiveBigInteger
+    g = x.gcd(y)
+  } yield (x.divide(g), y.divide(g))
+
+  property("longValue") = forAll { (l: Long) => BigInt(l).longValue ?= l }
+  property("toLong") = forAll { (l: Long) => BigInt(l).toLong ?= l }
+
+  property("new BigInt(bigInteger = BigInteger.ZERO)") = (new BigInt(bigInteger = BigInteger.ZERO)) == 0
+  property("BigInt.apply(i: Int)") = forAll { (i: Int) => BigInt(i) ?= BigInt(BigInteger.valueOf(i)) }
+  property("BigInt.apply(l: Long)") = forAll { (l: Long) => BigInt(l) ?= BigInt(BigInteger.valueOf(l)) }
+  property("BigInt.apply(x: Array[Byte])") = forAll(bigInteger) { bi => BigInt(bi) ?= BigInt(bi.toByteArray) }
+  property("BigInt.apply(0, Array.empty[Byte])") = BigInt(0, Array.empty[Byte]) ?= BigInt(0)
+  property("BigInt.apply(signum: Int, magnitude: Array[Byte])") = forAll(nonZeroSignum, byteArray) { (s, ba) => BigInt(s, ba) ?= BigInt(new BigInteger(s, ba)) }
+  property("BigInt.apply(x: String)") = forAll(numberString) { s => BigInt(s) ?= BigInt(new BigInteger(s)) }
+  property("BigInt.apply(x: String, radix: Int)") = forAll(stringAndRadix) { case (x, radix) => BigInt(x, radix) ?= BigInt(new BigInteger(x, radix)) }
+  property("BigInt.probablePrime") = forAll(Gen.choose(2, 100), arbitrary[Long]) { (bl, seed) => BigInt.probablePrime(bl, new Random(seed)).isProbablePrime(100) }
+  property("hashCode is unified across primitives (Int)") = forAll { (i: Int) => i.## ?= BigInt(i).## }
+  property("hashCode is unified across primitives (Long)") = forAll { (l: Long) => l.## ?= BigInt(l).## }
+  property("BigInt equals Double") = forAll { (i: Int) => BigInt(i) == i.toDouble }
+  property("BigInt equals Float") = forAll { (s: Short) => BigInt(s) == s.toFloat }
+  property("BigInt equals Long") = forAll { (l: Long) => BigInt(l) == l }
+  property("BigInt equals BigDecimal") = forAll(numberString) { ns => BigInt(ns) == BigDecimal(ns) }
+  property("Double equals BigInt") = forAll { (i: Int) => i.toDouble == BigInt(i) }
+  property("Float equals BigInt") = forAll { (s: Short) => s.toFloat == BigInt(s) }
+  property("Long equals BigInt") = forAll { (l: Long) => l == BigInt(l) }
+  property("BigDecimal equals BigInt") = forAll(numberString) { ns => BigDecimal(ns) == BigInt(ns) }
+  property("isValidByte") = forAll { (b: Byte) => BigInt(b).isValidByte }
+  property("isValidByte") = !BigInt(Byte.MinValue.toInt - 1).isValidByte
+  property("isValidByte") = !BigInt(Byte.MaxValue.toInt + 1).isValidByte
+  property("isValidShort") = forAll { (s: Short) => BigInt(s).isValidShort }
+  property("isValidShort") = !BigInt(Short.MinValue.toInt - 1).isValidShort
+  property("isValidShort") = !BigInt(Short.MaxValue.toInt + 1).isValidShort
+  property("isValidChar") = forAll { (c: Char) => BigInt(c).isValidChar }
+  property("isValidChar") = !BigInt(Char.MinValue.toInt - 1).isValidChar
+  property("isValidChar") = !BigInt(Char.MaxValue.toInt + 1).isValidChar
+  property("isValidInt") = forAll { (i: Int) => BigInt(i).isValidInt }
+  property("isValidInt") = !BigInt(Int.MinValue.toLong - 1).isValidInt
+  property("isValidInt") = !BigInt(Int.MaxValue.toLong + 1).isValidInt
+  property("isValidLong") = forAll { (l: Long) => BigInt(l).isValidLong }
+  property("isValidLong") = !BigInt("9223372036854775808").isValidLong
+  property("isValidLong") = !BigInt("-9223372036854775809").isValidLong
+  property("isWhole") = forAll { (bi: BigInt) => bi.isWhole: @nowarn }
+  property("underlying") = forAll(bigInteger) { bi => BigInt(bi).underlying ?= bi }
+  property("equals") = forAll(bigInteger, bigInteger) { (x, y) => (x == y) ?= (BigInt(x) equals BigInt(y)) }
+  property("compare") = forAll(bigInteger, bigInteger) { (x, y) => x.compareTo(y) ?= BigInt(x).compare(y) }
+  property("+") = forAll(bigInteger, bigInteger) { (x, y) => x.add(y) ?= (BigInt(x) + BigInt(y)).bigInteger }
+  property("-") = forAll(bigInteger, bigInteger) { (x, y) => x.subtract(y) ?= (BigInt(x) - BigInt(y)).bigInteger }
+  property("*") = forAll(bigInteger, bigInteger) { (x, y) => x.multiply(y) ?= (BigInt(x) * BigInt(y)).bigInteger }
+  property("/") = forAll(bigInteger, nonZeroBigInteger) { (x, y) => x.divide(y) ?= (BigInt(x) / BigInt(y)).bigInteger }
+  property("%") = forAll(bigInteger, nonZeroBigInteger) { (x, y) => x.remainder(y) ?= (BigInt(x) % BigInt(y)).bigInteger }
+  property("/%") = forAll(bigInteger, nonZeroBigInteger) { (x, y) =>
+    val Array(d1, r1) = x.divideAndRemainder(y)
+    val (d2, r2) = BigInt(x) /% BigInt(y)
+    (d1 ?= d2.bigInteger) && (r1 ?= r2.bigInteger)
+  }
+  property("<<") = forAll(bigInteger, shift) { (x, s) => x.shiftLeft(s) ?= (BigInt(x) << s).bigInteger }
+  property(">>") = forAll(bigInteger, shift) { (x, s) => x.shiftRight(s) ?= (BigInt(x) >> s).bigInteger }
+  property("&") = forAll(bigInteger, bigInteger) { (x, y) => x.and(y) ?= (BigInt(x) & BigInt(y)).bigInteger }
+  property("|") = forAll(bigInteger, bigInteger) { (x, y) => x.or(y) ?= (BigInt(x) | BigInt(y)).bigInteger }
+  property("^") = forAll(bigInteger, bigInteger) { (x, y) => x.xor(y) ?= (BigInt(x) ^ BigInt(y)).bigInteger }
+  property("&~") = forAll(bigInteger, bigInteger) { (x, y) => x.andNot(y) ?= (BigInt(x) &~ BigInt(y)).bigInteger }
+  property("gcd") = forAll(bigInteger, bigInteger) { (x, y) => x.gcd(y) ?= (BigInt(x) gcd BigInt(y)).bigInteger }
+  property("mod") = forAll(bigInteger, positiveBigInteger) { (x, y) => x.mod(y) ?= (BigInt(x) mod BigInt(y)).bigInteger }
+  property("min") = forAll(bigInteger, bigInteger) { (x, y) => x.min(y) ?= (BigInt(x) min BigInt(y)).bigInteger }
+  property("max") = forAll(bigInteger, bigInteger) { (x, y) => x.max(y) ?= (BigInt(x) max BigInt(y)).bigInteger }
+  property("pow") = forAll(bigInteger, smallExponent) { (x, e) => x.pow(e) ?= (BigInt(x) pow e).bigInteger }
+  property("modPow") = forAll(bigInteger, positiveBigInteger, positiveBigInteger) { (x, m, e) => x.modPow(e, m) ?= (BigInt(x).modPow(BigInt(e), BigInt(m))).bigInteger }
+  property("modPow") = forAll(relativelyPrimePositiveBigIntegers, bigInteger) { case ((x, m), e) => x.modPow(e, m) ?= (BigInt(x).modPow(BigInt(e), BigInt(m))).bigInteger }
+  property("modInteger") = forAll(relativelyPrimePositiveBigIntegers) { case (x, m) => x.modInverse(m) ?= BigInt(x).modInverse(BigInt(m)).bigInteger }
+  property("unary_-") = forAll(bigInteger) { x => x.negate ?= (-BigInt(x)).bigInteger }
+  property("abs") = forAll(bigInteger) { x => x.abs ?= BigInt(x).abs.bigInteger }
+  property("signum") = forAll(bigInteger) { x => x.signum ?= BigInt(x).signum }
+  property("sign") = forAll(bigInteger) { x => BigInt(x.signum) ?= BigInt(x).sign }
+  property("~") = forAll(bigInteger) { x => x.not ?= (~BigInt(x)).bigInteger }
+  property("testBit") = forAll(bigInteger, bitIndex) { (x, i) => x.testBit(i) ?= BigInt(x).testBit(i) }
+  property("setBit") = forAll(bigInteger, bitIndex) { (x, i) => x.setBit(i) ?= BigInt(x).setBit(i).bigInteger }
+  property("clearBit") = forAll(bigInteger, bitIndex) { (x, i) => x.clearBit(i) ?= BigInt(x).clearBit(i).bigInteger }
+  property("flipBit") = forAll(bigInteger, bitIndex) { (x, i) => x.flipBit(i) ?= BigInt(x).flipBit(i).bigInteger }
+  property("lowestSetBit") = forAll(bigInteger) { x => x.getLowestSetBit ?= BigInt(x).lowestSetBit }
+  property("bitLength") = forAll(bigInteger) { x => x.bitLength ?= BigInt(x).bitLength }
+  property("bitCount") = forAll(bigInteger) { x => x.bitCount ?= BigInt(x).bitCount }
+  property("byteValue") = forAll(bigInteger) { x => x.byteValue ?= BigInt(x).byteValue }
+  property("shortValue") = forAll(bigInteger) { x => x.shortValue ?= BigInt(x).shortValue }
+  property("charValue") = forAll(bigInteger) { x => x.intValue.toChar ?= BigInt(x).charValue }
+  property("intValue") = forAll(bigInteger) { x => x.intValue ?= BigInt(x).intValue }
+  property("longValue") = forAll(bigInteger) { x => x.longValue ?= BigInt(x).longValue }
+  property("floatValue") = forAll(bigInteger) { x => x.floatValue ?= BigInt(x).floatValue }
+  property("doubleValue") = forAll(bigInteger) { x => x.doubleValue ?= BigInt(x).doubleValue }
+  property("toString") = forAll(bigInteger) { bi => new BigInteger(BigInt(bi).toString) ?= bi }
+  property("toString(radix: Int)") = forAll(bigInt, radix) { (bi, r) => BigInt(bi.toString(r), r) ?= bi }
+  property("toByteArray") = forAll(bigInt) { bi => BigInt(bi.toByteArray) ?= bi }
+}

--- a/library/test/scala/util/CheckEither.scala
+++ b/library/test/scala/util/CheckEither.scala
@@ -1,0 +1,257 @@
+package scala.util
+
+import org.scalacheck.{Arbitrary, Properties}
+import org.scalacheck.Arbitrary.{arbitrary, arbThrowable}
+import org.scalacheck.Gen.oneOf
+import org.scalacheck.Prop.*
+import scala.util.Either.LeftProjection
+
+@annotation.nowarn("cat=deprecation")
+object CheckEitherTest extends Properties("Either") {
+  implicit class Failing[A, B](val e: Either[A, B]) {
+    def orFail = e.getOrElse(???)
+  }
+  implicit class FailingLeft[A, B](val e: LeftProjection[A, B]) {
+    def orFail = e.getOrElse(???)
+  }
+  implicit def arbitraryEither[X, Y](implicit xa: Arbitrary[X], ya: Arbitrary[Y]): Arbitrary[Either[X, Y]] =
+    Arbitrary[Either[X, Y]](oneOf(arbitrary[X].map(Left(_)), arbitrary[Y].map(Right(_))))
+
+  val prop_either1 = forAll((n: Int) => Left(n).fold(x => x, b => sys.error("fail")) == n)
+
+  val prop_either2 = forAll((n: Int) => Right(n).fold(a => sys.error("fail"), x => x) == n)
+
+  val prop_swap = forAll((e: Either[Int, Int]) => e match {
+    case Left(a) => e.swap.orFail == a
+    case Right(b) => e.swap.left.orFail == b
+  })
+
+  val prop_isLeftRight = forAll((e: Either[Int, Int]) => e.isLeft != e.isRight)
+
+  object CheckLeftProjection {
+    val prop_value = forAll((n: Int) => Left(n).left.orFail == n)
+
+    val prop_getOrElse = forAll((e: Either[Int, Int], or: Int) => e.left.getOrElse(or) == (e match {
+      case Left(a) => a
+      case Right(_) => or
+    }))
+
+    val prop_forall = forAll((e: Either[Int, Int]) =>
+      e.left.forall(_ % 2 == 0) == (e.isRight || e.left.orFail % 2 == 0))
+
+    val prop_exists = forAll((e: Either[Int, Int]) =>
+      e.left.exists(_ % 2 == 0) == (e.isLeft && e.left.orFail % 2 == 0))
+
+    val prop_flatMapLeftIdentity = forAll((e: Either[Int, Int], n: Int, s: String) => {
+      def f(x: Int) = if(x % 2 == 0) Left(s) else Right(s)
+      Left(n).left.flatMap(f(_)) == f(n)})
+
+    val prop_flatMapRightIdentity = forAll((e: Either[Int, Int]) => e.left.flatMap(Left(_)) == e)
+
+    val prop_flatMapComposition = forAll((e: Either[Int, Int]) => {
+      def f(x: Int) = if(x % 2 == 0) Left(x) else Right(x)
+      def g(x: Int) = if(x % 7 == 0) Right(x) else Left(x)
+      e.left.flatMap(f(_)).left.flatMap(g(_)) == e.left.flatMap(f(_).left.flatMap(g(_)))})
+
+    val prop_mapIdentity = forAll((e: Either[Int, Int]) => e.left.map(x => x) == e)
+
+    val prop_mapComposition = forAll((e: Either[String, Int]) => {
+      def f(s: String) = s.toLowerCase
+      def g(s: String) = s.reverse
+      e.left.map(x => f(g(x))) == e.left.map(x => g(x)).left.map(f(_))})
+
+    val prop_filterToOption = forAll((e: Either[Int, Int], x: Int) => e.left.filterToOption(_ % 2 == 0) ==
+      (if(e.isRight || e.left.orFail % 2 != 0) None else Some(e)))
+
+    val prop_seq = forAll((e: Either[Int, Int]) => e.left.toSeq == (e match {
+      case Left(a) => Seq(a)
+      case Right(_) => Seq.empty
+    }))
+
+    val prop_option = forAll((e: Either[Int, Int]) => e.left.toOption == (e match {
+      case Left(a) => Some(a)
+      case Right(_) => None
+    }))
+  }
+
+  object CheckRightProjection {
+    val prop_value = forAll((n: Int) => Right(n).orFail == n)
+
+    val prop_getOrElse = forAll((e: Either[Int, Int], or: Int) => e.getOrElse(or) == (e match {
+      case Left(_) => or
+      case Right(b) => b
+    }))
+
+    val prop_forall = forAll((e: Either[Int, Int]) =>
+      e.forall(_ % 2 == 0) == (e.isLeft || e.orFail % 2 == 0))
+
+    val prop_exists = forAll((e: Either[Int, Int]) =>
+      e.exists(_ % 2 == 0) == (e.isRight && e.orFail % 2 == 0))
+
+    val prop_flatMapLeftIdentity = forAll((e: Either[Int, Int], n: Int, s: String) => {
+      def f(x: Int) = if(x % 2 == 0) Left(s) else Right(s)
+      Right(n).flatMap(f(_)) == f(n)})
+
+    val prop_flatMapRightIdentity = forAll((e: Either[Int, Int]) => e.flatMap(Right(_)) == e)
+
+    val prop_flatMapComposition = forAll((e: Either[Int, Int]) => {
+      def f(x: Int) = if(x % 2 == 0) Left(x) else Right(x)
+      def g(x: Int) = if(x % 7 == 0) Right(x) else Left(x)
+      e.flatMap(f(_)).flatMap(g(_)) == e.flatMap(f(_).flatMap(g(_)))})
+
+    val prop_mapIdentity = forAll((e: Either[Int, Int]) => e.map(x => x) == e)
+
+    val prop_mapComposition = forAll((e: Either[Int, String]) => {
+      def f(s: String) = s.toLowerCase
+      def g(s: String) = s.reverse
+      e.map(x => f(g(x))) == e.map(x => g(x)).map(f(_))})
+
+    val prop_filterToOption = forAll((e: Either[Int, Int], x: Int) => e.right.filterToOption(_ % 2 == 0) ==
+      (if(e.isLeft || e.orFail % 2 != 0) None else Some(e)))
+
+    val prop_seq = forAll((e: Either[Int, Int]) => e.toSeq == (e match {
+      case Left(_) => Seq.empty
+      case Right(b) => Seq(b)
+    }))
+
+    val prop_option = forAll((e: Either[Int, Int]) => e.toOption == (e match {
+      case Left(_) => None
+      case Right(b) => Some(b)
+    }))
+  }
+
+  val prop_Either_left = forAll((n: Int) => Left(n).left.get == n)
+
+  val prop_Either_right = forAll((n: Int) => Right(n).orFail == n)
+
+  val prop_Either_joinLeft = forAll((e: Either[Either[Int, Int], Int]) => e match {
+    case Left(ee) => e.joinLeft == ee
+    case Right(n) => e.joinLeft == Right(n)
+  })
+
+  val prop_Either_joinRight = forAll((e: Either[Int, Either[Int, Int]]) => e match {
+    case Left(n) => e.joinRight == Left(n)
+    case Right(ee) => e.joinRight == ee
+  })
+
+  val prop_Either_reduce = forAll((e: Either[Int, Int]) =>
+    e.merge == (e match {
+      case Left(a) => a
+      case Right(a) => a
+    }))
+
+  val prop_getOrElse = forAll((e: Either[Int, Int], or: Int) => e.getOrElse(or) == (e match {
+    case Left(_) => or
+    case Right(b) => b
+  }))
+
+  val prop_orElse = forAll((e: Either[Int, Int], or: Either[Int, Int]) => e.orElse(or) == (e match {
+    case Left(_) => or
+    case Right(_) => e
+  }))
+
+  val prop_contains = forAll((e: Either[Int, Int], n: Int) =>
+    e.contains(n) == (e.isRight && e.right.get == n))
+
+  val prop_forall = forAll((e: Either[Int, Int]) =>
+    e.forall(_ % 2 == 0) == (e.isLeft || e.right.get % 2 == 0))
+
+  val prop_exists = forAll((e: Either[Int, Int]) =>
+    e.exists(_ % 2 == 0) == (e.isRight && e.right.get % 2 == 0))
+
+  val prop_flatMapLeftIdentity = forAll((e: Either[Int, Int], n: Int, s: String) => {
+    def f(x: Int) = if(x % 2 == 0) Left(s) else Right(s)
+    Right(n).flatMap(f(_)) == f(n)})
+
+  val prop_flatMapRightIdentity = forAll((e: Either[Int, Int]) => e.flatMap(Right(_)) == e)
+
+  val prop_flatMapComposition = forAll((e: Either[Int, Int]) => {
+    def f(x: Int) = if(x % 2 == 0) Left(x) else Right(x)
+    def g(x: Int) = if(x % 7 == 0) Right(x) else Left(x)
+    e.flatMap(f(_)).flatMap(g(_)) == e.flatMap(f(_).flatMap(g(_)))})
+
+  val prop_mapIdentity = forAll((e: Either[Int, Int]) => e.map(x => x) == e)
+
+  val prop_mapComposition = forAll((e: Either[Int, String]) => {
+    def f(s: String) = s.toLowerCase
+    def g(s: String) = s.reverse
+    e.map(x => f(g(x))) == e.map(x => g(x)).map(f(_))})
+
+  val prop_filterOrElse = forAll((e: Either[Int, Int], x: Int) => e.filterOrElse(_ % 2 == 0, -x) ==
+    (if(e.isLeft) e
+     else if(e.right.get % 2 == 0) e
+     else Left(-x)))
+
+  val prop_seq = forAll((e: Either[Int, Int]) => e.toSeq == (e match {
+    case Left(_)  => collection.immutable.Seq.empty
+    case Right(b) => collection.immutable.Seq(b)
+  }))
+
+  val prop_option = forAll((e: Either[Int, Int]) => e.toOption == (e match {
+    case Left(_)  => None
+    case Right(b) => Some(b)
+  }))
+
+  val prop_try = forAll((e: Either[Throwable, Int]) => e.toTry == (e match {
+    case Left(a)  => util.Failure(a)
+    case Right(b) => util.Success(b)
+  }))
+
+  /** Hard to believe I'm "fixing" a test to reflect B before A ... */
+  val prop_Either_cond = forAll((c: Boolean, a: Int, b: Int) =>
+    Either.cond(c, a, b) == (if(c) Right(a) else Left(b)))
+
+  val tests = List(
+      ("prop_either1", prop_either1),
+      ("prop_either2", prop_either2),
+      ("prop_swap", prop_swap),
+      ("prop_isLeftRight", prop_isLeftRight),
+      ("Left.prop_value", CheckLeftProjection.prop_value),
+      ("Left.prop_getOrElse", CheckLeftProjection.prop_getOrElse),
+      ("Left.prop_forall", CheckLeftProjection.prop_forall),
+      ("Left.prop_exists", CheckLeftProjection.prop_exists),
+      ("Left.prop_flatMapLeftIdentity", CheckLeftProjection.prop_flatMapLeftIdentity),
+      ("Left.prop_flatMapRightIdentity", CheckLeftProjection.prop_flatMapRightIdentity),
+      ("Left.prop_flatMapComposition", CheckLeftProjection.prop_flatMapComposition),
+      ("Left.prop_mapIdentity", CheckLeftProjection.prop_mapIdentity),
+      ("Left.prop_mapComposition", CheckLeftProjection.prop_mapComposition),
+      ("Left.prop_filterToOption", CheckLeftProjection.prop_filterToOption),
+      ("Left.prop_seq", CheckLeftProjection.prop_seq),
+      ("Left.prop_option", CheckLeftProjection.prop_option),
+      ("Right.prop_value", CheckRightProjection.prop_value),
+      ("Right.prop_getOrElse", CheckRightProjection.prop_getOrElse),
+      ("Right.prop_forall", CheckRightProjection.prop_forall),
+      ("Right.prop_exists", CheckRightProjection.prop_exists),
+      ("Right.prop_flatMapLeftIdentity", CheckRightProjection.prop_flatMapLeftIdentity),
+      ("Right.prop_flatMapRightIdentity", CheckRightProjection.prop_flatMapRightIdentity),
+      ("Right.prop_flatMapComposition", CheckRightProjection.prop_flatMapComposition),
+      ("Right.prop_mapIdentity", CheckRightProjection.prop_mapIdentity),
+      ("Right.prop_mapComposition", CheckRightProjection.prop_mapComposition),
+      ("Right.prop_filterToOption", CheckRightProjection.prop_filterToOption),
+      ("Right.prop_seq", CheckRightProjection.prop_seq),
+      ("Right.prop_option", CheckRightProjection.prop_option),
+      ("prop_Either_left", prop_Either_left),
+      ("prop_Either_right", prop_Either_right),
+      ("prop_Either_joinLeft", prop_Either_joinLeft),
+      ("prop_Either_joinRight", prop_Either_joinRight),
+      ("prop_Either_reduce", prop_Either_reduce),      
+      ("prop_getOrElse", prop_getOrElse),
+      ("prop_orElse", prop_orElse),
+      ("prop_contains", prop_contains),
+      ("prop_forall", prop_forall),
+      ("prop_exists", prop_exists),
+      ("prop_flatMapLeftIdentity", prop_flatMapLeftIdentity),
+      ("prop_flatMapRightIdentity", prop_flatMapRightIdentity),
+      ("prop_flatMapComposition", prop_flatMapComposition),
+      ("prop_mapIdentity", prop_mapIdentity),
+      ("prop_mapComposition", prop_mapComposition),
+      ("prop_filterOrElse", prop_filterOrElse),
+      ("prop_seq", prop_seq),
+      ("prop_option", prop_option),
+      ("prop_try", prop_try),
+      ("prop_Either_cond", prop_Either_cond))
+
+  for ((label, prop) <- tests) {
+    property(label) = prop
+  }
+}

--- a/library/test/scala/util/matching/Regex2460.scala
+++ b/library/test/scala/util/matching/Regex2460.scala
@@ -1,0 +1,32 @@
+package scala.util.matching
+
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Properties
+import org.scalacheck.Gen
+
+object Regex2460 extends Properties("Regex : Ticket 2460") {
+
+  val vowel = Gen.oneOf("a", "z")
+
+  val numberOfMatch = forAll(vowel) {
+    (s: String) => "\\s*([a-z])\\s*".r.findAllMatchIn((1 to 20).map(_ => s).mkString).size == 20
+  }
+
+  val numberOfGroup = forAll(vowel) {
+    (s: String) => "\\s*([a-z])\\s*([a-z])\\s*".r.findAllMatchIn((1 to 20).map(_ => s).mkString).next().groupCount == 2
+  }
+
+  val nameOfGroup = forAll(vowel) {
+    (s: String) => "(?<data>[a-z])".r.findAllMatchIn(s).next().group("data") == s
+  }
+
+  val tests = List(
+    ("numberOfMatch", numberOfMatch),
+    ("numberOfGroup", numberOfGroup),
+    ("nameOfGroup", nameOfGroup)
+  )
+
+    for {
+    (label, prop) <- tests
+  } property(label) = prop
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1144,6 +1144,7 @@ object Build {
       Test / unmanagedResourceDirectories := Seq(baseDirectory.value / "test-resources"),
       libraryDependencies ++= Seq(
         "com.github.sbt" % "junit-interface" % "0.13.3" % Test,
+        "org.scalacheck" %% "scalacheck" % "1.19.0" % Test
       ),
       // We do not want to list any dependency for the stdlib
       pomPostProcess := { (node: XmlNode) =>
@@ -1231,6 +1232,7 @@ object Build {
       Test / unmanagedResourceDirectories := Seq(baseDirectory.value / "test-resources"),
       libraryDependencies ++= Seq(
         "com.github.sbt" % "junit-interface" % "0.13.3" % Test,
+        "org.scalacheck" %% "scalacheck" % "1.19.0" % Test
       ),
       // We do not want to list any dependency for the stdlib
       pomPostProcess := { (node: XmlNode) =>


### PR DESCRIPTION
Fixes #25013

Copied straight from Scala2, with changes for explicit nulls and deprecated syntax.

Also moved things that didn't have a package to the right package

**Deliberately not ported**:
- `SanityCheck` (does not seem useful)
- Reflection-related stuff:
  - `reflect/quasiquotes/*`
  - `CheckCollections` (checks some reflection utilities despite the name)
  - `ReflectionExtractors`

## How much have you relied on LLM-based tools in this contribution?

not

## How was the solution tested?

duh
