### PR TITLE
Improve LambdaTypes handling in Quotes reflect memberType

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -1926,7 +1926,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
               boundary.break(false)
             })
           }
-          xCheckMacroWarning(isTypeRelatedToThePassedMember, s"$member is not a valid member of ${self.show}. Returned type might not be the one expected.")
+          xCheckMacroAssert(isTypeRelatedToThePassedMember, s"$member is not a valid member of ${self.show}")
 
           // we replace thisTypes here to avoid resolving otherwise unstable prefixes into Nothing
           val memberInfo =
@@ -3550,17 +3550,6 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     private inline def xCheckMacroAssert(inline cond: Boolean, inline msg: String): Unit =
       if xCheckMacro && !cond then
         xCheckMacroAssertFail(msg)
-
-    private inline def xCheckMacroWarning(inline cond: Boolean, inline msg: String): Unit =
-      if xCheckMacro && !cond then
-        val error = new AssertionError()
-        if !yDebugMacro then
-          // start stack trace at the place where the user called the reflection method
-          error.setStackTrace(
-            error.getStackTrace
-              .dropWhile(_.getClassName().startsWith("scala.quoted.runtime.impl")))
-        val stackTrace = error.getStackTrace().map(_.toString).mkString("\n")
-        report.warning(s"$msg\n${stackTrace}")
 
     private def xCheckMacroAssertFail(msg: String): Unit =
       val error = new AssertionError(msg)

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -28,7 +28,6 @@ import dotty.tools.dotc.core.NameKinds.ExceptionBinderName
 import dotty.tools.dotc.transform.TreeChecker
 import dotty.tools.dotc.core.Names
 import dotty.tools.dotc.util.Spans.NoCoord
