### PR TITLE
Display position in `TreeChecker.checkType`

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -820,7 +820,12 @@ object TreeChecker {
       // Accept NoType <:< NoType as true
       assert((tp1 eq tp2) || (tp1 <:< tp2), {
         val mismatch = TypeMismatch(tp1, tp2, None)
+        val posStr =
+          val sp = tree.srcPos.sourcePos
+          if sp.exists then s"${sp.source}:${sp.line + 1}:${sp.column + 1}"
+          else "<no position>"
         i"""|Type Mismatch (while checking $step):
+            |Position: $posStr
             |${mismatch.message}${mismatch.explanation}
             |tree = $tree ${tree.className}""".stripMargin
       })

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -820,12 +820,8 @@ object TreeChecker {
       // Accept NoType <:< NoType as true
       assert((tp1 eq tp2) || (tp1 <:< tp2), {
         val mismatch = TypeMismatch(tp1, tp2, None)
-        val posStr =
-          val sp = tree.srcPos.sourcePos
-          if sp.exists then s"${sp.source}:${sp.line + 1}:${sp.column + 1}"
-          else "<no position>"
         i"""|Type Mismatch (while checking $step):
-            |Position: $posStr
+            |Position: ${tree.srcPos.sourcePos.showLineColumn}
             |${mismatch.message}${mismatch.explanation}
             |tree = $tree ${tree.className}""".stripMargin
       })

--- a/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourcePosition.scala
@@ -85,6 +85,15 @@ extends SrcPos, interfaces.SourcePosition, Showable:
   override def toString: String =
     s"${if (source.exists) source.file.toString else "(no source)"}:$span"
 
+  /** A textual representation of this position in the format `file:line:column`.
+   *  Terminals in VS Code or  IntelliJ IDEA recognize this format and turn it
+   *  into a clickable link that jumps to the referenced location.
+   *  Returns `"<no position>"` if this position does not exist.
+   */
+  def showLineColumn: String =
+    if exists then s"$source:${line + 1}:${column + 1}"
+    else "<no position>"
+
   def toText(printer: Printer): Text = printer.toText(this)
 
 object SourcePosition:


### PR DESCRIPTION
This PR adds a position in the `TreeChecker.checkType` assertion message. It helps finding the cause when the assertion fails.

I also tried to use `report.error` to get nicer reporting, but it would require changing many things in the `TreeChecker`. Probably not worth it.