### PR TITLE
Fix test for JDK 2x

### DIFF
--- a/repl/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/repl/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -510,7 +510,7 @@ class ReplCompilerTests extends ReplTest:
       assertEquals("", storedOutput().trim)
       // Pure function arrow syntax requires pureFunctions
       run("val f: Int -> Int = (x: Int) => x + 1")
-      assertTrue(storedOutput().trim.startsWith("val f: Int -> Int = Lambda$"))
+      assertTrue("(?s)val f: Int -> Int = Lambda[$/].*".r.matches(storedOutput()))
 
   @Test def `i16250c`: Unit =
     initially:


### PR DESCRIPTION
Fixes a test that fails under JDK 25 because the spelling of `Lambda` changed in JDK 21 or was it 23.

## How much have you relied on LLM-based tools in this contribution?

Not at all

I didn't even rely on my native intelligence.

## How was the solution tested?

Covered by existing tests (yet this is _not_ a refactoring)

## Explanation no one asked for

`(?s)` is inline "single line" mode aka `DOTALL`, so that the trailing dot matches the trailing newline in input.

After `Lambda` is either a literal `$` (old style) or `/` (new style).

