### PR TITLE
Fix warning about `-Xcheck-macros`

### DIFF
--- a/docs/_docs/reference/metaprogramming/macros.md
+++ b/docs/_docs/reference/metaprogramming/macros.md
@@ -4,7 +4,7 @@ title: "Macros"
 nightlyOf: https://docs.scala-lang.org/scala3/reference/metaprogramming/macros.html
 ---
 
-> When developing macros enable `-Xcheck-macros` scalac option flag to have extra runtime checks.
+> When developing macros, enable the `-Xcheck-macros` compiler option to run extra safety checks.
 
 ## Multi-Staging
 

--- a/docs/_docs/reference/metaprogramming/macros.md
+++ b/docs/_docs/reference/metaprogramming/macros.md
@@ -4,7 +4,7 @@ title: "Macros"
 nightlyOf: https://docs.scala-lang.org/scala3/reference/metaprogramming/macros.html
 ---
 
-> **Warning:** Always enable `-Xcheck-macros` when developing macros. Without it, the compiler will not validate generated code, which may be unsound and lead to undefined behavior.
+> When developing macros enable `-Xcheck-macros` scalac option flag to have extra runtime checks.
 
 ## Multi-Staging
 

--- a/docs/_spec/TODOreference/metaprogramming/macros.md
+++ b/docs/_spec/TODOreference/metaprogramming/macros.md
@@ -4,7 +4,7 @@ title: "Macros"
 nightlyOf: https://docs.scala-lang.org/scala3/reference/metaprogramming/macros.html
 ---
 
-> When developing macros enable `-Xcheck-macros` scalac option flag to have extra runtime checks.
+> When developing macros, enable the `-Xcheck-macros` compiler option to run extra safety checks.
 
 ## Multi-Staging
 

--- a/docs/_spec/TODOreference/metaprogramming/macros.md
+++ b/docs/_spec/TODOreference/metaprogramming/macros.md
@@ -4,7 +4,7 @@ title: "Macros"
 nightlyOf: https://docs.scala-lang.org/scala3/reference/metaprogramming/macros.html
 ---
 
-> **Warning:** Always enable `-Xcheck-macros` when developing macros. Without it, the compiler will not validate generated code, which may be unsound and lead to undefined behavior.
+> When developing macros enable `-Xcheck-macros` scalac option flag to have extra runtime checks.
 
 ## Multi-Staging
 


### PR DESCRIPTION
Discussing with @bishabosha and further investigating, I realized the warning I introduced yesterday in #25750 is wrong.

Code generated by macros is actually checked, even without `-Xcheck-macros`, here:

https://github.com/scala/scala3/blob/20fc4c757617742af469c925d48beaf888f7ebfe/compiler/src/dotty/tools/dotc/inlines/Inliner.scala#L966-L967

The errors I am missing are due to these checks being run without an expected type, which I'll try to address separately (#25756).

This PR reverts #25750, but still rephrase to avoid saying these are _runtime_ checks.