### PR TITLE
Fix #25712: Reset frozenConstraint in `TypeComparer.init()`

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -55,6 +55,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
     maxErrorLevel = -1
     errorNotes = Nil
     undoLog.clear()
+    frozenConstraint = false
     if Config.checkTypeComparerReset then checkReset()
 
   private var pendingSubTypes: util.MutableSet[(Type, Type)] | Null = null


### PR DESCRIPTION
Fixes #25712.

`TypeComparer.init()` resets most mutable state (`monitored`, `recCount`, `GADTused`, etc.) when a pooled comparer is reused, but did not reset `frozenConstraint`. A stale `frozenConstraint = true` from a previous use causes subsequent `testSubType` calls to fail — `canConstrain` returns false when frozen, preventing type variable bounds from being added.

This manifested as the flaky test `pos-deep-subtype/i21015.scala` failing ~20% of the time during bootstrapped CI runs. The failure only occurred under parallel compilation with `-Ycheck:all`, because the extra overhead increased the likelihood of a `RecursionOverflow` preventing `inFrozenConstraint`'s finally block from fully restoring state.

## Additional notes

The root cause chain:
1. Deep match type recursion in `i21015.scala` can trigger `RecursionOverflow`
2. Under memory pressure from parallel compilation + `-Ycheck:all` overhead, the overflow occasionally prevents `inFrozenConstraint`'s `finally` block from restoring `frozenConstraint = false`
3. The stale frozen state persists on the pooled `TypeComparer` because `init()` didn't reset it
4. A subsequent `testSubType` call reuses the comparer and finds the constraint frozen
5. `canConstrain` returns false → `addConstraint` is never called → subtype check fails → type mismatch error

## How much have you relied on LLM-based tools in this contribution?

Claude Code identified the root cause through systematic instrumentation and bisection (ruling out `monitoredIsSubType`, StackOverflow, match type caching, then confirming the frozen constraint via targeted debug output), proposed and validated the fix.

## How was the solution tested?

- Without the fix: ~20% failure rate (2-3 failures per 10 runs of the pos test suite)
- With the fix: 30/30 consecutive passes (10 + 20 runs)