### PR TITLE
Simplify stdlib.yaml by removing compile-only jobs

### DIFF
--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -12,29 +12,11 @@ permissions:
 
 env:
   DOTTY_CI_RUN: true
-  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
-  scala-library-nonbootstrapped:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-
-      - uses: sbt/setup-sbt@v1
-      - name: Compile `scala-library-nonbootstrapped`
-        run: ./project/scripts/sbt scala-library-nonbootstrapped/compile
 
   test-scala-library-nonbootstrapped:
     name: Non-Bootstrapped Library Unit Tests
-    needs: scala-library-nonbootstrapped
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -46,114 +28,8 @@ jobs:
       - uses: sbt/setup-sbt@v1
       - run: ./project/scripts/sbt scala-library-nonbootstrapped/test
 
-  scala3-library-nonbootstrapped:
-    runs-on: ubuntu-latest
-    needs: [scala-library-nonbootstrapped]
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-
-      - uses: sbt/setup-sbt@v1
-      - name: Compile `scala3-library-nonbootstrapped`
-        run: ./project/scripts/sbt scala3-library-nonbootstrapped/compile
-
-  scala3-interfaces:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-
-      - uses: sbt/setup-sbt@v1
-      - name: Compile `scala3-interfaces`
-        run: ./project/scripts/sbt scala3-interfaces/compile
-
-  tasty-core-nonbootstrapped:
-    runs-on: ubuntu-latest
-    needs: [scala3-library-nonbootstrapped]
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-      - name: Compile `tasty-core-nonbootstrapped`
-        run: ./project/scripts/sbt tasty-core-nonbootstrapped/compile
-
-  scala3-compiler-nonbootstrapped:
-    runs-on: ubuntu-latest
-    needs: [tasty-core-nonbootstrapped, scala3-library-nonbootstrapped, scala3-interfaces]
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-      - name: Compile `scala3-compiler-nonbootstrapped`
-        run: ./project/scripts/sbt scala3-compiler-nonbootstrapped/compile
-
-  scala3-sbt-bridge-nonbootstrapped:
-    runs-on: ubuntu-latest
-    needs: [scala3-compiler-nonbootstrapped]
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-      - name: Compile `scala3-sbt-bridge-nonbootstrapped`
-        run: ./project/scripts/sbt scala3-sbt-bridge-nonbootstrapped/compile
-
-  scala-library-bootstrapped:
-    runs-on: ubuntu-latest
-    needs  : [scala-library-nonbootstrapped, scala3-library-nonbootstrapped, tasty-core-nonbootstrapped,
-              scala3-compiler-nonbootstrapped, scala3-sbt-bridge-nonbootstrapped]
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-
-      - uses: sbt/setup-sbt@v1
-      - name: Compile `scala-library-bootstrapped`
-        run: ./project/scripts/sbt scala-library-bootstrapped/compile
-
   test-scala-library-bootstrapped:
     name: Bootstrapped Library Unit Tests
-    needs: scala-library-bootstrapped
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -165,227 +41,12 @@ jobs:
       - uses: sbt/setup-sbt@v1
       - run: ./project/scripts/sbt scala-library-bootstrapped/test
 
