### PR TITLE
improvement: Use method type if it's available

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
@@ -33,6 +33,7 @@ import dotty.tools.dotc.interactive.Completion.Mode
 import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.dotc.util.SrcPos
 import dotty.tools.pc.AutoImports.AutoImportsGenerator
+import dotty.tools.pc.IndexedContext.Result
 import dotty.tools.pc.buildinfo.BuildInfo
 import dotty.tools.pc.completions.OverrideCompletions.OverrideExtractor
 import dotty.tools.pc.utils.InteractiveEnrichments.*
@@ -121,13 +122,16 @@ class Completions(
     if completionMode.is(Mode.Member) then CompletionFuzzy.matchesSubCharacters(completionPos.query, name.toString)
     else CompletionFuzzy.matches(completionPos.query, name.toString)
 
-  def enrichedCompilerCompletions(qualType: Type): (List[CompletionValue], SymbolSearch.Result) =
+  def enrichedCompilerCompletions(
+      qualType: Type,
+      fromPath: List[Tree] = path
+  ): (List[CompletionValue], SymbolSearch.Result) =
     val compilerCompletions = Completion
       .rawCompletions(
         completionPos.originalCursorPosition,
         completionMode,
         completionPos.query,
-        path,
+        fromPath,
         adjustedPath,
         Some(fuzzyMatcher)
       )
@@ -137,6 +141,23 @@ class Completions(
       .flatMap(toCompletionValues)
       .filterInteresting(qualType)
 
+  /** When we have an erroneous apply, but we know the symbol
+   *  of the qualifier symbol, we can still provide sensible completions
+   *  for the apply.
+   */
+  def withGuessApplyType(sel: Select)(using Context): List[CompletionValue] =
+    val qual = sel.qualifier
+    val name = sel.name
+    indexedContext.lookupSym(qual.symbol) match
+      case Result.InScope =>
+        val typedSel = Select(qual.withType(qual.symbol.info.resultType), name)
+        val newPath = typedSel +: path.drop(1)
+        val (compilerCompletions, _) =
+          enrichedCompilerCompletions(qual.symbol.info.resultType, newPath)
+        compilerCompletions
+      case _ =>
+        Nil
+
   def completions(): (List[CompletionValue], SymbolSearch.Result) =
     val (advanced, exclusive) = advancedCompletions(path, completionPos)
     val (all, result) =
@@ -144,13 +165,13 @@ class Completions(
       else
         val keywords = KeywordsCompletions.contribute(path, completionPos, comments)
         val allAdvanced = advanced ++ keywords
-
         path match
           // should not show completions for toplevel
           case Nil | (_: PackageDef) :: _ if !completionPos.originalCursorPosition.source.file.ext.isScalaScript =>
             (allAdvanced, SymbolSearch.Result.COMPLETE)
-          case Select(qual, _) :: _ if qual.typeOpt.isErroneous =>
-            (allAdvanced, SymbolSearch.Result.COMPLETE)
+          case (sel @ Select(qual, name)) :: _ if qual.typeOpt.isErroneous =>
+            val fromCompiler = withGuessApplyType(sel)
+            (allAdvanced ++ fromCompiler, SymbolSearch.Result.COMPLETE)
           case Select(qual, _) :: _ =>
             val (compiler, result) = enrichedCompilerCompletions(qual.typeOpt.widenDealias)
             (allAdvanced ++ compiler, result)
@@ -163,7 +184,6 @@ class Completions(
     val sorted = all.sorted(using ordering)
     val values = application.postProcess(sorted)
     (values, result)
-  end completions
 
   private def toCompletionValues(
       completion: Name,

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionErrorSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionErrorSuite.scala
@@ -1,0 +1,52 @@
+package dotty.tools.pc.tests.completion
+
+import scala.meta.internal.pc.PresentationCompilerConfigImpl
+import scala.meta.pc.PresentationCompilerConfig
+
+import dotty.tools.pc.base.BaseCompletionSuite
+
+import org.junit.Ignore
+import org.junit.Test
+
+class CompletionErrorSuite extends BaseCompletionSuite {
+
+  @Test def method =
+    check(
+      s"""|case class Person(name: String, age: Int)
+          |
+          |object Demo {
+          |
+          |  def hello(name: String, age: Int): Person = ???
+          |
+          |  def demo() = {
+          |    val z = hello("a", "b").@@
+          |  }
+          |
+          |}
+          |""".stripMargin,
+      """|age: Int
+         |name: String
+         |""".stripMargin,
+      topLines = Option(2)
+    )
+
+  @Test def method2 =
+    check(
+      s"""|case class Person(name: String, age: Int)
+          |
+          |object Demo {
+          |
+          |  def hello(name: String, age: Int): Person = ???
+          |
+          |  def demo() = {
+          |    val z = hello("a", "b").a@@
+          |  }
+          |
+          |}
+          |""".stripMargin,
+      """|age: Int
+         |asInstanceOf[X0]: X0
+         |""".stripMargin,
+      topLines = Option(2)
+    )
+}


### PR DESCRIPTION
Even if the apply has an error, we can provide sensible completions.

Fixes https://github.com/scala/scala3/issues/25635


## How much have you relied on LLM-based tools in this contribution?

Nothing (train mode on)

## How was the solution tested?

Added tests

## Additional notes

