### PR TITLE
Fix test slowdown caused by leaked child JVM processes

### DIFF
--- a/compiler/test/dotty/tools/vulpix/RunnerOrchestration.scala
+++ b/compiler/test/dotty/tools/vulpix/RunnerOrchestration.scala
@@ -215,7 +215,9 @@ trait RunnerOrchestration:
     }
 
     private def discardRunner(runner: Runner): Unit = synchronized {
+      runner.kill()
       busyRunners -= runner
+      notify()
     }
 
     private def withRunner(op: Runner => Status)(using SummaryReporting): Status =


### PR DESCRIPTION
## How much have you relied on LLM-based tools in this contribution?

**Almost Claude-only:** from investigation to fix. Claude Code identified the culprit commit by fetching CI run timings from the GitHub API, traced the root cause by reading the diffs, proposed the fix, validated it locally, and wrote this report.

## Summary

The `test-scala3-compiler-bootstrapped` CI job jumped from ~54 minutes to ~70 minutes (a ~30% increase) starting with commit `e679e6ad32` — "Restore stdio in test rig" (#24628), merged April 9, 2026.

The root cause is that `discardRunner` in `RunnerOrchestration.scala` leaks child JVM processes: it removes runners from tracking sets without killing the underlying process. Zombie processes from `VulpixUnitTests` (intentional infinite loops, deadlocks, long sleeps) then consume CPU and memory for the rest of the CI run.

## Timeline

| Date       | Commit       | Duration  | Status  |
|------------|--------------|-----------|---------|
| 2026-04-02 | `6c411a6ea6` | 53.3 min  | success |
| 2026-04-02 | `5ad705f658` | 53.1 min  | success |
| 2026-04-02 | `a16b497ced` | 53.7 min  | success |
| 2026-04-02 | `c39a78e9df` | 55.2 min  | success |
| 2026-04-02 | `ecf8e5c772` | 54.0 min  | success |
| 2026-04-03 | `268821150e` | 54.0 min  | failure |
| 2026-04-03 | `68d439f5c9` | 54.0 min  | success |
| 2026-04-03 | `a7f6cae5f6` | 53.6 min  | success |
| 2026-04-04 | `2a79b8e121` | 55.9 min  | success |
| 2026-04-04 | `9478256a04` | 54.3 min  | success |
| 2026-04-05 | `2c668b5a0b` | 54.9 min  | success |
| 2026-04-06 | `ec88c95f67` | 55.2 min  | success |
| 2026-04-07 | `cc7d6db700` | 53.8 min  | success |
| 2026-04-07 | `51397c224d` | 53.1 min  | success |
| 2026-04-07 | `e3f9fc1a6c` | 55.8 min  | success |
| 2026-04-07 | `cc4a3e6fac` | 52.2 min  | success |
| 2026-04-08 | `4da95f175b` | 51.8 min  | success |
| 2026-04-08 | `f1005e2a4b` | 51.9 min  | success |
| 2026-04-08 | `5feaf5ae80` | 54.0 min  | success |
| 2026-04-08 | `df7d8762a7` | 53.3 min  | success |
| 2026-04-08 | `c23f2348f6` | 54.1 min  | success |
| 2026-04-09 | `2885468769` | 53.6 min  | success |
| 2026-04-09 | `9c90195684` | 54.7 min  | success |
| 2026-04-09 | `91e097e6c2` | 54.7 min  | success |
| **2026-04-09** | **`e679e6ad32`** | **70.1 min** | **success** |
| 2026-04-10 | `77308197e9` | 66.8 min  | success |
| 2026-04-10 | `1610a73976` | 69.9 min  | success |
| 2026-04-10 | `20fc4c7576` | 67.3 min  | success |
| 2026-04-10 | `c1a14eed77` | 76.6 min  | failure |
| 2026-04-10 | `c1a14eed77` | 70.3 min  | success |

The transition is sharp: the last normal run (`91e097e6c2`, 54.7 min) is immediately followed by the first slow run (`e679e6ad32`, 70.1 min). The slowdown is consistent across all subsequent runs.

The non-bootstrapped test job shows the same pattern (~44 min to ~58 min, also ~31% increase), while compilation-only jobs are unaffected, confirming the issue is in test execution infrastructure.

## Culprit: PR #24628 — "Restore stdio in test rig"

Commit `e679e6ad32` refactored the vulpix test runner infrastructure. The key change is in `RunnerOrchestration.scala`.

### The bug: `discardRunner` leaks processes

The new `discardRunner` method removes a runner from `busyRunners` but does **not** kill the child JVM process:

```scala
// New code (broken)
private def discardRunner(runner: Runner): Unit = synchronized {
  busyRunners -= runner
  // BUG: process not killed, notify() not called
}
```

The old code always killed the process via `respawn()`:

```scala
// Old code (correct)
private def respawn(): Unit =
  process.destroy()        // killed the child JVM
  process = null
  process = createProcess()
```

`discardRunner` is called whenever a test run returns non-`Success` (failure or timeout):

```scala
private def withRunner(op: Runner => Status)(using SummaryReporting): Status =
  val runner = getRunner()
  val status = op(runner)
  if safeMode || !status.isSuccess then
    discardRunner(runner)   // ← leaks the process
  else
    freeRunner(runner)
  status
```

### Zombie processes from VulpixUnitTests

`VulpixUnitTests` (included in `scala3-compiler-bootstrapped/test`) intentionally creates pathological child JVM processes that are expected to fail/timeout:

| Test | Behavior | Resource impact |
|------|----------|-----------------|
| `infinite.scala` | `while(true) { sum += 1 }` | 100% CPU on one core, forever |
| `infiniteAlloc.scala` | Allocates maps in a loop | High CPU + memory until OOM |
| `deadlock.scala` | Two deadlocked threads | Holds ~1GB memory |
| `timeout.scala` | `Thread.sleep(1_000_000)` | Holds ~1GB memory for 1000s |

These tests time out after 3 seconds (`VulpixUnitTests.maxDuration = 3.seconds`). The old code killed the child process via `respawn()`. The new code discards the runner without killing the process.

Since discarded runners are removed from `busyRunners`, even `killAll()` (called in `@AfterClass` cleanup) can't find them:

```scala
def killAll(): Unit =
  freeRunners.foreach(_.kill())   // discarded runners aren't here
  busyRunners.foreach(_.kill())   // or here — they were removed
```

These zombie JVM processes (each launched with `-Xmx1g`) persist for the entire CI run, consuming CPU cores and memory on the `ubuntu-latest` runner while `CompilationTests` executes.

### Secondary issue: missing `notify()`

`discardRunner` also doesn't call `notify()`, unlike `freeRunner`. Threads waiting in `getRunner()` for a free slot won't wake up when a runner is discarded — they must wait for the next *successful* test to complete, reducing test parallelism.

## Fix

Add `runner.kill()` and `notify()` to `discardRunner`:

```scala
private def discardRunner(runner: Runner): Unit = synchronized {
  runner.kill()
  busyRunners -= runner
  notify()
}
```

## How was the solution tested?

Locally, we ran `VulpixUnitTests` with and without the fix and checked for leaked `ChildJVMMain` processes using `pgrep`:

- **Without the fix**: 5 zombie `ChildJVMMain` processes left behind after the test run (from the intentional infinite loop, infinite allocation, deadlock, timeout, and redirect tests).
- **With the fix**: 0 leaked processes.

We will confirm the CI timing improvement by checking that `test-scala3-compiler-bootstrapped` returns to its ~54 minute baseline.