### PR TITLE
Skip doc generation for nonbootstrapped projects

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1127,6 +1127,7 @@ object Build {
       ),
       // Packaging configuration of the stdlib
       Compile / publishArtifact := true,
+      Compile / packageDoc / publishArtifact := false,
       Test    / publishArtifact := false,
       // Project specific target folder. sbt doesn't like having two projects using the same target folder
       target := target.value / "scala-library-nonbootstrapped",
@@ -1176,6 +1177,7 @@ object Build {
       emptyPublishedJarSettings,  // Validate JAR is empty (only META-INF)
       // Packaging configuration of the stdlib
       Compile / publishArtifact := true,
+      Compile / packageDoc / publishArtifact := false,
       Test    / publishArtifact := false,
       // Project specific target folder. sbt doesn't like having two projects using the same target folder
       target := target.value / "scala3-library-nonbootstrapped",


### PR DESCRIPTION
fix https://github.com/scala/scala3/issues/25704

Previously, running `sbt publishLocal` causes scaladoc generation for `scala-library-nonbootstrapped` and `scala3-library-nonbootstrapped`.

These two projects don't explicitly set `Compile / packageDoc / publishArtifact := false`, and therefore sbt defaults to generate doc jars on `publishLocal`.

However, IIUC, there's no point of generating scaladoc for nonbootstrapped projects because these artifacts are only published locally for bootstrapping (and local development), and the bootstrapped projects reference packageBin outputs and don't care about packageDoc. In fact, other nonbootstrapped projects like `scala3-compiler-nonbootstrapped` and `tasty-core-nonbootstrapped` already set `packageDoc / publishArtifact := false`.

In my local environemnt, clean build with `publishLocal`, previously took 230s, and not it took around 90s.

<!-- Fixes #XYZ (where XYZ is the issue number from the issue tracker) -->

<!-- TODO description of the change -->
<!-- Ideally should have a title like "Fix #XYZ: Short fix description" -->

<!--
  TODO first sign the CLA
  https://contribute.akka.io/cla/scala
-->

<!-- if the PR is still a WIP, create it as a draft PR (or convert it into one) -->

## How much have you relied on LLM-based tools in this contribution?

not used

<!-- 
  State clearly in the pull request description, 
  whether LLM-based tools were used and to what extent 

  (extensively/moderately/minimally/not at all)
-->

<!--
  Refer to our [LLM usage policy](https://github.com/scala/scala3/blob/main/LLM_POLICY.md) for rules and guidelines
  regarding usage of LLM-based tools in contributions.
-->

## How was the solution tested?

Run `sbt publishLocal` locally. I'd like to confirm my assumption that disable doc publishing for nonbootstrapped project is safe.

<!-- 
  If automated tests are included, mention it.
  If they are not, explain why and how the solution was tested.
-->

## Additional notes

<!-- Placeholder for any extra context regarding this contribution. -->

<!--
  When in doubt, and for support regarding contributions to a particular component of the compiler, 
  refer to [our contribution guide](https://github.com/scala/scala3/blob/main/CONTRIBUTING.md),
  and feel free to tag the maintainers listed there for the area(s) you are modifying.
-->
