### PR TITLE
Bump `jackson-*` to 3.1.2 (was 2.15.1)

### DIFF
--- a/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
+++ b/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
@@ -7,7 +7,7 @@ import java.nio.file._
 import java.util.concurrent.{CompletableFuture, ConcurrentHashMap}
 import java.util.function.Function
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import _root_.tools.jackson.databind.ObjectMapper
 
 import org.eclipse.lsp4j
 

--- a/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
+++ b/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
@@ -7,7 +7,7 @@ import java.nio.file._
 import java.util.concurrent.{CompletableFuture, ConcurrentHashMap}
 import java.util.function.Function
 
-import _root_.tools.jackson.databind.ObjectMapper
+import _root_.tools.jackson.databind.json.JsonMapper
 
 import org.eclipse.lsp4j
 
@@ -68,7 +68,8 @@ class DottyLanguageServer extends LanguageServer
     if myDrivers == null then
       assert(rootUri != null, "`drivers` cannot be called before `initialize`")
       val configFile = new File(new URI(rootUri + '/' + IDE_CONFIG_FILE))
-      val configs: List[ProjectConfig] = (new ObjectMapper).readValue(configFile, classOf[Array[ProjectConfig]]).toList
+      val configs: List[ProjectConfig] =
+        JsonMapper.builder().build().readValue(configFile, classOf[Array[ProjectConfig]]).toList
 
       val defaultFlags = List("-color:never" /*, "-Yplain-printer","-Yprint-pos"*/)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
  *  to ensure the same version of the dependency is used in all projects
  */
 object Dependencies {
-  private val jacksonVersion = "2.15.1"
+  private val jacksonVersion = "2.21.2"
   val `jackson-databind` =
     "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
   val `jackson-dataformat-yaml` =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,11 +4,11 @@ import sbt._
  *  to ensure the same version of the dependency is used in all projects
  */
 object Dependencies {
-  private val jacksonVersion = "2.21.2"
+  private val jacksonVersion = "3.1.2"
   val `jackson-databind` =
-    "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
+    "tools.jackson.core" % "jackson-databind" % jacksonVersion
   val `jackson-dataformat-yaml` =
-    "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % jacksonVersion
+    "tools.jackson.dataformat" % "jackson-dataformat-yaml" % jacksonVersion
 
   // Freeze on 0.62.x as 0.64.0 requires Java 11
   private val flexmarkVersion = "0.62.2"

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
@@ -52,10 +52,10 @@ class HtmlRenderer(rootPackage: Member, members: Map[DRI, Member])(using ctx: Do
     super.render()
 
   private def serializeSideMenu() =
-    import _root_.tools.jackson.databind.*
+    import _root_.tools.jackson.databind.json.JsonMapper
     import _root_.tools.jackson.databind.node.ObjectNode
     import _root_.tools.jackson.databind.node.StringNode
-    val mapper = new ObjectMapper();
+    val mapper = JsonMapper.builder().build()
 
     def serializePage(page: Page): ObjectNode =
       import scala.jdk.CollectionConverters.SeqHasAsJava

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
@@ -52,20 +52,20 @@ class HtmlRenderer(rootPackage: Member, members: Map[DRI, Member])(using ctx: Do
     super.render()
 
   private def serializeSideMenu() =
-    import com.fasterxml.jackson.databind.*
-    import com.fasterxml.jackson.databind.node.ObjectNode
-    import com.fasterxml.jackson.databind.node.TextNode
+    import _root_.tools.jackson.databind.*
+    import _root_.tools.jackson.databind.node.ObjectNode
+    import _root_.tools.jackson.databind.node.StringNode
     val mapper = new ObjectMapper();
 
     def serializePage(page: Page): ObjectNode =
       import scala.jdk.CollectionConverters.SeqHasAsJava
       val children = mapper.createArrayNode().addAll(page.children.filterNot(_.hidden).map(serializePage).asJava)
-      val location = mapper.createArrayNode().addAll(rawLocation(page.link.dri).map(TextNode(_)).asJava)
+      val location = mapper.createArrayNode().addAll(rawLocation(page.link.dri).map(StringNode(_)).asJava)
       val obj = mapper.createObjectNode()
-      obj.set("name", new TextNode(page.link.name))
+      obj.set("name", new StringNode(page.link.name))
       obj.set("location", location)
       obj.set("kind", page.content match
-        case m: Member if m.needsOwnPage => new TextNode(m.kind.name)
+        case m: Member if m.needsOwnPage => new StringNode(m.kind.name)
         case _ => null
       )
       obj.set("children", children)

--- a/scaladoc/src/dotty/tools/scaladoc/site/BlogParser.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/site/BlogParser.scala
@@ -1,8 +1,6 @@
 package dotty.tools.scaladoc.site
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import com.fasterxml.jackson.databind.DeserializationFeature
+import _root_.tools.jackson.dataformat.yaml.YAMLMapper
 import java.io.File
 import scala.beans.{BooleanBeanProperty, BeanProperty}
 import scala.util.Try
@@ -16,8 +14,7 @@ case class BlogConfig(
 
 object BlogParser:
   def readYml(content: File | String): BlogConfig =
-    val mapper = ObjectMapper(YAMLFactory())
-      .findAndRegisterModules()
+    val mapper = YAMLMapper.builder().configureForJackson2().build()
 
     content match
       case f: File =>

--- a/scaladoc/src/dotty/tools/scaladoc/site/BlogParser.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/site/BlogParser.scala
@@ -1,5 +1,6 @@
 package dotty.tools.scaladoc.site
 
+import _root_.tools.jackson.databind.DeserializationFeature
 import _root_.tools.jackson.dataformat.yaml.YAMLMapper
 import java.io.File
 import scala.beans.{BooleanBeanProperty, BeanProperty}
@@ -14,7 +15,9 @@ case class BlogConfig(
 
 object BlogParser:
   def readYml(content: File | String): BlogConfig =
-    val mapper = YAMLMapper.builder().configureForJackson2().build()
+    val mapper = YAMLMapper.builder()
+      .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+      .build()
 
     content match
       case f: File =>

--- a/scaladoc/src/dotty/tools/scaladoc/site/SidebarParser.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/site/SidebarParser.scala
@@ -1,6 +1,7 @@
 package dotty.tools.scaladoc
 package site
 
+import _root_.tools.jackson.databind.DeserializationFeature;
 import _root_.tools.jackson.dataformat.yaml.YAMLMapper;
 import _root_.tools.jackson.core.`type`.TypeReference;
 import scala.jdk.CollectionConverters._
@@ -30,6 +31,15 @@ object Sidebar:
     def this() = this("", "", "", JList(), "", false)
 
   private object RawInputTypeRef extends TypeReference[RawInput]
+
+  /** Jackson 3 leaves absent YAML scalars as `null`; this code expects "" / empty list. */
+  private def coalesceRawInputNulls(r: RawInput): Unit =
+    if r.title == null then r.title = ""
+    if r.page == null then r.page = ""
+    if r.index == null then r.index = ""
+    if r.directory == null then r.directory = ""
+    if r.subsection == null then r.subsection = JList()
+    else r.subsection.asScala.foreach(coalesceRawInputNulls)
 
   private def toSidebar(r: RawInput, content: String | java.io.File)(using CompilerContext): Sidebar = r match
     case RawInput(title, page, index, subsection, dir, hidden) if page.nonEmpty && index.isEmpty && subsection.isEmpty() =>
@@ -78,7 +88,9 @@ object Sidebar:
 
   def load(content: String | java.io.File)(using CompilerContext): Sidebar.Category =
     import scala.util.Try
-    val mapper = YAMLMapper.builder().configureForJackson2().build()
+    val mapper = YAMLMapper.builder()
+      .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+      .build()
     def readValue = content match
       case s: String => mapper.readValue(s, RawInputTypeRef)
       case f: java.io.File => mapper.readValue(f, RawInputTypeRef)
@@ -89,7 +101,7 @@ object Sidebar:
           report.warn(schemaMessage, e)
           new RawInput()
         },
-        identity
+        r => { coalesceRawInputNulls(r); r }
       )
     toSidebar(root, content) match
       case c: Sidebar.Category => c

--- a/scaladoc/src/dotty/tools/scaladoc/site/SidebarParser.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/site/SidebarParser.scala
@@ -1,9 +1,8 @@
 package dotty.tools.scaladoc
 package site
 
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.core.`type`.TypeReference;
+import _root_.tools.jackson.dataformat.yaml.YAMLMapper;
+import _root_.tools.jackson.core.`type`.TypeReference;
 import scala.jdk.CollectionConverters._
 import java.util.Optional
 import scala.beans._
@@ -79,7 +78,7 @@ object Sidebar:
 
   def load(content: String | java.io.File)(using CompilerContext): Sidebar.Category =
     import scala.util.Try
-    val mapper = ObjectMapper(YAMLFactory())
+    val mapper = YAMLMapper.builder().configureForJackson2().build()
     def readValue = content match
       case s: String => mapper.readValue(s, RawInputTypeRef)
       case f: java.io.File => mapper.readValue(f, RawInputTypeRef)


### PR DESCRIPTION
Fixes https://github.com/scala/scala3/issues/25672

https://github.com/FasterXML/jackson/wiki/Jackson-Release-3.1.2
https://github.com/FasterXML/jackson/wiki/Jackson-Release-3.0

## How much have you relied on LLM-based tools in this contribution?
moderately, to identify which parts of the API changed between `jackson-*` 2.x and 3.x
used Cursor + Claude

## How was the solution tested?
- [x] Covered by existing tests (e.g., for refactorings)

## Additional notes
- I split the 2.21.2 bump into a separate commit, so that it's easier to go back to the previous major (if we need to for whatever reason) and/or easier to bisect 
  - 2.21.2 already addresses https://github.com/advisories/GHSA-72hv-8253-57qq
- some docs on migration from Jackson:
  - https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md
