### PR TITLE
FIx Ctrl+C handling in the REPL

### DIFF
--- a/repl/src/dotty/tools/repl/JLineTerminal.scala
+++ b/repl/src/dotty/tools/repl/JLineTerminal.scala
@@ -33,6 +33,9 @@ class JLineTerminal extends java.io.Closeable {
   private val history = new DefaultHistory
 
   private def magenta(str: String)(using Context) =
+    // Deliberately do not use these properties on `Console` to avoid initializing it,
+    // and thus capturing stdin/stdout/stderr state in its `Console.in/out/err` properties,
+    // since the REPL may wish to change the std streams before giving control to the user.
     if (ctx.settings.color.value != "never") AnsiColor.MAGENTA + str + AnsiColor.RESET
     else str
   protected def promptStr = "scala"

--- a/repl/src/dotty/tools/repl/JLineTerminal.scala
+++ b/repl/src/dotty/tools/repl/JLineTerminal.scala
@@ -3,7 +3,6 @@ package repl
 
 import scala.language.unsafeNulls
 import scala.io.AnsiColor
-
 import dotc.core.Contexts.*
 import dotc.parsing.Scanners.Scanner
 import dotc.parsing.Tokens.*
@@ -16,14 +15,10 @@ import org.jline.reader.*
 import org.jline.reader.impl.LineReaderImpl
 import org.jline.reader.impl.history.DefaultHistory
 import org.jline.terminal.TerminalBuilder
-import org.jline.terminal.Attributes
-import org.jline.terminal.Attributes.ControlChar
+import org.jline.terminal.Terminal.Signal
 import org.jline.utils.AttributedString
 
 class JLineTerminal extends java.io.Closeable {
-  // import java.util.logging.{Logger, Level}
-  // Logger.getLogger("org.jline").setLevel(Level.FINEST)
-
   private val terminal =
     val builder = TerminalBuilder.builder()
     if System.getenv("TERM") == "dumb" then
@@ -34,17 +29,6 @@ class JLineTerminal extends java.io.Closeable {
       // This option is used at https://github.com/jline/jline3/blob/894b5e72cde28a551079402add4caea7f5527806/terminal/src/main/java/org/jline/terminal/TerminalBuilder.java#L528.
       builder.dumb(true)
     builder.build()
-  
-  // Save original attributes before entering raw mode
-  private val originalAttributes = terminal.getAttributes
-
-  // Disable VINTR so Ctrl-C is not converted to SIGINT by the tty driver, then enter raw mode
-  // This disables special character processing so Ctrl-C is passed through as 0x03
-  val noIntr = new Attributes(originalAttributes)
-  noIntr.setControlChar(ControlChar.VINTR, 0)
-  terminal.setAttributes(noIntr)
-  terminal.enterRawMode()
-
 
   private val history = new DefaultHistory
 
@@ -101,37 +85,16 @@ class JLineTerminal extends java.io.Closeable {
   }
 
   def close(): Unit =
-    try terminal.setAttributes(originalAttributes)
-    finally terminal.close()
+    terminal.close()
 
   /** Execute a block while monitoring for Ctrl-C keypresses.
    *  Calls the handler when Ctrl-C is detected during block execution.
    */
   def withMonitoringCtrlC[T](handler: () => Unit)(block: => T): T = {
-    @volatile var monitoring = true
-
-    val monitorThread = new Thread(() => {
-      // Important: `terminal.reader()` is not thread-safe and cannot be used here!
-      while (monitoring) {
-        try System.in.synchronized {
-          if (System.in.available() > 0) {
-            System.in.mark(1)
-            val ch = System.in.read()
-            System.in.reset()
-            if (ch == 3 /* Ctrl-C is ASCII 0x03 */ && monitoring) handler()
-          }
-        } catch { case _: Exception => () } // don't bring down the thread even if weird things happen
-      }
-    }, "REPL-CtrlC-Monitor")
-    monitorThread.setDaemon(true)
-    monitorThread.start()
-
-    try block
-    finally {
-      monitoring = false
-      Thread.interrupted() // clear any interrupted flag so the `join` below doesn't explode
-      monitorThread.join()
-    }
+    terminal.handle(Signal.INT, _ => handler())
+    val res = block
+    terminal.handle(Signal.INT, _ => ())
+    res
   }
 
   /** Provide syntax highlighting */
@@ -192,7 +155,7 @@ class JLineTerminal extends java.io.Closeable {
 
 
           // we need to enclose the last backtick, which unclosed produces ERROR token
-          if (token == ERROR && input(start) == '`') then
+          if token == ERROR && input(start) == '`' then
             lastBacktickErrorStart = Some(start)
           else
             lastBacktickErrorStart = None

--- a/repl/src/dotty/tools/repl/JLineTerminal.scala
+++ b/repl/src/dotty/tools/repl/JLineTerminal.scala
@@ -2,6 +2,7 @@ package dotty.tools
 package repl
 
 import scala.language.unsafeNulls
+import scala.io.AnsiColor
 
 import dotc.core.Contexts.*
 import dotc.parsing.Scanners.Scanner
@@ -48,7 +49,7 @@ class JLineTerminal extends java.io.Closeable {
   private val history = new DefaultHistory
 
   private def magenta(str: String)(using Context) =
-    if (ctx.settings.color.value != "never") Console.MAGENTA + str + Console.RESET
+    if (ctx.settings.color.value != "never") AnsiColor.MAGENTA + str + AnsiColor.RESET
     else str
   protected def promptStr = "scala"
   private def prompt(using Context)        = magenta(s"\n$promptStr> ")
@@ -108,15 +109,18 @@ class JLineTerminal extends java.io.Closeable {
    */
   def withMonitoringCtrlC[T](handler: () => Unit)(block: => T): T = {
     @volatile var monitoring = true
-    val terminalReader = terminal.reader()
 
     val monitorThread = new Thread(() => {
+      // Important: `terminal.reader()` is not thread-safe and cannot be used here!
       while (monitoring) {
-        val ch =
-          try terminalReader.read(1) // timeout after 1ms so the loop gets a chance to check `monitoring`
-          catch { case _: Exception => -1 } // Ignore all read errors, just continue
-
-        if (ch == 3 /* Ctrl-C is ASCII 0x03 */ && monitoring) handler()
+        try System.in.synchronized {
+          if (System.in.available() > 0) {
+            System.in.mark(1)
+            val ch = System.in.read()
+            System.in.reset()
+            if (ch == 3 /* Ctrl-C is ASCII 0x03 */ && monitoring) handler()
+          }
+        } catch { case _: Exception => () } // don't bring down the thread even if weird things happen
       }
     }, "REPL-CtrlC-Monitor")
     monitorThread.setDaemon(true)

--- a/repl/src/dotty/tools/repl/JLineTerminal.scala
+++ b/repl/src/dotty/tools/repl/JLineTerminal.scala
@@ -91,10 +91,9 @@ class JLineTerminal extends java.io.Closeable {
    *  Calls the handler when Ctrl-C is detected during block execution.
    */
   def withMonitoringCtrlC[T](handler: () => Unit)(block: => T): T = {
-    terminal.handle(Signal.INT, _ => handler())
-    val res = block
-    terminal.handle(Signal.INT, _ => ())
-    res
+    val previousHandler = terminal.handle(Signal.INT, _ => handler())
+    try block
+    finally terminal.handle(Signal.INT, previousHandler)
   }
 
   /** Provide syntax highlighting */

--- a/repl/src/dotty/tools/repl/JLineTerminal.scala
+++ b/repl/src/dotty/tools/repl/JLineTerminal.scala
@@ -94,6 +94,9 @@ class JLineTerminal extends java.io.Closeable {
    *  Calls the handler when Ctrl-C is detected during block execution.
    */
   def withMonitoringCtrlC[T](handler: () => Unit)(block: => T): T = {
+  // If you change Ctrl+C handling in any way, such as by trying to read/peek from stdin for Ctrl+C,
+  // make sure you manually check that reading from, e.g., `Console.in` still works!
+  // Remember that the user can use stdin from code they enter into the REPL, we do not have exclusive access to it.
     val previousHandler = terminal.handle(Signal.INT, _ => handler())
     try block
     finally terminal.handle(Signal.INT, previousHandler)

--- a/repl/src/dotty/tools/repl/Rendering.scala
+++ b/repl/src/dotty/tools/repl/Rendering.scala
@@ -44,7 +44,7 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
         .plainText
     try
       if value != null && forcedToStringClasses(value.getClass.getName) then return value.toString
-      // normally, if we used vanilla JDK and layered classloaders, we wouldnt need reflection.
+      // normally, if we used vanilla JDK and layered classloaders, we wouldn't need reflection.
       // however PPrint works by runtime type testing to deconstruct values. This is
       // sensitive to which classloader instantiates the object under test, i.e.
       // `value` is constructed inside the repl classloader. Testing for
@@ -52,7 +52,7 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
       // because repl classloader has two layers where it can redefine `scala.Product`:
       // - `new URLClassLoader` constructed with contents of the `-classpath` setting
       // - `AbstractFileClassLoader` also might instrument the library code to support interrupt.
-      // Due the possible interruption instrumentation, it is unlikely that we can get
+      // Due to the possible interruption instrumentation, it is unlikely that we can get
       // rid of reflection here.
       val cl = classLoader()
       val pprintCls = Class.forName("pprint.PPrinter$Color$", false, cl)

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -79,7 +79,7 @@ case class State(objectIndex: Int,
 
 /** Main REPL instance, orchestrating input, compilation and presentation */
 class ReplDriver(settings: Array[String],
-                 out: PrintStream = Console.out,
+                 out: PrintStream = System.out,
                  classLoader: Option[ClassLoader] = None,
                  extraPredef: String = "") extends Driver:
 

--- a/repl/src/dotty/tools/repl/ScriptEngine.scala
+++ b/repl/src/dotty/tools/repl/ScriptEngine.scala
@@ -27,7 +27,7 @@ class ScriptEngine extends AbstractScriptEngine {
       "-Xrepl-disable-display",
       "-Xrepl-interrupt-instrumentation",
       "false"
-    ), System.out, None)
+    ))
 
   private val rendering = new Rendering(Some(getClass.getClassLoader))
   private var state: State = driver.initialState

--- a/repl/src/dotty/tools/repl/ScriptEngine.scala
+++ b/repl/src/dotty/tools/repl/ScriptEngine.scala
@@ -27,7 +27,7 @@ class ScriptEngine extends AbstractScriptEngine {
       "-Xrepl-disable-display",
       "-Xrepl-interrupt-instrumentation",
       "false"
-    ), Console.out, None)
+    ), System.out, None)
 
   private val rendering = new Rendering(Some(getClass.getClassLoader))
   private var state: State = driver.initialState


### PR DESCRIPTION
Fixes #25551

Basically a revert of #24842, plus some minor cleanups.

I've spent a day trying to make it work with raw mode and failed. A working REPL that offers suboptimal UX inside other processes is better than a nonworking REPL that offers slightly better UX.

I don't think the "raw mode" approach, nor any approach based on handling `System.in` manually in one way or another, can work for a REPL that lets users consume from `System.in` themselves.

## How much have you relied on LLM-based tools in this contribution?

not

## How was the solution tested?

manually with `scala3-repl / run` it no longer messes up stdin input, with `bin/replQ` after `sbt buildQuick` neither, and Ctrl+C works in these scenarios

and

`sbt scala3-bootstrapped/publishLocalBin`

then write `mill-build/build.mill`:

```scala
package build

import mill.*, scalalib.*
import mill.api.*

object `package` extends ScalaModule:
  object JvmWorker extends JvmWorkerModule:
    override def repositories =
      super.repositories() ++ Seq(CoursierModule.KnownRepositories.ScalaLangNightlies)

  override def jvmWorker: ModuleRef[JvmWorkerModule] = ModuleRef(JvmWorker)
  override def repositories =
    super.repositories() ++ Seq(CoursierModule.KnownRepositories.ScalaLangNightlies)
  def scalaVersion = "3.8.5-RC1-bin-SNAPSHOT" // change this
```

then `./mill.sh --repl` stdin works but Ctrl+C terminates the entire Mill process on Ctrl+C, which is not great but I think this should be handled in Mill.