### PR TITLE
Update migration message

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1768,8 +1768,8 @@ trait Implicits:
                           |Current result ${showResult(prevResult)} will be no longer eligible
                           |  because it is not defined before the search position.
                           |Result with new rules: ${showResult(result)}.
-                          |To opt into the new rules, compile with `-source future` or use
-                          |the `scala.language.future` language import.
+                          |To opt into the new rules, compile with `-source 3.6` (or higher) or use
+                          |the `scala.language.`3.6` language import.
                           |
                           |To fix the problem without the language import, you could try one of the following:
                           |  - use a `given ... with` clause as the enclosing given,

--- a/tests/warn/looping-givens.check
+++ b/tests/warn/looping-givens.check
@@ -5,8 +5,8 @@
   |                      Current result ab will be no longer eligible
   |                        because it is not defined before the search position.
   |                      Result with new rules: a.
-  |                      To opt into the new rules, compile with `-source future` or use
-  |                      the `scala.language.future` language import.
+  |                      To opt into the new rules, compile with `-source 3.6` (or higher) or use
+  |                      the `scala.language.`3.6` language import.
   |
   |                      To fix the problem without the language import, you could try one of the following:
   |                        - use a `given ... with` clause as the enclosing given,
@@ -20,8 +20,8 @@
    |                      Current result ab will be no longer eligible
    |                        because it is not defined before the search position.
    |                      Result with new rules: b.
-   |                      To opt into the new rules, compile with `-source future` or use
-   |                      the `scala.language.future` language import.
+   |                      To opt into the new rules, compile with `-source 3.6` (or higher) or use
+   |                      the `scala.language.`3.6` language import.
    |
    |                      To fix the problem without the language import, you could try one of the following:
    |                        - use a `given ... with` clause as the enclosing given,
@@ -35,8 +35,8 @@
    |                            Current result ab will be no longer eligible
    |                              because it is not defined before the search position.
    |                            Result with new rules: joint.
-   |                            To opt into the new rules, compile with `-source future` or use
-   |                            the `scala.language.future` language import.
+   |                            To opt into the new rules, compile with `-source 3.6` (or higher) or use
+   |                            the `scala.language.`3.6` language import.
    |
    |                            To fix the problem without the language import, you could try one of the following:
    |                              - use a `given ... with` clause as the enclosing given,


### PR DESCRIPTION
Noted during @WojciechMazur's talk: We should replace `-source future` by `source 3.6` because that's where the behavior changed.
