### PR TITLE
Fix direct fresh capability normalization

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -469,7 +469,8 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
         case t1 @ CapturingType(parent, refs) =>
           t1.derivedCapturingType(stripImpliedCaptureSet(mapAndMaybeDealias(parent)), refs)
         case t1 =>
-          if t1.containsGlobalFreshDirectly then t1 else mappedDealias(t1)
+          val t2 = mappedDealias(t1)
+          if t1.containsGlobalFreshDirectly && (t2 eq t1) then t1 else t2
 
       /** Map references to capability classes C to C^{any}, or (if Mutable)
        *  tp C^{any.rd}. Normalize captures and map to dependent functions.

--- a/tests/neg-custom-args/captures/outer-fresh.check
+++ b/tests/neg-custom-args/captures/outer-fresh.check
@@ -1,44 +1,44 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/outer-fresh.scala:11:43 ----------------------------------
 11 |  val _: (s: String) -> (t: String) -> A = x // error
    |                                           ^
-   |Found:    (s: String) -> (t: String) -> A^{outer_fresh}
-   |Required: (s: String) -> (t: String) -> A
+   |                  Found:    (Test.x : (s: String) -> (t: String) -> A^{fresh})
+   |                  Required: (s: String) -> (t: String) -> A
    |
-   |Note that capability `fresh` cannot flow into capture set {}.
+   |                  Note that capability `fresh` cannot flow into capture set {}.
    |
-   |where:    fresh and outer_fresh refer to a root capability associated with the result type of (s: String): (t: String) -> A^{outer_fresh}
+   |                  where:    fresh is a root capability associated with the result type of (t: String): A^{fresh}
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/outer-fresh.scala:14:43 ----------------------------------
 14 |  val _: (s: String) -> (t: String) -> A = y // error
    |                                           ^
-   |Found:    (s: String) -> (t: String) -> A^{outer_fresh}
-   |Required: (s: String) -> (t: String) -> A
+   |                  Found:    (Test.y : (s: String) -> (t: String) -> A^{fresh})
+   |                  Required: (s: String) -> (t: String) -> A
    |
-   |Note that capability `fresh` cannot flow into capture set {}.
+   |                  Note that capability `fresh` cannot flow into capture set {}.
    |
-   |where:    fresh and outer_fresh refer to a root capability associated with the result type of (s: String): (t: String) -> A^{outer_fresh}
+   |                  where:    fresh is a root capability associated with the result type of (t: String): A^{fresh}
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/outer-fresh.scala:17:34 ----------------------------------
 17 |  val _: () -> (t: String) -> A = z // error
    |                                  ^
-   |Found:    () -> (t: String) -> A^{outer_fresh}
-   |Required: () -> (t: String) -> A
+   |                  Found:    (Test.z : () -> (t: String) -> A^{fresh})
+   |                  Required: () -> (t: String) -> A
    |
-   |Note that capability `fresh` cannot flow into capture set {}.
+   |                  Note that capability `fresh` cannot flow into capture set {}.
    |
-   |where:    fresh and outer_fresh refer to a root capability associated with the result type of (): (t: String) -> A^{outer_fresh}
+   |                  where:    fresh is a root capability associated with the result type of (t: String): A^{fresh}
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/outer-fresh.scala:20:34 ----------------------------------
 20 |  val _: () -> (t: String) -> A = z2 // error
    |                                  ^^
-   |Found:    () -> (t: String) -> A^{outer_fresh}
-   |Required: () -> (t: String) -> A
+   |                  Found:    (Test.z2 : () -> (t: String) -> A^{fresh})
+   |                  Required: () -> (t: String) -> A
    |
-   |Note that capability `fresh` cannot flow into capture set {}.
+   |                  Note that capability `fresh` cannot flow into capture set {}.
    |
-   |where:    fresh and outer_fresh refer to a root capability associated with the result type of (): (t: String) -> A^{outer_fresh}
+   |                  where:    fresh is a root capability associated with the result type of (t: String): A^{fresh}
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/pos-custom-args/captures/outer-fresh-min.scala
+++ b/tests/pos-custom-args/captures/outer-fresh-min.scala
@@ -1,0 +1,14 @@
+import caps.fresh
+
+class A
+
+object Test:
+
+  type F[X] = (t: String) -> X
+  type G[cs^] = (t: String) -> A^{cs}
+
+  val x: (s: String) -> F[A^{fresh}] = ???
+  val y: (s: String) -> G[{fresh}] = ???
+
+  val z: () -> F[A^{fresh}] = ???
+  val z2: () -> G[{fresh}] = ???


### PR DESCRIPTION
Fixes #25652

The bug was discovered in https://github.com/scala/scala3/pull/25612.

The core issue was that `cc.Setup` stopped too early once a type contained direct `fresh`. That prevented a needed dealiasing step in cases like:

```scala
type G[cs^] = (t: String) -> A^{cs}
val y: (s: String) -> G[{fresh}] = ???
```

The fix is small: still try `mappedDealias`, and only keep the original type if that step makes no progress.

## How much have you relied on LLM-based tools in this contribution?

Minimally, let it point to the place where the problem originated.

## How was the solution tested?

This PR also adds a minimal positive regression test for the standalone `fresh` cases, and updates the existing `outer-fresh` negative checkfile to the cleaner diagnostics produced after the fix.
