### PR TITLE
Fix tree type conversion in `recheckClosure`

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Recheck.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Recheck.scala
@@ -420,7 +420,12 @@ abstract class Recheck extends Phase, SymTransformer:
 
     def recheckClosure(tree: Closure, pt: Type, forceDependent: Boolean = false)(using Context): Type =
       if tree.tpt.isEmpty then
-        tree.meth.tpe.widen.toFunctionType(tree.meth.symbol.is(JavaDefined), alwaysDependent = forceDependent)
+        val mtp = tree.meth.tpe.widen
+        mtp.match
+          case mtp: MethodOrPoly if mtp.isParamDependent =>
+            // Turn the method type into a PolyFunction type when there are inter-parameter dependencies
+            defn.PolyFunctionOf(mtp)
+          case _ => mtp.toFunctionType(tree.meth.symbol.is(JavaDefined), alwaysDependent = forceDependent)
       else if defn.isByNameFunction(tree.tpt.tpe) then
         val mt @ MethodType(Nil) = tree.meth.tpe.widen: @unchecked
         val cmt = ContextualMethodType(Nil, Nil, mt.resultType)

--- a/tests/neg-custom-args/captures/i25605.check
+++ b/tests/neg-custom-args/captures/i25605.check
@@ -1,0 +1,24 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i25605.scala:4:26 ----------------------------------------
+4 |def magic(): Id[IO^] = Id([R] => (x, op) => op(x))  // error, used to crash
+  |                          ^^^^^^^^^^^^^^^^^^^^^^^
+  |            Capability `x` outlives its scope: it leaks into outer capture set 's1 which is owned by method magic.
+  |            The leakage occurred when trying to match the following types:
+  |
+  |            Found:    [R] => (x: IO^, op: IO^{x} => R) ->'s2 R
+  |            Required: [R] => (x: IO^, op: IO^'s1 => R) -> R
+  |
+  |            where:    => and ^ refer to the root capability caps.any
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i25605.scala:6:24 ----------------------------------------
+6 |def magic2(): IO^ = foo([R] => (x, op) => op(x))  // error, used to crash
+  |                        ^^^^^^^^^^^^^^^^^^^^^^^
+  |           Capability `x` outlives its scope: it leaks into outer capture set 's3 which is owned by method magic2.
+  |           The leakage occurred when trying to match the following types:
+  |
+  |           Found:    [R] => (x: IO^, op: IO^{x} => R) ->'s4 R
+  |           Required: [R] => (x: IO^, op: IO^'s3 => R) -> R
+  |
+  |           where:    => and ^ refer to the root capability caps.any
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i25605.scala
+++ b/tests/neg-custom-args/captures/i25605.scala
@@ -1,0 +1,6 @@
+import language.experimental.captureChecking
+class IO
+case class Id[X](unwrap: [R] -> (x: IO^, op: X => R) -> R)
+def magic(): Id[IO^] = Id([R] => (x, op) => op(x))  // error, used to crash
+def foo[X](f: [R] -> (x: IO^, op: X => R) -> R): X = ???
+def magic2(): IO^ = foo([R] => (x, op) => op(x))  // error, used to crash


### PR DESCRIPTION
Fixes #25605.

## How much have you relied on LLM-based tools in this contribution?

Codex helped diagnose the issue. I wrote the fix.

## How was the solution tested?

`testCompilation`

## Additional notes

The example was a crash, because we tried to turn a parameter-dependent method type to a function type, which will trigger an assertion error. The fix detects this condition and instead turn that method type into a `PolyFunction` type.
