### PR TITLE
Remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,0 @@
-# Any changes to the Scala 3 Standard Library must be approve
-# by one of the officers responsible of maintaining it
-/library/      @scala/stdlib-officers
-/library-aux/  @scala/stdlib-officers
-/library-js/   @scala/stdlib-officers


### PR DESCRIPTION
The `CODEOWNERS` file proved valuable during the migration from Scala 3.7 to 3.8, allowing to closely monitor changes to the standard library.

Now that the migration is complete and the codebase has stabilized, it introduces more drawbacks than benefits. These include:
- Requiring double reviews in certain cases.
- Adding unnecessary pressure and notification noise for members of `@scala/stdlib-officers`.

Previous `CODEOWNERS`-related PRs:
- #23519
- #21581