### PR TITLE
Fix main build: use vcBoxing instead of unboxedVCs

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -266,7 +266,7 @@ object GenericSignatures {
       val tp = tp0.dealias
       tp match {
         case RefinedType(parent, _, _) =>
-          jsig(parent, toplevel = toplevel, unboxedVCs = unboxedVCs)
+          jsig(parent, toplevel = toplevel, vcBoxing = vcBoxing)
 
         case ref @ TypeParamRef(_: PolyType, _) =>
           val erasedUnderlying = fullErasure(ref.underlying.bounds.hi)


### PR DESCRIPTION
We introduced a new flags for vc boxing/unboxing in https://github.com/scala/scala3/pull/25631
that renames `unboxedVCs` to `vcBoxing`.

While, we added new `unboxedVCs` usage in
https://github.com/scala/scala3/pull/25626
that conflict with the former commit.

This commit fixes the conflict by using `unboxedVCs`.

<!-- Fixes #XYZ (where XYZ is the issue number from the issue tracker) -->

<!-- TODO description of the change -->
<!-- Ideally should have a title like "Fix #XYZ: Short fix description" -->

<!--
  TODO first sign the CLA
  https://contribute.akka.io/cla/scala
-->

<!-- if the PR is still a WIP, create it as a draft PR (or convert it into one) -->

## How much have you relied on LLM-based tools in this contribution?

not

<!-- 
  State clearly in the pull request description, 
  whether LLM-based tools were used and to what extent 

  (extensively/moderately/minimally/not at all)
-->

<!--
  Refer to our [LLM usage policy](https://github.com/scala/scala3/blob/main/LLM_POLICY.md) for rules and guidelines
  regarding usage of LLM-based tools in contributions.
-->

## How was the solution tested?

test `testCompilation` runs

<!-- 
  If automated tests are included, mention it.
  If they are not, explain why and how the solution was tested.
-->

## Additional notes

<!-- Placeholder for any extra context regarding this contribution. -->

<!--
  When in doubt, and for support regarding contributions to a particular component of the compiler, 
  refer to [our contribution guide](https://github.com/scala/scala3/blob/main/CONTRIBUTING.md),
  and feel free to tag the maintainers listed there for the area(s) you are modifying.
-->
