### PR TITLE
Backport "Fix `-Ymagic-offset-header` for `DoubleDefinition` error and `implicitNotFound` errors, and remove global unmanaged cache" to 3.8.4

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Positioned.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Positioned.scala
@@ -4,7 +4,6 @@ package ast
 
 import util.Spans.*
 import util.{SourceFile, SourcePosition, SrcPos, WrappedSourceFile}
-import WrappedSourceFile.MagicHeaderInfo, MagicHeaderInfo.*
 import core.Contexts.*
 import core.Decorators.*
 import core.NameOps.*
@@ -53,14 +52,7 @@ abstract class Positioned(implicit @constructorOnly src: SourceFile) extends Src
   def source: SourceFile = mySource
 
   def sourcePos(using Context): SourcePosition =
-    val info = WrappedSourceFile.locateMagicHeader(source)
-    info match
-      // This span is in user code
-      case HasHeader(offset, originalFile)
-        if span.exists && span.start >= offset =>
-          originalFile.atSpan(span.shift(-offset))
-      // Otherwise, return the source position in the wrapper code
-      case _ => source.atSpan(span)
+    WrappedSourceFile.sourcePos(source, span)
 
   /** This positioned item, widened to `SrcPos`. Used to make clear we only need the
    *  position, typically for error reporting.

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -14,7 +14,7 @@ import Uniques.*
 import ast.Trees.*
 import Flags.ParamAccessor
 import ast.untpd
-import util.{NoSource, SimpleIdentityMap, SourceFile, HashSet, ReusableInstance}
+import util.{NoSource, SimpleIdentityMap, SourceFile, HashSet, ReusableInstance, WrappedSourceFile}
 import typer.{Implicits, ImportInfo, SearchHistory, SearchRoot, TypeAssigner, Typer, Nullables}
 import inlines.Inliner
 import Nullables.*
@@ -1008,6 +1008,10 @@ object Contexts {
     /** Sources and Files that were loaded */
     val sources: util.HashMap[AbstractFile, SourceFile] = util.HashMap[AbstractFile, SourceFile]()
     val files: util.HashMap[TermName, AbstractFile] = util.HashMap()
+
+    /** Cache for magic offset header lookups, scoped to this compiler instance
+     *  so that concurrent compilers in the same classloader don't share stale entries. */
+    private[dotc] val magicHeaderCache: util.HashMap[SourceFile, WrappedSourceFile.MagicHeaderInfo] = util.HashMap()
 
     /** Was best effort file used during compilation? */
     private[core] var usedBestEffortTasty = false

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -25,7 +25,7 @@ import Variances.Variance
 import reporting.Message
 import collection.mutable
 import io.AbstractFile
-import util.{SourceFile, NoSource, Property, SourcePosition, SrcPos, EqHashMap}
+import util.{SourceFile, NoSource, Property, SourcePosition, SrcPos, EqHashMap, WrappedSourceFile}
 import scala.annotation.internal.sharable
 import config.Printers.typr
 import dotty.tools.dotc.classpath.FileUtils.isScalaBinary
