### PR TITLE
Tune SafeRefs allow list for scala.util classes

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/SafeRefs.scala
+++ b/compiler/src/dotty/tools/dotc/cc/SafeRefs.scala
@@ -58,6 +58,7 @@ object SafeRefs {
   def init()(using Context): Unit =
     assumeSafe("scala.Predef", except = List("print", "println", "printf"))
     assumeSafe("scala.runtime.coverage.Invoker")
+    assumeSafe("scala.util.Properties", except = List("setProp", "clearProp", "main"))
     assumeSafe("java.lang.Object")
     assumeSafe("java.lang.Boolean")
     assumeSafe("java.lang.Byte")
@@ -98,6 +99,7 @@ object SafeRefs {
     assumeSafe("java.util.OptionalInt")
     assumeSafe("java.util.OptionalLong")
     assumeSafe("java.util.OptionalDouble")
+    assumeSafe("scala.reflect.ClassTag")
 
     rejectSafe("scala.Console")
     rejectSafe("scala.unchecked")
@@ -105,6 +107,9 @@ object SafeRefs {
     rejectSafe("scala.annotation.unchecked.uncheckedStable")
     rejectSafe("scala.annotation.unchecked.uncheckedVariance")
     rejectSafe("scala.annotation.unchecked.uncheckedCaptures")
+    rejectSafe("scala.util.DynamicVariable")
+    rejectSafe("scala.util.Using") // todo capture check Using
+
     // Reject mutable classes in scala.runtime
     rejectSafe("scala.runtime.BooleanRef")
     rejectSafe("scala.runtime.ByteRef")

--- a/library/src/scala/util/ChainingOps.scala
+++ b/library/src/scala/util/ChainingOps.scala
@@ -15,6 +15,7 @@ package util
 
 import scala.language.`2.13`
 import scala.language.implicitConversions
+import language.experimental.captureChecking
 
 trait ChainingSyntax {
   @inline implicit final def scalaUtilChainingOps[A](a: A): ChainingOps[A] = new ChainingOps(a)

--- a/library/src/scala/util/Either.scala
+++ b/library/src/scala/util/Either.scala
@@ -14,6 +14,7 @@ package scala
 package util
 
 import scala.language.`2.13`
+import language.experimental.captureChecking
 
 /** Represents a value of one of two possible types (a disjoint union).
  *  An instance of `Either` is an instance of either [[scala.util.Left]] or [[scala.util.Right]].

--- a/library/src/scala/util/Properties.scala
+++ b/library/src/scala/util/Properties.scala
@@ -17,6 +17,7 @@ import scala.language.`2.13`
 import java.io.{IOException, PrintWriter}
 import java.util.jar.Attributes.{Name => AttributeName}
 import scala.annotation.tailrec
+import language.experimental.captureChecking
 
 /** Loads `library.properties` from the jar. */
 object Properties extends PropertiesTrait {

--- a/library/src/scala/util/Random.scala
+++ b/library/src/scala/util/Random.scala
@@ -19,8 +19,9 @@ import scala.collection.mutable.ArrayBuffer
 import scala.collection.BuildFrom
 import scala.collection.immutable.LazyList
 import scala.language.implicitConversions
+import language.experimental.captureChecking
 
-class Random(val self: java.util.Random) extends AnyRef with Serializable {
+class Random(val self: java.util.Random^) extends AnyRef with Serializable {
   /** Creates a new random number generator using a single long seed. */
   def this(seed: Long) = this(new java.util.Random(seed))
 
@@ -39,14 +40,14 @@ class Random(val self: java.util.Random) extends AnyRef with Serializable {
    *  array.
    */
   def nextBytes(bytes: Array[Byte]): Unit = { self.nextBytes(bytes) }
-  
+
   /** Generates `n` random bytes and returns them in a new array. */
   def nextBytes(n: Int): Array[Byte] = {
     val bytes = new Array[Byte](0 max n)
     self.nextBytes(bytes)
     bytes
   }
-  
+
   /** Returns the next pseudorandom, uniformly distributed double value
    *  between 0.0 and 1.0 from this random number generator's sequence.
    */

--- a/library/src/scala/util/Sorting.scala
+++ b/library/src/scala/util/Sorting.scala
@@ -16,6 +16,7 @@ package util
 import scala.language.`2.13`
 import scala.reflect.ClassTag
 import scala.math.Ordering
+import language.experimental.captureChecking
 
 /** The `Sorting` object provides convenience wrappers for `java.util.Arrays.sort`.
  *  Methods that defer to `java.util.Arrays.sort` say that they do or under what
@@ -38,13 +39,13 @@ import scala.math.Ordering
  */
 object Sorting {
   /** Sorts an array of Doubles using `java.util.Arrays.sort`. */
-  def quickSort(a: Array[Double]): Unit = java.util.Arrays.sort(a)
+  def quickSort(a: Array[Double]^): Unit = java.util.Arrays.sort(a)
 
   /** Sorts an array of Ints using `java.util.Arrays.sort`. */
-  def quickSort(a: Array[Int]): Unit    = java.util.Arrays.sort(a)
+  def quickSort(a: Array[Int]^): Unit    = java.util.Arrays.sort(a)
 
   /** Sorts an array of Floats using `java.util.Arrays.sort`. */
-  def quickSort(a: Array[Float]): Unit  = java.util.Arrays.sort(a)
+  def quickSort(a: Array[Float]^): Unit  = java.util.Arrays.sort(a)
 
   private final val qsortThreshold = 16
 
@@ -52,9 +53,9 @@ object Sorting {
    *  This algorithm sorts in place, so no additional memory is used aside from
    *  what might be required to box individual elements during comparison.
    */
-  def quickSort[K: Ordering](a: Array[K]): Unit = {
+  def quickSort[K: Ordering](a: Array[K]^): Unit = {
     // Must have iN >= i0 or math will fail.  Also, i0 >= 0.
-    def inner(a: Array[K], i0: Int, iN: Int, ord: Ordering[K]): Unit = {
+    def inner(a: Array[K]^, i0: Int, iN: Int, ord: Ordering[K]): Unit = {
       if (iN - i0 < qsortThreshold) insertionSort(a, i0, iN, ord)
       else {
         val iK = (i0 + iN) >>> 1    // Unsigned div by 2
@@ -145,7 +146,7 @@ object Sorting {
 
   // Ordering[T] might be slow especially for boxed primitives, so use binary search variant of insertion sort
   // Caller must pass iN >= i0 or math will fail.  Also, i0 >= 0.
-  private def insertionSort[@specialized T](a: Array[T], i0: Int, iN: Int, ord: Ordering[T]): Unit = {
+  private def insertionSort[@specialized T](a: Array[T]^, i0: Int, iN: Int, ord: Ordering[T]): Unit = {
     val n = iN - i0
     if (n < 2) return
     if (ord.compare(a(i0), a(i0+1)) > 0) {
@@ -178,7 +179,7 @@ object Sorting {
   }
 
   // Caller is required to pass iN >= i0, else math will fail.  Also, i0 >= 0.
-  private def mergeSort[@specialized T: ClassTag](a: Array[T], i0: Int, iN: Int, ord: Ordering[T], scratch: Array[T] | Null = null): Unit = {
+  private def mergeSort[@specialized T: ClassTag](a: Array[T]^, i0: Int, iN: Int, ord: Ordering[T], scratch: (Array[T]^) | Null = null): Unit = {
     if (iN - i0 < mergeThreshold) insertionSort(a, i0, iN, ord)
     else {
       val iK = (i0 + iN) >>> 1   // Bit shift equivalent to unsigned math, no overflow
@@ -190,7 +191,7 @@ object Sorting {
   }
 
   // Must have 0 <= i0 < iK < iN
-  private def mergeSorted[@specialized T](a: Array[T], i0: Int, iK: Int, iN: Int, ord: Ordering[T], scratch: Array[T]): Unit = {
+  private def mergeSorted[@specialized T](a: Array[T]^, i0: Int, iK: Int, iN: Int, ord: Ordering[T], scratch: Array[T]): Unit = {
     // Check to make sure we're not already in order
     if (ord.compare(a(iK-1), a(iK)) > 0) {
       var i = i0
@@ -214,7 +215,7 @@ object Sorting {
   }
 
   // Why would you even do this?
-  private def booleanSort(a: Array[Boolean], from: Int, until: Int): Unit = {
+  private def booleanSort(a: Array[Boolean]^, from: Int, until: Int): Unit = {
     var i = from
     var n = 0
     while (i < until) {
@@ -234,7 +235,7 @@ object Sorting {
 
   // TODO: add upper bound: T <: AnyRef, propagate to callers below (not binary compatible)
   // Maybe also rename all these methods to `sort`.
-  @inline private def sort[T](a: Array[T], from: Int, until: Int, ord: Ordering[T]): Unit = (a: @unchecked) match {
+  @inline private def sort[T](a: Array[T]^, from: Int, until: Int, ord: Ordering[T]): Unit = (a: @unchecked) match {
     case a: Array[AnyRef]  =>
       // Note that runtime matches are covariant, so could actually be any Array[T] s.t. T is not primitive (even boxed value classes)
       if (a.length > 1 && (ord eq null)) throw new NullPointerException("Ordering")
@@ -252,9 +253,9 @@ object Sorting {
   }
 
   /** Sorts array `a` using the Ordering on its elements, preserving the original ordering where possible.
-   *  Uses `java.util.Arrays.sort` unless `K` is a primitive type. This is the same as `stableSort(a, 0, a.length)`. 
+   *  Uses `java.util.Arrays.sort` unless `K` is a primitive type. This is the same as `stableSort(a, 0, a.length)`.
    */
-  @`inline` def stableSort[K: Ordering](a: Array[K]): Unit = stableSort(a, 0, a.length)
+  @`inline` def stableSort[K: Ordering](a: Array[K]^): Unit = stableSort(a, 0, a.length)
 
   /** Sorts array `a` or a part of it using the Ordering on its elements, preserving the original ordering where possible.
    *  Uses `java.util.Arrays.sort` unless `K` is a primitive type.
@@ -263,12 +264,12 @@ object Sorting {
    *  @param from The first index in the array to sort
    *  @param until The last index (exclusive) in the array to sort
    */
-  def stableSort[K: Ordering](a: Array[K], from: Int, until: Int): Unit = sort(a, from, until, Ordering[K])
+  def stableSort[K: Ordering](a: Array[K]^, from: Int, until: Int): Unit = sort(a, from, until, Ordering[K])
 
   /** Sorts array `a` using function `f` that computes the less-than relation for each element.
-   *  Uses `java.util.Arrays.sort` unless `K` is a primitive type. This is the same as `stableSort(a, f, 0, a.length)`. 
+   *  Uses `java.util.Arrays.sort` unless `K` is a primitive type. This is the same as `stableSort(a, f, 0, a.length)`.
    */
-  @`inline` def stableSort[K](a: Array[K], f: (K, K) => Boolean): Unit = stableSort(a, f, 0, a.length)
+  @`inline` def stableSort[K](a: Array[K]^, f: (K, K) => Boolean): Unit = stableSort(a, f, 0, a.length)
 
   // TODO: make this fast for primitive K (could be specialized if it didn't go through Ordering)
   /** Sorts array `a` or a part of it using function `f` that computes the less-than relation for each element.
@@ -279,7 +280,7 @@ object Sorting {
    *  @param from The first index in the array to sort
    *  @param until The last index (exclusive) in the array to sort
    */
-  def stableSort[K](a: Array[K], f: (K, K) => Boolean, from: Int, until: Int): Unit = sort(a, from, until, Ordering fromLessThan f)
+  def stableSort[K](a: Array[K]^, f: (K, K) => Boolean, from: Int, until: Int): Unit = sort(a, from, until, Ordering fromLessThan f)
 
   /** A sorted Array, using the Ordering for the elements in the sequence `a`.  Uses `java.util.Arrays.sort` unless `K` is a primitive type. */
   def stableSort[K: ClassTag: Ordering](a: scala.collection.Seq[K]): Array[K] = {

--- a/library/src/scala/util/package.scala
+++ b/library/src/scala/util/package.scala
@@ -13,6 +13,7 @@
 package scala
 
 import scala.language.`2.13`
+import language.experimental.captureChecking
 
 package object util {
   /**


### PR DESCRIPTION
 - Capture check all remaining classes in scala.util, except for scala.util.Using.
 - Reject setter methods in scala.util.Properties as unsafe.
 - Make scala.util.Random take a capability as parameter, which turns Random generator values themselves into capabilities.
