### PR TITLE
Ignore Scala.js IR `using` warnings

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1614,6 +1614,9 @@ object Build {
       transitiveClassifiers := Seq("sources"),
       libraryDependencies +=
         ("org.scala-js" %% "scalajs-ir" % scalaJSVersion % "sourcedeps").cross(CrossVersion.for3Use2_13),
+      // Silence `using` clause warnings in the scalajs-ir sources
+      Compile / compile / scalacOptions +=
+        "-Wconf:src=scalajs-ir-src/.*&msg=Implicit parameters should be provided with a `using` clause:s",
       Compile / sourceGenerators += Def.task {
         val s = streams.value
         val cacheDir = s.cacheDirectory
@@ -1732,6 +1735,9 @@ object Build {
       transitiveClassifiers := Seq("sources"),
       libraryDependencies +=
         ("org.scala-js" %% "scalajs-ir" % scalaJSVersion % "sourcedeps").cross(CrossVersion.for3Use2_13),
+      // Silence `using` clause warnings in the scalajs-ir sources
+      Compile / compile / scalacOptions +=
+        "-Wconf:src=scalajs-ir-src/.*&msg=Implicit parameters should be provided with a `using` clause:s",
       Compile / sourceGenerators += Def.task {
         val s = streams.value
         val cacheDir = s.cacheDirectory


### PR DESCRIPTION
Avoids the following warnings:

```
[info] Unpacking scala-library binaries to persistent directory: /localhome/bovel/scala3/library/target/scala-library-nonbootstrapped/streams/_global/manipulateBytecode/_global/streams/scala2-library-2.13.18.jar
[info] compiling 8 Scala sources to /localhome/bovel/scala3/tasty/target/tasty-core-nonbootstrapped/scala-3.8.4-RC1/classes ...
[info] compiling 606 Scala sources and 7 Java sources to /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/classes ...
[warn] -- Warning: /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/src_managed/main/scalajs-ir-src/org/scalajs/ir/Hashers.scala:44:52 
[warn] 44 |          methodDef.optimizerHints, hash)(methodDef.pos)
[warn]    |                                          ^^^^^^^^^^^^^tal 14s
[warn]    |Implicit parameters should be provided with a `using` clause.
[warn]    |This code can be rewritten automatically under -rewrite -source 3.7-migration.
[warn]    |To disable the warning, please use the following option:
[warn]    |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
[warn] -- Warning: /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/src_managed/main/scalajs-ir-src/org/scalajs/ir/Hashers.scala:66:48 
[warn] 66 |          ctorDef.optimizerHints, hash)(ctorDef.pos)
[warn]    |                                        ^^^^^^^^^^^
[warn]    |Implicit parameters should be provided with a `using` clause.
[warn]    |This code can be rewritten automatically under -rewrite -source 3.7-migration.
[warn]    |To disable the warning, please use the following option:
[warn]    |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
[warn] -- Warning: /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/src_managed/main/scalajs-ir-src/org/scalajs/ir/Hashers.scala:88:52 
[warn] 88 |          methodDef.optimizerHints, hash)(methodDef.pos)
[warn]    |                                          ^^^^^^^^^^^^^
[warn]    |Implicit parameters should be provided with a `using` clause.
[warn]    |This code can be rewritten automatically under -rewrite -source 3.7-migration.
[warn]    |To disable the warning, please use the following option:
[warn]    |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
[warn] -- Warning: /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/src_managed/main/scalajs-ir-src/org/scalajs/ir/Hashers.scala:110:77 
[warn] 110 |      JSPropertyDef(flags, name, getterBody, setterArgAndBody)(hash)(propDef.pos)
[warn]     |                                                                     ^^^^^^^^^^^
[warn]     |Implicit parameters should be provided with a `using` clause.
[warn]     |This code can be rewritten automatically under -rewrite -source 3.7-migration.
[warn]     |To disable the warning, please use the following option:
[warn]     |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
[warn] -- Warning: /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/src_managed/main/scalajs-ir-src/org/scalajs/ir/Hashers.scala:116:72 
[warn] 116 |      TopLevelMethodExportDef(moduleID, hashJSMethodDef(methodDef))(tle.pos)
[warn]     |                                                                    ^^^^^^^
[warn]     |Implicit parameters should be provided with a `using` clause.
[warn]     |This code can be rewritten automatically under -rewrite -source 3.7-migration.
[warn]     |To disable the warning, please use the following option:
[warn]     |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
[warn] -- Warning: /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/src_managed/main/scalajs-ir-src/org/scalajs/ir/Serializers.scala:1646:50 
[warn] 1646 |                      body, captureValues)(funArg.pos)
[warn]      |                                           ^^^^^^^^^^
[warn]      |Implicit parameters should be provided with a `using` clause.
[warn]      |This code can be rewritten automatically under -rewrite -source 3.7-migration.
[warn]      |To disable the warning, please use the following option:
[warn]      |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
[warn] -- Warning: /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/src_managed/main/scalajs-ir-src/org/scalajs/ir/Serializers.scala:1653:95 
[warn] 1653 |              NewLambda(HackNames.anonFunctionDescriptors(arity), typedClosure)(tree.tpe)(tree.pos)
[warn]      |                                                                                          ^^^^^^^^
[warn]      |Implicit parameters should be provided with a `using` clause.
[warn]      |This code can be rewritten automatically under -rewrite -source 3.7-migration.
[warn]      |To disable the warning, please use the following option:
[warn]      |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
[warn] -- Warning: /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/src_managed/main/scalajs-ir-src/org/scalajs/ir/Serializers.scala:1660:90 
[warn] 1660 |                  val newParam = oldParam.copy(ptpe = HackNames.ObjectArrayType)(oldParam.pos)
[warn]      |                                                                                 ^^^^^^^^^^^^
[warn]      |Implicit parameters should be provided with a `using` clause.
[warn]      |This code can be rewritten automatically under -rewrite -source 3.7-migration.
[warn]      |To disable the warning, please use the following option:
[warn]      |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
[warn] -- Warning: /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/src_managed/main/scalajs-ir-src/org/scalajs/ir/Serializers.scala:1663:96 
[warn] 1663 |                      case tree @ VarRef(newParam.name.name) => tree.copy()(newParam.ptpe)(tree.pos)
[warn]      |                                                                                           ^^^^^^^^
[warn]      |Implicit parameters should be provided with a `using` clause.
[warn]      |This code can be rewritten automatically under -rewrite -source 3.7-migration.
[warn]      |To disable the warning, please use the following option:
[warn]      |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
[warn] -- Warning: /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/src_managed/main/scalajs-ir-src/org/scalajs/ir/Serializers.scala:1668:53 
[warn] 1668 |                      newBody, captureValues)(funArg.pos)
[warn]      |                                              ^^^^^^^^^^
[warn]      |Implicit parameters should be provided with a `using` clause.
[warn]      |This code can be rewritten automatically under -rewrite -source 3.7-migration.
[warn]      |To disable the warning, please use the following option:
[warn]      |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
[warn] -- Warning: /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/src_managed/main/scalajs-ir-src/org/scalajs/ir/Serializers.scala:1675:90 
[warn] 1675 |              NewLambda(HackNames.anonFunctionXXLDescriptor, typedClosure)(tree.tpe)(tree.pos)
[warn]      |                                                                                     ^^^^^^^^
[warn]      |Implicit parameters should be provided with a `using` clause.
[warn]      |This code can be rewritten automatically under -rewrite -source 3.7-migration.
[warn]      |To disable the warning, please use the following option:
[warn]      |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
[warn] -- Warning: /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/src_managed/main/scalajs-ir-src/org/scalajs/ir/Serializers.scala:1806:70 
[warn] 1806 |          val newName = MethodIdent(NoArgConstructorName)(method.name.pos)
[warn]      |                                                          ^^^^^^^^^^^^^^^
[warn]      |Implicit parameters should be provided with a `using` clause.
[warn]      |This code can be rewritten automatically under -rewrite -source 3.7-migration.
[warn]      |To disable the warning, please use the following option:
[warn]      |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
[warn] -- Warning: /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/src_managed/main/scalajs-ir-src/org/scalajs/ir/Serializers.scala:2059:87 
[warn] 2059 |              val newBody = JSConstructorBody(beforeSuper, superCall, afterSuper)(body.pos)
[warn]      |                                                                                  ^^^^^^^^
[warn]      |Implicit parameters should be provided with a `using` clause.
[warn]      |This code can be rewritten automatically under -rewrite -source 3.7-migration.
[warn]      |To disable the warning, please use the following option:
[warn]      |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
[warn] -- Warning: /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/src_managed/main/scalajs-ir-src/org/scalajs/ir/Serializers.scala:2061:67 
[warn] 2061 |                  methodDef.optimizerHints, Unversioned)(methodDef.pos)
[warn]      |                                                         ^^^^^^^^^^^^^
[warn]      |Implicit parameters should be provided with a `using` clause.
[warn]      |This code can be rewritten automatically under -rewrite -source 3.7-migration.
[warn]      |To disable the warning, please use the following option:
[warn]      |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
[warn] -- Warning: /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/src_managed/main/scalajs-ir-src/org/scalajs/ir/Serializers.scala:2158:32 
[warn] 2158 |        )(OptimizerHints.empty)(pos) // throws away the `@inline`
[warn]      |                                ^^^
[warn]      |Implicit parameters should be provided with a `using` clause.
[warn]      |This code can be rewritten automatically under -rewrite -source 3.7-migration.
[warn]      |To disable the warning, please use the following option:
[warn]      |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
[warn] -- Warning: /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/src_managed/main/scalajs-ir-src/org/scalajs/ir/Serializers.scala:2205:51 
[warn] 2205 |          MethodIdent(StaticInitializerName)(name0.pos)
[warn]      |                                             ^^^^^^^^^
[warn]      |Implicit parameters should be provided with a `using` clause.
[warn]      |This code can be rewritten automatically under -rewrite -source 3.7-migration.
[warn]      |To disable the warning, please use the following option:
[warn]      |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
[warn] -- Warning: /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/src_managed/main/scalajs-ir-src/org/scalajs/ir/Serializers.scala:2289:71 
[warn] 2289 |      val body = JSConstructorBody(beforeSuper, superCall, afterSuper)(bodyPos)
[warn]      |                                                                       ^^^^^^^
[warn]      |Implicit parameters should be provided with a `using` clause.
[warn]      |This code can be rewritten automatically under -rewrite -source 3.7-migration.
[warn]      |To disable the warning, please use the following option:
[warn]      |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
[warn] -- Warning: /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/src_managed/main/scalajs-ir-src/org/scalajs/ir/Serializers.scala:2299:51 
[warn] 2299 |          case _                  => StoreModule()(superCallPos) :: afterSuper0
[warn]      |                                                   ^^^^^^^^^^^^
[warn]      |Implicit parameters should be provided with a `using` clause.
[warn]      |This code can be rewritten automatically under -rewrite -source 3.7-migration.
[warn]      |To disable the warning, please use the following option:
[warn]      |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
[warn] -- Warning: /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/src_managed/main/scalajs-ir-src/org/scalajs/ir/Transformers.scala:226:36 
[warn] 226 |          tree.optimizerHints)(tree.pos)
[warn]     |                               ^^^^^^^^
[warn]     |Implicit parameters should be provided with a `using` clause.
[warn]     |This code can be rewritten automatically under -rewrite -source 3.7-migration.
[warn]     |To disable the warning, please use the following option:
[warn]     |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
[warn] -- Warning: /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/src_managed/main/scalajs-ir-src/org/scalajs/ir/Transformers.scala:236:59 
[warn] 236 |          methodDef.optimizerHints, Unversioned)(methodDef.pos)
[warn]     |                                                 ^^^^^^^^^^^^^
[warn]     |Implicit parameters should be provided with a `using` clause.
[warn]     |This code can be rewritten automatically under -rewrite -source 3.7-migration.
[warn]     |To disable the warning, please use the following option:
[warn]     |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
[warn] -- Warning: /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/src_managed/main/scalajs-ir-src/org/scalajs/ir/Transformers.scala:242:67 
[warn] 242 |          jsConstructor.optimizerHints, Unversioned)(jsConstructor.pos)
[warn]     |                                                     ^^^^^^^^^^^^^^^^^
[warn]     |Implicit parameters should be provided with a `using` clause.
[warn]     |This code can be rewritten automatically under -rewrite -source 3.7-migration.
[warn]     |To disable the warning, please use the following option:
[warn]     |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
[warn] -- Warning: /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/src_managed/main/scalajs-ir-src/org/scalajs/ir/Transformers.scala:258:63 
[warn] 258 |          jsMethodDef.optimizerHints, Unversioned)(jsMethodDef.pos)
[warn]     |                                                   ^^^^^^^^^^^^^^^
[warn]     |Implicit parameters should be provided with a `using` clause.
[warn]     |This code can be rewritten automatically under -rewrite -source 3.7-migration.
[warn]     |To disable the warning, please use the following option:
[warn]     |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
[warn] -- Warning: /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/src_managed/main/scalajs-ir-src/org/scalajs/ir/Transformers.scala:270:35 
[warn] 270 |      )(Unversioned)(jsPropertyDef.pos)
[warn]     |                     ^^^^^^^^^^^^^^^^^
[warn]     |Implicit parameters should be provided with a `using` clause.
[warn]     |This code can be rewritten automatically under -rewrite -source 3.7-migration.
[warn]     |To disable the warning, please use the following option:
[warn]     |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
[warn] -- Warning: /localhome/bovel/scala3/compiler/target/scala3-compiler-nonbootstrapped/scala-3.8.4-RC1/src_managed/main/scalajs-ir-src/org/scalajs/ir/Transformers.scala:308:48 
[warn] 308 |            transformTrees(captureValues))(tree.pos)
[warn]     |                                           ^^^^^^^^
[warn]     |Implicit parameters should be provided with a `using` clause.
[warn]     |This code can be rewritten automatically under -rewrite -source 3.7-migration.
[warn]     |To disable the warning, please use the following option:
[warn]     |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
```