### PR TITLE
Reject News with unsupported Java classes

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/SafeRefs.scala
+++ b/compiler/src/dotty/tools/dotc/cc/SafeRefs.scala
@@ -15,6 +15,7 @@ import SymDenotations.*
 import Flags.*
 import Types.*
 import config.Feature
+import config.Printers.capt
 import typer.ProtoTypes.SelectionProto
 
 /** Check whether references from safe mode should be allowed */
@@ -69,15 +70,9 @@ object SafeRefs {
     assumeSafe("java.lang.String")
     assumeSafe("java.lang.Throwable")
     assumeSafe("java.lang.Void")
-    assumeSafe("java.util.Locale")
-    assumeSafe("java.util.Random")
-    assumeSafe("java.util.UUID")
-    assumeSafe("java.util.Objects")
-    assumeSafe("java.util.Optional")
-    assumeSafe("java.util.OptionalInt")
-    assumeSafe("java.util.OptionalLong")
-    assumeSafe("java.util.OptionalDouble")
-    assumeSafe("java.util.TimeZone")
+    assumeSafe("java.lang.Exception")
+    assumeSafe("java.lang.CharSequence")
+    assumeSafe("java.lang.Comparable")
     assumeSafe("java.lang.Class", except = List(
       "accessFlags", "asSubclass", "cast", "describeConstable",
       "descriptorString", "desiredAssertionStatus", "forName", "forPrimitiveName", "getAnnotatedInterfaces",
@@ -90,6 +85,15 @@ object SafeRefs {
       "getPackage", "getPackageName", "getPermittedSubclasses", "getProtectionDomain", "getRecordComponents",
       "getResource", "getResourceAsStream", "getSigners", "getTypeParameters", "getTypeName",
       "newInstance", "cast", "toGenericString"))
+    assumeSafe("java.util.Locale")
+    assumeSafe("java.util.Random")
+    assumeSafe("java.util.UUID")
+    assumeSafe("java.util.Objects")
+    assumeSafe("java.util.Optional")
+    assumeSafe("java.util.OptionalInt")
+    assumeSafe("java.util.OptionalLong")
+    assumeSafe("java.util.OptionalDouble")
+    assumeSafe("java.util.TimeZone")
     rejectSafe("scala.Console")
     rejectSafe("scala.unchecked")
     rejectSafe("scala.annotation.unchecked.uncheckedOverride")
@@ -151,7 +155,7 @@ object SafeRefs {
 
     val (sym, checkLater) = tree match
       case tree: New =>
-        (tree.tpt.symbol, false)
+        (tree.tpt.tpe.classSymbol, false)
       case tree: RefTree =>
         val checkLater =
           !tree.symbol.is(Method)
@@ -171,6 +175,8 @@ object SafeRefs {
         && !isSafe(sym)
     then
       fail(sym, "it is neither compiled in safe mode nor tagged with @assumedSafe", tree.srcPos)
+    else
+      capt.println(i"checked safe $tree, $sym, $checkLater")
   }
 
   private def checkSafeAnnot(ann: Annotation, pos: SrcPos)(using Context): Unit =

--- a/tests/neg-custom-args/captures/i25759.check
+++ b/tests/neg-custom-args/captures/i25759.check
@@ -1,0 +1,16 @@
+-- Error: tests/neg-custom-args/captures/i25759.scala:4:14 -------------------------------------------------------------
+4 |  val q = new java.util.concurrent.ConcurrentLinkedQueue[String]() // error
+  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |Cannot refer to class ConcurrentLinkedQueue in package java.util.concurrent from safe code since it is neither compiled in safe mode nor tagged with @assumedSafe
+-- Error: tests/neg-custom-args/captures/i25759.scala:9:15 -------------------------------------------------------------
+9 |  val xs = new java.util.ArrayList[String]()  // error
+  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |Cannot refer to class ArrayList in package java.util from safe code since it is neither compiled in safe mode nor tagged with @assumedSafe
+-- Error: tests/neg-custom-args/captures/i25759.scala:14:14 ------------------------------------------------------------
+14 |  val m = new java.util.HashMap[String, String]() // error
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |Cannot refer to class HashMap in package java.util from safe code since it is neither compiled in safe mode nor tagged with @assumedSafe
+-- Error: tests/neg-custom-args/captures/i25759.scala:19:15 ------------------------------------------------------------
+19 |  val dq = new java.util.ArrayDeque[String]() // error
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |Cannot refer to class ArrayDeque in package java.util from safe code since it is neither compiled in safe mode nor tagged with @assumedSafe

--- a/tests/neg-custom-args/captures/i25759.scala
+++ b/tests/neg-custom-args/captures/i25759.scala
@@ -1,0 +1,21 @@
+import language.experimental.safe
+def assertPure(op: () -> Unit): Unit = ()
+def testQueue(): Unit =
+  val q = new java.util.concurrent.ConcurrentLinkedQueue[String]() // error
+  assertPure: () =>
+    q.add("secret")
+
+def testArrayList(): Unit =
+  val xs = new java.util.ArrayList[String]()  // error
+  assertPure: () =>
+    xs.add("secret")
+
+def testHashMap(): Unit =
+  val m = new java.util.HashMap[String, String]() // error
+  assertPure: () =>
+    m.put("leak", "secret")
+
+def testArrayDeque(): Unit =
+  val dq = new java.util.ArrayDeque[String]() // error
+  assertPure: () =>
+    dq.addLast("secret")


### PR DESCRIPTION
This slipped through before since the `New` tree of a Java class did not have a symbol.

Fixes #25759

