### PR TITLE
Temporary disable `validate-generated-docs`

### DIFF
--- a/.github/workflows/scaladoc.yaml
+++ b/.github/workflows/scaladoc.yaml
@@ -79,6 +79,7 @@ jobs:
         run: scala-cli ./project/scripts/checkSidebarDocs.scala
 
   validate-generated-docs:
+    if: false
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
 `validate-generated-docs` CI job is currently failing on main because of this:

```
External link https://index.scala-lang.org/alexarchambault/data-class failed (status code 503)
```

https://github.com/scala/scala3/actions/runs/23796108156/job/69346158252#step:7:15467

Let's temporary disable this job, until Fabien comes back from holidays and we fix the `https://index.scala-lang.org` issue.