### PR TITLE
Don't cancel async TASTy write on success

### DIFF
--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -357,7 +357,10 @@ jobs:
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
       - name: Run SBT scripted tests
-        run: ./project/scripts/sbt scala3-bootstrapped/scripted
+        run: |
+          for i in $(seq 1 50); do
+            ./project/scripts/sbt scala3-bootstrapped/scripted
+          done
 
   community_build_a:
     runs-on: ubuntu-latest

--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -281,33 +281,42 @@ extends ImplicitRunInfo, ConstraintRunInfo, cc.CaptureRunInfo {
   /** populated when this run needs to write pipeline TASTy files. */
   def asyncTasty: Option[AsyncTastyHolder] = _asyncTasty
 
-  private def initializeAsyncTasty()(using Context): () => Unit =
+  private def initializeAsyncTasty()(using Context): Unit =
     // should we provide a custom ExecutionContext?
     // currently it is just used to call the `apiPhaseCompleted` and `dependencyPhaseCompleted` callbacks in Zinc
     import scala.concurrent.ExecutionContext.Implicits.global
-    val async = AsyncTastyHolder.init
-    _asyncTasty = Some(async)
-    () => async.cancel()
+    _asyncTasty = Some(AsyncTastyHolder.init)
 
   /** Wait for async TASTy operations (including Zinc callbacks like
    *  `apiPhaseCompleted`/`dependencyPhaseCompleted`) to complete and relay any
    *  buffered reports. This must happen before we return to Zinc, which calls
    *  `getCycleResultOnce` immediately after. See scala/scala3#25774.
+   *
+   *  On errors, cancels any pending async work first so this method does not block
+   *  (e.g. if the write task was never scheduled because Pickler failed early).
    */
   private def syncAsyncTasty()(using Context): Unit =
-    for
-      async <- _asyncTasty
-      bufferedReporter <- async.sync()
-      report <- bufferedReporter.resetReports()
-    do
-      import reporting.Diagnostic
-      report match
-        case FileWriters.Report.Error(msg, pos) =>
-          ctx.reporter.report(Diagnostic.Error(msg(ctx), pos))
-        case FileWriters.Report.Warning(msg, pos) =>
-          ctx.reporter.report(Diagnostic.Warning(msg(ctx), pos))
-        case FileWriters.Report.Log(msg) =>
-          ctx.reporter.report(Diagnostic.Info(msg, NoSourcePosition))
+    for async <- _asyncTasty do
+      // If compilation failed, the executor thread's write task may never have been
+      // scheduled — cancel to resolve the pending promise and unblock sync().
+      // On success, do NOT cancel: the executor thread must complete so that
+      // apiPhaseCompleted is called and Zinc can start downstream projects early.
+      // See scala/scala3#25797.
+      if ctx.reporter.hasErrors then
+        async.cancel()
+
+      for
+        bufferedReporter <- async.sync()
+        report <- bufferedReporter.resetReports()
+      do
+        import reporting.Diagnostic
+        report match
+          case FileWriters.Report.Error(msg, pos) =>
+            ctx.reporter.report(Diagnostic.Error(msg(ctx), pos))
+          case FileWriters.Report.Warning(msg, pos) =>
+            ctx.reporter.report(Diagnostic.Warning(msg(ctx), pos))
+          case FileWriters.Report.Log(msg) =>
+            ctx.reporter.report(Diagnostic.Info(msg, NoSourcePosition))
 
   /** Will be set to true if any of the compiled compilation units contains
    *  a pureFunctions language import.
@@ -433,13 +442,10 @@ extends ImplicitRunInfo, ConstraintRunInfo, cc.CaptureRunInfo {
       runCtx.setProperty(CyclicReference.Trace, new CyclicReference.Trace())
     runCtx.withProgressCallback: cb =>
       _progress = Progress(cb, this, fusedPhases.map(_.traversals).sum)
-    val cancelAsyncTasty: () => Unit =
-      if !myAsyncTastyWritten && Phases.picklerPhase.exists && !ctx.settings.XearlyTastyOutput.isDefault then
-        initializeAsyncTasty()
-      else () => {}
+    if !myAsyncTastyWritten && Phases.picklerPhase.exists && !ctx.settings.XearlyTastyOutput.isDefault then
+      initializeAsyncTasty()
 
     showProgress(runPhases(allPhases = fusedPhases)(using runCtx))
-    cancelAsyncTasty()
     syncAsyncTasty()
 
     suppressions.runFinished()


### PR DESCRIPTION
Fixes #25797

## Root cause

This fixes an intermittent `Not found: b` error when project `c` compiled against the early TASTy output of a Java-only project `b` in an sbt pipelining build.

The bug was introduced by #25618, which removed `async.sync()` from `GenBCode.runOn`. Before that PR, `GenBCode` always called `async.sync()` (even with an empty unit list, as is the case for Java-only projects compiled with `-Xjava-tasty`). That sync implicitly ensured the executor thread writing the early TASTy jar had completed before `cancelAsyncTasty()` was called in `Run.compile`.

After #25618, the call sequence in `Run.compile` became:

```
runPhases(...)       // GenBCode no longer syncs internally
cancelAsyncTasty()   // calls async.cancel() — always, even on success
syncAsyncTasty()     // added by #25776, but too late
```

`cancelAsyncTasty()` always called `async.cancel()`, which races with the executor thread writing TASTy:

- If the executor finishes first → `asyncTastyWritten` already resolved with `Some(state)` → `cancel()`'s `trySuccess(None)` is a harmless no-op → `apiPhaseCompleted` is called → pipelining works correctly.
- If `cancel()` wins → `asyncTastyWritten` is resolved with `None` → `backendFuture` evaluates to `None` → `apiPhaseCompleted` is **never called** → Zinc starts `c` with an empty early jar on the classpath → `Not found: b`.

The race was only reliably observable for Java-only projects because their compilation pipeline is very short after `ExtractAPI` (no JVM bytecode to generate), giving `cancel()` a large window to win. For Scala projects, `GenBCode` takes long enough that the executor always completes first.

## Fix

Move the cancel-on-error logic inside `syncAsyncTasty()`, conditioned on `ctx.reporter.hasErrors`:

```scala
// Run.scala
private def syncAsyncTasty()(using Context): Unit =
  for async <- _asyncTasty do
    // Cancel only on error: if the write task was never scheduled (e.g. Pickler
    // failed early), asyncTastyWritten would never resolve and sync() would block.
    // On success, do NOT cancel — the executor thread must complete so that
    // apiPhaseCompleted is called and Zinc can start downstream projects early.
    // See scala/scala3#25797.
    if ctx.reporter.hasErrors then
      async.cancel()

    for
      bufferedReporter <- async.sync()
      ...
```

`Run.compile` is simplified to just call `syncAsyncTasty()` after phases:

```scala
showProgress(runPhases(allPhases = fusedPhases)(using runCtx))
syncAsyncTasty()
```

On success, `syncAsyncTasty()` now waits for the executor thread to complete naturally (writing all TASTy entries and closing the jar) before `apiPhaseCompleted` is called. On error, the cancel unblocks the sync so we don't hang when the write task was never scheduled.

## How much have you relied on LLM-based tools in this contribution?

Extensively, for root cause investigation, diagnosis, and implementation of the fix.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)

The `pipelining/pipelining-scala-java-basic` scripted test already covers the scenario. A temporary CI step running it 30 times is added to confirm the race no longer triggers.
