### PR TITLE
Drop assertion in toFunctionType

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2042,7 +2042,10 @@ object Types extends TypeUtils {
           RefinedType(nonDependentFunType, nme.apply, mt)
         else nonDependentFunType
       case poly @ PolyType(_, mt: MethodType) =>
-        assert(!mt.isParamDependent)
+        // mt can be paramDependent here since we don't need to compute a
+        // non-dependent result approximation.
+        // TODO: Move all dependent functions to PolyFunctionOf and drop the
+        // no parameter dependencies restriction everywhere.
         defn.PolyFunctionOf(poly)
     }
 

--- a/tests/neg-custom-args/captures/i25605.check
+++ b/tests/neg-custom-args/captures/i25605.check
@@ -1,0 +1,24 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i25605.scala:3:26 ----------------------------------------
+3 |def magic(): Id[IO^] = Id([R] => (x, op) => op(x))  // error
+  |                          ^^^^^^^^^^^^^^^^^^^^^^^
+  |            Capability `x` outlives its scope: it leaks into outer capture set 's1 which is owned by method magic.
+  |            The leakage occurred when trying to match the following types:
+  |
+  |            Found:    [R] => (x: IO^, op: IO^{x} => R) ->'s2 R
+  |            Required: [R] => (x: IO^, op: IO^'s1 => R) -> R
+  |
+  |            where:    => and ^ refer to the root capability caps.any
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i25605.scala:6:24 ----------------------------------------
+6 |def magic2(): IO^ = foo([R] => (x, op) => op(x)) // error
+  |                        ^^^^^^^^^^^^^^^^^^^^^^^
+  |           Capability `x` outlives its scope: it leaks into outer capture set 's3 which is owned by method magic2.
+  |           The leakage occurred when trying to match the following types:
+  |
+  |           Found:    [R] => (x: IO^, op: IO^{x} => R) ->'s4 R
+  |           Required: [R] => (x: IO^, op: IO^'s3 => R) -> R
+  |
+  |           where:    => and ^ refer to the root capability caps.any
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i25605.scala
+++ b/tests/neg-custom-args/captures/i25605.scala
@@ -1,0 +1,6 @@
+class IO
+case class Id[X](unwrap: [R] -> (x: IO^, op: X => R) -> R)
+def magic(): Id[IO^] = Id([R] => (x, op) => op(x))  // error
+
+def foo[X](f: [R] -> (x: IO^, op: X => R) -> R): X = ???
+def magic2(): IO^ = foo([R] => (x, op) => op(x)) // error


### PR DESCRIPTION
There was an assertion that method types converted to function types cannot be parameter dependent. That was needed since there is no nonDependentResult approximation for such types. But if the methid is generic, we don't need that approximation anyway, so the assertion can be dropped.

Todo: Represent all dependent function types as `PolyFunction`s, which means that the assertion can be dropped everywhere.
