### PR TITLE
Backport "fix #25691: scalaXml Elem rendering in repl" to 3.8.4

### DIFF
--- a/compiler/test/dotty/Properties.scala
+++ b/compiler/test/dotty/Properties.scala
@@ -105,6 +105,9 @@ object Properties {
   /** fansi jar */
   def sourcecode: String = sys.props("dotty.tests.classes.sourcecode")
 
+  /** scala-xml jar */
+  def scalaXml: String = sys.props("dotty.tests.classes.scalaXml")
+
   /** scalajs-javalib jar */
   def scalaJSJavalib: String = sys.props("dotty.tests.classes.scalaJSJavalib")
 

--- a/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
+++ b/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
@@ -59,7 +59,8 @@ object TestConfiguration {
       Properties.jlineReader,
       Properties.fansi,
       Properties.pprint,
-      Properties.sourcecode
+      Properties.sourcecode,
+      Properties.scalaXml
   ))
 
   lazy val replWithStagingClasspath = 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1037,6 +1037,7 @@ object Build {
           (Compile / sourceManaged).value
         }
         val externalDeps = (ThisProject / Runtime / externalDependencyClasspath).value
+        val testExternalDeps = (ThisProject / Test / externalDependencyClasspath).value
         Seq(
           s"-Ddotty.tests.dottyCompilerManagedSources=${managedSrcDir}",
           s"-Ddotty.tests.classes.dottyInterfaces=${(`scala3-interfaces` / Compile / packageBin).value}",
@@ -1054,6 +1055,7 @@ object Build {
           s"-Ddotty.tests.classes.pprint=${findArtifactPath(externalDeps, "pprint_3")}",
           s"-Ddotty.tests.classes.fansi=${findArtifactPath(externalDeps, "fansi_3")}",
           s"-Ddotty.tests.classes.sourcecode=${findArtifactPath(externalDeps, "sourcecode_3")}",
+          s"-Ddotty.tests.classes.scalaXml=${findArtifactPath(testExternalDeps, "scala-xml_2.13")}",
           s"-Ddotty.tools.dotc.semanticdb.test=${(ThisBuild / baseDirectory).value/"tests"/"semanticdb"}",
         )
       },

--- a/repl/src/dotty/tools/repl/Rendering.scala
+++ b/repl/src/dotty/tools/repl/Rendering.scala
@@ -33,7 +33,8 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
   private val forcedToStringClasses = Set(
     "scala.collection.immutable.LazyList",
     "scala.collection.immutable.LazyListIterable",
-    "scala.collection.mutable.StringBuilder" // not technically needed but quite ugly to print as an iterable of characters
+    "scala.collection.mutable.StringBuilder", // not technically needed but quite ugly to print as an iterable of characters
+    "scala.xml.Elem" // Temporary fix for https://github.com/scala/scala3/issues/25691
   )
 
   private def pprintRender(value: Any, width: Int, height: Int, initialOffset: Int)(using Context): String = {

--- a/repl/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/repl/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -712,6 +712,17 @@ class ReplCompilerTests extends ReplTest:
     )
     assertEquals(expected, lines())
 
+  @Test def `i25691 scala xml printing`: Unit = initially:
+    run:
+      """
+      |import scala.xml.*
+      |<foo/>
+      |""".stripMargin
+    val expected = List(
+      "val res0: Elem = <foo/>"
+    )
+    assertEquals(expected, lines())
+
 object ReplCompilerTests:
 
   private val pattern = Pattern.compile("\\r[\\n]?|\\n");


### PR DESCRIPTION
Backports #25781 to the 3.8.4-RC2.

PR submitted by the release tooling.
[skip ci]