### PR TITLE
Tweak SafeRefs allow list for java.util classes

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/SafeRefs.scala
+++ b/compiler/src/dotty/tools/dotc/cc/SafeRefs.scala
@@ -21,6 +21,11 @@ import typer.ProtoTypes.SelectionProto
 /** Check whether references from safe mode should be allowed */
 object SafeRefs {
 
+  val assumedSafePackages = List(
+    "scala", "scala.runtime", "scala.collection.immutable", "scala.compiletime.ops",
+    "scala.math", "scala.util", "java.math", "java.time",
+  )
+
   private def rejectSafe(sym: Symbol)(using Context): Unit =
     if !sym.infoOrCompleter.isInstanceOf[StubInfo] then
       sym.addAnnotation(Annotation(defn.RejectSafeAnnot, List(Literal(Constant(""))), NoSpan))
@@ -85,15 +90,15 @@ object SafeRefs {
       "getPackage", "getPackageName", "getPermittedSubclasses", "getProtectionDomain", "getRecordComponents",
       "getResource", "getResourceAsStream", "getSigners", "getTypeParameters", "getTypeName",
       "newInstance", "cast", "toGenericString"))
-    assumeSafe("java.util.Locale")
-    assumeSafe("java.util.Random")
-    assumeSafe("java.util.UUID")
+    assumeSafe("java.util.Locale", except = List("setDefault"))
+    assumeSafe("java.util.TimeZone", except = List("setDefault", "setID", "setRawOffset"))
+    assumeSafe("java.util.UUID", except = List("randomUIID"))
     assumeSafe("java.util.Objects")
     assumeSafe("java.util.Optional")
     assumeSafe("java.util.OptionalInt")
     assumeSafe("java.util.OptionalLong")
     assumeSafe("java.util.OptionalDouble")
-    assumeSafe("java.util.TimeZone")
+
     rejectSafe("scala.Console")
     rejectSafe("scala.unchecked")
     rejectSafe("scala.annotation.unchecked.uncheckedOverride")

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -15,7 +15,7 @@ import Comments.{Comment, docCtx}
 import util.Spans.NoSpan
 import config.Feature
 import Symbols.requiredModuleRef
-import cc.{CaptureSet, RetainingAnnotation}
+import cc.{CaptureSet, RetainingAnnotation, SafeRefs}
 import ast.tpd.ref
 
 import scala.annotation.tailrec
@@ -1528,8 +1528,12 @@ class Definitions {
     Set(StringClass, NothingClass, NullClass) ++ ScalaValueClasses()
 
   @tu lazy val assumedSafePackages: Set[Symbol] =
-    Set(OpsPackageClass, ScalaPackageClass, ScalaCollectionImmutablePackageClass, ScalaRuntimePackageClass,
-        ScalaMathPackageClass, ScalaUtilPackageClass, JavaMathPackageClass, JavaTimePackageClass)
+    SafeRefs.assumedSafePackages
+      .map(requiredPackage)
+      .filter(!_.info.isInstanceOf[StubInfo])
+      .map(_.moduleClass)
+      .toSet
+    + OpsPackageClass
 
   @tu lazy val capsErasedValueMethods =
     Set(Caps_erasedValue, Caps_unsafeErasedValue)


### PR DESCRIPTION
Exclude setter methods from the safe subset

Also: Move list of assumed-safe packages to SafeRefs.scala, so everything is in one place.