-import dotty.tools.dotc.report
 
 object QuotesImpl {
 
@@ -1905,17 +1904,14 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
           //     (and failed dotty compilation tests)
           // Additionally, it can be useful to be able to learn a type of a symbol using some indirect prefix,
           // even if that symbol is not a direct member of that prefix, but a nested one.
-          def isTypeRelatedToThePassedMember = {
+          def isTypeRelatedToThePassedMember =
             import scala.util.boundary
-
-            // the symbol will not exist for LambdaTypes,
+            // the symbol for `self` will not exist for LambdaTypes,
             // which don't seem to be supported by asSeenFrom anyway
-            // (but don't seem to cause crashes, and return no-op member.info,
-            // which we might not have access other ways).
-            val selfSymExists = self.typeSymbol.exists
+            // (but also don't seem to cause crashes, and return no-op member.info,
+            // which we might not be able to access otherwise, so we need to allow this).
             val isLambdaType = self.isInstanceOf[LambdaType]
-            (!selfSymExists && isLambdaType) ||
-            (selfSymExists && boundary {
+            isLambdaType || boundary {
               var checked: Symbol = member
               while(checked.exists) {
                 if self.derivesFrom(checked)
@@ -1925,9 +1921,9 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
                 checked = checked.owner
               }
               boundary.break(false)
-            })
-          }
-          xCheckMacroAssert(isTypeRelatedToThePassedMember, s"$member is not a valid member of ${self.show}")
+            }
+
+          xCheckMacroAssert(isTypeRelatedToThePassedMember, s"$member is not a member of ${self.show}")
 
           // we replace thisTypes here to avoid resolving otherwise unstable prefixes into Nothing
           val memberInfo =

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -1906,13 +1906,14 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
           // Additionally, it can be useful to be able to learn a type of a symbol using some indirect prefix,
           // even if that symbol is not a direct member of that prefix, but a nested one.
           def isTypeRelatedToThePassedMember = {
+            import scala.util.boundary
+
             // the symbol will not exist for LambdaTypes,
             // which don't seem to be supported by asSeenFrom anyway
             // (but don't seem to cause crashes, and return no-op member.info,
             // which we might not have access other ways).
             val selfSymExists = self.typeSymbol.exists
             val isLambdaType = self.isInstanceOf[LambdaType]
-            import scala.util.boundary
             (!selfSymExists && isLambdaType) ||
             (selfSymExists && boundary {
               var checked: Symbol = member
@@ -1934,7 +1935,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
               member.info.substThis(self.classSymbol.asClass, self)
             else
               member.info
-          println("memInfo " + member.info)
+
           memberInfo.asSeenFrom(self, member.owner) match
             case dotc.core.Types.ClassInfo(prefix, sym, _, _, _) =>
               // We do not want to expose ClassInfo in the reflect API, instead we change it to a TypeRef,

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -28,6 +28,7 @@ import dotty.tools.dotc.core.NameKinds.ExceptionBinderName
 import dotty.tools.dotc.transform.TreeChecker
 import dotty.tools.dotc.core.Names
 import dotty.tools.dotc.util.Spans.NoCoord
+import dotty.tools.dotc.report
 
 object QuotesImpl {
 
@@ -1904,9 +1905,16 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
           //     (and failed dotty compilation tests)
           // Additionally, it can be useful to be able to learn a type of a symbol using some indirect prefix,
           // even if that symbol is not a direct member of that prefix, but a nested one.
-          def isTypeRelatedToThePassedMember =
+          def isTypeRelatedToThePassedMember = {
+            // the symbol will not exist for LambdaTypes,
+            // which don't seem to be supported by asSeenFrom anyway
+            // (but don't seem to cause crashes, and return no-op member.info,
+            // which we might not have access other ways).
+            val selfSymExists = self.typeSymbol.exists
+            val isLambdaType = self.isInstanceOf[LambdaType]
             import scala.util.boundary
-            boundary {
+            (!selfSymExists && isLambdaType) ||
+            (selfSymExists && boundary {
               var checked: Symbol = member
               while(checked.exists) {
                 if self.derivesFrom(checked)
@@ -1916,8 +1924,9 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
                 checked = checked.owner
               }
               boundary.break(false)
-            }
-          xCheckMacroAssert(isTypeRelatedToThePassedMember, s"$member is not a member of ${self.show}")
+            })
+          }
+          xCheckMacroWarning(isTypeRelatedToThePassedMember, s"$member is not a valid member of ${self.show}. Returned type might not be the one expected.")
 
           // we replace thisTypes here to avoid resolving otherwise unstable prefixes into Nothing
           val memberInfo =
@@ -1925,7 +1934,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
               member.info.substThis(self.classSymbol.asClass, self)
             else
               member.info
-
+          println("memInfo " + member.info)
           memberInfo.asSeenFrom(self, member.owner) match
             case dotc.core.Types.ClassInfo(prefix, sym, _, _, _) =>
               // We do not want to expose ClassInfo in the reflect API, instead we change it to a TypeRef,
@@ -3541,6 +3550,17 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
     private inline def xCheckMacroAssert(inline cond: Boolean, inline msg: String): Unit =
       if xCheckMacro && !cond then
         xCheckMacroAssertFail(msg)
+
+    private inline def xCheckMacroWarning(inline cond: Boolean, inline msg: String): Unit =
+      if xCheckMacro && !cond then
+        val error = new AssertionError()
+        if !yDebugMacro then
+          // start stack trace at the place where the user called the reflection method
+          error.setStackTrace(
+            error.getStackTrace
+              .dropWhile(_.getClassName().startsWith("scala.quoted.runtime.impl")))
+        val stackTrace = error.getStackTrace().map(_.toString).mkString("\n")
+        report.warning(s"$msg\n${stackTrace}")
 
     private def xCheckMacroAssertFail(msg: String): Unit =
       val error = new AssertionError(msg)

--- a/tests/pos-macros/i25541/Macro_1.scala
+++ b/tests/pos-macros/i25541/Macro_1.scala
@@ -1,0 +1,24 @@
+import scala.deriving.Mirror
+import scala.quoted.*
+
+object LocalMacros:
+  def macroRWImpl[T: Type](using Quotes): Expr[Unit] =
+    import quotes.reflect.*
+
+    def inspect(tpe: TypeRepr, typeArgs: List[TypeRepr]): Unit =
+      val constructorSym = tpe.typeSymbol.primaryConstructor
+      val constructorParamSymss = constructorSym.paramSymss
+      val (tparams0, params0) = constructorParamSymss.flatten.partition(_.isType)
+      val constructorTpe = tpe.memberType(constructorSym).widen
+      params0.foreach { param =>
+        constructorTpe.memberType(param).substituteTypes(tparams0, typeArgs)
+      }
+
+    TypeRepr.of[T] match
+      case applied: AppliedType => inspect(TypeRepr.of[T], applied.args)
+      case _ => inspect(TypeRepr.of[T], Nil)
+
+    '{ () }
+
+trait Custom:
+  inline def macroRW[T](using Mirror.Of[T]): Unit = ${ LocalMacros.macroRWImpl[T] }

--- a/tests/pos-macros/i25541/Test_2.scala
+++ b/tests/pos-macros/i25541/Test_2.scala
@@ -1,0 +1,5 @@
+final case class MessageError[Node](message: Option[String], code: Option[Int], data: Option[Node])
+
+object Test:
+  def readWriter(custom: Custom): Unit =
+    custom.macroRW[MessageError[Int]]


### PR DESCRIPTION
Fixes #25541

The problem with the original PR was the fact that LambdaTypes (MethodTypes, PolyTypes) do not hold any information about symbols (which are used extensively in the added check), so it's impossible to use those to check their relation to the LambdaTypes, a fact which I missed before.
After fruitlessly trying to figure out an alternative check, I realized that the underlying asSeenFrom method does not really operate on those either, effectively being a no-op.
e.g.:
```scala
AppliedType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,module class <root>)),object scala),class Option),List(TypeRef(NoPrefix,type Node)))
```
as seen from:
```scala
AppliedType(PolyType(List(Node), List(TypeBounds(TypeRef(ThisType(TypeRef(NoPrefix,module class scala)),class Nothing),TypeRef(ThisType(TypeRef(NoPrefix,module class scala)),class Any))), MethodType(List(data), List(AppliedType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,module class <root>)),object scala),class Option),List(TypeParamRef(Node)))), AppliedType(TypeRef(ThisType(TypeRef(NoPrefix,module class <empty>)),class MessageError),List(TypeParamRef(Node))))),List(TypeRef(ThisType(TypeRef(NoPrefix,module class scala)),class Int)))
```
will still return 
```scala
AppliedType(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,module class <root>)),object scala),class Option),List(TypeRef(NoPrefix,type Node)))
```

With that said, since memberType is the only safe way to get type info out of that member symbol, which is then no-oped into asSeenFrom call, we have to allow it I think, even if that means that we are back to allowing unsafe `member.info` code elsewhere (since now we can call symbol.info.asSeenFrom(lambdaType) on any unrelated lambdaType and get some member.info :(.

Some more context here, since the issues brought up here span many different PR's and discussions:
* We do not want to expose ClassInfo nodes, the decision about it was made early, it would not be possible to change that now, and ClassInfo generally would not give macro-users any more information than a TypeRef, but certain methods in the compiler can return it.
* Because of that we have to shield the users from that output by wrapping those into a TypeRef, otherwise the code would crash on macro runtime.
* symbol.info exposes ClassInfo (this is why the experimental wrapper method was never stabilized).
* so the only valid way to get the type from a symbol is memberType() fixed here. 
<!-- TODO description of the change -->
<!-- Ideally should have a title like "Fix #XYZ: Short fix description" -->

<!--
  TODO first sign the CLA
  https://contribute.akka.io/cla/scala
-->

<!-- if the PR is still a WIP, create it as a draft PR (or convert it into one) -->

## How much have you relied on LLM-based tools in this contribution?
I wanted to for additional tests, but they all came out redundant, so they are not included. 
<!-- 
  State clearly in the pull request description, 
  whether LLM-based tools were used and to what extent 

  (extensively/moderately/minimally/not at all)
-->

<!--
  Refer to our [LLM usage policy](https://github.com/scala/scala3/blob/main/LLM_POLICY.md) for rules and guidelines
  regarding usage of LLM-based tools in contributions.
-->

## How was the solution tested?
https://github.com/VirtusLab/community-build3/actions/runs/24502913431/job/71614026198
 - both automorph and neotype are fixed by this change.

<!-- 
  If automated tests are included, mention it.
  If they are not, explain why and how the solution was tested.
-->

## Additional notes

<!-- Placeholder for any extra context regarding this contribution. -->

<!--
  When in doubt, and for support regarding contributions to a particular component of the compiler, 
  refer to [our contribution guide](https://github.com/scala/scala3/blob/main/CONTRIBUTING.md),
  and feel free to tag the maintainers listed there for the area(s) you are modifying.
-->