### PR TITLE
Backport "Do not warn for package object at the top level" to 3.8.4

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -153,7 +153,9 @@ object SymbolLoaders {
       def enterScanned(unit: CompilationUnit)(using Context) = {
 
         def checkPathMatches(path: List[TermName], what: String, tree: NameTree): Boolean = {
-          val ok = filePath == path
+          // Ignore empty packages if necessary so we don't warn on top-level package objects
+          // (such as `package object scala` in the top-level "package.scala" of the standard library)
+          val ok = filePath == path || filePath == path.filter(_ != nme.EMPTY_PACKAGE)
           if (!ok)
             report.warning(i"""$what ${tree.name} is in the wrong directory.
                            |It was declared to be in package ${path.reverse.mkString(".")}


### PR DESCRIPTION
Backports #25826 to the 3.8.4-RC2.

PR submitted by the release tooling.