### PR TITLE
Wait for async TASTy operations before returning to sbt

### DIFF
--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -358,44 +358,6 @@ jobs:
       - uses: sbt/setup-sbt@v1
       - name: Run SBT scripted tests
         run: ./project/scripts/sbt scala3-bootstrapped/scripted
-      - name: Run SBT scripted tests (2)
-        run: ./project/scripts/sbt scala3-bootstrapped/scripted
-      - name: Run SBT scripted tests (3)
-        run: ./project/scripts/sbt scala3-bootstrapped/scripted
-      - name: Run SBT scripted tests (4)
-        run: ./project/scripts/sbt scala3-bootstrapped/scripted
-      - name: Run SBT scripted tests (5)
-        run: ./project/scripts/sbt scala3-bootstrapped/scripted
-      - name: Run SBT scripted tests (6)
-        run: ./project/scripts/sbt scala3-bootstrapped/scripted
-      - name: Run SBT scripted tests (7)
-        run: ./project/scripts/sbt scala3-bootstrapped/scripted
-      - name: Run SBT scripted tests (8)
-        run: ./project/scripts/sbt scala3-bootstrapped/scripted
-      - name: Run SBT scripted tests (9)
-        run: ./project/scripts/sbt scala3-bootstrapped/scripted
-      - name: Run SBT scripted tests (10)
-        run: ./project/scripts/sbt scala3-bootstrapped/scripted
-      - name: Run SBT scripted tests (11)
-        run: ./project/scripts/sbt scala3-bootstrapped/scripted
-      - name: Run SBT scripted tests (12)
-        run: ./project/scripts/sbt scala3-bootstrapped/scripted
-      - name: Run SBT scripted tests (13)
-        run: ./project/scripts/sbt scala3-bootstrapped/scripted
-      - name: Run SBT scripted tests (14)
-        run: ./project/scripts/sbt scala3-bootstrapped/scripted
-      - name: Run SBT scripted tests (15)
-        run: ./project/scripts/sbt scala3-bootstrapped/scripted
-      - name: Run SBT scripted tests (16)
-        run: ./project/scripts/sbt scala3-bootstrapped/scripted
-      - name: Run SBT scripted tests (17)
-        run: ./project/scripts/sbt scala3-bootstrapped/scripted
-      - name: Run SBT scripted tests (18)
-        run: ./project/scripts/sbt scala3-bootstrapped/scripted
-      - name: Run SBT scripted tests (19)
-        run: ./project/scripts/sbt scala3-bootstrapped/scripted
-      - name: Run SBT scripted tests (20)
-        run: ./project/scripts/sbt scala3-bootstrapped/scripted
 
   community_build_a:
     runs-on: ubuntu-latest

--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -358,6 +358,44 @@ jobs:
       - uses: sbt/setup-sbt@v1
       - name: Run SBT scripted tests
         run: ./project/scripts/sbt scala3-bootstrapped/scripted
+      - name: Run SBT scripted tests (2)
+        run: ./project/scripts/sbt scala3-bootstrapped/scripted
+      - name: Run SBT scripted tests (3)
+        run: ./project/scripts/sbt scala3-bootstrapped/scripted
+      - name: Run SBT scripted tests (4)
+        run: ./project/scripts/sbt scala3-bootstrapped/scripted
+      - name: Run SBT scripted tests (5)
+        run: ./project/scripts/sbt scala3-bootstrapped/scripted
+      - name: Run SBT scripted tests (6)
+        run: ./project/scripts/sbt scala3-bootstrapped/scripted
+      - name: Run SBT scripted tests (7)
+        run: ./project/scripts/sbt scala3-bootstrapped/scripted
+      - name: Run SBT scripted tests (8)
+        run: ./project/scripts/sbt scala3-bootstrapped/scripted
+      - name: Run SBT scripted tests (9)
+        run: ./project/scripts/sbt scala3-bootstrapped/scripted
+      - name: Run SBT scripted tests (10)
+        run: ./project/scripts/sbt scala3-bootstrapped/scripted
+      - name: Run SBT scripted tests (11)
+        run: ./project/scripts/sbt scala3-bootstrapped/scripted
+      - name: Run SBT scripted tests (12)
+        run: ./project/scripts/sbt scala3-bootstrapped/scripted
+      - name: Run SBT scripted tests (13)
+        run: ./project/scripts/sbt scala3-bootstrapped/scripted
+      - name: Run SBT scripted tests (14)
+        run: ./project/scripts/sbt scala3-bootstrapped/scripted
+      - name: Run SBT scripted tests (15)
+        run: ./project/scripts/sbt scala3-bootstrapped/scripted
+      - name: Run SBT scripted tests (16)
+        run: ./project/scripts/sbt scala3-bootstrapped/scripted
+      - name: Run SBT scripted tests (17)
+        run: ./project/scripts/sbt scala3-bootstrapped/scripted
+      - name: Run SBT scripted tests (18)
+        run: ./project/scripts/sbt scala3-bootstrapped/scripted
+      - name: Run SBT scripted tests (19)
+        run: ./project/scripts/sbt scala3-bootstrapped/scripted
+      - name: Run SBT scripted tests (20)
+        run: ./project/scripts/sbt scala3-bootstrapped/scripted
 
   community_build_a:
     runs-on: ubuntu-latest