@@ -386,8 +386,8 @@ object Symbols extends SymUtils {
     final def span: Span = if (coord.isSpan) coord.toSpan else NoSpan
 
     final def sourcePos(using Context): SourcePosition = {
-      val src = source
-      (if (src.exists) src else ctx.source).atSpan(span)
+      val src = if source.exists then source else ctx.source
+      WrappedSourceFile.sourcePos(src, span)
     }
 
     /** This positioned item, widened to `SrcPos`. Used to make clear we only need the

--- a/compiler/src/dotty/tools/dotc/util/SourceFile.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourceFile.scala
@@ -12,7 +12,6 @@ import core.Decorators.*
 import scala.io.Codec
 import Chars.*
 import scala.annotation.internal.sharable
-import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.compiletime.uninitialized
 import dotty.tools.dotc.util.chaining.*
@@ -67,29 +66,38 @@ object WrappedSourceFile:
     case NoHeader
   import MagicHeaderInfo.*
 
-  private val cache: mutable.HashMap[SourceFile, MagicHeaderInfo] = mutable.HashMap.empty
+  /** Convert a (source, span) pair into a SourcePosition, remapping through the
+   *  magic offset header if applicable. */
+  def sourcePos(sourceFile: SourceFile, span: Span)(using Context): SourcePosition =
+    lookupMagicHeader(sourceFile) match
+      case HasHeader(offset, originalFile) if span.exists && span.start >= offset =>
+        originalFile.atSpan(span.shift(-offset))
+      case _ => sourceFile.atSpan(span)
 
-  def locateMagicHeader(sourceFile: SourceFile)(using Context): MagicHeaderInfo =
-    def findOffset: MagicHeaderInfo =
-      val magicHeader = ctx.settings.YmagicOffsetHeader.value
-      if magicHeader.isEmpty then NoHeader
-      else
-        val text = new String(sourceFile.content)
-        val headerQuoted = java.util.regex.Pattern.quote("///" + magicHeader)
-        val regex = s"(?m)^$headerQuoted:(.+)$$".r
-        regex.findFirstMatchIn(text) match
-          case Some(m) =>
-            val markerOffset = m.start
-            val sourceStartOffset = sourceFile.nextLine(markerOffset)
-            val file = ctx.getFile(m.group(1))
-            if file.exists then
-              HasHeader(sourceStartOffset, ctx.getSource(file))
-            else
-              report.warning(em"original source file not found: ${file.path}")
-              NoHeader
-          case None => NoHeader
-    val result = cache.getOrElseUpdate(sourceFile, findOffset)
-    result
+  private def lookupMagicHeader(sourceFile: SourceFile)(using Context): MagicHeaderInfo =
+    val cache = ctx.base.magicHeaderCache
+    cache.lookup(sourceFile) match
+      case null =>
+        val magicHeader = ctx.settings.YmagicOffsetHeader.value
+        val result =
+          if magicHeader.isEmpty then NoHeader
+          else
+            val text = new String(sourceFile.content)
+            val headerQuoted = java.util.regex.Pattern.quote("///" + magicHeader)
+            val regex = s"(?m)^$headerQuoted:(.+)$$".r
+            regex.findFirstMatchIn(text) match
+              case Some(m) =>
+                val sourceStartOffset = sourceFile.nextLine(m.start)
+                val file = ctx.getFile(m.group(1))
+                if file.exists then
+                  HasHeader(sourceStartOffset, ctx.getSource(file))
+                else
+                  report.warning(em"original source file not found: ${file.path}")
+                  NoHeader
+              case None => NoHeader
+        cache(sourceFile) = result
+        result
+      case result => result
 
 class SourceFile(val file: AbstractFile, computeContent: => Array[Char]) extends interfaces.SourceFile {
   import SourceFile.*

--- a/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
@@ -17,7 +17,7 @@ import scala.annotation.internal.sharable
 case class SourcePosition(source: SourceFile, span: Span, outer: SourcePosition | Null = null)
 extends SrcPos, interfaces.SourcePosition, Showable:
 
-  def sourcePos(using Context) = this
+  def sourcePos(using Context) = WrappedSourceFile.sourcePos(source, span)
 
   /** Is `that` a source position contained in this source position?
    *  `outer` is not taken into account. */

--- a/tests/neg/magic-offset-header-e.scala
+++ b/tests/neg/magic-offset-header-e.scala
@@ -1,0 +1,2 @@
+
+def foo: Int = "not an int"  // error

--- a/tests/neg/magic-offset-header-e_wrapper.check
+++ b/tests/neg/magic-offset-header-e_wrapper.check
@@ -1,0 +1,19 @@
+-- [E007] Type Mismatch Error: tests/neg/magic-offset-header-e.scala:2:17 ----------------------------------------------
+2 |def foo: Int = "not an int"  // error
+  |                 ^^^^^^^^^^^^
+  |                 Found:    ("not an int" : String)
+  |                 Required: Int
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E120] Naming Error: tests/neg/magic-offset-header-e.scala:2:6 ------------------------------------------------------
+2 |def foo: Int = "not an int"  // error
+  |      ^
+  |      Conflicting definitions:
+  |      def foo: String in class Wrapper at line 6 and
+  |      def foo: Int in class Wrapper at line 2
+  |      have the same type (): Int after erasure.
+  |
+  |      Consider adding a @targetName annotation to one of the conflicting definitions
+  |      for disambiguation.
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/magic-offset-header-e_wrapper.scala
+++ b/tests/neg/magic-offset-header-e_wrapper.scala
@@ -1,0 +1,10 @@
+//> using options -Ymagic-offset-header:TEST_MARKER
+// Test that Symbol.sourcePos applies magic-offset-header remapping.
+// DoubleDefinition errors use Symbol.srcPos, which must also remap
+// through the magic header like Positioned.sourcePos does.
+abstract class Wrapper {
+  def foo: String  // a definition before the marker
+///TEST_MARKER:tests/neg/magic-offset-header-e.scala
+
+  def foo: Int = "not an int"  // anypos-error  // anypos-error
+}

--- a/tests/neg/magic-offset-header-f.scala
+++ b/tests/neg/magic-offset-header-f.scala
@@ -1,0 +1,6 @@
+import language.strictEquality
+
+class Foo
+class Bar
+
+def test2 = new Foo == new Bar // error

--- a/tests/neg/magic-offset-header-f_wrapper.check
+++ b/tests/neg/magic-offset-header-f_wrapper.check
@@ -1,0 +1,4 @@
+-- [E172] Type Error: tests/neg/magic-offset-header-f.scala:6:12 -------------------------------------------------------
+6 |def test2 = new Foo == new Bar // error
+  |            ^^^^^^^^^^^^^^^^^^
+  |            Values of types Foo and Bar cannot be compared with == or !=

--- a/tests/neg/magic-offset-header-f_wrapper.scala
+++ b/tests/neg/magic-offset-header-f_wrapper.scala
@@ -1,0 +1,11 @@
+//> using options -Ymagic-offset-header:TEST_MARKER -language:strictEquality
+val t1 = 1
+val t2 = 2
+val t3 = 3
+///TEST_MARKER:tests/neg/magic-offset-header-f.scala
+import language.strictEquality
+
+class Foo
+class Bar
+
+def test2 = new Foo == new Bar // anypos-error


### PR DESCRIPTION
Backports #25706 to the 3.8.4-RC2.

PR submitted by the release tooling.
[skip ci]