### PR TITLE
Fix cc neg test i24309-region-orig

### DIFF
--- a/tests/neg-custom-args/captures/i24309-region-orig.check
+++ b/tests/neg-custom-args/captures/i24309-region-orig.check
@@ -1,17 +1,12 @@
--- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i24309-region-orig.scala:17:38 ---------------------------
-17 |    val x = r1.subregion[Ref^{r1.R}]: r2 => // error, limitation
-   |                                      ^
-   | Found:    (r2: Region{type R^ <: 's1}^) ->{r1, r1.R} Ref^{r1.R}
-   | Required: Region{type R^}^ ->{any} Ref^{r1.R}
+-- [E223] CaptureChecking Error: tests/neg-custom-args/captures/i24309-region-orig.scala:21:6 --------------------------
+21 |      a                     // error, limitation
+   |      ^
+   | Reference `r1.R` is not included in the allowed capture set {any}
+   | of an enclosing function literal with expected type Region{type R^}^ => Ref^{r1.R}.
    |
-   | Note that capability `r1.R` cannot flow into capture set {any}
-   | because r1.R in trait Region is not visible from any in value x.
-   |
-   | where:    ^   refers to the root capability caps.any
-   |           any is a root capability created in value x when checking argument to parameter f of method subregion
-   |
-18 |      var a: Ref^{r1.R} = r1.alloc(0)
-19 |...
-21 |      a
-   |
-   | longer explanation available when compiling with `-explain`
+   | where:    any is a root capability created in value x when checking argument to parameter f of method subregion
+-- Error: tests/neg-custom-args/captures/i24309-region-orig.scala:20:26 ------------------------------------------------
+20 |      val c: Ref^{r1.R} = b // error, limitation
+   |                          ^
+   |                          Local reach capability r2.R leaks into capture scope of an enclosing function.
+   |                          You could try to abstract the capabilities referred to by r2.R in a capset variable.

--- a/tests/neg-custom-args/captures/i24309-region-orig.scala
+++ b/tests/neg-custom-args/captures/i24309-region-orig.scala
@@ -14,9 +14,9 @@ trait Region extends SharedCapability:
 def withRegion[T](f: Region => T): T = f(new Region {})
 @main def main() =
   withRegion: r1 =>
-    val x = r1.subregion[Ref^{r1.R}]: r2 => // error, limitation
+    val x = r1.subregion[Ref^{r1.R}]: r2 =>
       var a: Ref^{r1.R} = r1.alloc(0)
       var b: Ref^{r2.R} = r2.alloc(0)
-      val c: Ref^{r1.R} = b
-      a
+      val c: Ref^{r1.R} = b // error, limitation
+      a                     // error, limitation
     0


### PR DESCRIPTION
Fix the neg test and check file that broke after merging https://github.com/scala/scala3/pull/25584


## How much have you relied on LLM-based tools in this contribution?

Nope

## How was the solution tested?

`scala3-bootstrapped/testCompilation captures`