--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -419,6 +419,11 @@ extends ImplicitRunInfo, ConstraintRunInfo, cc.CaptureRunInfo {
 
     showProgress(runPhases(allPhases = fusedPhases)(using runCtx))
     cancelAsyncTasty()
+    // Wait for async TASTy operations (including Zinc callbacks like
+    // apiPhaseCompleted/dependencyPhaseCompleted) to complete. This must happen
+    // before we return to Zinc, which calls getCycleResultOnce immediately after.
+    // See https://github.com/scala/scala3/issues/25774
+    _asyncTasty.foreach(_.sync())
 
     suppressions.runFinished()
     ctx.reporter.finalizeReporting()

--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -38,6 +38,7 @@ import Run.Progress
 import scala.compiletime.uninitialized
 import dotty.tools.dotc.transform.MegaPhase
 import dotty.tools.dotc.transform.Pickler.AsyncTastyHolder
+import dotty.tools.io.FileWriters
 import dotty.tools.dotc.util.chaining.*
 import java.util.{Timer, TimerTask}
 
@@ -288,6 +289,26 @@ extends ImplicitRunInfo, ConstraintRunInfo, cc.CaptureRunInfo {
     _asyncTasty = Some(async)
     () => async.cancel()
 
+  /** Wait for async TASTy operations (including Zinc callbacks like
+   *  `apiPhaseCompleted`/`dependencyPhaseCompleted`) to complete and relay any
+   *  buffered reports. This must happen before we return to Zinc, which calls
+   *  `getCycleResultOnce` immediately after. See scala/scala3#25774.
+   */
+  private def syncAsyncTasty()(using Context): Unit =
+    for
+      async <- _asyncTasty
+      bufferedReporter <- async.sync()
+      report <- bufferedReporter.resetReports()
+    do
+      import reporting.Diagnostic
+      report match
+        case FileWriters.Report.Error(msg, pos) =>
+          ctx.reporter.report(Diagnostic.Error(msg(ctx), pos))
+        case FileWriters.Report.Warning(msg, pos) =>
+          ctx.reporter.report(Diagnostic.Warning(msg(ctx), pos))
+        case FileWriters.Report.Log(msg) =>
+          ctx.reporter.report(Diagnostic.Info(msg, NoSourcePosition))
+
   /** Will be set to true if any of the compiled compilation units contains
    *  a pureFunctions language import.
    */
@@ -419,11 +440,7 @@ extends ImplicitRunInfo, ConstraintRunInfo, cc.CaptureRunInfo {
 
     showProgress(runPhases(allPhases = fusedPhases)(using runCtx))
     cancelAsyncTasty()
-    // Wait for async TASTy operations (including Zinc callbacks like
-    // apiPhaseCompleted/dependencyPhaseCompleted) to complete. This must happen
-    // before we return to Zinc, which calls getCycleResultOnce immediately after.
-    // See https://github.com/scala/scala3/issues/25774
-    _asyncTasty.foreach(_.sync())
+    syncAsyncTasty()
 
     suppressions.runFinished()
     ctx.reporter.finalizeReporting()

--- a/sbt-bridge/test/xsbt/AsyncTastyErrorRelaySpecification.scala
+++ b/sbt-bridge/test/xsbt/AsyncTastyErrorRelaySpecification.scala
@@ -1,0 +1,75 @@
+package xsbt
+
+import dotty.tools.xsbt.CompilerBridge
+import sbt.io.IO
+import xsbti.*
+import xsbti.compile.SingleOutput
+
+import java.io.File
+import org.junit.Test
+import org.junit.Assert.*
+
+/** Test that errors from async TASTy Zinc callbacks (apiPhaseCompleted,
+  * dependencyPhaseCompleted) are properly relayed to the compiler reporter.
+  *
+  * This is a regression test for scala/scala3#25774: previously, the sync()
+  * call in GenBCode that relayed these reports was removed in #25618, causing
+  * errors from Zinc callbacks to be silently lost.
+  */
+class AsyncTastyErrorRelaySpecification:
+
+  /** When apiPhaseCompleted throws, the error should be reported. */
+  @Test
+  def asyncTastyErrorIsRelayed(): Unit =
+    val src = """class Foo"""
+    val temp = IO.createTemporaryDirectory
+    val classesDir = new File(temp, "classes")
+    classesDir.mkdir()
+    val earlyOut = new File(temp, "early.jar")
+
+    val callback = new ThrowingApiCallback
+    val reporter = new TestReporter
+    val bridge = new CompilerBridge
+
+    val srcFile = new File(temp, "Test.scala")
+    IO.write(srcFile, src)
+    val virtualSrcFile = new TestVirtualFile(srcFile.toPath)
+
+    try
+      bridge.run(
+        Array(virtualSrcFile),
+        new TestDependencyChanges,
+        Array(
+          "-classpath", classesDir.getAbsolutePath,
+          "-usejavacp",
+          "-d", classesDir.getAbsolutePath,
+          "-Yforce-sbt-phases",
+          "-Yearly-tasty-output", earlyOut.getAbsolutePath,
+        ),
+        new SingleOutput { def getOutputDirectory(): File = classesDir },
+        callback,
+        reporter,
+        new TestCompileProgress,
+        new TestLogger,
+      )
+    catch case _: CompileFailed => () // expected, since the relayed error causes compilation "failure"
+
+    assertTrue(
+      "apiPhaseCompleted should have been called",
+      callback.apiPhaseCompletedCalled
+    )
+    assertTrue(
+      "error from apiPhaseCompleted should be reported",
+      reporter.problems().exists(p =>
+        p.severity == Severity.Error
+          && p.message.contains("signaling API and Dependencies phases completion")
+      )
+    )
+
+  /** A callback that throws in apiPhaseCompleted to simulate a Zinc error. */
+  private class ThrowingApiCallback extends TestCallback:
+    @volatile var apiPhaseCompletedCalled = false
+
+    override def apiPhaseCompleted(): Unit =
+      apiPhaseCompletedCalled = true
+      throw new RuntimeException("simulated Zinc apiPhaseCompleted failure")


### PR DESCRIPTION

Fixes #25774

TL;DR: we're not waiting for `backendFuture` and therefore `asyncZincPhasesCompleted` to complete at the end of a compilation run. This PRs does that.

## Root cause

When pipelining is enabled, the compiler schedules Zinc callbacks (`apiPhaseCompleted` and `dependencyPhaseCompleted`) to run asynchronously inside `AsyncTastyHolder.backendFuture`. This future is composed from two promises (`asyncTastyWritten` and `asyncAPIComplete`) and then maps over their results to call `asyncZincPhasesCompleted`.

In the normal (successful) compilation path:

1. `signalAsyncTastyWritten()` resolves the first promise during the pickler phase.
2. `signalAPIComplete()` resolves the second promise from the `ExtractAPI` phase.
3. `backendFuture` then runs `asyncZincPhasesCompleted(incCallback, ...)` which calls `cb.apiPhaseCompleted()` and `cb.dependencyPhaseCompleted()` on the Zinc `IncrementalCallback`.

After `runPhases` returns, `cancelAsyncTasty()` is called. But if both promises were already resolved from the normal flow, `cancel()` is a no-op (`compareAndSet` fails). Meanwhile, `backendFuture`'s `.map` callback — which runs the Zinc callbacks — may still be executing on the global `ExecutionContext`.

The compiler then returns to sbt, which immediately calls `getCycleResultOnce`. Since the Zinc callbacks haven't completed yet, sbt observes incomplete state, causing transient assertion failures in tests like `pipelining/pipelining-scala-macro` and `pipelining/pipelining-cancel`.

## Fix

Add `_asyncTasty.foreach(_.sync())` after `cancelAsyncTasty()`. This calls `Await.result(backendFuture, Duration.Inf)`, ensuring the `backendFuture` (including the Zinc callbacks) has fully completed before we return control to sbt.

## How much have you relied on LLM-based tools in this contribution?

Extensively — the root cause analysis and fix were developed with Claude Code.

## How was the solution tested?

Can't reproduce locally. So we modified the CI to run scripted tests 20 times. Let's see.