-  scala3-library-bootstrapped:
-    runs-on: ubuntu-latest
-    needs: [scala-library-bootstrapped]
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-
-      - uses: sbt/setup-sbt@v1
-      - name: Compile `scala3-library-bootstrapped`
-        run: ./project/scripts/sbt scala3-library-bootstrapped/compile
-
-  tasty-core-bootstrapped:
-    runs-on: ubuntu-latest
-    needs: [scala3-library-bootstrapped]
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-      - name: Compile `tasty-core-bootstrapped`
-        run: ./project/scripts/sbt tasty-core-bootstrapped/compile
-
-  scala3-compiler-bootstrapped:
-    runs-on: ubuntu-latest
-    needs: [tasty-core-bootstrapped, scala3-library-bootstrapped, scala3-interfaces]
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-      - name: Compile `scala3-compiler-bootstrapped`
-        run: ./project/scripts/sbt scala3-compiler-bootstrapped/compile
-
-  scala3-sbt-bridge-bootstrapped:
-    runs-on: ubuntu-latest
-    needs: [scala3-compiler-bootstrapped]
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-      - name: Compile `scala3-sbt-bridge-bootstrapped`
-        run: ./project/scripts/sbt scala3-sbt-bridge-bootstrapped/compile
-
-  scala3-staging:
-    runs-on: ubuntu-latest
-    needs: [scala3-compiler-bootstrapped]
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-      - name: Compile `scala3-staging`
-        run: ./project/scripts/sbt scala3-staging/compile
-
-  scala3-tasty-inspector:
-    runs-on: ubuntu-latest
-    needs: [scala3-compiler-bootstrapped]
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-      - name: Compile `scala3-staging`
-        run: ./project/scripts/sbt scala3-staging/compile
-      - name: Compile `scala3-tasty-inspector`
-        run: ./project/scripts/sbt scala3-tasty-inspector/compile
-
-  scala-library-sjs:
-    runs-on: ubuntu-latest
-    needs: [scala-library-nonbootstrapped, scala3-library-nonbootstrapped, tasty-core-nonbootstrapped,
-            scala3-compiler-nonbootstrapped, scala3-sbt-bridge-nonbootstrapped]
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-      - name: Compile `scala3-staging`
-        run: ./project/scripts/sbt scala3-staging/compile
-      - name: Compile `scala-library` for Scala.js
-        run: ./project/scripts/sbt scala-library-sjs/compile
-
-  scala3-library-sjs:
-    runs-on: ubuntu-latest
-    needs: [scala-library-sjs]
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-      - name: Compile `scala3-staging`
-        run: ./project/scripts/sbt scala3-staging/compile
-      - name: Compile `scala3-library` for Scala.js
-        run: ./project/scripts/sbt scala3-library-sjs/compile
-
-  repl:
-    runs-on: ubuntu-latest
-    needs: [scala3-compiler-bootstrapped]
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-
-      - name: Compile REPL
-        run: ./project/scripts/sbt scala3-repl/compile
-
-  scaladoc:
-    runs-on: ubuntu-latest
-    needs: [scala3-compiler-bootstrapped, scala3-tasty-inspector]
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-
-      - name: Compile `scaladoc`
-        run: ./project/scripts/sbt scaladoc/compile
-
-  presentation-compiler:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-
-      - name: Compile `scala3-presentation-compiler`
-        run: ./project/scripts/sbt scala3-presentation-compiler/compile
-
-  language-server:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-
-      - name: Compile `scala3-language-server`
-        run: ./project/scripts/sbt scala3-language-server/compile
-
   #################################################################################################
   ########################################### MiMa JOBS ###########################################
   #################################################################################################
 
   mima-scala-library-nonbootstrapped:
     runs-on: ubuntu-latest
-    needs: scala-library-nonbootstrapped
     if: false
     steps:
       - name: Git Checkout
@@ -404,7 +65,6 @@ jobs:
 
   mima-scala3-interfaces:
     runs-on: ubuntu-latest
-    needs: scala3-interfaces
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -422,7 +82,6 @@ jobs:
 
   mima-tasty-core-nonbootstrapped:
     runs-on: ubuntu-latest
-    needs: tasty-core-nonbootstrapped
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -440,7 +99,6 @@ jobs:
 
   static-analysis-scala-library-bootstrapped:
     runs-on: ubuntu-latest
-    needs: scala-library-bootstrapped
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -461,7 +119,6 @@ jobs:
 
   mima-tasty-core-bootstrapped:
     runs-on: ubuntu-latest
-    needs: tasty-core-bootstrapped
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -479,7 +136,6 @@ jobs:
 
   mima-scala-library-sjs:
     runs-on: ubuntu-latest
-    needs: scala-library-sjs
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -501,7 +157,6 @@ jobs:
 
   test-scala3-compiler-nonbootstrapped:
     runs-on: ubuntu-latest
