### PR TITLE
Require explicit types in assumeSafe definitions in the empty package

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -796,6 +796,7 @@ extension (sym: Symbol) {
     sym.isLocalToCompilationUnit
     || sym.isScalaDocSnippet
     || sym.name.isReplWrapperName
+    || sym.isConstructor && sym.owner.name.isReplWrapperName
     || ctx.owner.enclosingPackageClass.isEmptyPackage
         && !sym.ownersIterator.takeWhile(!_.is(Package))
             .exists(_.hasAnnotation(defn.AssumeSafeAnnot))

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -781,6 +781,12 @@ extension (sym: Symbol) {
   def isDisallowedInCapset(using Context): Boolean =
     sym.isOneOf(if ccConfig.strictMutability then Method else UnstableValueFlags)
 
+  def isScalaDocSnippet(using Context): Boolean =
+    sym.is(ModuleClass)
+    && (sym.sourceModule.name == nme.Snippet)
+    && sym.owner.is(Package)
+    && sym.owner.name.toString.contains("snippet")
+
   /** Is symbol exempt from checking that its type or uses clause must
    *  be given explicitly? This is the case for symbols that are not
    *  visible outside the compilation unit where they are defined,
@@ -788,13 +794,19 @@ extension (sym: Symbol) {
    */
   def isExemptFromExplicitChecks(using Context): Boolean =
     sym.isLocalToCompilationUnit
+    || sym.isScalaDocSnippet
+    || sym.name.isReplWrapperName
     || ctx.owner.enclosingPackageClass.isEmptyPackage
-      // We make an exception for symbols in the empty package.
-      // these could theoretically be accessed from other files in the empty package, but
-      // usually it would be too annoying to require explicit types.
+        && !sym.ownersIterator.takeWhile(!_.is(Package))
+            .exists(_.hasAnnotation(defn.AssumeSafeAnnot))
+      // We make an exception for symbols in the empty package unless they are
+      // compiled in safe mode or wrapped in @assumeSafe. These could theoretically
+      // be accessed from other files in the empty package, but usually it would
+      // be too annoying to require explicit types. @assumeSafe symbols are not exempt,
+      // since for them precise recording of capabilities is essential.
     || sym.name.is(DefaultGetterName)
       // Default getters are exempted since otherwise it would be
-      // too annoying. This is a hole since a defualt getter's result type
+      // too annoying. This is a hole since a default getter's result type
       // might leak into a type variable.
 
   /** If `sym` is a method or a non-static inner class, a capture set

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -1389,32 +1389,6 @@ class CheckCaptures extends Recheck, SymTransformer:
           curEnv = saved
       }
 
-    def isScalaDocSnippet(sym: Symbol)(using Context): Boolean =
-      sym.is(ModuleClass)
-      && (sym.sourceModule.name == nme.Snippet)
-      && sym.owner.is(Package)
-      && sym.owner.name.toString.contains("snippet")
-
-    /** Is symbol exempt from checking that its type or uses clause must
-     *  be given explicitly? This is the case for symbols that are not
-     *  visible outside the compilation unit where they are defined,
-     *  and also for two pragmatic exemptions, explained below.
-     */
-    def isExemptFromExplicitChecks(sym: Symbol)(using Context): Boolean =
-      sym.isLocalToCompilationUnit
-      || isScalaDocSnippet(sym)
-      || sym.name.isReplWrapperName
-      || ctx.owner.enclosingPackageClass.isEmptyPackage
-        // We make an exception for symbols in the empty package.
-        // these could theoretically be accessed from other files in the empty package, but
-        // usually it would be too annoying to require explicit types.
-      || sym.name.is(DefaultGetterName)
-        // Default getters are exempted since otherwise it would be
-        // too annoying. This is a hole since a defualt getter's result type
-        // might leak into a type variable.
-      || sym.needsResultRefinement
-        // If we refine the result type anyway, the inferred type does not matter.
-
     /** Two tests for member definitions with inferred types:
      *
      *   1. If val or def definition with inferred (result) type is visible
@@ -1462,7 +1436,9 @@ class CheckCaptures extends Recheck, SymTransformer:
       tree.tpt match
         case tpt: InferredTypeTree =>
           // Test point (1) of doc comment above
-          if !isExemptFromExplicitChecks(sym) then // Symbols that can't be seen outside the compilation unit can have inferred types
+          if !sym.isExemptFromExplicitChecks // Symbols that can't be seen outside the compilation unit can have inferred types
+              && !sym.needsResultRefinement  // If we refine the result type anyway, the inferred type does not matter
+          then // Symbols that can't be seen outside the compilation unit can have inferred types
             val expected = tpt.tpe.dropAllRetains
             todoAtPostCheck += { () =>
               withGlobalCapAsRoot:
@@ -1514,7 +1490,7 @@ class CheckCaptures extends Recheck, SymTransformer:
                   |Field classifiers have to conform to the classifier of the containing class.""",
               cls.srcPos)
       // (2)
-      if !isExemptFromExplicitChecks(cls)
+      if !cls.isExemptFromExplicitChecks
           && !cls.derivesFromCapability
           && capFields.nonEmpty
       then

--- a/repl/test-resources/repl/safe-in-cc
+++ b/repl/test-resources/repl/safe-in-cc
@@ -1,0 +1,14 @@
+//> using options -language:experimental.captureChecking
+scala> import caps.*
+scala> class IO extends SharedCapability
+// defined class IO
+scala> @assumeSafe val io: IO^ = null
+val io: IO^ = null
+scala> val x = io
+val x: IO^{io} = null
+scala> import language.experimental.safe
+scala> val y: IO^{io} = io
+val y: IO^{io} = null
+scala> def f(x: Any): Unit = ()
+def f(x: Any): Unit
+scala> f(y)

--- a/tests/neg-custom-args/captures/assumesafe-emptypkg.check
+++ b/tests/neg-custom-args/captures/assumesafe-emptypkg.check
@@ -1,0 +1,9 @@
+-- [E223] CaptureChecking Error: tests/neg-custom-args/captures/assumesafe-emptypkg.scala:8:27 -------------------------
+8 |  def println(s: String) = Console.println(s) // error
+  |                           ^^^^^^^
+  |                           Reference `Console` is not included in the allowed capture set {}
+  |                           of the enclosing object A.
+  |
+  |                           External uses should be declared explicitly with a uses clause in object A:
+  |
+  |                               uses Console

--- a/tests/neg-custom-args/captures/assumesafe-emptypkg.scala
+++ b/tests/neg-custom-args/captures/assumesafe-emptypkg.scala
@@ -1,0 +1,9 @@
+import caps.*
+class Text
+
+object Console extends SharedCapability:
+  def println(s: String): Unit = ()
+
+@assumeSafe object A:
+  def println(s: String) = Console.println(s) // error
+

--- a/tests/neg-custom-args/captures/safemode-emptypkg.check
+++ b/tests/neg-custom-args/captures/safemode-emptypkg.check
@@ -1,0 +1,9 @@
+-- [E223] CaptureChecking Error: tests/neg-custom-args/captures/safemode-emptypkg.scala:9:27 ---------------------------
+9 |  def println(s: String) = Console.println(s) // error
+  |                           ^^^^^^^
+  |                           Reference `Console` is not included in the allowed capture set {}
+  |                           of the enclosing object A.
+  |
+  |                           External uses should be declared explicitly with a uses clause in object A:
+  |
+  |                               uses Console

--- a/tests/neg-custom-args/captures/safemode-emptypkg.scala
+++ b/tests/neg-custom-args/captures/safemode-emptypkg.scala
@@ -1,0 +1,10 @@
+import language.experimental.safe
+import caps.*
+class Text
+
+object Console extends SharedCapability:
+  def println(s: String): Unit = ()
+
+object A:
+  def println(s: String) = Console.println(s) // error
+


### PR DESCRIPTION

Also: Merge the duplications of two isExemptFromExplicitChecks definitions that
diverged with subtle differences.

Based on #25770. Only last commit is new.
