### PR TITLE
Honest `null`s in `SymbolicXMLBuilder.scala`.

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/xml/SymbolicXMLBuilder.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/xml/SymbolicXMLBuilder.scala
@@ -3,7 +3,6 @@ package dotc
 package parsing
 package xml
 
-import scala.language.unsafeNulls
 import scala.compiletime.uninitialized
 
 import scala.collection.mutable
@@ -55,6 +54,7 @@ class SymbolicXMLBuilder(parser: Parser, preserveWS: Boolean)(using Context) {
     val _Null: TermName     = "Null"
     val __Elem: TermName    = "Elem"
     val __Text: TermName    = "Text"
+    val _TopScope: TermName = "TopScope"
     val _buf: TermName      = "$buf"
     val _md: TermName       = "$md"
     val _plus: TermName     = "&+"
@@ -66,17 +66,19 @@ class SymbolicXMLBuilder(parser: Parser, preserveWS: Boolean)(using Context) {
   import xmltypes.{_Comment, _Elem, _EntityRef, _Group, _MetaData, _NamespaceBinding, _NodeBuffer,
     _PrefixedAttribute, _ProcInstr, _Text, _Unparsed, _UnprefixedAttribute}
 
-  import xmlterms.{_Null, __Elem, __Text, _buf, _md, _plus, _scope, _tmpscope, _xml, _toVector}
+  import xmlterms.{_Null, __Elem, __Text, _TopScope, _buf, _md, _plus, _scope, _tmpscope, _xml,
+    _toVector}
 
   // convenience methods
   private def LL[A](x: A*): List[List[A]] = List(x.toList)
-  // Changing type to String causes a compiler crash in pickler phase,
-  // so we leave it as Any for now.
-  private def const(x: Any) =
-    val lit = Literal(Constant(x))
-    if ctx.explicitNulls && x == null
+  private def const(x: String): Tree = Literal(Constant(x))
+
+  private def nullAsString: Tree =
+    val lit = Literal(Constant(null))
+    if ctx.explicitNulls
     then TypeApply(Select(lit, nme.asInstanceOf_), TypeTree(defn.StringType) :: Nil)
     else lit
+
   private def wild                          = Ident(nme.WILDCARD)
   private def wildStar                      = Ident(tpnme.WILDCARD_STAR)
   private def _scala(name: Name)            = scalaDot(name)
@@ -93,6 +95,7 @@ class SymbolicXMLBuilder(parser: Parser, preserveWS: Boolean)(using Context) {
   private def _scala_xml_PrefixedAttribute  = _scala_xml(_PrefixedAttribute)
   private def _scala_xml_ProcInstr          = _scala_xml(_ProcInstr)
   private def _scala_xml_Text               = _scala_xml(_Text)
+  private def _scala_xml_TopScope           = _scala_xml(_TopScope)
   private def _scala_xml_Unparsed           = _scala_xml(_Unparsed)
   private def _scala_xml_UnprefixedAttribute= _scala_xml(_UnprefixedAttribute)
   private def _scala_xml__Elem              = _scala_xml(__Elem)
@@ -145,7 +148,7 @@ class SymbolicXMLBuilder(parser: Parser, preserveWS: Boolean)(using Context) {
       case (Some(pre), rest)  => (const(pre), const(rest))
       case _                  => (wild, const(n))
     }
-    mkXML(span, true, prepat, labpat, null, null, false, args)
+    mkXML(span, true, prepat, labpat, _scala_xml_Null, _scala_xml_TopScope, false, args)
   }
 
   protected def convertToTextPat(t: Tree): Tree = t match {
@@ -192,15 +195,15 @@ class SymbolicXMLBuilder(parser: Parser, preserveWS: Boolean)(using Context) {
     atSpan(span)( New(_scala_xml_Unparsed, LL(const(str))) )
 
   def element(span: Span, qname: String, attrMap: mutable.Map[String, Tree], empty: Boolean, args: collection.Seq[Tree]): Tree = {
-    def handleNamespaceBinding(pre: String, z: String): Tree = {
+    def handleNamespaceBinding(pre: Tree, z: String): Tree = {
       def mkAssign(t: Tree): Tree = Assign(
         Ident(_tmpscope),
-        New(_scala_xml_NamespaceBinding, LL(const(pre), t, Ident(_tmpscope)))
+        New(_scala_xml_NamespaceBinding, LL(pre, t, Ident(_tmpscope)))
       )
 
       val uri1 = attrMap(z) match {
         case Apply(_, List(uri @ Literal(Constant(_)))) => mkAssign(uri)
-        case Select(_, nme.Nil)                         => mkAssign(const(null))  // allow for xmlns="" -- bug #1626
+        case Select(_, nme.Nil)                         => mkAssign(nullAsString)  // allow for xmlns="" -- bug #1626
         case x                                          => mkAssign(x)
       }
       attrMap -= z
@@ -211,18 +214,18 @@ class SymbolicXMLBuilder(parser: Parser, preserveWS: Boolean)(using Context) {
     val namespaces: List[Tree] =
       for z <- attrMap.keys.toList if z.startsWith("xmlns") yield {
         val ns = splitPrefix(z) match {
-          case (Some(_), rest)  => rest
-          case _                => null
+          case (Some(_), rest)  => const(rest)
+          case _                => nullAsString
         }
         handleNamespaceBinding(ns, z)
       }
 
     val (pre, newlabel) = splitPrefix(qname) match {
-      case (Some(p), x) => (p, x)
-      case (None, x)    => (null, x)
+      case (Some(p), x) => (const(p), x)
+      case (None, x)    => (nullAsString, x)
     }
 
-    def mkAttributeTree(pre: String, key: String, value: Tree) = atSpan(span.toSynthetic) {
+    def mkAttributeTree(pre: String | Null, key: String, value: Tree) = atSpan(span.toSynthetic) {
       // XXX this is where we'd like to put Select(value, nme.toString_) for #1787
       // after we resolve the Some(foo) situation.
       val baseArgs = List(const(key), value, Ident(_md))
@@ -258,7 +261,7 @@ class SymbolicXMLBuilder(parser: Parser, preserveWS: Boolean)(using Context) {
     val body = mkXML(
       span.toSynthetic,
       false,
-      const(pre),
+      pre,
       const(newlabel),
       makeSymbolicAttrs,
       Ident(_scope),


### PR DESCRIPTION

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

Covered by existing tests (this is a refactoring)

/cc @HarrisL2 Could you check that I did not break anything you did in #25221 ?