### PR TITLE
Pat var must be isVarPattern

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1569,8 +1569,8 @@ object desugar {
           case TuplePattern(pats, _) =>
             // We want to include wildcards for the optimizations, so we can't use `IdPattern` which excludes them
             val allVariables = pats.map {
-              case id: Ident => Some(id, TypeTree())
-              case Typed(id: Ident, tpt) => Some((id, tpt))
+              case id: Ident if isVarPattern(id) => Some(id, TypeTree())
+              case Typed(id: Ident, tpt) if isVarPattern(id) => Some((id, tpt))
               case _ => None
             }.flatten
             if allVariables.size == pats.size then

--- a/tests/neg/i4935.check
+++ b/tests/neg/i4935.check
@@ -1,0 +1,40 @@
+-- [E006] Not Found Error: tests/neg/i4935.scala:2:7 -------------------------------------------------------------------
+2 |  val (A, B) = () // error // error
+  |       ^
+  |       Not found: A
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E006] Not Found Error: tests/neg/i4935.scala:2:10 ------------------------------------------------------------------
+2 |  val (A, B) = () // error // error
+  |          ^
+  |          Not found: B
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E006] Not Found Error: tests/neg/i4935.scala:3:7 -------------------------------------------------------------------
+3 |  val (`a`, `b`) = () // error // error
+  |       ^^^
+  |       Not found: a
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E006] Not Found Error: tests/neg/i4935.scala:3:12 ------------------------------------------------------------------
+3 |  val (`a`, `b`) = () // error // error
+  |            ^^^
+  |            Not found: b
+  |
+  | longer explanation available when compiling with `-explain`
+-- Warning: tests/neg/i4935.scala:2:15 ---------------------------------------------------------------------------------
+2 |  val (A, B) = () // error // error
+  |               ^^
+  |       pattern's type (Any, Any) does not match the right hand side expression's type Unit
+  |
+  |       If the narrowing is intentional, this can be communicated by adding `.runtimeChecked` after the expression,
+  |       which may result in a MatchError at runtime.
+  |       This patch can be rewritten automatically under -rewrite -source 3.8-migration.
+-- Warning: tests/neg/i4935.scala:3:19 ---------------------------------------------------------------------------------
+3 |  val (`a`, `b`) = () // error // error
+  |                   ^^
+  |       pattern's type (Any, Any) does not match the right hand side expression's type Unit
+  |
+  |       If the narrowing is intentional, this can be communicated by adding `.runtimeChecked` after the expression,
+  |       which may result in a MatchError at runtime.
+  |       This patch can be rewritten automatically under -rewrite -source 3.8-migration.

--- a/tests/neg/i4935.scala
+++ b/tests/neg/i4935.scala
@@ -1,3 +1,4 @@
 object Foo {
-  val (A, B) = () // error
+  val (A, B) = () // error // error
+  val (`a`, `b`) = () // error // error
 }

--- a/tests/pos/i25700.scala
+++ b/tests/pos/i25700.scala
@@ -1,0 +1,21 @@
+sealed trait Updater
+final class Initializer extends Updater
+final class Mutator extends Updater
+
+final class IArray[+A]
+val Empty = new IArray[Nothing]
+
+def partitionCollect2[A, A1, A2](
+    as: IArray[A],
+    t1: PartialFunction[A, A1],
+    t2: PartialFunction[A, A2],
+): (IArray[A1], IArray[A2], IArray[A]) =
+  ???
+
+def test(updaters: IArray[Updater]) =
+  val (mutators: IArray[Mutator], initializers: IArray[Initializer], Empty) =
+    partitionCollect2(
+      updaters,
+      { case x: Mutator     => x },
+      { case x: Initializer => x },
+    )


### PR DESCRIPTION
Fixes #25700 

## How much have you relied on LLM-based tools in this contribution?

But can one _rely_ on LLM-based tools?

## How was the solution tested?

Apparently, there was not a test for val def with stable identifier pattern. The ticket minimization supplies it. Edit: a previous test was erroring incorrectly but flew under the radar. Its correct error is restored.

## Additional notes

Follow-up to https://github.com/scala/scala3/pull/25566 that tweaked https://github.com/scala/scala3/pull/24972.

Obviously, a pattern variable must be `isVarPattern`, but the degrees of freedom are lowercase, underscore, and backquoted.

The code comment, that "royal we" want wildcards, suggests our bases are not covered. `IdPattern` is for parsing and would not be useful here. But how do I ask whether I'm looking at a patvar? There is an attachment. Are we too early or late for it?

"One does not simply ask if an identifier is a pattern variable."
