### PR TITLE
Fix missing deprecation warning for implicit in non-accessible companion

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1095,7 +1095,7 @@ trait Implicits:
     val owner = ref.symbol.owner
     if owner.is(Module) then
       val companion = owner.sourceModule
-      if companion.isOneOf(Private | Protected) then ref.prefix match
+      ref.prefix match
         case companionRef: TermRef =>
           val pre = companionRef.prefix
           if !companion.isAccessibleFrom(pre) then

--- a/tests/warn/i25347.check
+++ b/tests/warn/i25347.check
@@ -1,4 +1,8 @@
--- Deprecation Warning: tests/warn/i25347.scala:17:18 ------------------------------------------------------------------
-17 |  def bar = O.foo(new i.C) // warn
-   |                  ^^^^^^^
-   |Usage of implicit given instance c2i defined in object C, which is not accessible here. In Scala 3.10, this implicit will no longer be found.
+-- Deprecation Warning: tests/warn/i25347.scala:30:4 -------------------------------------------------------------------
+30 |    d // warn
+   |    ^
+   |Usage of implicit given instance d2i defined in object D, which is not accessible here. In Scala 3.10, this implicit will no longer be found.
+-- Deprecation Warning: tests/warn/i25347.scala:39:4 -------------------------------------------------------------------
+39 |    e // warn
+   |    ^
+   |Usage of implicit method e2i defined in object E, which is not accessible here. In Scala 3.10, this implicit will no longer be found.

--- a/tests/warn/i25347.scala
+++ b/tests/warn/i25347.scala
@@ -1,18 +1,41 @@
 //> using options -deprecation -feature
+
+package p
+
+import scala.language.implicitConversions
+
 trait T {
   object i {
     class C
-    private object C {
-      import scala.language.implicitConversions
+    private[p] object C:
       given c2i: Conversion[C, Int] = _ => 42
-    }
   }
+  object j {
+    class D
+    private[j] object D:
+      given d2i: Conversion[D, Int] = _ => 42
+  }
+  class E
+  protected object E:
+    implicit def e2i(a: E): Int = 42
 }
 
-object O {
-  def foo(x: Int): String = "hi"
-}
-
-object P extends T {
-  def bar = O.foo(new i.C) // warn
+object Test extends T {
+  def t1: Int = {
+    val c = new i.C()
+    c // ok
+  }
+  def t2: Int = {
+    val d = new j.D()
+    d // warn
+  }
+  def t3: Int = {
+    val e = new E()
+    e // ok
+  }
+  def t4: Int = {
+    val t = new T {}
+    val e = new t.E()
+    e // warn
+  }
 }


### PR DESCRIPTION
Follow-up for https://github.com/scala/scala3/pull/25516. It turns out, `private[q]` symbols don't have the `Private` flag.

## How much have you relied on LLM-based tools in this contribution?

None
