### PR TITLE
Backport "Bump Scala CLI to v1.13.0 (was v1.12.5)" to 3.8.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -276,5 +276,5 @@ jobs:
         with:
           fetch-depth: 0
       - uses: coursier/cache-action@v8
-      - uses: VirtusLab/scala-cli-setup@v1.12.5
+      - uses: VirtusLab/scala-cli-setup@v1.13.0
       - run: scala-cli format --check

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -136,7 +136,7 @@ object Build {
   val mimaPreviousDottyVersion = "3.8.0"
 
   /** Version of Scala CLI to download */
-  val scalaCliLauncherVersion = "1.12.5"
+  val scalaCliLauncherVersion = "1.13.0"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
   val coursierJarVersion = "2.1.25-M24"
 


### PR DESCRIPTION
Backports #25810 to the 3.8.4-RC2.

PR submitted by the release tooling.