### PR TITLE
Add remark about JDK licensing to CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to AI coding agents when working with code in this repository.
 
+**Important**: Read `CONTRIBUTING.md`, in particular the "Forbidden" section!
+
 ## Project Overview
 
 Dotty is the Scala 3 compiler (`dotc`). It compiles Scala source code into JVM bytecode (and optionally Scala.js IR). The compiler is itself written in Scala 3.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,12 @@ You may also find the ["Compiler Academy"](https://www.youtube.com/channel/UCIH0
   (most maintainers do this part time, so we cannot commit to as short a turnaround time as we would ideally like)
 - Don't break our LLM policy linked above, especially in the form of PRs "vibe-coded" without proper understanding of the contributed change
 
+## Forbidden
+
+**Do not look at the source code of the Oracle JDK or OpenJDK** when working on anything related to the JVM backend!
+This is for license considerations: these JDKs are under a GPL-based license, which is not compatible with our Apache 2.0 license.
+It is also recommended not to look at any other JDK implementation (such as Apache Harmony), to minimize the chance of copyright debate.
+
 ## Maintainers
 
 Principal areas of the compiler and internal team members responsible for their maintenance:


### PR DESCRIPTION
Rikito was pointing this out to me on Slack, and it turns out we have nothing about this. Wording partly taken from https://github.com/scala-js/scala-js/blob/main/JAVALIB.md