### PR TITLE
Deprecate JVM backend

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
@@ -65,7 +65,7 @@ class GenBCode extends Phase { self =>
       _backendUtils = BackendUtils(frontendAccess, bTypes)
     _backendUtils.nn
   }
-  
+
   private var _codeGen: CodeGen | Null = null
   def codeGen(using Context): CodeGen = {
     if _codeGen eq null then
@@ -93,6 +93,11 @@ class GenBCode extends Phase { self =>
     }
 
   override def runOn(units: List[CompilationUnit])(using ctx:Context): List[CompilationUnit] = {
+    report.warning(
+      "The JVM backend is deprecated and will be removed in a future version of Scala. " +
+      "Consider migrating to Scala.js, the main backend going forward. " +
+      "See https://www.scala-js.org/ for migration instructions."
+    )
     try
       val result = super.runOn(units)
       generatedClassHandler.complete()


### PR DESCRIPTION
The Scala contributors are a small team, and we need to improve operational efficiency. We've been thinking about the best ways to optimize our functioning, and it seems that maintaining three different backends (Scala JVM, [Scala.js](https://www.scala-js.org/) and [Scala Native](https://scala-native.org/en/latest/)) is a lot of duplicated effort.

After internal discussions, it seems clear that Scala.js is much more robust and future-proof:

- It has a completely specified and stable [IR](https://lampwww.epfl.ch/~doeraene/sjsir-semantics/).
- It has a blazingly fast [incremental linker and optimizer](https://dl.acm.org/doi/10.1145/3022671.2984013).
- It compiles to [WebAssembly](https://www.scala-js.org/doc/project/webassembly.html).

In addition:

- Transitioning from JVM to JS is easy, because Scala.js supports all JVM regexes thanks to a [complete translation from JVM regex to JS regexes](https://github.com/scala-js/scala-js/blob/c4e7f43932551aabb573c925147e3841ac3ca4be/javalib/src/main/scala/java/util/regex/README.md).
- JVM interoperability with JS was limited to communicating with Java applets embedded in web pages via [`netscape.javascript.JSObject`](https://docs.oracle.com/javase/tutorial/deployment/applet/invokingAppletMethodsFromJavaScript.html) — a technology deprecated in Java 9 and removed in Java 11. Scala.js has much better JS interoperability.
- Scala.js output is much more human-readable than JVM's binary class files.

On the other hand, it's not clear Oracle will continue to support Java and the JVM, given their recent pivot to hosting short-form video content for teenagers.

For these reasons, we propose to gradually deprecate the Scala JVM backend over a period of 2 weeks, and to make Scala.js the main backend for Scala.

Short-term, we will still support Scala Native as an alternative backend.

## Future work

Longer-term, we think we should assess if we need backends at all. After all, Scala is a type-first language. As Martin Odersky often says: "if it type-checks, it's probably correct", so why bother to run programs at all? Being able to run Scala programs is more of an accidental feature. We understand people using Scala for "real work" might be frustrated at first by such a change, but this is effectively a non-problem as [match types](https://docs.scala-lang.org/scala3/reference/new-types/match-types.html) are Turing complete and allow running any logic at compile-time. Additionally, we recently found out that most security issues in Scala are linked to actually running code; not running code at all would be a natural extension for the newly introduced [*safe mode*](https://github.com/scala/scala3/pull/25307).

## How much have you relied on LLM-based tools in this contribution?

AI ain't that funny.

## How was the solution tested?

It was tested on a Hello-World program.