### PR TITLE
Do not warn for package object at the top level

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -153,7 +153,7 @@ object SymbolLoaders {
 
         def checkPathMatches(path: List[TermName], what: String, tree: NameTree): Boolean = {
           // Ignore empty packages so we don't warn on top-level package objects
-          // (such as `package object scala` in the top-level "package.scala" of the compiler itself)
+          // (such as `package object scala` in the top-level "package.scala" of the standard library)
           val ok = filePath == path.filter(_ != nme.EMPTY_PACKAGE)
           if (!ok)
             report.warning(i"""$what ${tree.name} is in the wrong directory.

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -152,7 +152,9 @@ object SymbolLoaders {
       def enterScanned(unit: CompilationUnit)(using Context) = {
 
         def checkPathMatches(path: List[TermName], what: String, tree: NameTree): Boolean = {
-          val ok = filePath == path
+          // Ignore empty packages so we don't warn on top-level package objects
+          // (such as `package object scala` in the top-level "package.scala" of the compiler itself)
+          val ok = filePath == path.filter(_ != nme.EMPTY_PACKAGE)
           if (!ok)
             report.warning(i"""$what ${tree.name} is in the wrong directory.
                            |It was declared to be in package ${path.reverse.mkString(".")}

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -152,9 +152,9 @@ object SymbolLoaders {
       def enterScanned(unit: CompilationUnit)(using Context) = {
 
         def checkPathMatches(path: List[TermName], what: String, tree: NameTree): Boolean = {
-          // Ignore empty packages so we don't warn on top-level package objects
+          // Ignore empty packages if necessary so we don't warn on top-level package objects
           // (such as `package object scala` in the top-level "package.scala" of the standard library)
-          val ok = filePath == path.filter(_ != nme.EMPTY_PACKAGE)
+          val ok = filePath == path || filePath == path.filter(_ != nme.EMPTY_PACKAGE)
           if (!ok)
             report.warning(i"""$what ${tree.name} is in the wrong directory.
                            |It was declared to be in package ${path.reverse.mkString(".")}


### PR DESCRIPTION
It was annoying.

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

Manual tests because writing automated tests is impractical, described below (in detail)

Compile the bootstrapped standard library, there is no warning about the top-level package object anymore.