-    needs: [scala3-compiler-nonbootstrapped, tasty-core-nonbootstrapped, scala-library-nonbootstrapped]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -518,7 +173,6 @@ jobs:
 
   test-scala3-compiler-bootstrapped:
     runs-on: ubuntu-latest
-    needs: [scala3-compiler-bootstrapped, tasty-core-bootstrapped, scala-library-bootstrapped, scala3-staging, scala3-tasty-inspector]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -535,7 +189,6 @@ jobs:
 
   test-scala3-bootstrapped-compilation-coverage:
     runs-on: ubuntu-latest
-    needs: [scala3-compiler-bootstrapped, tasty-core-bootstrapped, scala-library-bootstrapped, scala3-staging, scala3-tasty-inspector]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -552,7 +205,6 @@ jobs:
 
   test-scala3-sbt-bridge-nonbootstrapped:
     runs-on: ubuntu-latest
-    needs: [scala3-sbt-bridge-nonbootstrapped]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -569,7 +221,6 @@ jobs:
 
   test-scala3-sbt-bridge-bootstrapped:
     runs-on: ubuntu-latest
-    needs: [scala3-sbt-bridge-bootstrapped]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -586,7 +237,6 @@ jobs:
 
   test-tasty-core-nonbootstrapped:
     runs-on: ubuntu-latest
-    needs: [tasty-core-nonbootstrapped]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -603,7 +253,6 @@ jobs:
 
   test-tasty-core-bootstrapped:
     runs-on: ubuntu-latest
-    needs: [tasty-core-bootstrapped]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -620,7 +269,6 @@ jobs:
 
   test-scala-js:
     runs-on: ubuntu-latest
-    needs: [scala3-compiler-bootstrapped, tasty-core-bootstrapped, scala3-staging, scala3-tasty-inspector, scala-library-sjs]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -649,7 +297,6 @@ jobs:
 
   test-repl:
     runs-on: ubuntu-latest
-    needs: [repl]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -666,7 +313,6 @@ jobs:
 
   test-presentation-compiler:
     runs-on: ubuntu-latest
-    needs: [presentation-compiler]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -683,7 +329,6 @@ jobs:
 
   test-language-server:
     runs-on: ubuntu-latest
-    needs: [language-server]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -700,7 +345,6 @@ jobs:
 
   scripted-tests:
     runs-on: ubuntu-latest
-    needs: [scala3-compiler-bootstrapped, tasty-core-bootstrapped, scala3-staging, scala3-tasty-inspector, scala-library-sjs, scaladoc]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -776,7 +420,6 @@ jobs:
 
   scala-library-docs:
     runs-on: ubuntu-latest
-    needs  : [scala-library-bootstrapped, scaladoc]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Current situation

The stdlib workflow was originally designed with separate compile and test jobs, hoping that Gradle remote caching (via Develocity) would allow sharing build outputs between jobs. This never materialized, so in practice every job recompiles everything from scratch, making the compile-only jobs pure overhead.

## Proposed solution

Remove all compile-only jobs and their `needs` dependencies. All test, MiMa, community build, and docs jobs now run independently, each compiling what it needs. Also remove the unused `DEVELOCITY_ACCESS_KEY` env variable.

## Alternatives considered

1. Pass `target/` directories between jobs as artifacts. However, Zinc's incremental compilation state includes absolute paths, extracted API structures, dependency graphs, and classpath identity. Restoring `target/` across jobs would be unreliable because paths might differ between runners.
2. [SBT 1.4 introduced an experimental remote cache feature](https://www.scala-sbt.org/1.x/docs/Remote-Caching.html), but it is outdated and not well-supported.
3. [SBT 2.x has a new remote caching mechanism](https://www.scala-sbt.org/2.x/docs/en/concepts/caching.html), but we are not on SBT 2 yet.

See also [Discord thread](https://discord.com/channels/632150470000902164/922600050989875282/1492191477055619182).

## How much have you relied on LLM-based tools in this contribution?

Extensively.

## How was the solution tested?

Running the CI now.
