### PR TITLE
Revert "Remove CODEOWNERS (#25656)"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Any changes to the Scala 3 Standard Library must be approve
 # by one of the officers responsible of maintaining it
-/library/      @scala/stdlib-officers
-/library-aux/  @scala/stdlib-officers
-/library-js/   @scala/stdlib-officers
+/library/src/scala      @scala/stdlib-officers
+/library-aux/           @scala/stdlib-officers
+/library-js/            @scala/stdlib-officers


### PR DESCRIPTION
This was supposed to be part of the process for standard library changes.

There is no way unfortunately to differentiate between API and non API changes.

## How much have you relied on LLM-based tools in this contribution?

None
